### PR TITLE
docs: fix spelling mistakes

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -29,8 +29,8 @@
 
 #### 2.0.0 - Preview 4 - 2024.03.04
 - Update to DLLs to latest versions
-- Removes some unnessecary DLLs
-- Different way to build module and load depenedencies
+- Removes some unnecessary DLLs
+- Different way to build module and load dependencies
 - Removal of DLLs from source codes
 - Small updates to DLLs
 - Add new DLLs

--- a/Docs/Find-DKIMRecord.md
+++ b/Docs/Find-DKIMRecord.md
@@ -123,7 +123,7 @@ Accept wildcard characters: False
 ```
 
 ### -AsObject
-Returns an object rather than string based represantation for name servers (for easier display purposes)
+Returns an object rather than string based representation for name servers (for easier display purposes)
 
 ```yaml
 Type: SwitchParameter

--- a/Docs/Find-DMARCRecord.md
+++ b/Docs/Find-DMARCRecord.md
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ```
 
 ### -AsObject
-Returns an object rather than string based represantation for name servers (for easier display purposes)
+Returns an object rather than string based representation for name servers (for easier display purposes)
 
 ```yaml
 Type: SwitchParameter

--- a/Docs/Find-MxRecord.md
+++ b/Docs/Find-MxRecord.md
@@ -143,7 +143,7 @@ Accept wildcard characters: False
 ```
 
 ### -Separate
-Returns each MX record separatly
+Returns each MX record separately
 
 ```yaml
 Type: SwitchParameter
@@ -158,7 +158,7 @@ Accept wildcard characters: False
 ```
 
 ### -AsObject
-Returns an object rather than string based represantation for name servers (for easier display purposes)
+Returns an object rather than string based representation for name servers (for easier display purposes)
 
 ```yaml
 Type: SwitchParameter

--- a/Docs/Find-SPFRecord.md
+++ b/Docs/Find-SPFRecord.md
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ```
 
 ### -AsObject
-Returns an object rather than string based represantation for name servers (for easier display purposes)
+Returns an object rather than string based representation for name servers (for easier display purposes)
 
 ```yaml
 Type: SwitchParameter

--- a/README.MD
+++ b/README.MD
@@ -46,7 +46,7 @@ Additional dependencies due to features added
 
 - [System.DataSQLite](https://system.data.sqlite.org/)
 
-This started with a single goal to replace `Send-MailMessage` which is depracated/obsolete with something more modern, but since MailKit and MimeKit have lots of options why not build on that?
+This started with a single goal to replace `Send-MailMessage` which is deprecated/obsolete with something more modern, but since MailKit and MimeKit have lots of options why not build on that?
 
 ## Support This Project
 

--- a/Sources/Mailozaurr.PowerShell/CmdletImportMailFile.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletImportMailFile.cs
@@ -54,7 +54,7 @@ public sealed class CmdletImportMailFile : AsyncPSCmdlet {
                     WriteWarning($"Import-MailFile - File {InputPath} is not a .msg or .eml file.");
                 }
             } catch (System.Exception ex) {
-                WriteWarning($"Import-MailFile - File {InputPath} is not a .msg or .eml file or another error occured. Error: {ex.Message}");
+                WriteWarning($"Import-MailFile - File {InputPath} is not a .msg or .eml file or another error occurred. Error: {ex.Message}");
             }
         } else {
             WriteWarning($"Import-MailFile - File {InputPath} doesn't exist.");


### PR DESCRIPTION
## Summary
- fix some typos across docs and scripts
- replace a misspelled word in README

## Testing
- `codespell -q 3`

------
https://chatgpt.com/codex/tasks/task_e_6842d717b1c4832e8bf35bdd5bcb1991