### PR TITLE
Implement Graph certificate example

### DIFF
--- a/Examples/Example-SendEmail-GraphCertificate.ps1
+++ b/Examples/Example-SendEmail-GraphCertificate.ps1
@@ -5,15 +5,7 @@ $CertPath = 'path-to-your.pfx'
 $CertPassword = 'your-cert-password'
 
 $Credential = ConvertTo-GraphCertificateCredential -ClientId $ClientId -TenantId $TenantId -CertificatePath $CertPath -CertificatePassword $CertPassword
-$Token = $Credential.GetNetworkCredential().Password
 
-$Graph = [Mailozaurr.Graph]::new()
-$Graph.From = 'sender@yourtenant.onmicrosoft.com'
-$Graph.To = 'recipient@example.com'
-$Graph.Subject = 'Certificate Graph Test'
-$Graph.HTML = '<p>Hello from Graph using certificate auth!</p>'
-$Graph.AccessToken = $Token
-$Graph.TokenType = 'Bearer'
-
-$Result = $Graph.SendMessageAsync().GetAwaiter().GetResult()
-$Result
+Send-EmailMessage -From 'sender@yourtenant.onmicrosoft.com' -To 'recipient@example.com' `
+    -Credential $Credential -Subject 'Certificate Graph Test' `
+    -HTML '<p>Hello from Graph using certificate auth!</p>' -Graph -Verbose

--- a/Examples/Example-SendEmail-GraphCertificate.ps1
+++ b/Examples/Example-SendEmail-GraphCertificate.ps1
@@ -1,0 +1,19 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+$ClientId = 'your-client-id'
+$TenantId = 'your-tenant-id'
+$CertPath = 'path-to-your.pfx'
+$CertPassword = 'your-cert-password'
+
+$Credential = ConvertTo-GraphCertificateCredential -ClientId $ClientId -TenantId $TenantId -CertificatePath $CertPath -CertificatePassword $CertPassword
+$Token = $Credential.GetNetworkCredential().Password
+
+$Graph = [Mailozaurr.Graph]::new()
+$Graph.From = 'sender@yourtenant.onmicrosoft.com'
+$Graph.To = 'recipient@example.com'
+$Graph.Subject = 'Certificate Graph Test'
+$Graph.HTML = '<p>Hello from Graph using certificate auth!</p>'
+$Graph.AccessToken = $Token
+$Graph.TokenType = 'Bearer'
+
+$Result = $Graph.SendMessageAsync().GetAwaiter().GetResult()
+$Result

--- a/Mailozaurr.psd1
+++ b/Mailozaurr.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @('Connect-POP3', 'Disconnect-POP3', 'Get-POP3Message', 'Save-POP3Message')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Connect-IMAP', 'Connect-OAuthGoogle', 'Connect-OAuthO365', 'Connect-POP', 'ConvertFrom-EmlToMsg', 'ConvertTo-GraphCredential', 'ConvertTo-OAuth2Credential', 'ConvertTo-SendGridCredential', 'ConvertTo-MailgunCredential', 'Disconnect-IMAP', 'Disconnect-POP', 'Get-IMAPFolder', 'Get-IMAPMessage', 'Get-MailFolder', 'Get-MailMessage', 'Get-MailMessageAttachment', 'Get-POPMessage', 'Import-MailFile', 'Save-MailMessage', 'Save-POPMessage', 'Send-EmailMessage', 'Test-EmailAddress')
+    CmdletsToExport      = @('Connect-IMAP', 'Connect-OAuthGoogle', 'Connect-OAuthO365', 'Connect-POP', 'ConvertFrom-EmlToMsg', 'ConvertTo-GraphCredential', 'ConvertTo-GraphCertificateCredential', 'ConvertTo-OAuth2Credential', 'ConvertTo-SendGridCredential', 'ConvertTo-MailgunCredential', 'Disconnect-IMAP', 'Disconnect-POP', 'Get-IMAPFolder', 'Get-IMAPMessage', 'Get-MailFolder', 'Get-MailMessage', 'Get-MailMessageAttachment', 'Get-POPMessage', 'Import-MailFile', 'Save-MailMessage', 'Save-POPMessage', 'Send-EmailMessage', 'Test-EmailAddress')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/Mailozaurr.Examples/SendEmailGraphCertificate.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailGraphCertificate.cs
@@ -1,24 +1,39 @@
+using Mailozaurr;
+using System;
 using System.Threading.Tasks;
 
-// Microsoft Graph Certificate Authentication Example (NOT IMPLEMENTED)
-// This is a placeholder for future support in Mailozaurr.
-//
-// To implement certificate-based authentication, you would typically use Microsoft.Identity.Client
-// to acquire a token with a certificate, then set graph.AccessToken and graph.TokenType = "Bearer"
-// before calling SendMessageAsync().
-
 public static class SendEmailGraphCertificate {
-    // === CONFIGURATION ===
-    // string clientId = "your-client-id";
-    // string tenantId = "your-tenant-id";
-    // string certificatePath = "path-to-your.pfx";
-    // string certificatePassword = "your-cert-password";
-    // string sender = "sender@yourtenant.onmicrosoft.com";
-    // string recipient = "recipient@example.com";
-
-    // === EXAMPLE (PSEUDOCODE) ===
     public static async Task RunAsync() {
-        // Not implemented in Mailozaurr yet.
-        // See comments above for how this would be done with Microsoft.Identity.Client.
+        // === CONFIGURATION ===
+        string clientId = "your-client-id";
+        string tenantId = "your-tenant-id";
+        string certificatePath = "path-to-your.pfx";
+        string certificatePassword = "your-cert-password";
+        string sender = "sender@yourtenant.onmicrosoft.com";
+        string recipient = "recipient@example.com";
+
+        // === EXAMPLE ===
+        try {
+            var token = await OAuthHelpers.AcquireGraphCertificateTokenAsync(
+                clientId,
+                tenantId,
+                certificatePath,
+                certificatePassword);
+
+            var graph = new Graph();
+            graph.From = sender;
+            graph.To = new[] { recipient };
+            graph.Subject = "Test Email via Microsoft Graph (Certificate)";
+            graph.HTML = "<p>Hello from Mailozaurr via Microsoft Graph (Certificate)!</p>";
+            graph.AccessToken = token.AccessToken;
+            graph.TokenType = token.TokenType;
+
+            var sendResult = await graph.SendMessageAsync();
+            Console.WriteLine(sendResult.Status
+                ? "Graph (Certificate): Email sent!"
+                : $"Graph (Certificate): Failed: {sendResult.Error}");
+        } catch (Exception ex) {
+            Console.WriteLine($"Graph (Certificate) Example Error: {ex.Message}");
+        }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCertificateCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCertificateCredential.cs
@@ -1,0 +1,55 @@
+namespace Mailozaurr.PowerShell;
+
+using System.Management.Automation;
+using System.Security;
+using System.Threading.Tasks;
+
+/// <summary>
+/// <para type="synopsis">Creates a PSCredential containing a Microsoft Graph access token obtained using certificate authentication.</para>
+/// <para type="description">The <c>ConvertTo-GraphCertificateCredential</c> cmdlet authenticates with Microsoft Graph using a client certificate and returns a <see cref="PSCredential"/> with the access token. Use the resulting credential with cmdlets that accept Graph tokens.</para>
+/// <example>
+///   <summary>Acquire a token using a certificate</summary>
+///   <code>ConvertTo-GraphCertificateCredential -ClientId "id" -TenantId "tenant" -CertificatePath "cert.pfx" -CertificatePassword "pass"</code>
+/// </example>
+/// <remarks>
+/// This cmdlet simplifies obtaining an app-only token for Microsoft Graph when using certificate authentication.
+/// </remarks>
+/// </summary>
+[Cmdlet(VerbsData.ConvertTo, "GraphCertificateCredential")]
+[OutputType(typeof(PSCredential))]
+public class CmdletConvertToGraphCertificateCredential : PSCmdlet {
+    [Parameter(Mandatory = true)]
+    public string? ClientId { get; set; }
+
+    [Parameter(Mandatory = true)]
+    public string? TenantId { get; set; }
+
+    [Parameter(Mandatory = true)]
+    public string? CertificatePath { get; set; }
+
+    [Parameter(Mandatory = true)]
+    public string? CertificatePassword { get; set; }
+
+    [Parameter]
+    public string[]? Scopes { get; set; }
+
+    protected override void ProcessRecord() {
+        GraphAuthorization token;
+        try {
+            token = Task.Run(() => Mailozaurr.OAuthHelpers.AcquireGraphCertificateTokenAsync(
+                    ClientId!,
+                    TenantId!,
+                    CertificatePath!,
+                    CertificatePassword!,
+                    Scopes)).GetAwaiter().GetResult();
+        } catch (System.Exception ex) {
+            WriteError(new ErrorRecord(ex, "GraphCertificateAuthFailed", ErrorCategory.AuthenticationError, null));
+            return;
+        }
+        SecureString secure = new();
+        foreach (var ch in token.AccessToken) secure.AppendChar(ch);
+        var username = $"{ClientId}@{TenantId}";
+        var credential = new PSCredential(username, secure);
+        WriteObject(credential);
+    }
+}

--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -2,6 +2,7 @@ using Microsoft.Identity.Client;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Auth.OAuth2.Flows;
 using Google.Apis.Util.Store;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Mailozaurr;
 
@@ -57,6 +58,26 @@ public static class OAuthHelpers {
         return new OAuthCredential {
             UserName = credential.UserId,
             AccessToken = credential.Token.AccessToken
+        };
+    }
+
+    public static async Task<GraphAuthorization> AcquireGraphCertificateTokenAsync(
+        string clientId,
+        string tenantId,
+        string certificatePath,
+        string certificatePassword,
+        IEnumerable<string>? scopes = null) {
+        var certificate = new X509Certificate2(certificatePath, certificatePassword);
+        var app = ConfidentialClientApplicationBuilder
+            .Create(clientId)
+            .WithTenantId(tenantId)
+            .WithCertificate(certificate)
+            .Build();
+        scopes ??= new[] { "https://graph.microsoft.com/.default" };
+        var result = await app.AcquireTokenForClient(scopes).ExecuteAsync();
+        return new GraphAuthorization {
+            AccessToken = result.AccessToken,
+            TokenType = "Bearer"
         };
     }
 }


### PR DESCRIPTION
## Summary
- add GraphCertificateCredential cmdlet for token acquisition
- implement certificate-based token helper
- update Graph certificate example to use cmdlet

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `pwsh -NoLogo -File Mailozaurr.Tests.ps1` *(fails: 5 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e7b28b6d0832e8058b6c2e5f495ce