### PR TITLE
Implement webhook callbacks

### DIFF
--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -1,5 +1,8 @@
 ﻿using System.Net;
+using System.Net.Http;
 using System.Security;
+using System.Text;
+using System.Text.Json;
 
 namespace Mailozaurr;
 
@@ -88,12 +91,13 @@ public static class Helpers {
     public static bool IsTransient(Exception ex) {
         switch (ex) {
             case HttpRequestException httpEx:
-    #if NET5_0_OR_GREATER
+                // HttpRequestException.StatusCode was introduced in .NET 5.0
+#if NET5_0_OR_GREATER
                 if (httpEx.StatusCode.HasValue) {
                     var code = (int)httpEx.StatusCode.Value;
                     return code >= 500 || code == 408 || code == 429;
                 }
-    #endif
+#endif
                 return true;
             case SmtpCommandException smtpEx:
                 var smtpCode = (int)smtpEx.StatusCode;
@@ -102,6 +106,20 @@ public static class Helpers {
                 return true;
             default:
                 return false;
+        }
+    }
+
+    public static async Task PostWebhookAsync(string? url, SmtpResult result) {
+        if (string.IsNullOrEmpty(url)) {
+            return;
+        }
+
+        try {
+            using var client = new HttpClient();
+            var json = JsonSerializer.Serialize(result);
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+            await client.PostAsync(url, content);
+        } catch {
         }
     }
 }

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -51,6 +51,8 @@ public class MailgunClient : IDisposable {
     /// </summary>
     public bool RetryAlways { get; set; } = false;
 
+    public string? WebhookUrl { get; set; }
+
     public string SentFrom => Helpers.GetEmailAddress(From);
     public string SentTo {
         get {
@@ -141,7 +143,9 @@ public class MailgunClient : IDisposable {
                 request.Headers.Authorization = new AuthenticationHeaderValue("Basic", auth);
                 var response = await _client.SendAsync(request);
                 if (response.IsSuccessStatusCode) {
-                    return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString(), "");
+                    var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString(), "");
+                    await Helpers.PostWebhookAsync(WebhookUrl, okResult);
+                    return okResult;
                 }
                 var error = await response.Content.ReadAsStringAsync();
                 throw new HttpRequestException(error);
@@ -150,14 +154,18 @@ public class MailgunClient : IDisposable {
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Mailgun: {ex.Message}");
                 if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
                     if (ErrorAction == ActionPreference.Stop) throw;
-                    return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", ex.Message);
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", ex.Message);
+                    await Helpers.PostWebhookAsync(WebhookUrl, failResult);
+                    return failResult;
                 }
                 var delay = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
                 if (delay > 0) await Task.Delay(TimeSpan.FromMilliseconds(delay));
             }
             attempts++;
         } while (attempts <= RetryCount);
-        return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", lastException?.Message);
+        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", lastException?.Message);
+        await Helpers.PostWebhookAsync(WebhookUrl, finalResult);
+        return finalResult;
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -124,6 +124,8 @@ public class Graph {
     /// </summary>
     public bool RetryAlways { get; set; } = false;
 
+    public string? WebhookUrl { get; set; }
+
     /// <summary>
     /// Size in bytes of the chunks used when uploading attachments. Defaults to
     /// 9MB.
@@ -341,7 +343,9 @@ public class Graph {
                 using var response = await _client.SendAsync(request);
                 var content = await response.Content.ReadAsStringAsync();
                 if (response.IsSuccessStatusCode) {
-                    return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, response.StatusCode.ToString(), "");
+                    var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, response.StatusCode.ToString(), "");
+                    await Helpers.PostWebhookAsync(WebhookUrl, okResult);
+                    return okResult;
                 }
                 var error = JsonSerializer.Deserialize<GraphApiError>(content);
                 var errorMessage = (error == null || error.Error == null || error.Error.InnerError == null)
@@ -355,7 +359,9 @@ public class Graph {
                     if (ErrorAction == ActionPreference.Stop) {
                         throw;
                     }
-                    return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", ex.Message);
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", ex.Message);
+                    await Helpers.PostWebhookAsync(WebhookUrl, failResult);
+                    return failResult;
                 }
                 var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
                 if (delayMilliseconds > 0) {
@@ -365,7 +371,9 @@ public class Graph {
             attempts++;
         } while (attempts <= RetryCount);
 
-        return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", lastException?.Message);
+        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", lastException?.Message);
+        await Helpers.PostWebhookAsync(WebhookUrl, finalResult);
+        return finalResult;
     }
 
     /// <summary>
@@ -391,7 +399,9 @@ public class Graph {
                     if (ErrorAction == ActionPreference.Stop) {
                         throw;
                     }
-                    return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", ex.Message);
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", ex.Message);
+                    await Helpers.PostWebhookAsync(WebhookUrl, failResult);
+                    return failResult;
                 }
                 var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
                 if (delayMilliseconds > 0) {
@@ -401,7 +411,9 @@ public class Graph {
             attempts++;
         } while (attempts <= RetryCount);
 
-        return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", lastException?.Message);
+        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", lastException?.Message);
+        await Helpers.PostWebhookAsync(WebhookUrl, finalResult);
+        return finalResult;
     }
 
     /// <summary>
@@ -422,7 +434,9 @@ public class Graph {
 
         // If the status code indicates success, return a successful result
         if (sendResponse.IsSuccessStatusCode) {
-            return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, sendResponse.StatusCode.ToString(), "");
+            var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, sendResponse.StatusCode.ToString(), "");
+            await Helpers.PostWebhookAsync(WebhookUrl, okResult);
+            return okResult;
         }
 
         // If the status code indicates an error, throw an exception with the content
@@ -431,7 +445,10 @@ public class Graph {
         var sendErrorMessage = (sendError == null || sendError.Error == null || sendError.Error.InnerError == null)
             ? $"Unknown error: {sendContent}"
             : $"Error code: {sendError.Error.Code}, message: {sendError.Error.Message}, request ID: {sendError.Error.InnerError.RequestId}, date: {sendError.Error.InnerError.Date}";
-        throw new HttpRequestException(sendErrorMessage);
+        var ex = new HttpRequestException(sendErrorMessage);
+        var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, sendContent, ex.Message);
+        await Helpers.PostWebhookAsync(WebhookUrl, failResult);
+        throw ex;
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -106,6 +106,8 @@ public class SendGridClient {
     /// </summary>
     public bool RetryAlways { get; set; } = false;
 
+    public string? WebhookUrl { get; set; }
+
     /// <summary>
     /// Gets a string containing the email addresses of all recipients of the email.
     /// </summary>
@@ -235,7 +237,9 @@ public class SendGridClient {
             if (ErrorAction == ActionPreference.Stop) {
                 throw;
             }
-            return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, "", ex.Message);
+            var credFail = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, "", ex.Message);
+            await Helpers.PostWebhookAsync(WebhookUrl, credFail);
+            return credFail;
         }
 
         request.Headers.Add("Authorization", $"Bearer {apiKey}");
@@ -250,7 +254,9 @@ public class SendGridClient {
                 LogCollector.LogVerbose($"Send-EmailMessage - Sent email to {SentTo} using SendGrid");
 
                 if (response.IsSuccessStatusCode) {
-                    return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString());
+                    var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString());
+                    await Helpers.PostWebhookAsync(WebhookUrl, okResult);
+                    return okResult;
                 }
 
                 var message = $"Status code {response.StatusCode}: {lastContent}";
@@ -263,7 +269,9 @@ public class SendGridClient {
                     if (ErrorAction == ActionPreference.Stop && lastException != null) {
                         throw lastException;
                     }
-                    return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
+                    await Helpers.PostWebhookAsync(WebhookUrl, failResult);
+                    return failResult;
                 }
 
                 var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
@@ -274,7 +282,9 @@ public class SendGridClient {
             attempts++;
         } while (attempts <= RetryCount);
 
-        return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
+        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
+        await Helpers.PostWebhookAsync(WebhookUrl, finalResult);
+        return finalResult;
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -102,6 +102,8 @@ public class Smtp {
     /// </summary>
     public bool RetryAlways { get; set; } = false;
 
+    public string? WebhookUrl { get; set; }
+
     public bool CheckCertificateRevocation {
         get => Client.CheckCertificateRevocation;
         set => Client.CheckCertificateRevocation = value;
@@ -354,7 +356,9 @@ public class Smtp {
             try {
                 Client.Send(Message);
                 LoggingMessages.Logger.WriteVerbose($"Send-EmailMessage - Sent email to {SentTo}");
-                return new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
+                var result = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
+                Helpers.PostWebhookAsync(WebhookUrl, result).GetAwaiter().GetResult();
+                return result;
             } catch (Exception ex) {
                 lastException = ex;
                 LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending: {ex.Message}");
@@ -362,7 +366,9 @@ public class Smtp {
                     if (ErrorAction == ActionPreference.Stop) {
                         throw;
                     }
-                    return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message);
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message);
+                    Helpers.PostWebhookAsync(WebhookUrl, failResult).GetAwaiter().GetResult();
+                    return failResult;
                 }
 
                 var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
@@ -373,7 +379,9 @@ public class Smtp {
             attempts++;
         } while (attempts <= RetryCount);
 
-        return new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", lastException?.Message);
+        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", lastException?.Message);
+        Helpers.PostWebhookAsync(WebhookUrl, finalResult).GetAwaiter().GetResult();
+        return finalResult;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- expose `WebhookUrl` for Smtp, SendGrid, Mailgun and Graph clients
- post `SmtpResult` as JSON to the webhook after sending
- add helper method to send webhook payload
- document NET5 check for HttpRequestException.StatusCode

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.sln` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_685926d5ddd0832e9e4a3eb2934342b3