### PR TITLE
Improvement of Microsoft Graph API / Email Addreses and other issues

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,7 @@
 - Add `RequestDeliveryReceipt` switch to `Send-EmailMessage` for Microsoft Graph to request a delivery receipt. SMTP uses `DeliveryNotificationOption` and `DeliveryStatusNotificationType`.
 - Require `Send-EmailMessage` to have From field [#33](https://github.com/EvotecIT/Mailozaurr/issues/33)
 - Warn if attachment in `Send-EmailMessage` doesn't exists, no error is thrown [#34](https://github.com/EvotecIT/Mailozaurr/issues/34)
+- Fixes special chars issue in file names [#26](https://github.com/EvotecIT/Mailozaurr/issues/26)
 
 #### - 0.0.25 - 2022.06.07
 - Updated `MailKit`

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,7 @@
 - Add `RequestReadReceipt` support to `Send-EmailMessage` for Microsoft Graph to request a read receipt from the recipient.
 - Add `RequestDeliveryReceipt` switch to `Send-EmailMessage` for Microsoft Graph to request a delivery receipt. SMTP uses `DeliveryNotificationOption` and `DeliveryStatusNotificationType`.
 - Require `Send-EmailMessage` to have From field [#33](https://github.com/EvotecIT/Mailozaurr/issues/33)
+- Warn if attachment in `Send-EmailMessage` doesn't exists, no error is thrown [#34](https://github.com/EvotecIT/Mailozaurr/issues/34)
 
 #### - 0.0.25 - 2022.06.07
 - Updated `MailKit`

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,11 @@
-﻿#### - 0.0.25 - 2022.06.07
+﻿#### 0.0.26
+- Fix `Suppress` for sending emails via SendGrid
+- Fix `Suppress` for sending emails via Microsoft Graph
+- Add support to `Send-EmailMessage` for attachments **4MB** to **150MB** in size for Microsoft Graph. Before it would only send attachments up to **4MB** in size. Detects size automatically and uses the appropriate API endpoint.
+- Add `RequestReadReceipt` support to `Send-EmailMessage` for Microsoft Graph to request a read receipt from the recipient.
+- Add `RequestDeliveryReceipt` switch to `Send-EmailMessage` for Microsoft Graph to request a delivery receipt. SMTP uses `DeliveryNotificationOption` and `DeliveryStatusNotificationType`.
+
+#### - 0.0.25 - 2022.06.07
 - Updated `MailKit`
 - Updated `MimeKit`
 - Added missing libraries so that the project can work on more systems without installing higher version of .NET Framework

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,4 @@
-﻿#### 0.0.26
+﻿#### 0.9.0 - 2022.10.01
 - Fix `Suppress` for sending emails via SendGrid
 - Fix `Suppress` for sending emails via Microsoft Graph
 - Add support to `Send-EmailMessage` for attachments **4MB** to **150MB** in size for Microsoft Graph. Before it would only send attachments up to **4MB** in size. Detects size automatically and uses the appropriate API endpoint.
@@ -7,31 +7,32 @@
 - Require `Send-EmailMessage` to have From field [#33](https://github.com/EvotecIT/Mailozaurr/issues/33)
 - Warn if attachment in `Send-EmailMessage` doesn't exists, no error is thrown [#34](https://github.com/EvotecIT/Mailozaurr/issues/34)
 - Fixes special chars issue in file names [#26](https://github.com/EvotecIT/Mailozaurr/issues/26)
+- 
 
-#### - 0.0.25 - 2022.06.07
+#### 0.0.25 - 2022.06.07
 - Updated `MailKit`
 - Updated `MimeKit`
 - Added missing libraries so that the project can work on more systems without installing higher version of .NET Framework
 - Added tests for SMTP with Auth and Graph API
 
-#### - 0.0.24 - 2021.01.24
+#### 0.0.24 - 2021.01.24
   - Improved logging logic for `Send-EmailMessage`
-#### - 0.0.23 - 2021.01.22
+#### 0.0.23 - 2021.01.22
   - Added option to `Send-EmailMessage` to specify the `LocalDomain` to be able to troubleshoot issue [#1314](https://github.com/jstedfast/MailKit/issues/1314)
   - Added option to `Send-EmailMessage` - `LogConsole` and `LogObject` which joins `LogPath` in saving whole conversation to console, or to final object as Message property
 
-#### - 0.0.22 - 2021.01.21
+#### 0.0.22 - 2021.01.21
   - Upgraded `MailKit\MimeKit` to 3.1.0
   - Added support to save MimeMessage in `Send-EmailMessage` using `MimeMessagePath`
   - Fixed `Cloudflare DNS calls` for `Find-DMARCRecord`,`Find-DKIMRecord`, `Find-MXRecord`, `Find-SPFRecord`, `Find-DNSBNL`
   - Updated docs
   - More output fields on `Send-EmailMessage`
 
-#### - 0.0.21 - 2022.01.07
+#### 0.0.21 - 2022.01.07
   - Added support for logging in the `Send-EmailMessage` for SMTP to allow for debugging.
     - By adding `LogPath $PSScriptRoot\Output\Log1.txt` log file will be created with full information
     - Parameters such as `LogSecrets`, `LogTimeStamps`, `LogTimeStampsFormat` and `LogClientPrefix`,`LogServerPrefix` are available
-#### - 0.0.20 - 2022.01.02
+#### 0.0.20 - 2022.01.02
   - Added support for using `Get-MsalToken` instead of built-in token creation for GraphApi
 
 ```powershell
@@ -56,32 +57,32 @@ $Credential = ConvertTo-GraphCredential -MsalToken $MsalToken.AccessToken
 Send-EmailMessage -From 'przemyslaw.klys@something.pl' -To 'przemyslaw.klys@something.else' -Credential $Credential -HTML $Body -Subject 'This is another test email 2' -Graph -Verbose -Priority Low -DoNotSaveToSentItems
 ```
 
-#### - 0.0.19 - 2021.12.25
+#### 0.0.19 - 2021.12.25
   - Fixes encoding for Send-EmailMessage wen using GraphApi (forces UTF8)
-#### - 0.0.18 - 2021.09.23
+#### 0.0.18 - 2021.09.23
   - Improved error handling of `Send-EmailMessage` when sending with GraphApi
-#### - 0.0.17 - 2021.09.19
+#### 0.0.17 - 2021.09.19
   - Upgraded `MailKit/Mimekit` `2.15.0`
   - Upgraded `DNSClient` to `1.5.0`
   - Fixes `oAuth2` [#17](https://github.com/EvotecIT/Mailozaurr/issues/17)
   - Removed wrong parameterset from `Send-EmailMessage`
   - Improved `ConvertTo-GraphCredential` to support encrypted graph client secret.
-#### - 0.0.16 - 2021.07.23
+#### 0.0.16 - 2021.07.23
   - Moved Class.MySmtpClient to be loaded from separate file via dot sourcing - hopefully fixes [#16](https://github.com/EvotecIT/Mailozaurr/issues/16)
-#### - 0.0.15 - 2021.07.18
+#### 0.0.15 - 2021.07.18
   - Moved Class.MySmtpClient to be loaded as last in PSM1. This should make it load when loaded by other modules - hopefully!
-#### - 0.0.14 - 2021.06.28
+#### 0.0.14 - 2021.06.28
   - Added missing library `System.Buffers`
-#### - 0.0.13 - 2021.06.27
+#### 0.0.13 - 2021.06.27
   - Added `SkipCertificateValidatation` to `Send-EmailMessage`
   - Downgraded `MailKit/MimeKit 2.12.0`
-#### - 0.0.12 - 2021.06.20
+#### 0.0.12 - 2021.06.20
   - Added `AsSecureString` to `Send-EmailMessage` which allows to provide `-AsSecureString -Username 'przemyslaw.klys@domain.pl' -Password $secStringPassword`
-#### - 0.0.11 - 2021.06.18
+#### 0.0.11 - 2021.06.18
   - Added `SkipCertificateRevocation` to `Send-EmailMessage` [#13](https://github.com/EvotecIT/Mailozaurr/issues/13)
   - 🐛 Fixed PTR records in `Find-MXRecord` when using HTTPS
   - Small improvement to `Send-EmailMessage` returning object when using `WhatIf`
-#### - 0.0.10 - 2020.10.25
+#### 0.0.10 - 2020.10.25
   - `Send-EmailMessage` - fix for Graph where attachments where not attached and nobody reported
   - `Send-EmailMessage` - updated error messages with tips what could be wrong
   - `Send-EmailMessage` - updated ErrorAction Stop in few places for those that prefer errors
@@ -92,10 +93,10 @@ Send-EmailMessage -From 'przemyslaw.klys@something.pl' -To 'przemyslaw.klys@some
   - `Find-DMARCRecord` - updated with `DNSProvider` (`Cloudflare`/`Google`) for calls over HTTPS
   - `Find-DNSBL` - added, same options as above
   - `Resolve-DNSRequestRest` - Added just in case
-#### - 0.0.9 - 2020.08.11
+#### 0.0.9 - 2020.08.11
   - DNS Records
     - Fixed `DNSServer` parameter usage [#5](https://github.com/EvotecIT/Mailozaurr/issues/5)
-#### - 0.0.8 - 2020.08.06
+#### 0.0.8 - 2020.08.06
   - MS Graph API
     - Added `Get-MailFolder` - work in progress
     - Added `Get-MailMessage` - work in progress
@@ -103,24 +104,24 @@ Send-EmailMessage -From 'przemyslaw.klys@something.pl' -To 'przemyslaw.klys@some
     - Added check for attachments/message body less than 10 characters. - by andrew0wells [#3](https://github.com/EvotecIT/Mailozaurr/issues/3)
   - SMTP
     - Updated `Send-EmailMessage` error handling
-#### - 0.0.7 - 2020.08.04
+#### 0.0.7 - 2020.08.04
   - More updates making it better toolkit
-#### - 0.0.6 - 2020.08.03
+#### 0.0.6 - 2020.08.03
   - Public release
   - Added GraphAPI support for Send-EmailMessage
   - Added oAuth2 support for Send-EmailMessage
   - Added oAuth2 support for POP3
   - Added oAuth2 support for IMAP4
   - Fixed lots of stuff
-#### - 0.0.3 - 2020.07.26
+#### 0.0.3 - 2020.07.26
   - Added `Test-EmailAddress`
   - Added `Connect-OAuthGoogle`
   - Added `Connect-OAuthO365`
   - Added `Resolve-DNSQuery`
-#### - 0.0.2 - 2020.07.25
+#### 0.0.2 - 2020.07.25
   - Added `Find-MXRecord`
   - Added `Find-DMARCRecord`
   - Added `Find-DKIMRecord`
   - Added `Find-SPFRecord`
-#### - 0.0.1 - 2020.06.13
+#### 0.0.1 - 2020.06.13
   - Initial release

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,7 @@
 - Add support to `Send-EmailMessage` for attachments **4MB** to **150MB** in size for Microsoft Graph. Before it would only send attachments up to **4MB** in size. Detects size automatically and uses the appropriate API endpoint.
 - Add `RequestReadReceipt` support to `Send-EmailMessage` for Microsoft Graph to request a read receipt from the recipient.
 - Add `RequestDeliveryReceipt` switch to `Send-EmailMessage` for Microsoft Graph to request a delivery receipt. SMTP uses `DeliveryNotificationOption` and `DeliveryStatusNotificationType`.
+- Require `Send-EmailMessage` to have From field [#33](https://github.com/EvotecIT/Mailozaurr/issues/33)
 
 #### - 0.0.25 - 2022.06.07
 - Updated `MailKit`

--- a/Mailozaurr.Tests.ps1
+++ b/Mailozaurr.Tests.ps1
@@ -43,7 +43,7 @@ foreach ($Module in $PSDInformation.RequiredModules) {
 Write-Color
 
 Import-Module $PSScriptRoot\*.psd1 -Force
-$result = Invoke-Pester -Script $PSScriptRoot\Tests -Verbose -EnableExit
+$result = Invoke-Pester -Script $PSScriptRoot\Tests -Verbose -PassThru
 
 if ($result.FailedCount -gt 0) {
     throw "$($result.FailedCount) tests failed."

--- a/Mailozaurr.psd1
+++ b/Mailozaurr.psd1
@@ -8,7 +8,7 @@
     Description          = 'Mailozaurr is a PowerShell module that aims to provide SMTP, POP3, IMAP and few other ways to interact with Email. Underneath it uses MimeKit and MailKit and EmailValidation libraries written by Jeffrey Stedfast.            '
     FunctionsToExport    = @('Connect-IMAP', 'Connect-oAuthGoogle', 'Connect-oAuthO365', 'Connect-POP', 'ConvertTo-GraphCredential', 'ConvertTo-OAuth2Credential', 'ConvertTo-SendGridCredential', 'Disconnect-IMAP', 'Disconnect-POP', 'Find-DKIMRecord', 'Find-DMARCRecord', 'Find-DNSBL', 'Find-MxRecord', 'Find-SPFRecord', 'Get-IMAPFolder', 'Get-IMAPMessage', 'Get-MailFolder', 'Get-MailMessage', 'Get-POPMessage', 'Resolve-DnsQuery', 'Resolve-DnsQueryRest', 'Save-MailMessage', 'Save-POPMessage', 'Send-EmailMessage', 'Test-EmailAddress')
     GUID                 = '2b0ea9f1-3ff1-4300-b939-106d5da608fa'
-    ModuleVersion        = '0.0.25'
+    ModuleVersion        = '0.9.0'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{
@@ -19,7 +19,7 @@
         }
     }
     RequiredModules      = @(@{
-            ModuleVersion = '0.0.232'
+            ModuleVersion = '0.0.246'
             ModuleName    = 'PSSharedGoods'
             Guid          = 'ee272aa8-baaa-4edf-9f45-b6d6f7d844fe'
         }, 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Security', 'Microsoft.PowerShell.Utility')

--- a/Private/ConvertTo-GraphAddress.ps1
+++ b/Private/ConvertTo-GraphAddress.ps1
@@ -5,42 +5,52 @@ function ConvertTo-GraphAddress {
         [object] $From,
         [switch] $LimitedFrom
     )
-    foreach ($_ in $MailboxAddress) {
-        if ($_ -is [string]) {
-            if ($_) {
-                @{
-                    emailAddress = @{
-                        address = $_
+    foreach ($E in $MailboxAddress) {
+        if ($E -is [string]) {
+            if ($E) {
+                if ($E -notlike "*<*>*") {
+                    @{
+                        emailAddress = @{
+                            address = $E
+                        }
+                    }
+                } else {
+                    # supports 'User01 <user01@fabrikam.com>'
+                    $Mailbox = [MimeKit.MailboxAddress] $E
+                    @{
+                        emailAddress = @{
+                            address = $Mailbox.Address
+                        }
                     }
                 }
             }
-        } elseif ($_ -is [System.Collections.IDictionary]) {
-            if ($_.Email) {
+        } elseif ($E -is [System.Collections.IDictionary]) {
+            if ($E.Email) {
                 @{
                     emailAddress = @{
-                        address = $_.Email
+                        address = $E.Email
                     }
                 }
             }
-        } elseif ($_ -is [MimeKit.MailboxAddress]) {
-            if ($_.Address) {
+        } elseif ($E -is [MimeKit.MailboxAddress]) {
+            if ($E.Address) {
                 @{
                     emailAddress = @{
-                        address = $_.Address
+                        address = $E.Address
                     }
                 }
             }
         } else {
-            if ($_.Name -and $_.Email) {
+            if ($E.Name -and $E.Email) {
                 @{
                     emailAddress = @{
-                        address = $_.Email
+                        address = $E.Email
                     }
                 }
-            } elseif ($_.Email) {
+            } elseif ($E.Email) {
                 @{
                     emailAddress = @{
-                        address = $_.Email
+                        address = $E.Email
                     }
                 }
 
@@ -49,12 +59,26 @@ function ConvertTo-GraphAddress {
     }
     if ($From) {
         if ($From -is [string]) {
-            if ($LimitedFrom) {
-                $From
+            if ($From -notlike "*<*>*") {
+                if ($LimitedFrom) {
+                    $From
+                } else {
+                    @{
+                        emailAddress = @{
+                            address = $From
+                        }
+                    }
+                }
             } else {
-                @{
-                    emailAddress = @{
-                        address = $From
+                # supports 'User01 <user01@fabrikam.com>'
+                $Mailbox = [MimeKit.MailboxAddress] $From
+                if ($LimitedFrom) {
+                    $Mailbox.Address
+                } else {
+                    @{
+                        emailAddress = @{
+                            address = $Mailbox.Address
+                        }
                     }
                 }
             }
@@ -66,6 +90,28 @@ function ConvertTo-GraphAddress {
                     emailAddress = @{
                         address = $From.Name
                         #name    = $From.Name
+                    }
+                }
+            }
+        } elseif ($From -is [MimeKit.MailboxAddress]) {
+            if ($LimitedFrom) {
+                $From.Address
+            } else {
+                @{
+                    emailAddress = @{
+                        address = $From.Address
+                    }
+                }
+            }
+        } else {
+            if ($From.Email) {
+                if ($LimitedFrom) {
+                    $From.Email
+                } else {
+                    @{
+                        emailAddress = @{
+                            address = $From.Email
+                        }
                     }
                 }
             }

--- a/Private/ConvertTo-GraphAttachment.ps1
+++ b/Private/ConvertTo-GraphAttachment.ps1
@@ -5,7 +5,7 @@
     )
     foreach ($A in $Attachment) {
         try {
-            $ItemInformation = Get-Item -Path $A -ErrorAction Stop
+            $ItemInformation = Get-Item -LiteralPath $A -ErrorAction Stop
         } catch {
             Write-Warning -Message "ConvertTo-GraphAttachment: Attachment '$A' processing error. Error: $($_.Exception.Message)"
         }

--- a/Private/ConvertTo-GraphAttachment.ps1
+++ b/Private/ConvertTo-GraphAttachment.ps1
@@ -7,22 +7,22 @@
         try {
             $ItemInformation = Get-Item -Path $A -ErrorAction Stop
         } catch {
-            if ($PSBoundParameters.ErrorAction -eq 'Stop') {
-                throw
-                return
-            } else {
-                Write-Warning -Message "ConvertTo-GraphAttachment: Attachment '$A' processing error. Error: $($_.Exception.Message)"
-            }
+            Write-Warning -Message "ConvertTo-GraphAttachment: Attachment '$A' processing error. Error: $($_.Exception.Message)"
         }
         if ($ItemInformation) {
-            $File = [system.io.file]::ReadAllBytes($A)
-            $Bytes = [System.Convert]::ToBase64String($File)
-            @{
-                '@odata.type'  = '#microsoft.graph.fileAttachment'
-                #'@odata.type'  = '#Microsoft.OutlookServices.FileAttachment'
-                'name'         = $ItemInformation.Name
-                #'contentType'  = 'text/plain'
-                'contentBytes' = $Bytes
+            try {
+                $File = [system.io.file]::ReadAllBytes($A)
+                $Bytes = [System.Convert]::ToBase64String($File)
+
+                @{
+                    '@odata.type'  = '#microsoft.graph.fileAttachment'
+                    #'@odata.type'  = '#Microsoft.OutlookServices.FileAttachment'
+                    'name'         = $ItemInformation.Name
+                    #'contentType'  = 'text/plain'
+                    'contentBytes' = $Bytes
+                }
+            } catch {
+                Write-Warning -Message "ConvertTo-GraphAttachment: Attachment '$A' reading error. Error: $($_.Exception.Message)"
             }
         }
     }

--- a/Private/ConvertTo-GraphAttachment.ps1
+++ b/Private/ConvertTo-GraphAttachment.ps1
@@ -1,0 +1,29 @@
+﻿function ConvertTo-GraphAttachment {
+    [CmdletBinding()]
+    param(
+        [string[]] $Attachment
+    )
+    foreach ($A in $Attachment) {
+        try {
+            $ItemInformation = Get-Item -Path $A -ErrorAction Stop
+        } catch {
+            if ($PSBoundParameters.ErrorAction -eq 'Stop') {
+                throw
+                return
+            } else {
+                Write-Warning -Message "ConvertTo-GraphAttachment: Attachment '$A' processing error. Error: $($_.Exception.Message)"
+            }
+        }
+        if ($ItemInformation) {
+            $File = [system.io.file]::ReadAllBytes($A)
+            $Bytes = [System.Convert]::ToBase64String($File)
+            @{
+                '@odata.type'  = '#microsoft.graph.fileAttachment'
+                #'@odata.type'  = '#Microsoft.OutlookServices.FileAttachment'
+                'name'         = $ItemInformation.Name
+                #'contentType'  = 'text/plain'
+                'contentBytes' = $Bytes
+            }
+        }
+    }
+}

--- a/Private/ConvertTo-MailboxAddress.ps1
+++ b/Private/ConvertTo-MailboxAddress.ps1
@@ -5,7 +5,11 @@
     )
     foreach ($_ in $MailboxAddress) {
         if ($_ -is [string]) {
-            $SmtpTo = [MimeKit.MailboxAddress]::new("$_", "$_")
+            if ($_ -notlike "*<*>*") {
+                $SmtpTo = [MimeKit.MailboxAddress]::new("$_", "$_")
+            } else {
+                $SmtpTo = [MimeKit.MailboxAddress] $_
+            }
         } elseif ($_ -is [System.Collections.IDictionary]) {
             $SmtpTo = [MimeKit.MailboxAddress]::new($_.Name, $_.Email)
         } elseif ($_ -is [MimeKit.MailboxAddress]) {

--- a/Private/ConvertTo-SendGridAddress.ps1
+++ b/Private/ConvertTo-SendGridAddress.ps1
@@ -5,27 +5,33 @@
         [alias('ReplyTo')][object] $From,
         [switch] $LimitedFrom
     )
-    foreach ($_ in $MailboxAddress) {
-        if ($_ -is [string]) {
-            if ($_) {
-                @{ email = $_ }
+    foreach ($E in $MailboxAddress) {
+        if ($E -is [string]) {
+            if ($E) {
+                if ($E -notlike "*<*>*") {
+                    @{ email = $E }
+                } else {
+                    # supports 'User01 <user01@fabrikam.com>'
+                    $Mailbox = [MimeKit.MailboxAddress] $E
+                    @{ email = $Mailbox.Address }
+                }
             }
-        } elseif ($_ -is [System.Collections.IDictionary]) {
-            if ($_.Email) {
-                @{ email = $_.Email }
+        } elseif ($E -is [System.Collections.IDictionary]) {
+            if ($E.Email) {
+                @{ email = $E.Email }
             }
-        } elseif ($_ -is [MimeKit.MailboxAddress]) {
-            if ($_.Address) {
-                @{ email = $_.Address }
+        } elseif ($E -is [MimeKit.MailboxAddress]) {
+            if ($E.Address) {
+                @{ email = $E.Address }
             }
         } else {
-            if ($_.Name -and $_.Email) {
+            if ($E.Name -and $E.Email) {
                 @{
-                    email = $_.Email
-                    name  = $_.Name
+                    email = $E.Email
+                    name  = $E.Name
                 }
-            } elseif ($_.Email) {
-                @{ email = $_.Email }
+            } elseif ($E.Email) {
+                @{ email = $E.Email }
             }
         }
     }
@@ -44,6 +50,24 @@
                     email = $From.Email
                     name  = $From.Name
                 }
+            }
+        } elseif ($From -is [MimeKit.MailboxAddress]) {
+            if ($LimitedFrom) {
+                $From.Address
+            } else {
+                @{
+                    email = $From.Address
+                    name  = $From.Name
+                }
+            }
+        } else {
+            if ($From.Email) {
+                @{
+                    email = $From.Email
+                    name  = $From.Name
+                }
+            } elseif ($From.Email) {
+                @{ email = $From.Email }
             }
         }
     }

--- a/Private/IsLargerThan.ps1
+++ b/Private/IsLargerThan.ps1
@@ -7,7 +7,7 @@
     $AttachmentsSize = 0
     foreach ($A in $FilePath) {
         try {
-            $ItemInformation = Get-Item -Path $A -ErrorAction Stop
+            $ItemInformation = Get-Item -LiteralPath $A -ErrorAction Stop
             $AttachmentsSize += $ItemInformation.Length
         } catch {
             Write-Warning -Message "ConvertTo-GraphAttachment: Attachment '$A' processing error. Error: $($_.Exception.Message)"

--- a/Private/IsLargerThan.ps1
+++ b/Private/IsLargerThan.ps1
@@ -1,0 +1,19 @@
+﻿function IsLargerThan {
+    [CmdletBinding()]
+    param(
+        [string[]] $FilePath,
+        [int] $Size = 4000000
+    )
+    $AttachmentsSize = 0
+    foreach ($A in $FilePath) {
+        try {
+            $ItemInformation = Get-Item -Path $A -ErrorAction Stop
+            $AttachmentsSize += $ItemInformation.Length
+        } catch {
+            Write-Warning -Message "ConvertTo-GraphAttachment: Attachment '$A' processing error. Error: $($_.Exception.Message)"
+        }
+    }
+    if ($AttachmentsSize -gt $Size) {
+        $true
+    }
+}

--- a/Private/New-GraphAttachment.ps1
+++ b/Private/New-GraphAttachment.ps1
@@ -1,0 +1,70 @@
+﻿function New-GraphAttachment {
+	[cmdletbinding()]
+	param(
+		[PSCustomObject] $DraftMessage,
+		[string] $FromField,
+		[System.Collections.IDictionary] $Authorization,
+		[string[]] $Attachments
+	)
+	[Int32] $UploadChunkSize = 9000000 # 9MB chunks
+	$Authorization['AnchorMailbox'] = $FromField
+	foreach ($Attachment in $Attachments) {
+		$StopWatchAttachment = [System.Diagnostics.Stopwatch]::StartNew()
+		Write-Verbose -Message "New-GraphAttachment - Uploading attachment '$Attachment'"
+		$UploadSession = "https://graph.microsoft.com/v1.0/users('" + $FromField + "')/messages/" + $DraftMessage.id + "/attachments/createUploadSession"
+		$fileStream = [System.IO.StreamReader]::new($Attachment)
+		$FileSize = $fileStream.BaseStream.Length
+		$FileName = [System.IO.Path]::GetFileName($Attachment)
+		$File = @{
+			"AttachmentItem" = [ordered] @{
+				"attachmentType" = "file"
+				"name"           = $FileName
+				"size"           = $FileSize
+			}
+		}
+		$FileJson = $File | ConvertTo-Json -Depth 2
+
+		$Results = Invoke-RestMethod -Method POST -Uri $UploadSession -Headers $Authorization -Body $FileJson -ContentType 'application/json; charset=UTF-8' -UserAgent "Mailozaurr"
+		$UploadUrl = $Results.uploadUrl
+		if ($UploadChunkSize -gt $fileStream.BaseStream.Length) {
+			$UploadChunkSize = $fileStream.BaseStream.Length
+		}
+		$FileOffsetStart = 0
+		$FileBuffer = [byte[]]::new($UploadChunkSize)
+		do {
+			$FileChunkByteCount = $fileStream.BaseStream.Read($FileBuffer, 0, $FileBuffer.Length)
+			$FileOffsetEnd = $fileStream.BaseStream.Position - 1
+			if ($FileChunkByteCount -gt 0) {
+				$UploadRangeHeader = "bytes " + $FileOffsetStart + "-" + $FileOffsetEnd + "/" + $FileSize
+				$FileOffsetStart = $fileStream.BaseStream.Position
+				$BinaryContent = [System.Net.Http.ByteArrayContent]::new($FileBuffer, 0, $FileChunkByteCount)
+				$FileBuffer = [byte[]]::new($UploadChunkSize)
+				$Headers = @{
+					"Content-Range"  = $UploadRangeHeader
+					"AnrchorMailbox" = $FromField
+				}
+				$Results = Invoke-RestMethod -Method PUT -Uri $UploadUrl -Headers $Headers -Body $BinaryContent.ReadAsByteArrayAsync().Result -ContentType "application/octet-stream" -UserAgent "Mailozaurr" -Verbose:$false
+			}
+
+		} while ($FileChunkByteCount -ne 0)
+
+		$Authorization.Remove('AnchorMailbox')
+		$StopWatchAttachment.Stop()
+		Write-Verbose -Message "New-GraphAttachment - Attachment '$Attachment' uploaded in $($StopWatchAttachment.Elapsed.TotalSeconds) seconds"
+	}
+}
+
+<#
+POST https://graph.microsoft.com/v1.0/me/messages/AAMkAGUwNjQ4ZjIxLTQ3Y2YtNDViMi1iZjc4LTMA=/attachments/createUploadSession
+Content-type: application/json
+
+{
+  "AttachmentItem": {
+    "attachmentType": "file",
+    "name": "scenary",
+    "size": 7208534,
+    "isInline": true,
+    "contentId": "my_inline_picture"
+  }
+}
+#>

--- a/Private/New-GraphDraftMessage.ps1
+++ b/Private/New-GraphDraftMessage.ps1
@@ -1,0 +1,73 @@
+﻿function New-GraphDraftMessage {
+    [cmdletbinding(SupportsShouldProcess)]
+    param(
+        [string] $MailSentTo,
+        [string] $FromField,
+        [System.Collections.IDictionary] $Authorization,
+        [string] $Body
+    )
+
+    Try {
+        if ($PSCmdlet.ShouldProcess("$MailSentTo", 'Send-EmailMessage')) {
+            $Uri = "https://graph.microsoft.com/v1.0/users/$FromField/mailfolders/drafts/messages"
+            #$Authorization['AnchorMailbox'] = $FromField
+
+            #$Uri = "https://graph.microsoft.com/v1.0/users/$FromField/sendMail"
+            $OutputRest = Invoke-RestMethod -Uri $Uri -Headers $Authorization -Method POST -Body $Body -ContentType 'application/json; charset=UTF-8' -ErrorAction Stop
+            $OutputRest
+            # if (-not $Suppress) {
+            #     [PSCustomObject] @{
+            #         Status        = $True
+            #         Error         = ''
+            #         SentTo        = $MailSentTo
+            #         SentFrom      = $FromField
+            #         Message       = ''
+            #         TimeToExecute = $StopWatch.Elapsed
+            #     }
+            # }
+        } else {
+            # if (-not $Suppress) {
+            #     [PSCustomObject] @{
+            #         Status        = $false
+            #         Error         = 'Email not sent (WhatIf)'
+            #         SentTo        = $MailSentTo
+            #         SentFrom      = $FromField
+            #         Message       = ''
+            #         TimeToExecute = $StopWatch.Elapsed
+            #     }
+            # }
+        }
+    } catch {
+        if ($PSBoundParameters.ErrorAction -eq 'Stop') {
+            throw
+            return
+        }
+        $RestError = $_.ErrorDetails.Message
+        $RestMessage = $_.Exception.Message
+        if ($RestError) {
+            try {
+                $ErrorMessage = ConvertFrom-Json -InputObject $RestError -ErrorAction Stop
+                $ErrorText = $ErrorMessage.error.message
+                Write-Warning -Message "Send-GraphMailMessage - Error during draft message creation: $($RestMessage) $($ErrorText)"
+            } catch {
+                $ErrorText = ''
+                Write-Warning -Message "Send-GraphMailMessage - Error during draft message creation: $($RestMessage)"
+            }
+        } else {
+            Write-Warning -Message "Send-GraphMailMessage - Error during draft message creation: $($_.Exception.Message)"
+        }
+        if ($_.ErrorDetails.RecommendedAction) {
+            Write-Warning -Message "Send-GraphMailMessage - Error during draft message creation. Recommended action: $RecommendedAction"
+        }
+        # if (-not $Suppress) {
+        #     [PSCustomObject] @{
+        #         Status        = $False
+        #         Error         = if ($RestError) { "$($RestMessage) $($ErrorText)" }  else { $RestMessage }
+        #         SentTo        = $MailSentTo
+        #         SentFrom      = $FromField
+        #         Message       = ''
+        #         TimeToExecute = $StopWatch.Elapsed
+        #     }
+        # }
+    }
+}

--- a/Private/New-GraphSendMessage.ps1
+++ b/Private/New-GraphSendMessage.ps1
@@ -1,0 +1,73 @@
+﻿function New-GraphSendMessage {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [System.Diagnostics.Stopwatch] $StopWatch,
+        [string] $MailSentTo,
+        [string] $FromField,
+        [System.Collections.IDictionary] $Authorization,
+        [string] $Body,
+        [switch] $Suppress
+    )
+    Try {
+        if ($PSCmdlet.ShouldProcess("$MailSentTo", 'Send-EmailMessage')) {
+            #$Uri = "https://graph.microsoft.com/v1.0/users/$FromField/mailfolders/drafts/messages"
+            #$Authorization['AnchorMailbox'] = $FromField
+
+            $Uri = "https://graph.microsoft.com/v1.0/users/$FromField/sendMail"
+            $null = Invoke-RestMethod -Uri $Uri -Headers $Authorization -Method POST -Body $Body -ContentType 'application/json; charset=UTF-8' -ErrorAction Stop
+            if (-not $Suppress) {
+                [PSCustomObject] @{
+                    Status        = $True
+                    Error         = ''
+                    SentTo        = $MailSentTo
+                    SentFrom      = $FromField
+                    Message       = ''
+                    TimeToExecute = $StopWatch.Elapsed
+                }
+            }
+        } else {
+            if (-not $Suppress) {
+                [PSCustomObject] @{
+                    Status        = $false
+                    Error         = 'Email not sent (WhatIf)'
+                    SentTo        = $MailSentTo
+                    SentFrom      = $FromField
+                    Message       = ''
+                    TimeToExecute = $StopWatch.Elapsed
+                }
+            }
+        }
+    } catch {
+        if ($PSBoundParameters.ErrorAction -eq 'Stop') {
+            Write-Error $_
+            return
+        }
+        $RestError = $_.ErrorDetails.Message
+        $RestMessage = $_.Exception.Message
+        if ($RestError) {
+            try {
+                $ErrorMessage = ConvertFrom-Json -InputObject $RestError -ErrorAction Stop
+                $ErrorText = $ErrorMessage.error.message
+                Write-Warning -Message "Send-GraphMailMessage - Error: $($RestMessage) $($ErrorText)"
+            } catch {
+                $ErrorText = ''
+                Write-Warning -Message "Send-GraphMailMessage - Error: $($RestMessage)"
+            }
+        } else {
+            Write-Warning -Message "Send-GraphMailMessage - Error: $($_.Exception.Message)"
+        }
+        if ($_.ErrorDetails.RecommendedAction) {
+            Write-Warning -Message "Send-GraphMailMessage - Recommended action: $RecommendedAction"
+        }
+        if (-not $Suppress) {
+            [PSCustomObject] @{
+                Status        = $False
+                Error         = if ($RestError) { "$($RestMessage) $($ErrorText)" }  else { $RestMessage }
+                SentTo        = $MailSentTo
+                SentFrom      = $FromField
+                Message       = ''
+                TimeToExecute = $StopWatch.Elapsed
+            }
+        }
+    }
+}

--- a/Private/Send-GraphMailMessageDraft.ps1
+++ b/Private/Send-GraphMailMessageDraft.ps1
@@ -1,0 +1,71 @@
+﻿function Send-GraphMailMessageDraft {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [System.Diagnostics.Stopwatch] $StopWatch,
+        [string] $MailSentTo,
+        [string] $FromField,
+        [System.Collections.IDictionary] $Authorization,
+        [switch] $Suppress,
+        [PSCustomObject] $DraftMessage
+
+    )
+    Try {
+        if ($PSCmdlet.ShouldProcess("$MailSentTo", 'Send-EmailMessage')) {
+            $Uri = "https://graph.microsoft.com/v1.0/users('" + $FromField + "')/messages/" + $DraftMessage.id + "/send"
+            $null = Invoke-RestMethod -Uri $Uri -Headers $Authorization -Method POST -ContentType 'application/json; charset=UTF-8' -ErrorAction Stop
+            if (-not $Suppress) {
+                [PSCustomObject] @{
+                    Status        = $True
+                    Error         = ''
+                    SentTo        = $MailSentTo
+                    SentFrom      = $FromField
+                    Message       = ''
+                    TimeToExecute = $StopWatch.Elapsed
+                }
+            }
+        } else {
+            if (-not $Suppress) {
+                [PSCustomObject] @{
+                    Status        = $false
+                    Error         = 'Email not sent (WhatIf)'
+                    SentTo        = $MailSentTo
+                    SentFrom      = $FromField
+                    Message       = ''
+                    TimeToExecute = $StopWatch.Elapsed
+                }
+            }
+        }
+    } catch {
+        if ($PSBoundParameters.ErrorAction -eq 'Stop') {
+            Write-Error $_
+            return
+        }
+        $RestError = $_.ErrorDetails.Message
+        $RestMessage = $_.Exception.Message
+        if ($RestError) {
+            try {
+                $ErrorMessage = ConvertFrom-Json -InputObject $RestError -ErrorAction Stop
+                $ErrorText = $ErrorMessage.error.message
+                Write-Warning -Message "Send-GraphMailMessageDraft - Error: $($RestMessage) $($ErrorText)"
+            } catch {
+                $ErrorText = ''
+                Write-Warning -Message "Send-GraphMailMessageDraft - Error: $($RestMessage)"
+            }
+        } else {
+            Write-Warning -Message "Send-GraphMailMessageDraft - Error: $($_.Exception.Message)"
+        }
+        if ($_.ErrorDetails.RecommendedAction) {
+            Write-Warning -Message "Send-GraphMailMessageDraft - Recommended action: $RecommendedAction"
+        }
+        if (-not $Suppress) {
+            [PSCustomObject] @{
+                Status        = $False
+                Error         = if ($RestError) { "$($RestMessage) $($ErrorText)" }  else { $RestMessage }
+                SentTo        = $MailSentTo
+                SentFrom      = $FromField
+                Message       = ''
+                TimeToExecute = $StopWatch.Elapsed
+            }
+        }
+    }
+}

--- a/Private/Send-SendGridMailMessage.ps1
+++ b/Private/Send-SendGridMailMessage.ps1
@@ -13,7 +13,8 @@
         [PSCredential] $Credential,
         [alias('Importance')][ValidateSet('Low', 'Normal', 'High')][string] $Priority,
         [switch] $SeparateTo,
-        [System.Diagnostics.Stopwatch] $StopWatch
+        [System.Diagnostics.Stopwatch] $StopWatch,
+        [switch] $Suppress
     )
     # https://sendgrid.api-docs.io/v3.0/mail-send/v3-mail-send
     if ($Credential) {

--- a/Private/Send-SendGridMailMessage.ps1
+++ b/Private/Send-SendGridMailMessage.ps1
@@ -33,7 +33,7 @@
         )
         attachments      = @(
             foreach ($A in $Attachment) {
-                $ItemInformation = Get-Item -Path $A
+                $ItemInformation = Get-Item -LiteralPath $A
                 if ($ItemInformation) {
                     $File = [system.io.file]::ReadAllBytes($A)
                     $Bytes = [System.Convert]::ToBase64String($File)

--- a/Private/Send-SendGridMailMessage.ps1
+++ b/Private/Send-SendGridMailMessage.ps1
@@ -124,7 +124,7 @@
         }
         # And here we process error
         if ($PSBoundParameters.ErrorAction -eq 'Stop') {
-            Write-Error $_
+            throw
         } else {
             Write-Warning "Send-EmailMessage - Error: $($_.Exception.Message) $ErrorDetails"
         }

--- a/Public/Send-EmailMessage.ps1
+++ b/Public/Send-EmailMessage.ps1
@@ -144,6 +144,12 @@
     .PARAMETER LocalDomain
     Specifies the local domain name.
 
+    .PARAMETER RequestReadReceipt
+    Specifies whether to request a read receipt for the email message when using Microsoft Graph API (Graph switch)
+
+    .PARAMETER RequestDeliveryReceipt
+    Specifies whether to request a delivery receipt for the email message when using Microsoft Graph API (Graph switch)
+
     .EXAMPLE
     if (-not $MailCredentials) {
         $MailCredentials = Get-Credential
@@ -363,6 +369,12 @@
         [alias('oAuth')][switch] $oAuth2,
 
         [Parameter(ParameterSetName = 'Graph')]
+        [switch] $RequestReadReceipt,
+
+        [Parameter(ParameterSetName = 'Graph')]
+        [switch] $RequestDeliveryReceipt,
+
+        [Parameter(ParameterSetName = 'Graph')]
         [switch] $Graph,
 
         [Parameter(ParameterSetName = 'SecureString')]
@@ -509,19 +521,22 @@
         } elseif ($Graph.IsPresent) {
             # Sending email via Office 365 Graph
             $sendGraphMailMessageSplat = @{
-                From                 = $From
-                To                   = $To
-                Cc                   = $CC
-                Bcc                  = $Bcc
-                Subject              = $Subject
-                HTML                 = $HTML
-                Text                 = $Text
-                Attachment           = $Attachment
-                Credential           = $Credential
-                Priority             = $Priority
-                ReplyTo              = $ReplyTo
-                DoNotSaveToSentItems = $DoNotSaveToSentItems.IsPresent
-                StopWatch            = $StopWatch
+                From                   = $From
+                To                     = $To
+                Cc                     = $CC
+                Bcc                    = $Bcc
+                Subject                = $Subject
+                HTML                   = $HTML
+                Text                   = $Text
+                Attachment             = $Attachment
+                Credential             = $Credential
+                Priority               = $Priority
+                ReplyTo                = $ReplyTo
+                DoNotSaveToSentItems   = $DoNotSaveToSentItems.IsPresent
+                StopWatch              = $StopWatch
+                Suppress               = $Suppress.IsPresent
+                RequestReadReceipt     = $RequestReadReceipt.IsPresent
+                RequestDeliveryReceipt = $RequestDeliveryReceipt.IsPresent
             }
             Remove-EmptyValue -Hashtable $sendGraphMailMessageSplat
             return Send-GraphMailMessage @sendGraphMailMessageSplat
@@ -541,6 +556,7 @@
                 ReplyTo    = $ReplyTo
                 SeparateTo = $SeparateTo.IsPresent
                 StopWatch  = $StopWatch
+                Suppress   = $Suppress.IsPresent
             }
             Remove-EmptyValue -Hashtable $sendGraphMailMessageSplat
             return Send-SendGridMailMessage @sendGraphMailMessageSplat

--- a/Public/Send-EmailMessage.ps1
+++ b/Public/Send-EmailMessage.ps1
@@ -228,16 +228,14 @@
         [Parameter(ParameterSetName = 'Compatibility')]
         [int] $Port = 587,
 
-        [Parameter(ParameterSetName = 'SecureString')]
-
-        [Parameter(ParameterSetName = 'oAuth')]
-        [Parameter(ParameterSetName = 'Graph')]
-        [Parameter(ParameterSetName = 'Compatibility')]
-        [Parameter(ParameterSetName = 'SendGrid')]
+        [Parameter(Mandatory, ParameterSetName = 'SecureString')]
+        [Parameter(Mandatory, ParameterSetName = 'oAuth')]
+        [Parameter(Mandatory, ParameterSetName = 'Graph')]
+        [Parameter(Mandatory, ParameterSetName = 'Compatibility')]
+        [Parameter(Mandatory, ParameterSetName = 'SendGrid')]
         [object] $From,
 
         [Parameter(ParameterSetName = 'SecureString')]
-
         [Parameter(ParameterSetName = 'oAuth')]
         [Parameter(ParameterSetName = 'Graph')]
         [Parameter(ParameterSetName = 'Compatibility')]
@@ -245,7 +243,6 @@
         [string] $ReplyTo,
 
         [Parameter(ParameterSetName = 'SecureString')]
-
         [Parameter(ParameterSetName = 'oAuth')]
         [Parameter(ParameterSetName = 'Graph')]
         [Parameter(ParameterSetName = 'Compatibility')]
@@ -253,7 +250,6 @@
         [string[]] $Cc,
 
         [Parameter(ParameterSetName = 'SecureString')]
-
         [Parameter(ParameterSetName = 'oAuth')]
         [Parameter(ParameterSetName = 'Graph')]
         [Parameter(ParameterSetName = 'Compatibility')]

--- a/Publish/Manage-Mailozaurr.ps1
+++ b/Publish/Manage-Mailozaurr.ps1
@@ -17,7 +17,7 @@ $Configuration = @{
 
         Manifest          = @{
             # Version number of this module.
-            ModuleVersion              = '0.0.X'
+            ModuleVersion              = '0.9.0'
             # Supported PSEditions
             CompatiblePSEditions       = @('Desktop', 'Core')
             # ID used to uniquely identify this module

--- a/Tests/Find-DMARCRecord.Tests.ps1
+++ b/Tests/Find-DMARCRecord.Tests.ps1
@@ -3,7 +3,7 @@
         $DNS = Find-DMARCRecord -DomainName 'evotec.pl', 'evotec.xyz'
         $DNS.Count | Should -Be 2
         $DNS[0].Name | Should -Be 'evotec.pl'
-        $DNS[0].DMARC | Should -Be 'v=DMARC1;p=none;rua=mailto:dmarc_agg@vali.email;sp=none;aspf=s;'
+        $DNS[0].DMARC | Should -Be 'v=DMARC1; p=reject; rua=mailto:dmarc_agg@vali.email; adkim=s; aspf=s;'
         $DNS[1].Name | Should -Be 'evotec.xyz'
         $DNS[1].DMARC | Should -Be ''
     }
@@ -11,7 +11,7 @@
         $DNS = Find-DMARCRecord -DomainName 'evotec.pl', 'evotec.xyz' -DnsServer 1.1.1.1
         $DNS.Count | Should -Be 2
         $DNS[0].Name | Should -Be 'evotec.pl'
-        $DNS[0].DMARC | Should -Be 'v=DMARC1;p=none;rua=mailto:dmarc_agg@vali.email;sp=none;aspf=s;'
+        $DNS[0].DMARC | Should -Be 'v=DMARC1; p=reject; rua=mailto:dmarc_agg@vali.email; adkim=s; aspf=s;'
         $DNS[1].Name | Should -Be 'evotec.xyz'
         $DNS[1].DMARC | Should -Be ''
         $DNS[0].QueryServer | Should -Be '1.1.1.1:53'
@@ -21,7 +21,7 @@
         $DNS = Find-DMARCRecord -DomainName 'evotec.pl', 'evotec.xyz' -DNSProvider Google
         $DNS.Count | Should -Be 2
         $DNS[0].Name | Should -Be 'evotec.pl'
-        $DNS[0].DMARC | Should -Be 'v=DMARC1;p=none;rua=mailto:dmarc_agg@vali.email;sp=none;aspf=s;'
+        $DNS[0].DMARC | Should -Be 'v=DMARC1; p=reject; rua=mailto:dmarc_agg@vali.email; adkim=s; aspf=s;'
         $DNS[1].Name | Should -Be 'evotec.xyz'
         $DNS[1].DMARC | Should -Be ''
         $DNS[0].QueryServer | Should -Be 'dns.google.com'
@@ -31,7 +31,7 @@
         $DNS = Find-DMARCRecord -DomainName 'evotec.pl', 'evotec.xyz' -DNSProvider Cloudflare
         $DNS.Count | Should -Be 2
         $DNS[0].Name | Should -Be 'evotec.pl'
-        $DNS[0].DMARC | Should -Be 'v=DMARC1;p=none;rua=mailto:dmarc_agg@vali.email;sp=none;aspf=s;'
+        $DNS[0].DMARC | Should -Be 'v=DMARC1; p=reject; rua=mailto:dmarc_agg@vali.email; adkim=s; aspf=s;'
         $DNS[1].Name | Should -Be 'evotec.xyz'
         $DNS[1].DMARC | Should -Be ''
         $DNS[0].QueryServer | Should -Be 'cloudflare-dns.com'


### PR DESCRIPTION
- Fix `Suppress` for sending emails via SendGrid
- Fix `Suppress` for sending emails via Microsoft Graph
- Add support to `Send-EmailMessage` for attachments **4MB** to **150MB** in size for Microsoft Graph. Before it would only send attachments up to **4MB** in size. Detects size automatically and uses the appropriate API endpoint.
- Add `RequestReadReceipt` support to `Send-EmailMessage` for Microsoft Graph to request a read receipt from the recipient.
- Add `RequestDeliveryReceipt` switch to `Send-EmailMessage` for Microsoft Graph to request a delivery receipt. SMTP uses `DeliveryNotificationOption` and `DeliveryStatusNotificationType`.