### PR TITLE
Handle plain email strings correctly

### DIFF
--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -207,10 +207,11 @@ public partial class ClientSmtp : SmtpClient {
 
     private IEnumerable<MailboxAddress> ConvertToMailboxAddress(object input) {
         if (input is string str) {
-            if (!str.Contains("<>")) {
-                yield return new MailboxAddress(str, str);
+            var mailbox = MailboxAddress.Parse(str);
+            if (str.Contains('<') || str.Contains('>')) {
+                yield return mailbox;
             } else {
-                yield return MailboxAddress.Parse(str);
+                yield return new MailboxAddress(string.Empty, mailbox.Address);
             }
         } else if (input is IDictionary dict) {
             if (dict.Contains("Name") && dict.Contains("Email")) {


### PR DESCRIPTION
## Summary
- fix ClientSmtp address parsing when a plain email string is provided

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --no-build` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_6858363722d0832e9951e377880a7467