### PR TITLE
Add OAuth token examples using helpers

### DIFF
--- a/Examples/Example-AcquireGoogleTokenInteractive.ps1
+++ b/Examples/Example-AcquireGoogleTokenInteractive.ps1
@@ -9,3 +9,19 @@ $Credential = Connect-OAuthGoogle -GmailAccount $GmailAccount -ClientID $ClientI
 
 $CredInfo = ConvertFrom-OAuth2Credential -Credential $Credential
 $CredInfo | Format-List
+
+# Send a test email using the token
+Send-EmailMessage -From $GmailAccount -To 'recipient@example.com' `
+    -Server 'smtp.gmail.com' -Subject 'Test OAuth email' -Text 'Hello' `
+    -SecureSocketOptions Auto -Credential $Credential -OAuth2
+
+# Connect to Gmail via IMAP
+$ImapClient = Connect-IMAP -Server 'imap.gmail.com' -Port 993 -Options Auto `
+    -Credential $Credential -OAuth2
+Get-IMAPFolder -Client $ImapClient -Verbose
+Disconnect-IMAP -Client $ImapClient
+
+# And POP3
+$PopClient = Connect-POP3 -Server 'pop.gmail.com' -Port 995 -Options Auto `
+    -Credential $Credential -OAuth2
+Disconnect-POP3 -Client $PopClient

--- a/Examples/Example-AcquireGoogleTokenInteractive.ps1
+++ b/Examples/Example-AcquireGoogleTokenInteractive.ps1
@@ -1,0 +1,11 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$GmailAccount = 'user@gmail.com'
+$ClientID = 'Your-Client-ID'
+$ClientSecret = 'Your-Client-Secret'
+$Scopes = @('https://mail.google.com/')
+
+$Credential = Connect-OAuthGoogle -GmailAccount $GmailAccount -ClientID $ClientID -ClientSecret $ClientSecret -Scope $Scopes
+
+$CredInfo = ConvertFrom-OAuth2Credential -Credential $Credential
+$CredInfo | Format-List

--- a/Examples/Example-AcquireO365TokenInteractive.ps1
+++ b/Examples/Example-AcquireO365TokenInteractive.ps1
@@ -16,3 +16,19 @@ $Credential = Connect-OAuthO365 -Login $Login -ClientID $ClientID -TenantID $Ten
 
 $CredInfo = ConvertFrom-OAuth2Credential -Credential $Credential
 $CredInfo | Format-List
+
+# Use the OAuth token to send mail via SMTP
+Send-EmailMessage -From $Login -To 'recipient@example.com' `
+    -Server 'smtp.office365.com' -Subject 'Test OAuth email' -Text 'Hello' `
+    -SecureSocketOptions Auto -Credential $Credential -OAuth2
+
+# Use the same credential with IMAP
+$ImapClient = Connect-IMAP -Server 'outlook.office365.com' -Port 993 -Options Auto `
+    -Credential $Credential -OAuth2
+Get-IMAPFolder -Client $ImapClient -Verbose
+Disconnect-IMAP -Client $ImapClient
+
+# And with POP3
+$PopClient = Connect-POP3 -Server 'outlook.office365.com' -Port 995 -Options Auto `
+    -Credential $Credential -OAuth2
+Disconnect-POP3 -Client $PopClient

--- a/Examples/Example-AcquireO365TokenInteractive.ps1
+++ b/Examples/Example-AcquireO365TokenInteractive.ps1
@@ -1,0 +1,18 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$Login = 'user@example.com'
+$ClientID = 'Your-Application-ID'
+$TenantID = 'Your-Tenant-ID'
+$RedirectUri = 'https://login.microsoftonline.com/common/oauth2/nativeclient'
+$Scopes = @(
+    'email',
+    'offline_access',
+    'https://outlook.office.com/IMAP.AccessAsUser.All',
+    'https://outlook.office.com/POP.AccessAsUser.All',
+    'https://outlook.office.com/SMTP.Send'
+)
+
+$Credential = Connect-OAuthO365 -Login $Login -ClientID $ClientID -TenantID $TenantID -RedirectUri $RedirectUri -Scopes $Scopes
+
+$CredInfo = ConvertFrom-OAuth2Credential -Credential $Credential
+$CredInfo | Format-List

--- a/Mailozaurr.psd1
+++ b/Mailozaurr.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @('Connect-POP3', 'Disconnect-POP3', 'Get-POP3Message', 'Save-POP3Message')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Connect-IMAP', 'Connect-OAuthGoogle', 'Connect-OAuthO365', 'Connect-POP', 'ConvertFrom-EmlToMsg', 'ConvertTo-GraphCredential', 'ConvertTo-GraphCertificateCredential', 'ConvertTo-OAuth2Credential', 'ConvertTo-SendGridCredential', 'ConvertTo-MailgunCredential', 'Disconnect-IMAP', 'Disconnect-POP', 'Get-IMAPFolder', 'Get-IMAPMessage', 'Get-MailFolder', 'Get-MailMessage', 'Get-MailMessageAttachment', 'Get-POPMessage', 'Import-MailFile', 'Save-MailMessage', 'Save-POPMessage', 'Send-EmailMessage', 'Test-EmailAddress')
+    CmdletsToExport      = @('Connect-IMAP', 'Connect-OAuthGoogle', 'Connect-OAuthO365', 'Connect-POP', 'ConvertFrom-EmlToMsg', 'ConvertFrom-OAuth2Credential', 'ConvertTo-GraphCredential', 'ConvertTo-GraphCertificateCredential', 'ConvertTo-OAuth2Credential', 'ConvertTo-SendGridCredential', 'ConvertTo-MailgunCredential', 'Disconnect-IMAP', 'Disconnect-POP', 'Get-IMAPFolder', 'Get-IMAPMessage', 'Get-MailFolder', 'Get-MailMessage', 'Get-MailMessageAttachment', 'Get-POPMessage', 'Import-MailFile', 'Save-MailMessage', 'Save-POPMessage', 'Send-EmailMessage', 'Test-EmailAddress')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -114,6 +114,12 @@ While I didn't spent much time creating WIKI, working on Get-Help documentation,
 
 You can also utilize Examples which should help to understand use cases. Of course it would be great having pretty help so if you can help me out feel free to submit PR's.
 
+-Some useful examples:
+- `Examples/Example-AcquireO365TokenInteractive.ps1` – demonstrates `Connect-OAuthO365` and `ConvertFrom-OAuth2Credential`.
+- `Examples/Example-AcquireGoogleTokenInteractive.ps1` – demonstrates `Connect-OAuthGoogle` and `ConvertFrom-OAuth2Credential`.
+- `Sources/Mailozaurr.Examples/AcquireO365TokenInteractive.cs` – C# sample for `OAuthHelpers.AcquireO365TokenInteractiveAsync`.
+- `Sources/Mailozaurr.Examples/AcquireGoogleTokenInteractive.cs` – C# sample for `OAuthHelpers.AcquireGoogleTokenInteractiveAsync`.
+
 Keep in mind PSSharedGoods is only required for development. When you use this module from PowerShellGallery it's not installed as everything is merged.
 
 ### Limiting access to mailboxes (Microsoft Graph API)

--- a/README.MD
+++ b/README.MD
@@ -115,8 +115,8 @@ While I didn't spent much time creating WIKI, working on Get-Help documentation,
 You can also utilize Examples which should help to understand use cases. Of course it would be great having pretty help so if you can help me out feel free to submit PR's.
 
 -Some useful examples:
-- `Examples/Example-AcquireO365TokenInteractive.ps1` – demonstrates `Connect-OAuthO365` and `ConvertFrom-OAuth2Credential`.
-- `Examples/Example-AcquireGoogleTokenInteractive.ps1` – demonstrates `Connect-OAuthGoogle` and `ConvertFrom-OAuth2Credential`.
+- `Examples/Example-AcquireO365TokenInteractive.ps1` – demonstrates `Connect-OAuthO365`, `ConvertFrom-OAuth2Credential`, and using the token with `Send-EmailMessage`, IMAP, and POP3.
+- `Examples/Example-AcquireGoogleTokenInteractive.ps1` – demonstrates `Connect-OAuthGoogle`, `ConvertFrom-OAuth2Credential`, and using the token with `Send-EmailMessage`, IMAP, and POP3.
 - `Sources/Mailozaurr.Examples/AcquireO365TokenInteractive.cs` – C# sample for `OAuthHelpers.AcquireO365TokenInteractiveAsync`.
 - `Sources/Mailozaurr.Examples/AcquireGoogleTokenInteractive.cs` – C# sample for `OAuthHelpers.AcquireGoogleTokenInteractiveAsync`.
 

--- a/Sources/Mailozaurr.Examples/AcquireGoogleTokenInteractive.cs
+++ b/Sources/Mailozaurr.Examples/AcquireGoogleTokenInteractive.cs
@@ -1,0 +1,25 @@
+using Mailozaurr;
+using System;
+using System.Threading.Tasks;
+
+public static class AcquireGoogleTokenInteractive {
+    public static async Task RunAsync() {
+        // === CONFIGURATION ===
+        string gmailAccount = "user@gmail.com";
+        string clientId = "your-client-id";
+        string clientSecret = "your-client-secret";
+        string[] scopes = { "https://mail.google.com/" };
+
+        // === EXAMPLE ===
+        try {
+            var cred = await OAuthHelpers.AcquireGoogleTokenInteractiveAsync(
+                gmailAccount,
+                clientId,
+                clientSecret,
+                scopes);
+            Console.WriteLine($"Token acquired for {cred.UserName}: {cred.AccessToken.Substring(0,5)}...");
+        } catch (Exception ex) {
+            Console.WriteLine($"AcquireGoogleTokenInteractive Example Error: {ex.Message}");
+        }
+    }
+}

--- a/Sources/Mailozaurr.Examples/AcquireO365TokenInteractive.cs
+++ b/Sources/Mailozaurr.Examples/AcquireO365TokenInteractive.cs
@@ -1,0 +1,33 @@
+using Mailozaurr;
+using System;
+using System.Threading.Tasks;
+
+public static class AcquireO365TokenInteractive {
+    public static async Task RunAsync() {
+        // === CONFIGURATION ===
+        string login = "user@example.com";
+        string clientId = "your-client-id";
+        string tenantId = "your-tenant-id";
+        string redirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+        string[] scopes = {
+            "email",
+            "offline_access",
+            "https://outlook.office.com/IMAP.AccessAsUser.All",
+            "https://outlook.office.com/POP.AccessAsUser.All",
+            "https://outlook.office.com/SMTP.Send"
+        };
+
+        // === EXAMPLE ===
+        try {
+            var cred = await OAuthHelpers.AcquireO365TokenInteractiveAsync(
+                login,
+                clientId,
+                tenantId,
+                redirectUri,
+                scopes);
+            Console.WriteLine($"Token acquired for {cred.UserName}: {cred.AccessToken.Substring(0,5)}...");
+        } catch (Exception ex) {
+            Console.WriteLine($"AcquireO365TokenInteractive Example Error: {ex.Message}");
+        }
+    }
+}

--- a/Sources/Mailozaurr.Examples/Program.cs
+++ b/Sources/Mailozaurr.Examples/Program.cs
@@ -1,10 +1,12 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 class Program {
     static async Task Main(string[] args) {
         // Uncomment the example you want to run:
 
         // SendEmailGmail.Run();
+        // await AcquireGoogleTokenInteractive.RunAsync();
+        // await AcquireO365TokenInteractive.RunAsync();
         await SendEmailGraphClientSecret.RunAsync();
         // await SendEmailGraphCertificate.RunAsync();
         await SendEmailMailgun.RunAsync();
@@ -13,6 +15,9 @@ class Program {
 
 // See individual example files for usage of Mailozaurr.
 // Examples:
-//   - SmtpGmailExample.cs
-//   - GraphClientSecretExample.cs
-//   - GraphCertificateExample.cs
+//   - SendEmailGmail.cs
+//   - SendEmailGraphClientSecret.cs
+//   - SendEmailGraphCertificate.cs
+//   - AcquireGoogleTokenInteractive.cs
+//   - AcquireO365TokenInteractive.cs
+//   - SendEmailMailgun.cs

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
@@ -55,8 +55,7 @@ public class CmdletConnectOAuthGoogle : PSCmdlet {
             return;
         }
         if (cred != null) {
-            var secure = new System.Security.SecureString();
-            foreach (var c in cred.AccessToken) secure.AppendChar(c);
+            var secure = CredentialHelpers.ToSecureString(cred.AccessToken);
             var psCred = new PSCredential(cred.UserName, secure);
             WriteObject(psCred);
         }

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthO365.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthO365.cs
@@ -68,8 +68,7 @@ public class CmdletConnectOAuthO365 : PSCmdlet {
             return;
         }
         if (cred != null) {
-            var secure = new System.Security.SecureString();
-            foreach (var c in cred.AccessToken) secure.AppendChar(c);
+            var secure = CredentialHelpers.ToSecureString(cred.AccessToken);
             var psCred = new PSCredential(cred.UserName, secure);
             WriteObject(psCred);
         }

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertFromOAuth2Credential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertFromOAuth2Credential.cs
@@ -1,0 +1,36 @@
+namespace Mailozaurr.PowerShell;
+
+using System.Management.Automation;
+
+/// <summary>
+/// <para type="synopsis">Extracts username and token from an OAuth2 PSCredential.</para>
+/// <para type="description">The <c>ConvertFrom-OAuth2Credential</c> cmdlet converts a <see cref="PSCredential"/> containing an OAuth2 access token into a PSCustomObject with <c>UserName</c> and <c>Token</c> properties.</para>
+/// <example>
+///   <summary>Convert credential back to plain token</summary>
+///   <code>$info = ConvertFrom-OAuth2Credential -Credential $OAuthCred</code>
+/// </example>
+/// </summary>
+[Cmdlet(VerbsData.ConvertFrom, "OAuth2Credential")]
+[OutputType(typeof(PSObject))]
+public class CmdletConvertFromOAuth2Credential : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Specifies the PSCredential containing the OAuth2 token.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ValueFromPipeline = true)]
+    public PSCredential? Credential { get; set; }
+
+    /// <summary>
+    /// Processes the record by extracting the user name and token from the credential.
+    /// </summary>
+    protected override void ProcessRecord() {
+        if (Credential is null) {
+            return;
+        }
+        var network = Credential.GetNetworkCredential();
+        var (userName, token) = Helpers.ConvertFromOAuth2Credential(network);
+        var obj = new PSObject();
+        obj.Properties.Add(new PSNoteProperty("UserName", userName));
+        obj.Properties.Add(new PSNoteProperty("Token", token));
+        WriteObject(obj);
+    }
+}


### PR DESCRIPTION
## Summary
- refine OAuth token acquisition examples
- show token helper usage in PowerShell examples
- add C# examples for interactive OAuth flows
- reference C# samples in README
- use Connect-OAuth cmdlets in example scripts
- add ConvertFrom-OAuth2Credential cmdlet for exposing token info

## Testing
- `dotnet restore Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug`
- `pwsh ./run-tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68586e996b3c832e8a54d2ccb959bcaa