### PR TITLE
fix(logging): pass correct progress percentage

### DIFF
--- a/Sources/Mailozaurr.Tests/InternalLoggerTests.cs
+++ b/Sources/Mailozaurr.Tests/InternalLoggerTests.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class InternalLoggerTests
+{
+    [Fact]
+    public void WriteProgress_RaisesEventWithCorrectPercentage()
+    {
+        var logger = new Mailozaurr.InternalLogger();
+        int? percentage = null;
+        logger.OnProgressMessage += (_, e) => percentage = e.ProgressPercentage;
+
+        logger.WriteProgress("Activity", "Operation", 42);
+
+        Assert.Equal(42, percentage);
+    }
+}

--- a/Sources/Mailozaurr/Logging/InternalLogger.cs
+++ b/Sources/Mailozaurr/Logging/InternalLogger.cs
@@ -84,7 +84,7 @@ public class InternalLogger {
     /// <param name="totalSteps">The total steps of the operation (optional).</param>
     public void WriteProgress(string activity, string currentOperation, int percentCompleted, int? currentSteps = null, int? totalSteps = null) {
         lock (_lock) {
-            OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, totalSteps));
+            OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, percentCompleted));
             if (IsProgress) {
                 if (currentSteps.HasValue && totalSteps.HasValue) {
                     Console.WriteLine("[progress] activity: {0} / operation: {1} / percent completed: {2}% ({3} out of {4})", activity, currentOperation, percentCompleted, currentSteps, totalSteps);


### PR DESCRIPTION
## Summary
- fix progress percentage parameter for `InternalLogger.WriteProgress`
- add regression test for correct percentage

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0 --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685055e27578832e8bc3a172687e9b8e