### PR TITLE
Add configurable Graph chunk size

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -119,6 +119,12 @@ public class Graph {
     public double RetryDelayBackoff { get; set; } = 1.0;
 
     /// <summary>
+    /// Size in bytes of the chunks used when uploading attachments. Defaults to
+    /// 9MB.
+    /// </summary>
+    public int ChunkSize { get; set; } = 9000000;
+
+    /// <summary>
     /// The type of token that was issued.
     /// </summary>
     public string TokenType { get; set; }
@@ -508,7 +514,7 @@ public class Graph {
         var attachmentItemWrapper = new GraphAttachmentItemWrapper(attachmentItem);
         var attachmentItemJson = JsonSerializer.Serialize(attachmentItemWrapper);
 
-        var content = await PrepareByteArrayContentForUpload(attachmentPath, 9000000);
+        var content = await PrepareByteArrayContentForUpload(attachmentPath, ChunkSize);
 
         return new GraphAttachmentPlaceHolder() {
             Json = attachmentItemJson,


### PR DESCRIPTION
## Summary
- add `ChunkSize` property to `Graph`
- use `ChunkSize` when building attachment content

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_68586abd2e0c832ebdd0b5cbdebab7c3