### PR TITLE
changes to Get-IMAPMessage to return a filtered object

### DIFF
--- a/Public/Get-IMAPMessage.ps1
+++ b/Public/Get-IMAPMessage.ps1
@@ -1,15 +1,51 @@
 ﻿function Get-IMAPMessage {
     [cmdletBinding()]
     param(
-        [Parameter()][System.Collections.IDictionary] $Client,
-        [MailKit.FolderAccess] $FolderAccess = [MailKit.FolderAccess]::ReadOnly
+        [Parameter(Mandatory=$true)][System.Collections.IDictionary] $Client,
+        [MailKit.FolderAccess] $FolderAccess = [MailKit.FolderAccess]::ReadOnly,
+        [string]$From,
+        [string]$To,
+        [string]$SubjectContains,
+        [string]$BodyContains
     )
     if ($Client) {
-        $Folder = $Client.Data.Inbox
-        $null = $Folder.Open($FolderAccess)
 
+        # Open inbox folder
+        $Folder = $Client.Data.Inbox
+        $Folder.Open($FolderAccess) | Out-Null
         Write-Verbose "Get-IMAPMessage - Total messages $($Folder.Count), Recent messages $($Folder.Recent)"
         $Client.Folder = $Folder
+        
+        # Get messages
+        $messagesList = New-Object 'System.Collections.Generic.List[psobject]'
+        foreach ($message in $Folder)
+        {
+            $currentMessage = [PSCustomObject]@{
+                Id      = $message.MessageId 
+                From    = $message.From
+                To      = $message.To
+                CC      = $message.CC
+                BCC     = $message.BCC
+                Date    = $message.Date
+                Subject = $message.Subject
+                HtmlBody    = $message.HtmlBody
+                TextBody    = $message.TextBody
+                Importance  = $message.Importance
+                Priority    = $message.Priority
+                Sender      = $message.Sender
+                Headers     = $message.Headers
+                Attachments = $message.Attachments
+            }
+            $messagesList.Add($currentMessage)           
+        }
+
+        # Return message list
+        $messagesList | Where-Object { ($_.From -like "*$From*") `
+            -and ($_.To -like "*$To*") `
+            -and ($_.Subject -like "*$SubjectContains*") `
+            -and ($_.BodyHtml -like "*$BodyContains*") `
+        }
+
     } else {
         Write-Verbose 'Get-IMAPMessage - Client not connected?'
     }


### PR DESCRIPTION
Hello! First-time contributor here, please be understanding...😄

I found myself using the `Get-IMAPMessage` cmdlet, but it looked a bit hard to use to find a specific message - which I thought it was its main purpose, given the name.

At the moment `Get-IMAPMessage` set the `$Client.Folder` property containing all the messages in the Inbox.
This PR is a proposal to return a list of PSCustomObjects made of the main properties of each message: From, To, Subject, Body, etc. 

This way
- You may save the messages into a variable (`$allMessages = Get-IMAPMessage -Client $Client`)
- You may filter them by sender or recipient or anything else (`Get-IMAPMessage -Client $Client -From Jones`)

Individual or collection of messages may then be piped to any additional cmdlet (e.g. `Remove-IMAPMessage` as requested by #37) to be further manipulated.

Thank you