### PR TITLE
Add tests for ConvertFromGraphCredential

### DIFF
--- a/Tests/ConvertFromGraphCredential.Tests.ps1
+++ b/Tests/ConvertFromGraphCredential.Tests.ps1
@@ -1,0 +1,12 @@
+Describe 'MicrosoftGraphUtils.ConvertFromGraphCredential' {
+    It 'Parses "client@tenant" credential' {
+        $cred = [Mailozaurr.MicrosoftGraphUtils]::ConvertFromGraphCredential('client@tenant', 'secret')
+        $cred.ClientId | Should -Be 'client'
+        $cred.DirectoryId | Should -Be 'tenant'
+        $cred.ClientSecret | Should -Be 'secret'
+    }
+
+    It 'Throws for invalid format' {
+        { [Mailozaurr.MicrosoftGraphUtils]::ConvertFromGraphCredential('invalid', 'pwd') } | Should -Throw -ErrorType [System.ArgumentException]
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester tests for `MicrosoftGraphUtils.ConvertFromGraphCredential`

## Testing
- `pwsh -File ./Mailozaurr.Tests.ps1` *(fails: Write-Color and Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d784e4f0832e8537358b6ca08907