### PR TITLE
Add async SMTP send API

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpSendAsyncTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSendAsyncTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MimeKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpSendAsyncTests
+{
+    private class FakeClient : ClientSmtp
+    {
+        public bool Called;
+        public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken = default, ITransferProgress? progress = null)
+        {
+            Called = true;
+            return Task.FromResult(string.Empty);
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_InvokesClientSendAsync()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeClient();
+        var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(smtp, fake);
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "b@c.com" };
+        smtp.Subject = "test";
+        smtp.TextBody = "body";
+        smtp.WebhookUrl = null;
+        smtp.CreateMessage();
+
+        var result = await smtp.SendAsync();
+
+        Assert.True(fake.Called);
+        Assert.True(result.Status);
+    }
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mailozaurr;
 
@@ -391,6 +392,45 @@ public class Smtp {
 
         var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", lastException?.Message);
         Helpers.PostWebhookAsync(WebhookUrl, finalResult).GetAwaiter().GetResult();
+        return finalResult;
+    }
+
+    /// <summary>
+    /// Send the email message asynchronously.
+    /// </summary>
+    /// <returns></returns>
+    public async Task<SmtpResult> SendAsync() {
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            try {
+                await Client.SendAsync(Message);
+                LoggingMessages.Logger.WriteVerbose($"Send-EmailMessage - Sent email to {SentTo}");
+                var result = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
+                await Helpers.PostWebhookAsync(WebhookUrl, result);
+                return result;
+            } catch (Exception ex) {
+                lastException = ex;
+                LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending: {ex.Message}");
+                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
+                    if (ErrorAction == ActionPreference.Stop) {
+                        throw;
+                    }
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message);
+                    await Helpers.PostWebhookAsync(WebhookUrl, failResult);
+                    return failResult;
+                }
+
+                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (delayMilliseconds > 0) {
+                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds));
+                }
+            }
+            attempts++;
+        } while (attempts <= RetryCount);
+
+        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", lastException?.Message);
+        await Helpers.PostWebhookAsync(WebhookUrl, finalResult);
         return finalResult;
     }
 


### PR DESCRIPTION
## Summary
- extend Smtp with asynchronous SendAsync method
- add unit test to confirm SendAsync uses Client.SendAsync

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68593635b574832ea3efdfe22ce40b65