### PR TITLE
Include offending input in exception message

### DIFF
--- a/Sources/Mailozaurr.Tests/ClientSmtpTests.cs
+++ b/Sources/Mailozaurr.Tests/ClientSmtpTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Reflection;
+using MimeKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ClientSmtpTests
+{
+    [Fact]
+    public void ConvertToMailboxAddress_InvalidType_IncludesValueInException()
+    {
+        var client = new ClientSmtp();
+        MethodInfo? method = typeof(ClientSmtp).GetMethod(
+            "ConvertToMailboxAddress",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        var enumerable = (IEnumerable<MailboxAddress>)method!.Invoke(client, new object[] { 42 })!;
+        using var enumerator = enumerable.GetEnumerator();
+        var ex = Assert.Throws<ArgumentException>(() => enumerator.MoveNext());
+        Assert.Contains("42", ex.Message, StringComparison.Ordinal);
+    }
+}

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -228,7 +228,7 @@ public partial class ClientSmtp : SmtpClient {
                 }
             }
         } else {
-            throw new ArgumentException("Invalid input type for ConvertToMailboxAddress");
+            throw new ArgumentException($"Invalid input type for ConvertToMailboxAddress: {input}");
         }
     }
 


### PR DESCRIPTION
## Summary
- show the provided value when ConvertToMailboxAddress throws
- add unit test to verify message content

## Testing
- `dotnet test -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6859005b7838832ea0dd0007208e4021