### PR TITLE
Add GetEmailAddress unit tests

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class HelpersTests
+{
+    [Fact]
+    public void GetEmailAddress_ReturnsInputString_WhenStringProvided()
+    {
+        var result = Mailozaurr.Helpers.GetEmailAddress("test@example.com");
+        Assert.Equal("test@example.com", result);
+    }
+
+    [Fact]
+    public void GetEmailAddress_ReturnsEmailFromDictionary_WhenEmailKeyPresent()
+    {
+        var dict = new Dictionary<string, object> { { "Email", "dict@example.com" } };
+        var result = Mailozaurr.Helpers.GetEmailAddress(dict);
+        Assert.Equal("dict@example.com", result);
+    }
+
+    private class CustomObject
+    {
+        public override string ToString() => "Custom";
+    }
+
+    [Fact]
+    public void GetEmailAddress_ReturnsObjectToString_WhenNotStringOrDictionary()
+    {
+        var obj = new CustomObject();
+        var result = Mailozaurr.Helpers.GetEmailAddress(obj);
+        Assert.Equal("Custom", result);
+    }
+}

--- a/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
+++ b/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mailozaurr\Mailozaurr.csproj" />
+  </ItemGroup>
+
+
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Sources/Mailozaurr.sln
+++ b/Sources/Mailozaurr.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mailozaurr.Examples", "Mail
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mailozaurr", "Mailozaurr\Mailozaurr.csproj", "{74FF5540-DB31-4031-BBE1-1A471A17CCFC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mailozaurr.Tests", "Mailozaurr.Tests\Mailozaurr.Tests.csproj", "{B511A3B4-3C33-4F41-B140-47342F4E521B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{74FF5540-DB31-4031-BBE1-1A471A17CCFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74FF5540-DB31-4031-BBE1-1A471A17CCFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74FF5540-DB31-4031-BBE1-1A471A17CCFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B511A3B4-3C33-4F41-B140-47342F4E521B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B511A3B4-3C33-4F41-B140-47342F4E521B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B511A3B4-3C33-4F41-B140-47342F4E521B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B511A3B4-3C33-4F41-B140-47342F4E521B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add new xUnit test project
- cover `Helpers.GetEmailAddress` for string, dictionary and other types

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --no-build -p:TargetFramework=net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6842d783964c832eac9e2f55a45c57fb