### PR TITLE
Add Mailgun provider support

### DIFF
--- a/Examples/Example-SendEmail-Mailgun.ps1
+++ b/Examples/Example-SendEmail-Mailgun.ps1
@@ -1,0 +1,13 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+# Use Mailgun API
+$Key = Get-Content -Raw -Path "C:\Support\Important\Mailgun.txt"
+$Credential = ConvertTo-MailgunCredential -ApiKey $Key
+
+Send-EmailMessage -From 'sender@yourdomain.com' `
+    -To 'recipient@example.com' `
+    -Subject 'Mailgun Test' `
+    -Body 'Hello from Mailgun' `
+    -EmailProvider Mailgun `
+    -Credential $Credential `
+    -Verbose

--- a/Examples/Example-SendEmail-Mailgun.ps1
+++ b/Examples/Example-SendEmail-Mailgun.ps1
@@ -4,10 +4,15 @@ Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 $Key = Get-Content -Raw -Path "C:\Support\Important\Mailgun.txt"
 $Credential = ConvertTo-MailgunCredential -ApiKey $Key
 
-Send-EmailMessage -From 'sender@yourdomain.com' `
-    -To 'recipient@example.com' `
-    -Subject 'Mailgun Test' `
-    -Body 'Hello from Mailgun' `
-    -EmailProvider Mailgun `
-    -Credential $Credential `
-    -Verbose
+$sendEmailMessageSplat = @{
+    From          = 'postmaster@sandbox814085ede3524b939d4b7f518ef9877a.mailgun.org'
+    To            = 'przemyslaw.klys+mailgun@xxx.pl'
+    Subject       = 'Mailgun Test'
+    HTML          = 'Hello from Mailgun'
+    Credential    = $Credential
+    Verbose       = $true
+    EmailProvider = 'Mailgun'
+    WhatIf        = $false
+}
+
+Send-EmailMessage @sendEmailMessageSplat

--- a/Mailozaurr.psd1
+++ b/Mailozaurr.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @('Connect-POP3', 'Disconnect-POP3', 'Get-POP3Message', 'Save-POP3Message')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Connect-IMAP', 'Connect-OAuthGoogle', 'Connect-OAuthO365', 'Connect-POP', 'ConvertFrom-EmlToMsg', 'ConvertTo-GraphCredential', 'ConvertTo-OAuth2Credential', 'ConvertTo-SendGridCredential', 'Disconnect-IMAP', 'Disconnect-POP', 'Get-IMAPFolder', 'Get-IMAPMessage', 'Get-MailFolder', 'Get-MailMessage', 'Get-MailMessageAttachment', 'Get-POPMessage', 'Import-MailFile', 'Save-MailMessage', 'Save-POPMessage', 'Send-EmailMessage', 'Test-EmailAddress')
+    CmdletsToExport      = @('Connect-IMAP', 'Connect-OAuthGoogle', 'Connect-OAuthO365', 'Connect-POP', 'ConvertFrom-EmlToMsg', 'ConvertTo-GraphCredential', 'ConvertTo-OAuth2Credential', 'ConvertTo-SendGridCredential', 'ConvertTo-MailgunCredential', 'Disconnect-IMAP', 'Disconnect-POP', 'Get-IMAPFolder', 'Get-IMAPMessage', 'Get-MailFolder', 'Get-MailMessage', 'Get-MailMessageAttachment', 'Get-POPMessage', 'Import-MailFile', 'Save-MailMessage', 'Save-POPMessage', 'Send-EmailMessage', 'Test-EmailAddress')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/Mailozaurr.Examples/Program.cs
+++ b/Sources/Mailozaurr.Examples/Program.cs
@@ -7,6 +7,7 @@ class Program {
         // SendEmailGmail.Run();
         await SendEmailGraphClientSecret.RunAsync();
         // await SendEmailGraphCertificate.RunAsync();
+        await SendEmailMailgun.RunAsync();
     }
 }
 

--- a/Sources/Mailozaurr.Examples/SendEmailMailgun.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailMailgun.cs
@@ -1,0 +1,28 @@
+using Mailozaurr;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+public static class SendEmailMailgun {
+    public static async Task RunAsync() {
+        // === CONFIGURATION ===
+        string apiKey = "your-mailgun-api-key";
+        string sender = "sender@yourdomain.com";
+        string recipient = "recipient@example.com";
+
+        // === EXAMPLE ===
+        try {
+            var mailgun = new MailgunClient();
+            mailgun.From = sender;
+            mailgun.To = new[] { recipient }.ToList<object>();
+            mailgun.Subject = "Test Email via Mailgun";
+            mailgun.Text = "Hello from Mailozaurr via Mailgun!";
+            mailgun.Html = "<p>Hello from Mailozaurr via Mailgun!</p>";
+            mailgun.Credentials = new NetworkCredential("api", apiKey);
+            var result = await mailgun.SendEmailAsync();
+            Console.WriteLine(result.Status ? "Mailgun: Email sent!" : $"Mailgun: Failed: {result.Error}");
+        } catch (Exception ex) {
+            Console.WriteLine($"Mailgun Example Error: {ex.Message}");
+        }
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToMailgunCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToMailgunCredential.cs
@@ -1,0 +1,25 @@
+namespace Mailozaurr.PowerShell;
+
+using System.Management.Automation;
+using System.Security;
+
+/// <summary>
+/// <para type="synopsis">Creates a PSCredential object for Mailgun API authentication from an API key.</para>
+/// <para type="description">Use <c>ConvertTo-MailgunCredential</c> to generate a <see cref="PSCredential"/> that can be passed to <c>Send-EmailMessage</c> when using the Mailgun provider.</para>
+/// <example>
+///   <summary>Create a Mailgun credential</summary>
+///   <code>ConvertTo-MailgunCredential -ApiKey "key-xxxxx"</code>
+/// </example>
+/// </summary>
+[Cmdlet(VerbsData.ConvertTo, "MailgunCredential")]
+[OutputType(typeof(PSCredential))]
+public class CmdletConvertToMailgunCredential : PSCmdlet {
+    [Parameter(Mandatory = true)]
+    public string? ApiKey { get; set; }
+
+    protected override void ProcessRecord() {
+        SecureString secret = CredentialHelpers.ToSecureString(ApiKey);
+        var credential = new PSCredential("Mailgun", secret);
+        WriteObject(credential);
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -554,10 +554,35 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
                 }
             }
         } else if (EmailProvider == EmailProvider.Mailgun) {
-            WriteVerbose("Mailgun provide is not ready yet");
-            return;
+            var logCollector = new LogCollector();
+            MailgunClient mailgun = new MailgunClient();
+            mailgun.LogCollector = logCollector;
+            mailgun.From = Helpers.GetFromObject(fromEmail, fromName);
+            if (Bcc != null) mailgun.Bcc = Bcc.ToList();
+            if (Cc != null) mailgun.Cc = Cc.ToList();
+            if (To != null) mailgun.To = To.ToList();
+            mailgun.ReplyTo = ReplyTo;
+            mailgun.Subject = Subject;
+            if (Text != null) mailgun.Text = string.Join("", Text);
+            if (HTML != null) mailgun.Html = string.Join("", HTML);
+            mailgun.Attachment = Attachment;
+            mailgun.ErrorAction = errorAction;
+            mailgun.RetryCount = RetryCount;
+            mailgun.RetryDelayMilliseconds = RetryDelayMilliseconds;
+            mailgun.RetryDelayBackoff = RetryDelayBackoff;
             NetworkCredential networkCredential = new NetworkCredential(Credential?.UserName, Credential?.Password);
-            //MailgunClient mailgun = new MailgunClient(networkCredential, From, To, Cc, Bcc, Subject, Text, HTML);
+            mailgun.Credentials = networkCredential;
+            if (ShouldProcess(mailgun.SentTo, "Sending email message via Mailgun")) {
+                var result = mailgun.SendEmailAsync().GetAwaiter().GetResult();
+                LogEmitter.EmitLogs(logCollector, this);
+                if (!Suppress) {
+                    WriteObject(result);
+                }
+            } else {
+                if (!Suppress) {
+                    WriteObject(new SmtpResult(false, EmailAction.Send, mailgun.SentTo, mailgun.SentFrom, "MailgunApi", 0, mailgun.Stopwatch.Elapsed, "", "Email not sent (WhatIf)"));
+                }
+            }
         } else if (Graph) {
             Graph graph = new Graph();
             graph.From = Helpers.GetFromObject(fromEmail, fromName);

--- a/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
+++ b/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
@@ -59,6 +59,10 @@
         </PackageReference>
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="G:\Source\MSGReader1\MsgReaderCore\MsgReader.csproj" />
+    </ItemGroup>
+
     <!-- Copy help documentation to publish output after publish -->
     <Target Name="CopyHelpDocumentationToPublishOutput" AfterTargets="Publish">
         <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll-Help.xml"

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -1,76 +1,112 @@
-﻿namespace Mailozaurr;
+using System.Net.Http.Headers;
+using System.Diagnostics;
 
+namespace Mailozaurr;
+
+/// <summary>
+/// Simple client for sending emails using the Mailgun API.
+/// </summary>
 public class MailgunClient : IDisposable {
     private readonly HttpClient _client;
+    public readonly Stopwatch Stopwatch;
 
-    /// <summary>
-    /// Gets the API key used for authentication with the Mailgun API.
-    /// </summary>
-    private string _apiKey => Helpers.CredentialToApiKey(Credentials);
+    private string ApiKey => Helpers.CredentialToApiKey(Credentials);
+    private string EmailDomain => Helpers.GetEmailAddress(From).Split('@')[1];
 
-    /// <summary>
-    /// Gets or sets the domain of the email address.
-    /// </summary>
-    private string EmailDomain {
+    public ICredentials Credentials { get; set; }
+    public ActionPreference? ErrorAction { get; set; }
+
+    public List<object> To { get; set; } = new();
+    public List<object> Cc { get; set; } = new();
+    public List<object> Bcc { get; set; } = new();
+    public object From { get; set; }
+    public object? ReplyTo { get; set; }
+    public string? Subject { get; set; }
+    public string Text { get; set; } = string.Empty;
+    public string Html { get; set; } = string.Empty;
+    public string[]? Attachment { get; set; }
+
+    public LogCollector LogCollector { get; set; } = new();
+    public int RetryCount { get; set; } = 0;
+    public int RetryDelayMilliseconds { get; set; } = 0;
+    public double RetryDelayBackoff { get; set; } = 1.0;
+
+    public string SentFrom => Helpers.GetEmailAddress(From);
+    public string SentTo {
         get {
-            //var emailInformation = From.Split("@");
-            //return emailInformation[1];
-            // TODO - Implement this
-            return "";
+            var addresses = new List<string>();
+            if (To != null) addresses.AddRange(To.Select(Helpers.GetEmailAddress));
+            if (Cc != null) addresses.AddRange(Cc.Select(Helpers.GetEmailAddress));
+            if (Bcc != null) addresses.AddRange(Bcc.Select(Helpers.GetEmailAddress));
+            return string.Join(",", addresses);
         }
     }
 
-    /// <summary>
-    /// Gets or sets the credentials used for authentication with the Mailgun API.
-    /// </summary>
-    public ICredentials Credentials { get; set; }
-
-    /// <summary>
-    /// Gets or sets the action to take when an error occurs.
-    /// </summary>
-    public ActionPreference? ErrorAction { get; set; }
-
-    public object[]? Bcc { get; set; }
-    public object[]? Cc { get; set; }
-    public object From { get; set; }
-    public object[]? To { get; set; }
-    public string Subject { get; set; }
-    public string BodyText { get; set; }
-    public string BodyHtml { get; set; }
-
-
-    public MailgunClient(ICredentials credentials, object from, object[] to, object[] cc, object[] bcc, string subject, string bodyText, string bodyHtml) {
+    public MailgunClient() {
+        Stopwatch = Stopwatch.StartNew();
         _client = new HttpClient();
-        Credentials = credentials;
-        From = from;
-        To = to;
-        Subject = subject;
-        BodyText = bodyText;
-        BodyHtml = bodyHtml;
     }
 
-    public async Task<bool> SendEmailAsync() {
+    private static string ConvertAddress(object address) {
+        var (email, name) = Helpers.GetEmailAndName(address);
+        return string.IsNullOrEmpty(name) ? email : $"{name} <{email}>";
+    }
+
+    private MultipartFormDataContent CreateContent() {
+        var content = new MultipartFormDataContent();
+        content.Add(new StringContent(ConvertAddress(From)), "from");
+        foreach (var t in To) content.Add(new StringContent(ConvertAddress(t)), "to");
+        foreach (var c in Cc) content.Add(new StringContent(ConvertAddress(c)), "cc");
+        foreach (var b in Bcc) content.Add(new StringContent(ConvertAddress(b)), "bcc");
+        if (ReplyTo != null) content.Add(new StringContent(ConvertAddress(ReplyTo)), "h:Reply-To");
+        if (!string.IsNullOrEmpty(Subject)) content.Add(new StringContent(Subject), "subject");
+        if (!string.IsNullOrEmpty(Text)) content.Add(new StringContent(Text), "text");
+        if (!string.IsNullOrEmpty(Html)) content.Add(new StringContent(Html), "html");
+        if (Attachment != null) {
+            foreach (var path in Attachment) {
+                var bytes = File.ReadAllBytes(path);
+                var fileContent = new ByteArrayContent(bytes);
+                fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                content.Add(fileContent, "attachment", Path.GetFileName(path));
+            }
+        }
+        return content;
+    }
+
+    public async Task<SmtpResult> SendEmailAsync() {
         var url = $"https://api.mailgun.net/v3/{EmailDomain}/messages";
-        var idpass = $"api:{_apiKey}";
-        var basicauth = Convert.ToBase64String(Encoding.ASCII.GetBytes(idpass));
-        _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", basicauth);
+        var auth = Convert.ToBase64String(Encoding.ASCII.GetBytes($"api:{ApiKey}"));
 
-        var formData = new Dictionary<string, string> {
-            // TODO - Implement the rest of the form data
-                //{ "from", From },
-                { "to", string.Join(",", To) },
-                { "subject", Subject },
-                { "text", BodyText },
-                { "html", BodyHtml }
-        };
-
-        var content = new FormUrlEncodedContent(formData);
-        var response = await _client.PostAsync(url, content);
-
-        return response.IsSuccessStatusCode;
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            try {
+                using var request = new HttpRequestMessage(HttpMethod.Post, url) {
+                    Content = CreateContent()
+                };
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", auth);
+                var response = await _client.SendAsync(request);
+                if (response.IsSuccessStatusCode) {
+                    return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString(), "");
+                }
+                var error = await response.Content.ReadAsStringAsync();
+                throw new HttpRequestException(error);
+            } catch (Exception ex) {
+                lastException = ex;
+                LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Mailgun: {ex.Message}");
+                if (attempts >= RetryCount) {
+                    if (ErrorAction == ActionPreference.Stop) throw;
+                    return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", ex.Message);
+                }
+                var delay = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (delay > 0) await Task.Delay(TimeSpan.FromMilliseconds(delay));
+            }
+            attempts++;
+        } while (attempts <= RetryCount);
+        return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", lastException?.Message);
     }
 
     public void Dispose() {
-        _client?.Dispose();
+        _client.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- implement `MailgunClient` to send mail via Mailgun HTTP API
- enable Mailgun in `Send-EmailMessage` cmdlet
- add `ConvertTo-MailgunCredential` cmdlet
- export new cmdlet in module manifest
- provide Mailgun examples for PowerShell and C#

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6849ca9b1ac0832eb8c5e9113ebec5cf