### PR TITLE
Use logger instead of console in MicrosoftGraphUtils

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -288,7 +288,7 @@ namespace Mailozaurr {
                         File.WriteAllText(filePath, content);
                     } catch (Exception ex) {
                         // Log or handle error
-                        Console.WriteLine($"SaveMailMessage - Couldn't save file to {filePath}. Error: {ex.Message}");
+                        LoggingMessages.Logger.WriteWarning($"SaveMailMessage - Couldn't save file to {filePath}. Error: {ex.Message}");
                     }
                 }
             }
@@ -305,7 +305,7 @@ namespace Mailozaurr {
                         File.WriteAllBytes(filePath, bytes);
                     } catch (Exception ex) {
                         // Log or handle error
-                        Console.WriteLine($"SaveAttachment - Couldn't save file to {filePath}. Error: {ex.Message}");
+                        LoggingMessages.Logger.WriteWarning($"SaveAttachment - Couldn't save file to {filePath}. Error: {ex.Message}");
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- replace Console.WriteLine calls in MicrosoftGraphUtils with LoggingMessages.Logger.WriteWarning

## Testing
- `dotnet restore Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln --configuration Debug --no-restore`
- `pwsh ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6858020edd84832e91d021d36eac9c03