### PR TITLE
Fix restoring default auth header

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -551,12 +551,17 @@ public class Graph {
             Content = byteArrayContent
         };
         requestMessage.Headers.Add("AnchorMailbox", SentFrom); // This is correctly added to HttpRequestMessage
+        var originalAuthorization = _client.DefaultRequestHeaders.Authorization;
         _client.DefaultRequestHeaders.Authorization = null;
-        var uploadChunkResponse = await _client.SendAsync(requestMessage);
-        if (!uploadChunkResponse.IsSuccessStatusCode) {
-            // Handle upload error
-            Console.WriteLine(uploadChunkResponse);
-            return;
+        try {
+            var uploadChunkResponse = await _client.SendAsync(requestMessage);
+            if (!uploadChunkResponse.IsSuccessStatusCode) {
+                // Handle upload error
+                Console.WriteLine(uploadChunkResponse);
+                return;
+            }
+        } finally {
+            _client.DefaultRequestHeaders.Authorization = originalAuthorization;
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix Graph.Upload to restore authorization header after sending chunk
- run Pester tests

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6857fe329ce0832e826124a77e2bbb2a