### PR TITLE
Support SASL auth mechanism selection

### DIFF
--- a/Examples/Example-SendEmail-CramMd5.ps1
+++ b/Examples/Example-SendEmail-CramMd5.ps1
@@ -1,0 +1,7 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$cred = Get-Credential
+
+Send-EmailMessage -From $cred.UserName -To 'recipient@example.com' -Server 'smtp.example.com' \
+    -Port 587 -Username $cred.UserName -Password $cred.GetNetworkCredential().Password \
+    -AuthenticationMechanism CramMd5 -Verbose -WhatIf

--- a/Sources/Mailozaurr.Examples/SendEmailSasl.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailSasl.cs
@@ -1,0 +1,16 @@
+using MailKit.Security;
+using Mailozaurr;
+
+public static class SendEmailSasl {
+    public static void Run() {
+        var smtp = new Smtp();
+        smtp.From = "sender@example.com";
+        smtp.To = new[] { "recipient@example.com" };
+        smtp.Subject = "Test with CRAM-MD5";
+        smtp.HtmlBody = "<b>Hello</b>";
+        smtp.Connect("smtp.example.com", 587, SecureSocketOptions.StartTls);
+        smtp.Authenticate("user", "pass", false, AuthenticationMechanism.CramMd5);
+        smtp.Send();
+        smtp.Disconnect();
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -194,7 +194,11 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "SecureString")]
     public string? Password { get; set; }
-
+    /// <summary>
+    /// <para>Specifies the SASL mechanism for authentication. Defaults to Plain.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "SecureString")]
+    public AuthenticationMechanism AuthenticationMechanism { get; set; } = AuthenticationMechanism.Plain;
     /// <summary>
     /// <para>Specifies the secure socket options for SMTP connection. Options: None, Auto, StartTls, StartTlsWhenAvailable, SslOnConnect. Default is Auto.</para>
     /// </summary>
@@ -792,7 +796,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
                 NetworkCredential networkCredential = new NetworkCredential(Credential.UserName, Credential.Password);
                 Status = SmtpClient.Authenticate(networkCredential, OAuth2);
             } else if (!string.IsNullOrWhiteSpace(Username) || !string.IsNullOrWhiteSpace(Password)) {
-                Status = SmtpClient.Authenticate(Username, Password, AsSecureString);
+                Status = SmtpClient.Authenticate(Username, Password, AsSecureString, AuthenticationMechanism);
             } else {
                 LoggingMessages.Logger.WriteVerbose("Send-EmailMessage - Skipping authentication");
                 Status = new SmtpResult(true, EmailAction.Authenticate, SmtpClient.SentTo, SmtpClient.SentFrom, SmtpClient.Server, SmtpClient.Port, SmtpClient.Stopwatch.Elapsed, "Authentication skipped");

--- a/Sources/Mailozaurr.Tests/SmtpAuthenticationMechanismTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAuthenticationMechanismTests.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using MailKit.Security;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpAuthenticationMechanismTests
+{
+    private class FakeClient : ClientSmtp
+    {
+        public SaslMechanism? Mechanism;
+        public override void Authenticate(SaslMechanism mechanism, System.Threading.CancellationToken cancellationToken = default)
+        {
+            Mechanism = mechanism;
+        }
+    }
+
+    [Fact]
+    public void Authenticate_UsesSelectedMechanism()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeClient();
+        var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(smtp, fake);
+
+        smtp.Authenticate("user", "pass", false, AuthenticationMechanism.CramMd5);
+
+        Assert.IsType<SaslMechanismCramMd5>(fake.Mechanism);
+    }
+}

--- a/Sources/Mailozaurr/Enums/AuthenticationMechanism.cs
+++ b/Sources/Mailozaurr/Enums/AuthenticationMechanism.cs
@@ -1,4 +1,4 @@
-namespace Mailozaurr;
+﻿namespace Mailozaurr;
 
 /// <summary>
 /// Supported SASL authentication mechanisms.

--- a/Sources/Mailozaurr/Enums/AuthenticationMechanism.cs
+++ b/Sources/Mailozaurr/Enums/AuthenticationMechanism.cs
@@ -1,0 +1,10 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Supported SASL authentication mechanisms.
+/// </summary>
+public enum AuthenticationMechanism {
+    Plain,
+    Login,
+    CramMd5
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -320,10 +320,20 @@ public class Smtp {
     /// <param name="isSecureString">Indicates whether the password was
     /// previously protected.</param>
     /// <returns>An <see cref="SmtpResult"/> representing the outcome.</returns>
-    public SmtpResult Authenticate(string username, string password, bool isSecureString) {
+    public SmtpResult Authenticate(string username, string password, bool isSecureString, AuthenticationMechanism mechanism = AuthenticationMechanism.Plain) {
         password = ConvertSecureStringToPlainString(password, isSecureString);
         try {
-            Client.Authenticate(username, password);
+            switch (mechanism) {
+                case AuthenticationMechanism.CramMd5:
+                    Client.Authenticate(new SaslMechanismCramMd5(username, password));
+                    break;
+                case AuthenticationMechanism.Login:
+                    Client.Authenticate(new SaslMechanismLogin(username, password));
+                    break;
+                default:
+                    Client.Authenticate(new SaslMechanismPlain(username, password));
+                    break;
+            }
             LoggingMessages.Logger.WriteVerbose($"Send-EmailMessage - Authenticated as {username}");
             return new SmtpResult(true, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
         } catch (Exception ex) {


### PR DESCRIPTION
## Summary
- add `AuthenticationMechanism` enum
- allow `Smtp.Authenticate` to choose SASL mechanism

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet build Sources/Mailozaurr.sln`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685926954850832e80a21987d7d0d6ee