### PR TITLE
Add validation attributes to PowerShell cmdlets

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -38,6 +38,7 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
     [Parameter(ParameterSetName = "Credential")]
     [Parameter(ParameterSetName = "ClearText")]
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string Server { get; set; }
 
     /// <summary>
@@ -68,12 +69,14 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
     /// <para type="description">Specifies the username for clear text authentication. Required for the ClearText parameter set.</para>
     /// </summary>
     [Parameter(ParameterSetName = "ClearText", Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string UserName { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the password for clear text authentication. Required for the ClearText parameter set.</para>
     /// </summary>
     [Parameter(ParameterSetName = "ClearText", Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string Password { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
@@ -23,18 +23,21 @@ public class CmdletConnectOAuthGoogle : PSCmdlet {
     /// <para type="description">Specifies the Gmail account (email address) to authenticate.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? GmailAccount { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the OAuth2 client ID from the Google Developer Console.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? ClientID { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the OAuth2 client secret from the Google Developer Console.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? ClientSecret { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthO365.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthO365.cs
@@ -30,12 +30,14 @@ public class CmdletConnectOAuthO365 : PSCmdlet {
     /// <para type="description">Specifies the OAuth2 client ID from Azure AD App Registration.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? ClientID { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the Azure AD tenant ID (Directory ID).</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? TenantID { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP.cs
@@ -38,6 +38,7 @@ public sealed class CmdletConnectPOP : AsyncPSCmdlet {
     [Parameter(ParameterSetName = "Credential")]
     [Parameter(ParameterSetName = "ClearText")]
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? Server { get; set; }
 
     /// <summary>
@@ -52,12 +53,14 @@ public sealed class CmdletConnectPOP : AsyncPSCmdlet {
     /// <para type="description">Specifies the username for clear text authentication. Required for the ClearText parameter set.</para>
     /// </summary>
     [Parameter(ParameterSetName = "ClearText", Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? UserName { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the password for clear text authentication. Required for the ClearText parameter set.</para>
     /// </summary>
     [Parameter(ParameterSetName = "ClearText", Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? Password { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertFromEmlToMsg.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertFromEmlToMsg.cs
@@ -23,6 +23,7 @@ public sealed class CmdletConvertFromEmlToMsg : AsyncPSCmdlet {
     /// <para type="description">Specifies the paths to the EML files to convert. Accepts an array of strings. This parameter is mandatory.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+    [ValidateNotNullOrEmpty]
     public string[]? InputPath;
 
     /// <summary>
@@ -30,6 +31,7 @@ public sealed class CmdletConvertFromEmlToMsg : AsyncPSCmdlet {
     /// </summary>
     [Alias("OutputPath")]
     [Parameter(Mandatory = true, Position = 1)]
+    [ValidateNotNullOrEmpty]
     public string? OutputFolder { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCertificateCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCertificateCredential.cs
@@ -19,15 +19,19 @@ using System.Threading.Tasks;
 [OutputType(typeof(PSCredential))]
 public class CmdletConvertToGraphCertificateCredential : PSCmdlet {
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? ClientId { get; set; }
 
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? TenantId { get; set; }
 
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? CertificatePath { get; set; }
 
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? CertificatePassword { get; set; }
 
     [Parameter]

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCredential.cs
@@ -27,18 +27,21 @@ public class CmdletConvertToGraphCredential: PSCmdlet {
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "ClearText")]
     [Parameter(Mandatory = true, ParameterSetName = "Encrypted")]
+    [ValidateNotNullOrEmpty]
     public string? ClientId { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the client secret in clear text. Use only with the ClearText parameter set.</para>
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "ClearText")]
+    [ValidateNotNullOrEmpty]
     public string? ClientSecret { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the client secret in encrypted form. Use only with the Encrypted parameter set.</para>
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Encrypted")]
+    [ValidateNotNullOrEmpty]
     public string? ClientSecretEncrypted { get; set; }
 
     /// <summary>
@@ -46,6 +49,7 @@ public class CmdletConvertToGraphCredential: PSCmdlet {
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "ClearText")]
     [Parameter(Mandatory = true, ParameterSetName = "Encrypted")]
+    [ValidateNotNullOrEmpty]
     public string? DirectoryId { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToMailgunCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToMailgunCredential.cs
@@ -15,6 +15,7 @@ using System.Security;
 [OutputType(typeof(PSCredential))]
 public class CmdletConvertToMailgunCredential : PSCmdlet {
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? ApiKey { get; set; }
 
     protected override void ProcessRecord() {

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToOAuth2Credential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToOAuth2Credential.cs
@@ -22,11 +22,13 @@ public class CmdletConvertToOAuth2Credential : PSCmdlet {
     /// <para type="description">Specifies the username for OAuth2 authentication.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? UserName { get; set; }
     /// <summary>
     /// <para type="description">Specifies the OAuth2 access token.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? Token { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToSendGridCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToSendGridCredential.cs
@@ -22,6 +22,7 @@ public class CmdletConvertToSendGridCredential : PSCmdlet {
     /// <para type="description">Specifies the SendGrid API key.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? ApiKey { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletDisconnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletDisconnectIMAP.cs
@@ -19,6 +19,7 @@ public sealed class CmdletDisconnectIMAP : AsyncPSCmdlet {
     /// <para type="description">The <see cref="ImapConnectionInfo"/> object containing the MailKit IMAP client instance to disconnect. This is the object returned by <c>Connect-IMAP</c>.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [ValidateNotNull]
     public ImapConnectionInfo? Client { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletDisconnectPOP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletDisconnectPOP.cs
@@ -24,6 +24,7 @@ public sealed class CmdletDisconnectPOP : AsyncPSCmdlet {
     /// <para type="description">The <see cref="PopConnectionInfo"/> object containing the MailKit POP3 client instance to disconnect. This is the object returned by <c>Connect-POP</c>.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [ValidateNotNull]
     public PopConnectionInfo? Client { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
@@ -24,6 +24,7 @@ public sealed class CmdletGetIMAPFolder : AsyncPSCmdlet {
     /// <para type="description">The <see cref="ImapConnectionInfo"/> object representing the active IMAP connection. This is the object returned by <c>Connect-IMAP</c>.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [ValidateNotNull]
     public ImapConnectionInfo? Client { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
@@ -27,6 +27,7 @@ public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
     /// <para type="description">The <see cref="ImapConnectionInfo"/> object representing the active IMAP connection. This is the object returned by <c>Connect-IMAP</c>.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [ValidateNotNull]
     public ImapConnectionInfo? Client { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletGetMailFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetMailFolder.cs
@@ -22,6 +22,7 @@ public class CmdletGetMailFolder : PSCmdlet {
     /// <para type="description">Specifies the user principal name (email address) whose mail folders will be retrieved.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
     /// <summary>
     /// <para type="description">Specifies the client ID for Microsoft Graph authentication.</para>

--- a/Sources/Mailozaurr.PowerShell/CmdletGetMailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetMailMessage.cs
@@ -28,6 +28,7 @@ public class CmdletGetMailMessage : PSCmdlet {
     /// <para type="description">Specifies the user principal name (email address) whose mail messages will be retrieved.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
     /// <summary>
     /// <para type="description">Specifies the client ID for Microsoft Graph authentication.</para>

--- a/Sources/Mailozaurr.PowerShell/CmdletGetMailMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetMailMessageAttachment.cs
@@ -23,11 +23,13 @@ public class CmdletGetMailMessageAttachment : PSCmdlet {
     /// <para type="description">Specifies the user principal name (email address) whose mail message attachments will be retrieved.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
     /// <summary>
     /// <para type="description">Specifies the message ID for which attachments will be retrieved.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? MessageId { get; set; }
     /// <summary>
     /// <para type="description">Specifies the client ID for Microsoft Graph authentication.</para>

--- a/Sources/Mailozaurr.PowerShell/CmdletGetPOPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetPOPMessage.cs
@@ -28,6 +28,7 @@ public sealed class CmdletGetPOPMessage : AsyncPSCmdlet {
     /// <para type="description">The <see cref="PopConnectionInfo"/> object representing the active POP3 connection. This is the object returned by <c>Connect-POP</c>.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [ValidateNotNull]
     public PopConnectionInfo? Client { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletImportMailFile.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletImportMailFile.cs
@@ -29,6 +29,7 @@ public sealed class CmdletImportMailFile : AsyncPSCmdlet {
     /// </summary>
     [Parameter(Mandatory = true, Position = 0)]
     [Alias("FilePath", "Path")]
+    [ValidateNotNullOrEmpty]
     public string? InputPath { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveMailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveMailMessage.cs
@@ -21,11 +21,13 @@ public class CmdletSaveMailMessage : PSCmdlet {
     /// <para type="description">Specifies the <see cref="GraphEmailMessage"/> objects to save. Accepts pipeline input.</para>
     /// </summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
+    [ValidateNotNullOrEmpty]
     public GraphEmailMessage[]? Message { get; set; }
     /// <summary>
     /// <para type="description">Specifies the path where the messages will be saved.</para>
     /// </summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string? Path { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletSavePOPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSavePOPMessage.cs
@@ -24,6 +24,7 @@ public sealed class CmdletSavePOPMessage : AsyncPSCmdlet {
     /// <para type="description">The <see cref="PopConnectionInfo"/> object representing the active POP3 connection. This is the object returned by <c>Connect-POP</c>.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [ValidateNotNull]
     public PopConnectionInfo? Client { get; set; }
 
     /// <summary>
@@ -36,6 +37,7 @@ public sealed class CmdletSavePOPMessage : AsyncPSCmdlet {
     /// <para type="description">Specifies the path where the message will be saved.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 2)]
+    [ValidateNotNullOrEmpty]
     public string? Path { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -39,6 +39,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "Compatibility")]
     [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
     [Alias("SmtpServer")]
+    [ValidateNotNullOrEmpty]
     public string? Server { get; set; }
 
     /// <summary>
@@ -61,6 +62,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "Compatibility")]
     [Parameter(Mandatory = true, ParameterSetName = "SendGrid")]
     [Parameter(Mandatory = true, ParameterSetName = "EmailProviders")]
+    [ValidateNotNullOrEmpty]
     public object? From { get; set; }
 
     /// <summary>
@@ -178,6 +180,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "SendGrid")]
     [Parameter(Mandatory = true, ParameterSetName = "EmailProviders")]
     [Parameter(Mandatory = true, ParameterSetName = "oAuth")]
+    [ValidateNotNull]
     public PSCredential? Credential { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletTestEmailAddress.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletTestEmailAddress.cs
@@ -31,6 +31,7 @@ public sealed class CmdletTestEmailAddress : AsyncPSCmdlet {
     /// <para type="description">Specifies the email addresses to check. Accepts an array of strings. This parameter is mandatory.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+    [ValidateNotNullOrEmpty]
     public string[]? EmailAddress;
 
     /// <summary>


### PR DESCRIPTION
## Summary
- ensure mandatory parameters are not null or empty
- use `[ValidateNotNull]` on object parameters

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68586e8f8ee4832e99974a7cdbd36ad7