### PR TITLE
Fix SmtpResult status when certificate missing

### DIFF
--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -485,7 +485,7 @@ public class Smtp {
             if (ErrorAction == ActionPreference.Stop) {
                 throw new Exception("Certificate not found in the store.");
             }
-            return new SmtpResult(true, EmailAction.SMimeEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "Certificate not found in the store.");
+            return new SmtpResult(false, EmailAction.SMimeEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", "Certificate not found in the store.");
         }
     }
 
@@ -614,7 +614,7 @@ public class Smtp {
             if (ErrorAction == ActionPreference.Stop) {
                 throw new Exception("Certificate not found in the store.");
             }
-            return new SmtpResult(true, EmailAction.SMimeSignaturePKCS7, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", "Certificate not found in the store.");
+            return new SmtpResult(false, EmailAction.SMimeSignaturePKCS7, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", "Certificate not found in the store.");
         }
     }
 


### PR DESCRIPTION
## Summary
- mark encryption/signing failures as false when certificate thumbprint not found

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685ae80d8bd8832e9d84de24f0d0c9ab