### PR TITLE
Add attachment examples

### DIFF
--- a/Examples/Example-SendEmail-Attachments.ps1
+++ b/Examples/Example-SendEmail-Attachments.ps1
@@ -1,0 +1,13 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+# Custom attachment built from memory
+$bytes = [System.Text.Encoding]::UTF8.GetBytes('Hello from memory')
+$memoryStream = [System.IO.MemoryStream]::new($bytes)
+$mimePart = [MimeKit.MimePart]::new('text/plain')
+$mimePart.Content = [MimeKit.MimeContent]::new($memoryStream)
+$mimePart.FileName = 'Memory.txt'
+
+Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' \
+    -Server 'smtp.example.com' -Port 25 -Subject 'Attachment Demo' -Body 'Check attachments' \
+    -Attachment 'C:\\Temp\\report.pdf', $mimePart \
+    -InlineAttachment 'C:\\Temp\\logo.png' -WhatIf -Verbose

--- a/README.MD
+++ b/README.MD
@@ -129,6 +129,7 @@ While I didn't spent much time creating WIKI, working on Get-Help documentation,
 You can also utilize Examples which should help to understand use cases. Of course it would be great having pretty help so if you can help me out feel free to submit PR's.
 - [Example-SendEmail-SignEncrypt.ps1](Examples/Example-SendEmail-SignEncrypt.ps1) - sign and encrypt an email using SMTP.
 - [Example-SendEmail-Pgp.ps1](Examples/Example-SendEmail-Pgp.ps1) - send a PGP encrypted email.
+- [Example-SendEmail-Attachments.ps1](Examples/Example-SendEmail-Attachments.ps1) - demonstrate file and in-memory attachments.
 - [PGP documentation](Docs/PGP.md) - overview of OpenPGP support.
 
 -Some useful examples:
@@ -136,6 +137,7 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - `Examples/Example-AcquireGoogleTokenInteractive.ps1` – demonstrates `Connect-OAuthGoogle`, `ConvertFrom-OAuth2Credential`, and using the token with `Send-EmailMessage`, IMAP, and POP3.
 - `Sources/Mailozaurr.Examples/AcquireO365TokenInteractive.cs` – C# sample for `OAuthHelpers.AcquireO365TokenInteractiveAsync`.
 - `Sources/Mailozaurr.Examples/AcquireGoogleTokenInteractive.cs` – C# sample for `OAuthHelpers.AcquireGoogleTokenInteractiveAsync`.
+- `Sources/Mailozaurr.Examples/SendEmailAttachments.cs` – C# sample demonstrating attachments and inline resources.
 
 Keep in mind PSSharedGoods is only required for development. When you use this module from PowerShellGallery it's not installed as everything is merged.
 

--- a/Sources/Mailozaurr.Examples/SendEmailAttachments.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailAttachments.cs
@@ -1,0 +1,52 @@
+using Mailozaurr;
+
+using MimeKit;
+
+using System.Collections.Generic;
+
+
+
+public static class SendEmailAttachments
+
+{
+
+    public static void Run()
+
+    {
+
+        var smtp = new Smtp();
+
+        smtp.From = "sender@example.com";
+
+        smtp.To = new[] { "recipient@example.com" };
+
+        smtp.Subject = "Attachment Demo";
+
+        smtp.TextBody = "Check attachments";
+
+        smtp.Attachments = new List<object> { "C:\\Temp\\report.pdf" };
+
+        var part = new MimePart("text/plain")
+
+        {
+
+            Content = new MimeContent(new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes("Hello from memory"))),
+
+            FileName = "Memory.txt"
+
+        };
+
+        smtp.Attachments.Add(part);
+
+        smtp.InlineAttachments = new List<object> { "C:\\Temp\\logo.png" };
+
+        smtp.Connect("smtp.example.com", 25);
+
+        smtp.Send();
+
+        smtp.Disconnect();
+
+    }
+
+}
+


### PR DESCRIPTION
## Summary
- add PowerShell example `Example-SendEmail-Attachments.ps1`
- add C# example `SendEmailAttachments.cs`
- document new examples in README

## Testing
- `dotnet restore Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln --configuration Debug`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68595835647c832e964d92919426355d