### PR TITLE
Add optional logging and Graph chunk parameters

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -309,6 +309,13 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     public double RetryDelayBackoff { get; set; } = 1.0;
 
     /// <summary>
+    /// <para>Specifies chunk size in bytes used for Graph attachment uploads. Default is 9MB.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Graph")]
+    [Parameter(Mandatory = false, ParameterSetName = "MgGraphRequest")]
+    public int ChunkSize { get; set; } = 9000000;
+
+    /// <summary>
     /// <para>Enables sending email via OAuth2 authentication for SMTP.</para>
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "oAuth")]
@@ -426,6 +433,12 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     /// </summary>
     [Parameter(Mandatory = false)]
     public string? LogClientPrefix { get; set; }
+
+    /// <summary>
+    /// <para>Overwrites the existing log file when using <c>-LogPath</c>.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public SwitchParameter LogOverwrite { get; set; }
 
     /// <summary>
     /// <para>Saves the email message to a file for troubleshooting purposes.</para>
@@ -602,6 +615,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             }
         } else if (Graph) {
             Graph graph = new Graph();
+            graph.ChunkSize = ChunkSize;
             graph.From = Helpers.GetFromObject(fromEmail, fromName);
             graph.To = To;
             graph.Cc = Cc;
@@ -650,6 +664,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             LogEmitter.EmitLogs(graph.LogCollector, this);
         } else if (MgGraphRequest) {
             Graph graph = new Graph();
+            graph.ChunkSize = ChunkSize;
             graph.From = Helpers.GetFromObject(fromEmail, fromName);
             graph.To = To;
             graph.Cc = Cc;
@@ -689,7 +704,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
                 LogEmitter.EmitLogs(graph.LogCollector, this);
             }
         } else {
-            Smtp SmtpClient = new Smtp(LogPath, LogConsole, LogObject, LogTimestamps, LogSecrets, LogTimeStampsFormat, LogClientPrefix, LogServerPrefix);
+            Smtp SmtpClient = new Smtp(LogPath, LogConsole, LogObject, LogTimestamps, LogSecrets, LogTimeStampsFormat, LogServerPrefix, LogClientPrefix, LogOverwrite);
             SmtpClient.From = Helpers.GetFromObject(fromEmail, fromName);
             SmtpClient.ReplyTo = ReplyTo;
             SmtpClient.Cc = Cc;


### PR DESCRIPTION
## Summary
- add `ChunkSize` parameter for Graph API uploads
- add `LogOverwrite` switch to control log file overwriting
- wire up new parameters in Send-EmailMessage implementation

## Testing
- `dotnet restore Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj --no-restore`
- `dotnet restore Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj --no-restore`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68586e830f80832e9ce1a0f442f69655