### PR TITLE
Add validation for ConvertFromGraphCredential

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -45,14 +45,15 @@ namespace Mailozaurr {
         /// </summary>
         public static GraphCredential ConvertFromGraphCredential(string username, string password) {
             var parts = username.Split('@');
-            if (parts.Length == 2) {
-                return new GraphCredential {
-                    ClientId = parts[0],
-                    DirectoryId = parts[1],
-                    ClientSecret = password
-                };
+            if (parts.Length != 2) {
+                throw new ArgumentException("Invalid credential format. Expected 'clientid@directoryid'.");
             }
-            throw new ArgumentException("Invalid credential format. Expected 'clientid@directoryid'.");
+
+            return new GraphCredential {
+                ClientId = parts[0],
+                DirectoryId = parts[1],
+                ClientSecret = password
+            };
         }
 
         /// <summary>

--- a/Tests/ConvertFromGraphCredential.Tests.ps1
+++ b/Tests/ConvertFromGraphCredential.Tests.ps1
@@ -9,4 +9,8 @@ Describe 'MicrosoftGraphUtils.ConvertFromGraphCredential' {
     It 'Throws for invalid format' {
         { [Mailozaurr.MicrosoftGraphUtils]::ConvertFromGraphCredential('invalid', 'pwd') } | Should -Throw
     }
+
+    It 'Throws for invalid format with multiple @' {
+        { [Mailozaurr.MicrosoftGraphUtils]::ConvertFromGraphCredential('client@tenant@other', 'pwd') } | Should -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- validate credential format in `MicrosoftGraphUtils`
- add regression test for invalid credential with multiple `@`

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6858361f79bc832ebe0bbbb94aacc046