### PR TITLE
Dispose MemoryStream for inline attachments

### DIFF
--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -171,9 +171,10 @@ public partial class ClientSmtp : SmtpClient {
                 MimeEntity? entity = null;
                 switch (inline) {
                     case string path:
+                    {
                         // Read the file into memory so it can be removed immediately
                         var bytes = File.ReadAllBytes(path);
-                        var ms = new MemoryStream(bytes);
+                        using var ms = new MemoryStream(bytes);
                         var part = new MimePart(MimeTypes.GetMimeType(path))
                         {
                             Content = new MimeContent(ms),
@@ -184,6 +185,7 @@ public partial class ClientSmtp : SmtpClient {
                         bodyBuilder.LinkedResources.Add(part);
                         entity = part;
                         break;
+                    }
                     case MimeEntity mime:
                         bodyBuilder.LinkedResources.Add(mime);
                         entity = mime;


### PR DESCRIPTION
## Summary
- dispose the MemoryStream used to load inline attachments so it doesn't remain open
- ensure attachments continue to work via existing tests

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_68586adbdbe4832ebea791986fddf8d5