### PR TITLE
Fix Graph API provider name

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -274,7 +274,7 @@ public class Graph {
             if (ErrorAction == ActionPreference.Stop) {
                 throw;
             }
-            return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, "", ex.Message);
+            return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", ex.Message);
 
         }
 
@@ -294,7 +294,7 @@ public class Graph {
             if (ErrorAction == ActionPreference.Stop) {
                 throw;
             }
-            return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, "", ex.Message);
+            return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", ex.Message);
         }
     }
 


### PR DESCRIPTION
## Summary
- fix `SmtpResult` provider value inside `ConnectO365GraphAsync`

## Testing
- `pwsh -NoLogo -Command ./run-tests.ps1` *(fails: Compiled module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586acfa674832e80b4167d745febbc