### PR TITLE
Fix Graph Connect SmtpResult

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -301,7 +301,7 @@ public class Graph {
                 ? ex.Message
                 : $"{ex.Message} - {errorContent}";
 
-            return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, errorContent, errorMessage);
+            return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, errorContent, errorMessage);
         }
     }
 


### PR DESCRIPTION
## Summary
- return `GraphAPI` rather than `SendGridApi` for failed Graph connections

## Testing
- `dotnet test Sources/Mailozaurr.sln --verbosity minimal` *(tests on .NET 4.7.2 aborted: missing mono host)*

------
https://chatgpt.com/codex/tasks/task_e_68586ddd2f14832e9001fb9c26da8d9f