### PR TITLE
Add API documentation comments

### DIFF
--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -6,7 +6,19 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Mailozaurr;
 
+/// <summary>
+/// Helper methods for acquiring OAuth tokens for various services.
+/// </summary>
 public static class OAuthHelpers {
+    /// <summary>
+    /// Acquires an OAuth token for Office 365 using an interactive browser flow.
+    /// </summary>
+    /// <param name="login">Optional login hint for the account.</param>
+    /// <param name="clientId">The application (client) identifier.</param>
+    /// <param name="tenantId">The tenant identifier.</param>
+    /// <param name="redirectUri">The redirect URI registered for the application.</param>
+    /// <param name="scopes">The scopes to request for the token.</param>
+    /// <returns>A credential containing the access token.</returns>
     public static async Task<OAuthCredential> AcquireO365TokenInteractiveAsync(
         string login,
         string clientId,
@@ -34,6 +46,14 @@ public static class OAuthHelpers {
         };
     }
 
+    /// <summary>
+    /// Acquires an OAuth token for a Gmail account using an interactive browser flow.
+    /// </summary>
+    /// <param name="gmailAccount">The Gmail account to authenticate.</param>
+    /// <param name="clientId">The OAuth client identifier.</param>
+    /// <param name="clientSecret">The OAuth client secret.</param>
+    /// <param name="scopes">The scopes to request for the token.</param>
+    /// <returns>A credential containing the access token.</returns>
     public static async Task<OAuthCredential> AcquireGoogleTokenInteractiveAsync(
         string gmailAccount,
         string clientId,
@@ -61,6 +81,15 @@ public static class OAuthHelpers {
         };
     }
 
+    /// <summary>
+    /// Acquires an app-only Microsoft Graph token using a certificate.
+    /// </summary>
+    /// <param name="clientId">The application (client) identifier.</param>
+    /// <param name="tenantId">The tenant identifier.</param>
+    /// <param name="certificatePath">Path to the certificate file (PFX).</param>
+    /// <param name="certificatePassword">Password for the certificate.</param>
+    /// <param name="scopes">Optional scopes to request.</param>
+    /// <returns>The authorization information including access token.</returns>
     public static async Task<GraphAuthorization> AcquireGraphCertificateTokenAsync(
         string clientId,
         string tenantId,

--- a/Sources/Mailozaurr/EmailMessage.cs
+++ b/Sources/Mailozaurr/EmailMessage.cs
@@ -2,7 +2,17 @@
 
 namespace Mailozaurr;
 
+/// <summary>
+/// Provides helper methods for converting EML messages to MSG format.
+/// </summary>
 public static class EmailMessage {
+    /// <summary>
+    /// Converts one or more EML files to MSG format.
+    /// </summary>
+    /// <param name="emlFile">Paths to the EML files to convert.</param>
+    /// <param name="outputFolder">The folder where MSG files should be saved.</param>
+    /// <param name="force">If set to <c>true</c>, existing MSG files will be overwritten.</param>
+    /// <returns>A collection of conversion results for each processed file.</returns>
     public static IEnumerable<EmlConversionResult> ConvertEmlToMsg(string[] emlFile, string outputFolder, bool force) {
         LoggingMessages.Logger.WriteVerbose($"Converting {emlFile.Length} EML file(s) to MSG file(s)...");
         foreach (var eml in emlFile) {
@@ -13,6 +23,13 @@ public static class EmailMessage {
         }
     }
 
+    /// <summary>
+    /// Converts a single EML file to MSG format.
+    /// </summary>
+    /// <param name="emlFile">The input EML file.</param>
+    /// <param name="msgFile">The target MSG file.</param>
+    /// <param name="force">If set to <c>true</c>, an existing MSG file will be overwritten.</param>
+    /// <returns>The result of the conversion.</returns>
     public static EmlConversionResult ConvertEmlToMsg(FileInfo emlFile, FileInfo msgFile, bool force) {
         if (File.Exists(emlFile.FullName)) {
             LoggingMessages.Logger.WriteVerbose("Processing EML file: {0}", emlFile);

--- a/Sources/Mailozaurr/Enums/ActionPreference.cs
+++ b/Sources/Mailozaurr/Enums/ActionPreference.cs
@@ -1,5 +1,8 @@
 namespace Mailozaurr;
 
+/// <summary>
+/// Specifies how the client should react when an error occurs.
+/// </summary>
 public enum ActionPreference {
     Stop,
     Continue,

--- a/Sources/Mailozaurr/Enums/DeliveryNotification.cs
+++ b/Sources/Mailozaurr/Enums/DeliveryNotification.cs
@@ -1,5 +1,8 @@
 ﻿namespace Mailozaurr;
 
+/// <summary>
+/// Delivery status notification options.
+/// </summary>
 public enum DeliveryNotification {
     None,
     Delay,

--- a/Sources/Mailozaurr/Enums/EmailAction.cs
+++ b/Sources/Mailozaurr/Enums/EmailAction.cs
@@ -1,5 +1,8 @@
 ﻿namespace Mailozaurr;
 
+/// <summary>
+/// Represents actions performed when sending or preparing an email.
+/// </summary>
 public enum EmailAction {
     Authenticate,
     Connect,

--- a/Sources/Mailozaurr/Enums/EmailActionEncryption.cs
+++ b/Sources/Mailozaurr/Enums/EmailActionEncryption.cs
@@ -1,5 +1,8 @@
 ﻿namespace Mailozaurr;
 
+/// <summary>
+/// Specifies encryption or signing actions for S/MIME operations.
+/// </summary>
 public enum EmailActionEncryption {
     None,
     SMIMESign,
@@ -7,3 +10,4 @@ public enum EmailActionEncryption {
     SMIMEEncrypt,
     SMIMESignAndEncrypt,
 }
+

--- a/Sources/Mailozaurr/Enums/EmailProvider.cs
+++ b/Sources/Mailozaurr/Enums/EmailProvider.cs
@@ -1,4 +1,7 @@
 ﻿namespace Mailozaurr;
+/// <summary>
+/// Supported external email providers.
+/// </summary>
 public enum EmailProvider {
     None,
     SendGrid,
@@ -11,3 +14,4 @@ public enum EmailProvider {
     //MessageBird (SparkPost),
     //MailerSend
 }
+

--- a/Sources/Mailozaurr/Enums/MessagePriority.cs
+++ b/Sources/Mailozaurr/Enums/MessagePriority.cs
@@ -1,5 +1,8 @@
 ﻿namespace Mailozaurr;
 
+/// <summary>
+/// Indicates the priority of an email message.
+/// </summary>
 public enum MessagePriority {
     High,
     Low,

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -3,11 +3,21 @@ using System.Security;
 
 namespace Mailozaurr;
 
+/// <summary>
+/// Utility methods used throughout the library.
+/// </summary>
 public static class Helpers {
+    /// <summary>Converts a credential into an OAuth token tuple.</summary>
+    /// <param name="credential">The credential containing the token.</param>
+    /// <returns>The username and token.</returns>
     public static (string UserName, string Token) ConvertFromOAuth2Credential(NetworkCredential credential) {
         return (credential.UserName, credential.Password);
     }
 
+    /// <summary>Creates a <see cref="NetworkCredential"/> from plain text.</summary>
+    /// <param name="userName">The user name.</param>
+    /// <param name="password">The password.</param>
+    /// <returns>The resulting credential.</returns>
     public static NetworkCredential ConvertFromPlainText(string userName, string password) {
         var secStringPassword = new SecureString();
         foreach (char c in password) {
@@ -16,6 +26,9 @@ public static class Helpers {
         return new NetworkCredential(userName, secStringPassword);
     }
 
+    /// <summary>Extracts the API key from a credential object.</summary>
+    /// <param name="credentials">Credential containing the key.</param>
+    /// <returns>The API key.</returns>
     public static string CredentialToApiKey(ICredentials credentials) {
         string apiKey;
         try {
@@ -27,6 +40,9 @@ public static class Helpers {
         return apiKey;
     }
 
+    /// <summary>Retrieves the email address string from various types of objects.</summary>
+    /// <param name="from">String or dictionary representation.</param>
+    /// <returns>The email address.</returns>
     public static string GetEmailAddress(object from) {
         if (from is string s) {
             return s;
@@ -37,6 +53,10 @@ public static class Helpers {
         return from?.ToString() ?? string.Empty;
     }
 
+    /// <summary>Creates an object representing the sender.</summary>
+    /// <param name="email">Email address.</param>
+    /// <param name="name">Display name.</param>
+    /// <returns>The object to be used as sender.</returns>
     public static object GetFromObject(string email, string name) {
         if (!string.IsNullOrEmpty(name)) {
             return new Dictionary<string, object> { { "Name", name }, { "Email", email } };
@@ -44,6 +64,9 @@ public static class Helpers {
         return email;
     }
 
+    /// <summary>Parses an object into an email and optional name.</summary>
+    /// <param name="from">String or dictionary representation.</param>
+    /// <returns>Tuple containing the email and name.</returns>
     public static (string Email, string? Name) GetEmailAndName(object from) {
         if (from is string s) {
             return (s, null);

--- a/Sources/Mailozaurr/Logging/LoggingConfigurator.cs
+++ b/Sources/Mailozaurr/Logging/LoggingConfigurator.cs
@@ -1,18 +1,43 @@
 namespace Mailozaurr;
 
+/// <summary>
+/// Configures protocol logging for SMTP and other clients.
+/// </summary>
 public class LoggingConfigurator {
+    /// <summary>Gets the in-memory log stream when logging to an object.</summary>
     public MemoryStream? LogStream { get; private set; }
+    /// <summary>True when logging to the console is enabled.</summary>
     public bool LogConsole { get; private set; }
+    /// <summary>True when log entries should be captured for later emission.</summary>
     public bool LogObject { get; private set; }
+    /// <summary>True when timestamps should be included.</summary>
     public bool LogTimestamps { get; private set; }
+    /// <summary>True when secrets should appear in logs.</summary>
     public bool LogSecrets { get; private set; }
+    /// <summary>Optional format string for timestamps.</summary>
     public string? LogTimestampsFormat { get; private set; }
+    /// <summary>Optional prefix for server messages.</summary>
     public string? LogServerPrefix { get; private set; }
+    /// <summary>Optional prefix for client messages.</summary>
     public string? LogClientPrefix { get; private set; }
+    /// <summary>Indicates whether existing log files should be overwritten.</summary>
     public bool LogOverwrite { get; private set; }
+    /// <summary>The path of the log file.</summary>
     public string? LogPath { get; private set; }
     internal ProtocolLogger? ProtocolLogger { get; set; }
 
+    /// <summary>
+    /// Configures protocol logging.
+    /// </summary>
+    /// <param name="logPath">Path to the log file or <c>null</c> to disable file logging.</param>
+    /// <param name="logConsole">Enable console logging.</param>
+    /// <param name="logObject">Capture log entries in memory for later use.</param>
+    /// <param name="logTimestamps">Include timestamps in the log.</param>
+    /// <param name="logSecrets">Include secret values in the log.</param>
+    /// <param name="logTimestampsFormat">Optional timestamp format.</param>
+    /// <param name="logServerPrefix">Optional prefix for server messages.</param>
+    /// <param name="logClientPrefix">Optional prefix for client messages.</param>
+    /// <param name="logOverwrite">Overwrite existing log file if it exists.</param>
     public void ConfigureLogging(string logPath, bool logConsole, bool logObject, bool logTimestamps, bool logSecrets, string? logTimestampsFormat = null, string? logServerPrefix = null, string? logClientPrefix = null, bool logOverwrite = false) {
         LogTimestamps = logTimestamps;
         LogSecrets = logSecrets;

--- a/Sources/Mailozaurr/Logging/LoggingMessages.cs
+++ b/Sources/Mailozaurr/Logging/LoggingMessages.cs
@@ -1,32 +1,44 @@
 namespace Mailozaurr;
 
+/// <summary>
+/// Static accessors for the global <see cref="InternalLogger"/> instance used throughout the library.
+/// </summary>
 public class LoggingMessages {
+    /// <summary>Gets the global logger.</summary>
     public static InternalLogger Logger = new InternalLogger();
 
+    /// <summary>Enable or disable error logging.</summary>
     public static bool Error {
         get => Logger.IsError;
         set => Logger.IsError = value;
     }
 
+    /// <summary>Enable or disable verbose logging.</summary>
     public static bool Verbose {
         get => Logger.IsVerbose;
         set => Logger.IsVerbose = value;
     }
 
+    /// <summary>Enable or disable warning logging.</summary>
     public static bool Warning {
         get => Logger.IsWarning;
         set => Logger.IsWarning = value;
     }
 
+    /// <summary>Enable or disable progress logging.</summary>
     public static bool Progress {
         get => Logger.IsProgress;
         set => Logger.IsProgress = value;
     }
 
+    /// <summary>Enable or disable debug logging.</summary>
     public static bool Debug {
         get => Logger.IsDebug;
         set => Logger.IsDebug = value;
     }
 
+    /// <summary>
+    /// Internal lock object used to synchronize logging operations.
+    /// </summary>
     internal static object _LockObject = new object();
 }

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -13,20 +13,33 @@ public class MailgunClient : IDisposable {
     private string ApiKey => Helpers.CredentialToApiKey(Credentials);
     private string EmailDomain => Helpers.GetEmailAddress(From).Split('@')[1];
 
+    /// <summary>Credentials used to authenticate to the API.</summary>
     public ICredentials Credentials { get; set; }
+    /// <summary>Determines how errors are handled.</summary>
     public ActionPreference? ErrorAction { get; set; }
 
+    /// <summary>Primary recipients.</summary>
     public List<object> To { get; set; } = new();
+    /// <summary>Carbon copy recipients.</summary>
     public List<object> Cc { get; set; } = new();
+    /// <summary>Blind carbon copy recipients.</summary>
     public List<object> Bcc { get; set; } = new();
+    /// <summary>The sender address.</summary>
     public object From { get; set; }
+    /// <summary>Reply-to address.</summary>
     public object? ReplyTo { get; set; }
+    /// <summary>Message subject.</summary>
     public string? Subject { get; set; }
+    /// <summary>Plain text body.</summary>
     public string Text { get; set; } = string.Empty;
+    /// <summary>HTML body.</summary>
     public string Html { get; set; } = string.Empty;
+    /// <summary>File paths to include as attachments.</summary>
     public string[]? Attachment { get; set; }
+    /// <summary>File paths to include as inline attachments.</summary>
     public string[]? InlineAttachment { get; set; }
 
+    /// <summary>Collector used to store log entries.</summary>
     public LogCollector LogCollector { get; set; } = new();
     public int RetryCount { get; set; } = 0;
     public int RetryDelayMilliseconds { get; set; } = 0;

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -2,6 +2,9 @@
 
 namespace Mailozaurr;
 
+/// <summary>
+/// Helper class for sending messages via Microsoft Graph API.
+/// </summary>
 public class Graph {
     private readonly HttpClient _client;
     public string MessageJson = string.Empty;

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachment.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachment.cs
@@ -1,21 +1,36 @@
 ﻿namespace Mailozaurr;
 
+/// <summary>
+/// Represents a placeholder for an attachment upload session.
+/// </summary>
 public class GraphAttachmentPlaceHolder {
+    /// <summary>Serialized attachment metadata.</summary>
     public string Json { get; set; }
+    /// <summary>Chunks of the file content.</summary>
     public List<ByteArrayContent> Content { get; set; }
+    /// <summary>Size of the file in bytes.</summary>
     public long FileSize { get; set; }
+    /// <summary>Name of the file.</summary>
     public string FileName { get; set; }
 }
 
+/// <summary>
+/// Wrapper used when creating an upload session.
+/// </summary>
 public class GraphAttachmentItemWrapper {
     [JsonPropertyName("AttachmentItem")]
     public GraphAttachmentItem AttachmentItem { get; set; }
 
+    /// <summary>Initializes a new instance of the wrapper.</summary>
+    /// <param name="attachmentItem">The attachment item.</param>
     public GraphAttachmentItemWrapper(GraphAttachmentItem attachmentItem) {
         AttachmentItem = attachmentItem;
     }
 }
 
+/// <summary>
+/// Metadata describing an attachment for upload.
+/// </summary>
 public class GraphAttachmentItem {
     [JsonPropertyName("attachmentType")]
     public string AttachmentType { get; set; }
@@ -26,6 +41,10 @@ public class GraphAttachmentItem {
     [JsonPropertyName("size")]
     public long Size { get; set; }
 
+    /// <summary>Creates a new attachment item.</summary>
+    /// <param name="attachmentType">Type of the attachment.</param>
+    /// <param name="name">File name.</param>
+    /// <param name="size">File size.</param>
     public GraphAttachmentItem(string attachmentType, string name, long size) {
         AttachmentType = attachmentType;
         Name = name;
@@ -33,6 +52,9 @@ public class GraphAttachmentItem {
     }
 }
 
+/// <summary>
+/// Represents a simple file attachment used when sending messages.
+/// </summary>
 public class GraphAttachment {
     [JsonPropertyName("@odata.type")]
     public string ODataType { get; set; } = "#microsoft.graph.fileAttachment";
@@ -43,6 +65,11 @@ public class GraphAttachment {
     [JsonPropertyName("contentBytes")]
     public string ContentBytes { get; set; }
 
+    /// <summary>
+    /// Creates a <see cref="GraphAttachment"/> from a local file path.
+    /// </summary>
+    /// <param name="filePath">Path to the file.</param>
+    /// <returns>The created attachment.</returns>
     public static GraphAttachment FromFile(string filePath) {
         var fileInfo = new FileInfo(filePath);
         var fileBytes = File.ReadAllBytes(filePath);

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAuthorization.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAuthorization.cs
@@ -1,14 +1,22 @@
 ﻿namespace Mailozaurr;
 
+/// <summary>
+/// Result returned when creating an upload session for large attachments.
+/// </summary>
 public class GraphUploadSessionResult {
     [JsonPropertyName("uploadUrl")]
     public string UploadUrl { get; set; }
 }
 
+/// <summary>
+/// Authorization information returned by Microsoft Graph OAuth flows.
+/// </summary>
 public class GraphAuthorization {
+    /// <summary>The type of token issued.</summary>
     [JsonPropertyName("token_type")]
     public string TokenType { get; set; }
 
+    /// <summary>The access token value.</summary>
     [JsonPropertyName("access_token")]
     public string AccessToken { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphErrors.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphErrors.cs
@@ -1,10 +1,16 @@
 ﻿namespace Mailozaurr;
 
+/// <summary>
+/// Container for an error returned by the Graph API.
+/// </summary>
 public class GraphApiError {
     [JsonPropertyName("error")]
     public GraphApiErrorDetail Error { get; set; }
 }
 
+/// <summary>
+/// Detailed information about a Graph API error.
+/// </summary>
 public class GraphApiErrorDetail {
     [JsonPropertyName("code")]
     public string Code { get; set; }
@@ -16,6 +22,9 @@ public class GraphApiErrorDetail {
     public GraphApiInnerError InnerError { get; set; }
 }
 
+/// <summary>
+/// Additional error details returned by the Graph API.
+/// </summary>
 public class GraphApiInnerError {
     [JsonPropertyName("request-id")]
     public string RequestId { get; set; }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMessage.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMessage.cs
@@ -1,5 +1,8 @@
 ﻿namespace Mailozaurr;
 
+/// <summary>
+/// Wrapper used when serializing a message for Graph API calls.
+/// </summary>
 public class GraphMessageContainer {
     [JsonPropertyName("message")]
     public GraphMessage Message { get; set; }
@@ -7,6 +10,9 @@ public class GraphMessageContainer {
     public bool SaveToSentItems { get; set; }
 }
 
+/// <summary>
+/// Represents an email message for use with the Graph API.
+/// </summary>
 public class GraphMessage {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("id")]
@@ -51,16 +57,25 @@ public class GraphMessage {
     public List<GraphAttachment>? Attachments { get; set; }
 }
 
+/// <summary>
+/// Represents an email address object for Graph API payloads.
+/// </summary>
 public class GraphEmailAddress {
     [JsonPropertyName("emailAddress")]
     public GraphEmail Email { get; set; }
 }
 
+/// <summary>
+/// Simple email address container.
+/// </summary>
 public class GraphEmail {
     [JsonPropertyName("address")]
     public string Address { get; set; }
 }
 
+/// <summary>
+/// Body content for a message.
+/// </summary>
 public class GraphContent {
     [JsonPropertyName("contentType")]
     public string Type { get; set; } = "Text";

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -9,12 +9,18 @@ using System.Linq;
 using System.IO;
 
 namespace Mailozaurr {
+    /// <summary>
+    /// Represents credentials required for Microsoft Graph authentication.
+    /// </summary>
     public class GraphCredential {
         public string ClientId { get; set; }
         public string DirectoryId { get; set; }
         public string ClientSecret { get; set; }
     }
 
+    /// <summary>
+    /// Simplified representation of an email message returned from Graph.
+    /// </summary>
     public class GraphEmailMessage {
         public string Id { get; set; }
         public string Subject { get; set; }
@@ -24,6 +30,9 @@ namespace Mailozaurr {
         // Add more properties as needed
     }
 
+    /// <summary>
+    /// Represents a file attachment from Microsoft Graph.
+    /// </summary>
     public class Attachment {
         public string Name { get; set; }
         public string ContentBytes { get; set; }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -2,20 +2,37 @@ using MimeKit.Utils;
 
 namespace Mailozaurr;
 
+/// <summary>
+/// Extension of <see cref="SmtpClient"/> used to build and send messages.
+/// </summary>
 public partial class ClientSmtp : SmtpClient {
+    /// <summary>Subject of the message.</summary>
     public string Subject { get; set; } = string.Empty;
+    /// <summary>HTML body of the message.</summary>
     public string HtmlBody { get; set; } = string.Empty;
+    /// <summary>Plain text body of the message.</summary>
     public string TextBody { get; set; } = string.Empty;
+    /// <summary>Attachments to include with the message.</summary>
     public List<object>? Attachments { get; set; } = new List<object>();
+    /// <summary>Inline attachments to embed in the message.</summary>
     public List<object>? InlineAttachments { get; set; } = new List<object>();
+    /// <summary>The sender address.</summary>
     public object From { get; set; }
+    /// <summary>Primary recipients.</summary>
     public IEnumerable<object>? To { get; set; } = new List<object>();
+    /// <summary>Carbon copy recipients.</summary>
     public IEnumerable<object>? Cc { get; set; } = new List<object>();
+    /// <summary>Blind carbon copy recipients.</summary>
     public IEnumerable<object>? Bcc { get; set; } = new List<object>();
+    /// <summary>Reply-to address.</summary>
     public object? ReplyTo { get; set; }
+    /// <summary>The underlying MIME message.</summary>
     public MimeMessage Message { get; set; }
+    /// <summary>Priority of the message.</summary>
     public MessagePriority Priority { get; set; }
+    /// <summary>Delivery notification options.</summary>
     public DeliveryNotification[]? DeliveryNotificationOption { get; set; }
+    /// <summary>Comma separated list of all recipients.</summary>
     public string SentTo {
         get {
             var addresses = new List<string>();
@@ -32,6 +49,7 @@ public partial class ClientSmtp : SmtpClient {
         }
     }
 
+    /// <summary>The address(es) the message is sent from.</summary>
     public string SentFrom {
         get {
             var addresses = ConvertToMailboxAddress(From).Select(x => x.Address);
@@ -43,6 +61,12 @@ public partial class ClientSmtp : SmtpClient {
 
     public ClientSmtp(ProtocolLogger protocolLogger) : base(protocolLogger) { }
 
+    /// <summary>
+    /// Determines which delivery status notifications should be requested for the specified recipient.
+    /// </summary>
+    /// <param name="message">The message being sent.</param>
+    /// <param name="mailbox">The recipient mailbox address.</param>
+    /// <returns>The delivery status notification flags to use, or <c>null</c>.</returns>
     protected override DeliveryStatusNotification? GetDeliveryStatusNotifications(MimeMessage message, MailboxAddress mailbox) {
         DeliveryStatusNotification combinedOption = 0;
         if (DeliveryNotificationOption != null) {
@@ -68,6 +92,9 @@ public partial class ClientSmtp : SmtpClient {
         return combinedOption;
     }
 
+    /// <summary>
+    /// Builds the <see cref="MimeMessage"/> based on the configured properties.
+    /// </summary>
     public void CreateMessage() {
         var message = new MimeMessage();
         AddAddressesToMessage(message);
@@ -170,6 +197,10 @@ public partial class ClientSmtp : SmtpClient {
         message.Body = bodyBuilder.ToMessageBody();
     }
 
+    /// <summary>
+    /// Saves the constructed message to the specified file path.
+    /// </summary>
+    /// <param name="path">Destination file path.</param>
     public void SaveMessage(string path) {
         Message.WriteTo(path);
     }

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -8,6 +8,9 @@ using System.Threading;
 
 namespace Mailozaurr;
 
+/// <summary>
+/// High level wrapper around <see cref="ClientSmtp"/> that exposes convenient methods and retry logic.
+/// </summary>
 public class Smtp {
     public LoggingConfigurator? Logging;
 

--- a/Sources/Mailozaurr/Smtp/SmtpResult.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpResult.cs
@@ -4,14 +4,23 @@ namespace Mailozaurr;
 /// Class that holds the result of the SMTP operation
 /// </summary>
 public class SmtpResult {
+    /// <summary>Whether the operation succeeded.</summary>
     public bool Status { get; set; }
+    /// <summary>The type of email action that was performed.</summary>
     public EmailAction EmailAction { get; set; }
+    /// <summary>The recipients the message was sent to.</summary>
     public string SentTo { get; set; }
+    /// <summary>The sender address.</summary>
     public string SentFrom { get; set; }
+    /// <summary>Optional message returned by the operation.</summary>
     public string? Message { get; set; }
+    /// <summary>Time taken to perform the action.</summary>
     public TimeSpan TimeToExecute { get; set; }
+    /// <summary>The server used to send the message.</summary>
     public string Server { get; set; }
+    /// <summary>The port used to connect.</summary>
     public int Port { get; set; }
+    /// <summary>Error information if the operation failed.</summary>
     public string? Error { get; set; }
     /// <summary>
     /// Initializes a new instance of the <see cref="SmtpResult"/> class.


### PR DESCRIPTION
## Summary
- document helper methods for converting emails
- add OAuthHelpers summaries and param documentation
- document logging configuration and global logger
- expand docs for SMTP client classes and result types
- add summaries for Graph models and helper utilities
- annotate enums with summary comments

## Testing
- `dotnet build Sources/Mailozaurr.sln -p:GenerateDocumentationFile=true --configfile NuGet.Config` *(fails: File '/workspace/Mailozaurr/NuGet.Config' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6857b76c5164832e9357bc9e954e02af