### PR TITLE
docs: fix permissions typo in README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -133,7 +133,7 @@ Following permissions (as shown on the screenshot) are required to send emails u
 
 ![Microsoft Graph Permissions](https://raw.githubusercontent.com/EvotecIT/Mailozaurr/refs/heads/v2-speedygonzales/Docs/Images/MicrosoftGraphPermissions.png)
 
-The rest of the permissins is not required and is there for other features that Microsoft Graph provides.
+The rest of the permissions is not required and is there for other features that Microsoft Graph provides.
 
 ## To install
 


### PR DESCRIPTION
## Summary
- fix a spelling error in the README section describing Microsoft Graph permissions

## Testing
- `pwsh ./Mailozaurr.Tests.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ce9a756c832ebb7f8c7ef33d93ca