### PR TITLE
Improve retry always feature

### DIFF
--- a/Examples/Example-RetryAlways.Tests.ps1
+++ b/Examples/Example-RetryAlways.Tests.ps1
@@ -1,0 +1,16 @@
+Describe 'RetryAlways example' {
+    It 'Uses RetryAlways switch' {
+        $params = @{ 
+            From = 'test@contoso.com'
+            To = 'recipient@contoso.com'
+            Server = 'smtp.example.com'
+            Subject = 'Test'
+            Text = 'Hello'
+            RetryAlways = $true
+            RetryCount = 2
+            WhatIf = $true
+        }
+        $result = Send-EmailMessage @params -ErrorAction Stop
+        $result.Error | Should -Be 'Email not sent (WhatIf)'
+    }
+}

--- a/Examples/Example-RetryAlways.cs
+++ b/Examples/Example-RetryAlways.cs
@@ -1,0 +1,17 @@
+using Mailozaurr;
+using System.Net;
+
+// Example demonstrating RetryAlways
+var smtp = new Smtp();
+smtp.From = "sender@example.com";
+smtp.To = new object[] { "recipient@example.com" };
+smtp.Subject = "Retry demo";
+smtp.TextBody = "Hello";
+smtp.RetryAlways = true;
+smtp.RetryCount = 5;
+smtp.RetryDelayMilliseconds = 500;
+smtp.RetryDelayBackoff = 1.5;
+// Replace with real credentials and server
+smtp.Connect("smtp.example.com", 587);
+var result = smtp.Send();
+System.Console.WriteLine($"Status: {result.Status}, Error: {result.Error}");

--- a/README.MD
+++ b/README.MD
@@ -90,10 +90,11 @@ This will make sure the project has required libraries.
   - [x] SMTP with SendGrid
   - [x] SendGrid API
   - [x] Office 365 Graph API
-- Optional retry logic for `Send-EmailMessage` via `-RetryCount`, `-RetryDelayMilliseconds` and `-RetryDelayBackoff`
-- POP3
-  - [x] Connect to POP3
-  - [x] Get POP3 Emails
+- Optional retry logic for `Send-EmailMessage` via `-RetryCount`, `-RetryDelayMilliseconds`, `-RetryDelayBackoff` and `-RetryAlways`.
+  Retries are only attempted for transient errors by default, but `-RetryAlways` forces retries on all errors.
+  - POP3
+    - [x] Connect to POP3
+    - [x] Get POP3 Emails
   - [x] Save POP3 Emails
 - IMAP
   - [x] Connect to IMAP

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -312,6 +312,13 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     public double RetryDelayBackoff { get; set; } = 1.0;
 
     /// <summary>
+    /// <para>When specified, retries are attempted regardless of the error
+    /// type. Without this switch, only transient errors are retried.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public SwitchParameter RetryAlways { get; set; }
+
+    /// <summary>
     /// <para>Specifies chunk size in bytes used for Graph attachment uploads. Default is 9MB.</para>
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "Graph")]
@@ -566,6 +573,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             sendGrid.RetryCount = RetryCount;
             sendGrid.RetryDelayMilliseconds = RetryDelayMilliseconds;
             sendGrid.RetryDelayBackoff = RetryDelayBackoff;
+            sendGrid.RetryAlways = RetryAlways.IsPresent;
             NetworkCredential networkCredential = new NetworkCredential(Credential?.UserName, Credential?.Password);
             sendGrid.Credentials = networkCredential;
             // create JSON message
@@ -603,6 +611,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             mailgun.RetryCount = RetryCount;
             mailgun.RetryDelayMilliseconds = RetryDelayMilliseconds;
             mailgun.RetryDelayBackoff = RetryDelayBackoff;
+            mailgun.RetryAlways = RetryAlways.IsPresent;
             NetworkCredential networkCredential = new NetworkCredential(Credential?.UserName, Credential?.Password);
             mailgun.Credentials = networkCredential;
             if (ShouldProcess(mailgun.SentTo, "Sending email message via Mailgun")) {
@@ -630,6 +639,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             graph.RetryCount = RetryCount;
             graph.RetryDelayMilliseconds = RetryDelayMilliseconds;
             graph.RetryDelayBackoff = RetryDelayBackoff;
+            graph.RetryAlways = RetryAlways.IsPresent;
             graph.RequestReadReceipt = RequestReadReceipt;
             graph.RequestDeliveryReceipt = RequestDeliveryReceipt;
             graph.HTML = string.Join("", HTML);
@@ -733,6 +743,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             SmtpClient.RetryCount = RetryCount;
             SmtpClient.RetryDelayMilliseconds = RetryDelayMilliseconds;
             SmtpClient.RetryDelayBackoff = RetryDelayBackoff;
+            SmtpClient.RetryAlways = RetryAlways.IsPresent;
 
             if (!ShouldProcess(SmtpClient.SentTo, "Sending email message")) {
                 LoggingMessages.Logger.WriteVerbose("Send-EmailMessage - Skipping authentication");

--- a/Sources/Mailozaurr.Tests/RetryAlwaysTests.cs
+++ b/Sources/Mailozaurr.Tests/RetryAlwaysTests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+
+namespace Mailozaurr.Tests {
+    public class RetryAlwaysTests {
+        [Fact]
+        public void Smtp_RetryAlways_DefaultsFalse() {
+            var smtp = new Smtp();
+            Assert.False(smtp.RetryAlways);
+        }
+
+        [Fact]
+        public void Smtp_RetryAlways_Settable() {
+            var smtp = new Smtp { RetryAlways = true };
+            Assert.True(smtp.RetryAlways);
+        }
+    }
+}

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -78,4 +78,30 @@ public static class Helpers {
         }
         return (from?.ToString(), null);
     }
+
+    /// <summary>
+    /// Determines whether the specified exception represents a transient error
+    /// that can be retried safely.
+    /// </summary>
+    /// <param name="ex">The exception to inspect.</param>
+    /// <returns><c>true</c> if the error is transient; otherwise <c>false</c>.</returns>
+    public static bool IsTransient(Exception ex) {
+        switch (ex) {
+            case HttpRequestException httpEx:
+    #if NET5_0_OR_GREATER
+                if (httpEx.StatusCode.HasValue) {
+                    var code = (int)httpEx.StatusCode.Value;
+                    return code >= 500 || code == 408 || code == 429;
+                }
+    #endif
+                return true;
+            case SmtpCommandException smtpEx:
+                var smtpCode = (int)smtpEx.StatusCode;
+                return smtpCode >= 400 && smtpCode < 500;
+            case SmtpProtocolException:
+                return true;
+            default:
+                return false;
+        }
+    }
 }

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -45,6 +45,12 @@ public class MailgunClient : IDisposable {
     public int RetryDelayMilliseconds { get; set; } = 0;
     public double RetryDelayBackoff { get; set; } = 1.0;
 
+    /// <summary>
+    /// When set to <c>true</c> the client retries sending even if the
+    /// encountered error is not transient.
+    /// </summary>
+    public bool RetryAlways { get; set; } = false;
+
     public string SentFrom => Helpers.GetEmailAddress(From);
     public string SentTo {
         get {
@@ -142,7 +148,7 @@ public class MailgunClient : IDisposable {
             } catch (Exception ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Mailgun: {ex.Message}");
-                if (attempts >= RetryCount) {
+                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
                     if (ErrorAction == ActionPreference.Stop) throw;
                     return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", ex.Message);
                 }

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -119,6 +119,12 @@ public class Graph {
     public double RetryDelayBackoff { get; set; } = 1.0;
 
     /// <summary>
+    /// Forces retries even when the encountered error is not classified as
+    /// transient.
+    /// </summary>
+    public bool RetryAlways { get; set; } = false;
+
+    /// <summary>
     /// Size in bytes of the chunks used when uploading attachments. Defaults to
     /// 9MB.
     /// </summary>
@@ -345,7 +351,7 @@ public class Graph {
             } catch (Exception ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Graph API: {ex.Message}");
-                if (attempts >= RetryCount) {
+                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
                     if (ErrorAction == ActionPreference.Stop) {
                         throw;
                     }
@@ -381,7 +387,7 @@ public class Graph {
             } catch (Exception ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Graph API: {ex.Message}");
-                if (attempts >= RetryCount) {
+                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
                     if (ErrorAction == ActionPreference.Stop) {
                         throw;
                     }

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -101,6 +101,12 @@ public class SendGridClient {
     public double RetryDelayBackoff { get; set; } = 1.0;
 
     /// <summary>
+    /// If set to <c>true</c>, retries will occur even on non-transient
+    /// failures. Otherwise only transient errors trigger retries.
+    /// </summary>
+    public bool RetryAlways { get; set; } = false;
+
+    /// <summary>
     /// Gets a string containing the email addresses of all recipients of the email.
     /// </summary>
     public string SentTo {
@@ -253,18 +259,17 @@ public class SendGridClient {
             } catch (Exception ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SendGrid: {ex.Message}");
-            }
-
-            if (attempts >= RetryCount) {
-                if (ErrorAction == ActionPreference.Stop && lastException != null) {
-                    throw lastException;
+                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
+                    if (ErrorAction == ActionPreference.Stop && lastException != null) {
+                        throw lastException;
+                    }
+                    return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
                 }
-                return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
-            }
 
-            var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-            if (delayMilliseconds > 0) {
-                await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds));
+                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (delayMilliseconds > 0) {
+                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds));
+                }
             }
             attempts++;
         } while (attempts <= RetryCount);

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -96,6 +96,12 @@ public class Smtp {
 
     public double RetryDelayBackoff { get; set; } = 1.0;
 
+    /// <summary>
+    /// Forces retries even when the encountered error is not considered
+    /// transient. By default retries occur only for transient failures.
+    /// </summary>
+    public bool RetryAlways { get; set; } = false;
+
     public bool CheckCertificateRevocation {
         get => Client.CheckCertificateRevocation;
         set => Client.CheckCertificateRevocation = value;
@@ -352,12 +358,13 @@ public class Smtp {
             } catch (Exception ex) {
                 lastException = ex;
                 LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending: {ex.Message}");
-                if (attempts >= RetryCount) {
+                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
                     if (ErrorAction == ActionPreference.Stop) {
                         throw;
                     }
                     return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message);
                 }
+
                 var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
                 if (delayMilliseconds > 0) {
                     Thread.Sleep(TimeSpan.FromMilliseconds(delayMilliseconds));

--- a/Tests/Send-EmailMessage.Tests.ps1
+++ b/Tests/Send-EmailMessage.Tests.ps1
@@ -64,4 +64,10 @@
         $Output.Port | Should -Be 25
         $Output.Status | Should -Be $false
     }
+
+    It 'Accepts RetryAlways switch' {
+        $params = @{ From = 'a@b.com'; To = 'c@d.com'; Server = 'smtp.example.com'; Subject = 't'; Text = 'b'; RetryAlways = $true; RetryCount = 1; WhatIf = $true }
+        $result = Send-EmailMessage @params
+        $result.Error | Should -Be 'Email not sent (WhatIf)'
+    }
 }


### PR DESCRIPTION
## Summary
- add `RetryAlways` property and cmdlet switch to force retries
- support `RetryAlways` across SMTP, Mailgun, Graph and SendGrid clients
- add C# example and Pester test example
- add basic unit tests
- document retry behavior in README
- add XML comments for `RetryAlways`

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj` *(fails for net472: mono missing; net8.0 tests pass)*
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_685901bf9ee4832eb015eaf59b40d7ba