### PR TITLE
Add CreateMessage tests for Graph and SendGrid

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class GraphCreateMessageTests
+{
+    [Fact]
+    public void CreateMessage_WithValidData_BuildsJson()
+    {
+        var graph = new Graph
+        {
+            From = "from@example.com",
+            To = new object[] { "to@example.com" },
+            Subject = "subject",
+            HTML = "body",
+            ContentType = "HTML"
+        };
+        graph.CreateMessage();
+        Assert.Contains("subject", graph.MessageJson, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("to@example.com", graph.MessageJson, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateAttachments_WithMissingFile_ThrowsFileNotFoundException()
+    {
+        var graph = new Graph
+        {
+            Attachments = new object[] { "missing.file" }
+        };
+        Assert.Throws<FileNotFoundException>(() => graph.CreateAttachments());
+    }
+
+    [Fact]
+    public void CreateMessage_WithLargeAttachment_DoesNotIncludeAttachment()
+    {
+        string tmp = Path.GetTempFileName();
+        File.WriteAllBytes(tmp, new byte[4000001]);
+        var graph = new Graph
+        {
+            From = "from@example.com",
+            To = new object[] { "to@example.com" },
+            Subject = "subject",
+            HTML = "body",
+            ContentType = "HTML",
+            Attachments = new object[] { tmp }
+        };
+        graph.CreateAttachments();
+        graph.CreateMessage();
+        File.Delete(tmp);
+        Assert.True(graph.IsLargerAttachment);
+        Assert.Null(graph.MessageContainer.Message.Attachments);
+    }
+}

--- a/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Reflection;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SendGridCreateMessageTests
+{
+    [Fact]
+    public void CreateMessage_WithValidData_BuildsJson()
+    {
+        var client = new SendGridClient
+        {
+            From = "from@example.com",
+            To = new List<object> { "to@example.com" },
+            Subject = "subject",
+            Text = "text",
+            Html = "<b>body</b>",
+            Credentials = new NetworkCredential("apikey", "test")
+        };
+        client.CreateMessage();
+        PropertyInfo? prop = typeof(SendGridClient).GetProperty("MessageJson", BindingFlags.NonPublic | BindingFlags.Instance);
+        var json = prop?.GetValue(client) as string;
+        Assert.NotNull(json);
+        Assert.Contains("subject", json!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("to@example.com", json!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateMessage_InvalidAddress_ThrowsArgumentException()
+    {
+        var client = new SendGridClient
+        {
+            From = "from@example.com",
+            To = new List<object> { new Dictionary<string, object> { { "Name", "Test" } } },
+            Subject = "subject",
+            Text = "text",
+            Html = "<b>body</b>",
+            Credentials = new NetworkCredential("apikey", "test")
+        };
+        Assert.Throws<ArgumentException>(() => client.CreateMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- add GraphCreateMessageTests covering CreateMessage and attachment failures
- add SendGridCreateMessageTests verifying CreateMessage and invalid email handling
- remove unnecessary Solution Items section

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68586eb29da8832eb7cad0a85d11fd69