### PR TITLE
fix: correct verbose message for Get-IMAPFolder

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
@@ -39,13 +39,13 @@ public sealed class CmdletGetIMAPFolder : AsyncPSCmdlet {
         if (Client != null) {
             var folder = Client.Data.Inbox;
             folder.Open(FolderAccess);
-            WriteVerbose($"Get-IMAPMessage - Total messages {folder.Count}, Recent messages {folder.Recent}");
+            WriteVerbose($"Get-IMAPFolder - Total messages {folder.Count}, Recent messages {folder.Recent}");
             Client.Messages = folder;
             Client.Count = folder.Count;
             Client.Recent = folder.Recent;
             WriteObject(Client);
         } else {
-            WriteVerbose("Get-IMAPMessage - Client not connected?");
+            WriteVerbose("Get-IMAPFolder - Client not connected?");
         }
         return Task.CompletedTask;
     }


### PR DESCRIPTION
## Summary
- fix verbose messages in `CmdletGetIMAPFolder`

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ceac2220832e898870d6a03fe2cb