### PR TITLE
Fix content ranges for Graph uploads

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class GraphUploadRangeTests
+{
+    [Fact]
+    public async Task PrepareByteArrayContentForUpload_ComputesRangesCorrectly()
+    {
+        string tmp = Path.GetTempFileName();
+        File.WriteAllBytes(tmp, Enumerable.Range(0, 25).Select(b => (byte)b).ToArray());
+        Graph graph = new Graph();
+        MethodInfo? method = typeof(Graph).GetMethod(
+            "PrepareByteArrayContentForUpload",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        Task<List<ByteArrayContent>> task = (Task<List<ByteArrayContent>>)method!.Invoke(graph, new object[] { tmp, 10 })!;
+        List<ByteArrayContent> chunks = await task;
+        File.Delete(tmp);
+        Assert.Equal(3, chunks.Count);
+        Assert.Equal("bytes 0-9/25", chunks[0].Headers.GetValues("Content-Range").First());
+        Assert.Equal("bytes 10-19/25", chunks[1].Headers.GetValues("Content-Range").First());
+        Assert.Equal("bytes 20-24/25", chunks[2].Headers.GetValues("Content-Range").First());
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -502,11 +502,13 @@ public class Graph {
         using var fileStream = new FileStream(filePath, FileMode.Open);
         var buffer = new byte[chunkSize];
         int bytesRead;
+        long offset = 0;
         while ((bytesRead = await fileStream.ReadAsync(buffer, 0, buffer.Length)) > 0) {
-            var contentRange = $"bytes 0-{bytesRead - 1}/{fileSize}";
+            var contentRange = $"bytes {offset}-{offset + bytesRead - 1}/{fileSize}";
             var byteArrayContent = new ByteArrayContent(buffer, 0, bytesRead);
             byteArrayContent.Headers.Add("Content-Range", contentRange);
             fileContents.Add(byteArrayContent);
+            offset += bytesRead;
         }
 
         return fileContents;


### PR DESCRIPTION
## Summary
- compute running offset when chunking attachment data for Microsoft Graph
- add regression tests to ensure Content-Range headers are correct

## Testing
- `dotnet test Sources/Mailozaurr.sln -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_685055e3badc832ea72f2a11e5d1b016