### PR TITLE
Fix ReplyTo conversion

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -196,7 +196,7 @@ public class Graph {
                 To = ConvertToGraphEmailAddress(To),
                 Cc = ConvertToGraphEmailAddress(Cc),
                 Bcc = ConvertToGraphEmailAddress(Bcc),
-                ReplyTo = string.IsNullOrEmpty(ReplyTo) ? null : ConvertToGraphEmailAddress([ReplyTo]),
+                ReplyTo = string.IsNullOrEmpty(ReplyTo) ? null : new List<GraphEmailAddress> { ConvertToGraphEmailAddress(ReplyTo)! },
                 Subject = Subject,
                 Body = new GraphContent { Content = HTML, Type = ContentType },
                 IsDeliveryReceiptRequested = RequestDeliveryReceipt,


### PR DESCRIPTION
## Summary
- ensure `ReplyTo` uses the correct converter in Graph email creation

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -v minimal`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -v minimal`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685055e515d8832ea632301675223fcf