### PR TITLE
Add retry delay and backoff

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -9,6 +9,8 @@
 * Add GetEmailAddress unit tests by @PrzemyslawKlys in https://github.com/EvotecIT/Mailozaurr/pull/70
 * Futher improvements by @PrzemyslawKlys in https://github.com/EvotecIT/Mailozaurr/pull/73
 * Fix SMTP auth optional by @PrzemyslawKlys in https://github.com/EvotecIT/Mailozaurr/pull/76
+* feat: add `RetryCount` parameter to `Send-EmailMessage` allowing optional retries
+* feat: support configurable delay and exponential backoff via `RetryDelayMilliseconds` and `RetryDelayBackoff`
 
 **Full Changelog**: https://github.com/EvotecIT/Mailozaurr/compare/v2.0.0-Preview5...v2.0.0-Preview6
 

--- a/README.MD
+++ b/README.MD
@@ -90,6 +90,7 @@ This will make sure the project has required libraries.
   - [x] SMTP with SendGrid
   - [x] SendGrid API
   - [x] Office 365 Graph API
+- Optional retry logic for `Send-EmailMessage` via `-RetryCount`, `-RetryDelayMilliseconds` and `-RetryDelayBackoff`
 - POP3
   - [x] Connect to POP3
   - [x] Get POP3 Emails

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -281,6 +281,24 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     public int Timeout { get; set; } = 12000;
 
     /// <summary>
+    /// <para>Specifies how many times the cmdlet should retry sending the message when an error occurs. Default is 0 (no retries).</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public int RetryCount { get; set; } = 0;
+
+    /// <summary>
+    /// <para>Delay in milliseconds between retry attempts.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    /// <summary>
+    /// <para>Multiplicative backoff applied to the retry delay. Value of 1 disables backoff.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public double RetryDelayBackoff { get; set; } = 1.0;
+
+    /// <summary>
     /// <para>Enables sending email via OAuth2 authentication for SMTP.</para>
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "oAuth")]
@@ -517,6 +535,9 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             sendGrid.Attachment = Attachment;
             sendGrid.SeparateTo = SeparateTo;
             sendGrid.ErrorAction = errorAction;
+            sendGrid.RetryCount = RetryCount;
+            sendGrid.RetryDelayMilliseconds = RetryDelayMilliseconds;
+            sendGrid.RetryDelayBackoff = RetryDelayBackoff;
             NetworkCredential networkCredential = new NetworkCredential(Credential?.UserName, Credential?.Password);
             sendGrid.Credentials = networkCredential;
             // create JSON message
@@ -547,6 +568,9 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             graph.Subject = Subject;
             graph.DoNotSaveToSentItems = DoNotSaveToSentItems;
             graph.ErrorAction = errorAction;
+            graph.RetryCount = RetryCount;
+            graph.RetryDelayMilliseconds = RetryDelayMilliseconds;
+            graph.RetryDelayBackoff = RetryDelayBackoff;
             graph.RequestReadReceipt = RequestReadReceipt;
             graph.RequestDeliveryReceipt = RequestDeliveryReceipt;
             graph.HTML = string.Join("", HTML);
@@ -583,6 +607,9 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             graph.Subject = Subject;
             graph.DoNotSaveToSentItems = DoNotSaveToSentItems;
             graph.ErrorAction = errorAction;
+            graph.RetryCount = RetryCount;
+            graph.RetryDelayMilliseconds = RetryDelayMilliseconds;
+            graph.RetryDelayBackoff = RetryDelayBackoff;
             graph.RequestReadReceipt = RequestReadReceipt;
             graph.RequestDeliveryReceipt = RequestDeliveryReceipt;
             graph.HTML = string.Join("", HTML);
@@ -633,6 +660,9 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             SmtpClient.Timeout = Timeout;
 
             SmtpClient.ErrorAction = errorAction;
+            SmtpClient.RetryCount = RetryCount;
+            SmtpClient.RetryDelayMilliseconds = RetryDelayMilliseconds;
+            SmtpClient.RetryDelayBackoff = RetryDelayBackoff;
 
             // Connect
             var Status = SmtpClient.Connect(Server, Port, SecureSocketOptions, UseSsl);

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -100,6 +100,22 @@ public class Graph {
     public ActionPreference? ErrorAction { get; set; }
 
     /// <summary>
+    /// Number of times to retry sending the message when an error occurs.
+    /// </summary>
+    public int RetryCount { get; set; } = 0;
+
+    /// <summary>
+    /// Delay in milliseconds between retry attempts.
+    /// </summary>
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    /// <summary>
+    /// Factor used to increase the delay for each subsequent retry. A value of
+    /// 1 disables backoff.
+    /// </summary>
+    public double RetryDelayBackoff { get; set; } = 1.0;
+
+    /// <summary>
     /// The type of token that was issued.
     /// </summary>
     public string TokenType { get; set; }
@@ -278,28 +294,38 @@ public class Graph {
         // Add the authorization header.
         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(TokenType, AccessToken);
 
-        try {
-            // Send the HTTP request.
-            var response = await _client.SendAsync(request);
-            // Read the response content.
-            var content = await response.Content.ReadAsStringAsync();
-            // If the status code indicates success, return a successful result.
-            if (response.IsSuccessStatusCode) {
-                return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, response.StatusCode.ToString(), "");
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            try {
+                var response = await _client.SendAsync(request);
+                var content = await response.Content.ReadAsStringAsync();
+                if (response.IsSuccessStatusCode) {
+                    return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, response.StatusCode.ToString(), "");
+                }
+                var error = JsonSerializer.Deserialize<GraphApiError>(content);
+                var errorMessage = (error == null || error.Error == null || error.Error.InnerError == null)
+                    ? $"Unknown error: {content}"
+                    : $"Error code: {error.Error.Code}, message: {error.Error.Message}, request ID: {error.Error.InnerError.RequestId}, date: {error.Error.InnerError.Date}";
+                throw new HttpRequestException(errorMessage);
+            } catch (Exception ex) {
+                lastException = ex;
+                LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Graph API: {ex.Message}");
+                if (attempts >= RetryCount) {
+                    if (ErrorAction == ActionPreference.Stop) {
+                        throw;
+                    }
+                    return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", ex.Message);
+                }
+                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (delayMilliseconds > 0) {
+                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds));
+                }
             }
-            // If the status code indicates an error, throw an exception with the content.
-            var error = JsonSerializer.Deserialize<GraphApiError>(content);
-            var errorMessage = (error == null || error.Error == null || error.Error.InnerError == null)
-                ? $"Unknown error: {content}"
-                : $"Error code: {error.Error.Code}, message: {error.Error.Message}, request ID: {error.Error.InnerError.RequestId}, date: {error.Error.InnerError.Date}";
-            throw new HttpRequestException(errorMessage);
-        } catch (Exception ex) {
-            LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Graph API: {ex.Message}");
-            if (ErrorAction == ActionPreference.Stop) {
-                throw;
-            }
-            return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", ex.Message);
-        }
+            attempts++;
+        } while (attempts <= RetryCount);
+
+        return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", lastException?.Message);
     }
 
     public async Task<SmtpResult> SendMessageDraftAsync() {
@@ -309,8 +335,29 @@ public class Graph {
         // Upload attachments to the draft message
         await UploadAttachmentsAsync(draftMessage);
 
-        // Send the draft message
-        return await SendDraftMessage(draftMessage);
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            try {
+                return await SendDraftMessage(draftMessage);
+            } catch (Exception ex) {
+                lastException = ex;
+                LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Graph API: {ex.Message}");
+                if (attempts >= RetryCount) {
+                    if (ErrorAction == ActionPreference.Stop) {
+                        throw;
+                    }
+                    return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", ex.Message);
+                }
+                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (delayMilliseconds > 0) {
+                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds));
+                }
+            }
+            attempts++;
+        } while (attempts <= RetryCount);
+
+        return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", lastException?.Message);
     }
 
     public async Task<SmtpResult> SendDraftMessage(GraphMessage draftMessage) {

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -85,6 +85,22 @@ public class SendGridClient {
     public ActionPreference? ErrorAction { get; set; }
 
     /// <summary>
+    /// Number of times to retry sending the message when an error occurs.
+    /// </summary>
+    public int RetryCount { get; set; } = 0;
+
+    /// <summary>
+    /// Delay in milliseconds between retry attempts.
+    /// </summary>
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    /// <summary>
+    /// Factor used to increase the delay for each subsequent retry. A value of
+    /// 1 disables backoff.
+    /// </summary>
+    public double RetryDelayBackoff { get; set; } = 1.0;
+
+    /// <summary>
     /// Gets a string containing the email addresses of all recipients of the email.
     /// </summary>
     public string SentTo {
@@ -199,17 +215,31 @@ public class SendGridClient {
 
         request.Headers.Add("Authorization", $"Bearer {apiKey}");
 
-        try {
-            var response = await _client.SendAsync(request);
-            LogCollector.LogVerbose($"Send-EmailMessage - Sent email to {SentTo} using SendGrid");
-            return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, response.EnsureSuccessStatusCode().ToString());
-        } catch (Exception ex) {
-            LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SendGrid: {ex.Message}");
-            if (ErrorAction == ActionPreference.Stop) {
-                throw;
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            try {
+                var response = await _client.SendAsync(request);
+                LogCollector.LogVerbose($"Send-EmailMessage - Sent email to {SentTo} using SendGrid");
+                return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, response.EnsureSuccessStatusCode().ToString());
+            } catch (Exception ex) {
+                lastException = ex;
+                LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SendGrid: {ex.Message}");
+                if (attempts >= RetryCount) {
+                    if (ErrorAction == ActionPreference.Stop) {
+                        throw;
+                    }
+                    return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, "", ex.Message);
+                }
+                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (delayMilliseconds > 0) {
+                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds));
+                }
             }
-            return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, "", ex.Message);
-        }
+            attempts++;
+        } while (attempts <= RetryCount);
+
+        return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, "", lastException?.Message);
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -4,6 +4,7 @@ using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 
 namespace Mailozaurr;
 
@@ -80,6 +81,12 @@ public class Smtp {
         get => Client.Timeout;
         set => Client.Timeout = value;
     }
+
+    public int RetryCount { get; set; } = 0;
+
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    public double RetryDelayBackoff { get; set; } = 1.0;
 
     public bool CheckCertificateRevocation {
         get => Client.CheckCertificateRevocation;
@@ -291,18 +298,31 @@ public class Smtp {
     /// </summary>
     /// <returns></returns>
     public SmtpResult Send() {
-        try {
-            Client.Send(Message);
-            LoggingMessages.Logger.WriteVerbose($"Send-EmailMessage - Sent email to {SentTo}");
-            return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
-        } catch (Exception ex) {
-            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending: {ex.Message}");
-            //LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Possible issue: Message? ({Message} was used).");
-            if (ErrorAction == ActionPreference.Stop) {
-                throw;
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            try {
+                Client.Send(Message);
+                LoggingMessages.Logger.WriteVerbose($"Send-EmailMessage - Sent email to {SentTo}");
+                return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
+            } catch (Exception ex) {
+                lastException = ex;
+                LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending: {ex.Message}");
+                if (attempts >= RetryCount) {
+                    if (ErrorAction == ActionPreference.Stop) {
+                        throw;
+                    }
+                    return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message);
+                }
+                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (delayMilliseconds > 0) {
+                    Thread.Sleep(TimeSpan.FromMilliseconds(delayMilliseconds));
+                }
             }
-            return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message);
-        }
+            attempts++;
+        } while (attempts <= RetryCount);
+
+        return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", lastException?.Message);
     }
 
     public void Disconnect() {


### PR DESCRIPTION
## Summary
- add optional delay and backoff parameters for Send-EmailMessage
- implement retry delay logic in SMTP, Graph, and SendGrid clients
- document the new parameters in README and changelog
- use milliseconds instead of seconds for delay handling

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release` *(fails: MsgReader namespace not found)*
- `Invoke-Pester` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b5438f30832e85cc40a092f7b8d5