### PR TITLE
Fix SMTP auth optional

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -666,14 +666,17 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
                 }
             }
 
-            // Authenticate
+            // Authenticate - skip when no credentials are provided
             if (UseDefaultCredentials) {
                 Status = SmtpClient.AuthenticateDefaultCredentials();
             } else if (Credential != null) {
                 NetworkCredential networkCredential = new NetworkCredential(Credential.UserName, Credential.Password);
                 Status = SmtpClient.Authenticate(networkCredential, OAuth2);
-            } else {
+            } else if (!string.IsNullOrWhiteSpace(Username) || !string.IsNullOrWhiteSpace(Password)) {
                 Status = SmtpClient.Authenticate(Username, Password, AsSecureString);
+            } else {
+                LoggingMessages.Logger.WriteVerbose("Send-EmailMessage - Skipping authentication");
+                Status = new SmtpResult(true, EmailAction.Authenticate, SmtpClient.SentTo, SmtpClient.SentFrom, SmtpClient.Server, SmtpClient.Port, SmtpClient.Stopwatch.Elapsed, "Authentication skipped");
             }
 
             if (!Status.Status) {

--- a/Tests/Send-EmailMessage.SkipAuth.Tests.ps1
+++ b/Tests/Send-EmailMessage.SkipAuth.Tests.ps1
@@ -1,0 +1,9 @@
+Describe 'Send-EmailMessage - Authentication Skipped' {
+    It 'Skips authentication when no credentials provided' {
+        $result = Send-EmailMessage -From 'noauth@example.com' -To 'recipient@example.com' -Subject 'Skip Auth Test' -Body 'test' -Server 'smtp.example.com' -Port 25 -WhatIf -Verbose 4>&1
+        $output = $result | Where-Object { $_ -isnot [System.Management.Automation.VerboseRecord] }
+        $verbose = $result | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+        ($verbose | Select-Object -ExpandProperty Message) | Should -Contain 'Send-EmailMessage - Skipping authentication'
+        $output.Error | Should -Be 'Email not sent (WhatIf)'
+    }
+}


### PR DESCRIPTION
## Summary
- avoid referencing specific issues in comments
- add dummy Pester test to ensure authentication is skipped when no credentials are supplied

## Testing
- `pwsh -NoLogo -File Mailozaurr.Tests.ps1` *(fails: Write-Color and Invoke-Pester commands not found)*
- `dotnet test Sources/Mailozaurr.sln` *(fails: NETSDK1045, .NET 9.0 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68499ae8c5a8832ea51e7bc4bc16cb01