### PR TITLE
Remove unused IMAP and POP stubs

### DIFF
--- a/Sources/Mailozaurr/Imap.cs
+++ b/Sources/Mailozaurr/Imap.cs
@@ -1,9 +1,0 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Mailozaurr;
-internal class Imap {
-}

--- a/Sources/Mailozaurr/Pop.cs
+++ b/Sources/Mailozaurr/Pop.cs
@@ -1,9 +1,0 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Mailozaurr;
-internal class Pop {
-}


### PR DESCRIPTION
## Summary
- delete empty `Imap` and `Pop` class files

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj`
- `pwsh ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68505640c594832ea165fc4060a46957