### PR TITLE
Fix certificate disposal

### DIFF
--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -348,8 +348,9 @@ public class Smtp {
 
     public SmtpResult Encrypt(string pfxFilePath, string password, bool isSecureString) {
         password = ConvertSecureStringToPlainString(password, isSecureString);
-        X509Certificate2 certificate = new X509Certificate2(pfxFilePath, password, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
-        return Encrypt(certificate);
+        using (X509Certificate2 certificate = new X509Certificate2(pfxFilePath, password, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet)) {
+            return Encrypt(certificate);
+        }
     }
 
     public SmtpResult Encrypt(string certificateThumbprint) {
@@ -422,8 +423,9 @@ public class Smtp {
 
     public SmtpResult Sign(string pfxFilePath, string password, bool isSecureString) {
         password = ConvertSecureStringToPlainString(password, isSecureString);
-        X509Certificate2 certificate = new X509Certificate2(pfxFilePath, password, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
-        return Sign(certificate);
+        using (X509Certificate2 certificate = new X509Certificate2(pfxFilePath, password, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet)) {
+            return Sign(certificate);
+        }
     }
 
     public SmtpResult Sign(string certificateThumbprint) {
@@ -445,8 +447,9 @@ public class Smtp {
 
     public SmtpResult Pkcs7Sign(string pfxFilePath, string password, bool isSecureString) {
         password = ConvertSecureStringToPlainString(password, isSecureString);
-        X509Certificate2 certificate = new X509Certificate2(pfxFilePath, password, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
-        return Pkcs7Sign(certificate);
+        using (X509Certificate2 certificate = new X509Certificate2(pfxFilePath, password, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet)) {
+            return Pkcs7Sign(certificate);
+        }
     }
 
     public SmtpResult Pkcs7Sign(string certificateThumbprint) {


### PR DESCRIPTION
## Summary
- dispose of `X509Certificate2` instances created from file paths

## Testing
- `dotnet restore Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln -c Debug --no-restore`
- `dotnet test Sources/Mailozaurr.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68580215f334832e8cc76649716159ac