### PR TITLE
Fix SkipCertificateValidation for Send-EmailMessage

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -625,7 +625,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             SmtpClient.DeliveryStatusNotificationType = DeliveryStatusNotificationType;
 
             SmtpClient.CheckCertificateRevocation = !SkipCertificateRevocation;
-            // SmtpClient.SkipCertificateValidation = SkipCertificateValidation;
+            SmtpClient.SkipCertificateValidation = SkipCertificateValidation;
             if (HTML != null) SmtpClient.HtmlBody = string.Join("", HTML);
             if (Text != null) SmtpClient.TextBody = string.Join("", Text);
 

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -86,16 +86,18 @@ public class Smtp {
         set => Client.CheckCertificateRevocation = value;
     }
 
-    //public bool SkipCertificateValidation {
-    //    get
-    //    {
-
-    //    };
-    //    set
-    //    {
-
-    //    };
-    //}
+    private bool _skipCertificateValidation;
+    public bool SkipCertificateValidation {
+        get => _skipCertificateValidation;
+        set {
+            _skipCertificateValidation = value;
+            if (value) {
+                Client.ServerCertificateValidationCallback = (s, c, h, e) => true;
+            } else {
+                Client.ServerCertificateValidationCallback = null;
+            }
+        }
+    }
 
     public string LocalDomain {
         get => Client.LocalDomain;


### PR DESCRIPTION
## Summary
- wire SkipCertificateValidation parameter into SMTP client
- expose SkipCertificateValidation property on Smtp class

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release -p:TargetFrameworks=net8.0`
- `Invoke-Pester` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b5a4d2d0832eae24a6434584657c