### PR TITLE
Check PGP key paths

### DIFF
--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -694,6 +694,12 @@ public class Smtp {
     }
 
     public SmtpResult PgpEncrypt(string publicKeyPath) {
+        if (!File.Exists(publicKeyPath)) {
+            string messageText = $"Public key file not found: {publicKeyPath}";
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - {messageText}");
+            return new SmtpResult(false, EmailAction.PgpEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
+        }
+
         MimeMessage message = Message;
         using var ctx = new EphemeralOpenPgpContext();
         using (var pub = File.OpenRead(publicKeyPath))
@@ -714,6 +720,17 @@ public class Smtp {
         password = ConvertSecureStringToPlainString(password, isSecureString);
         MimeMessage message = Message;
         using var ctx = new EphemeralOpenPgpContext(password);
+        if (!File.Exists(publicKeyPath)) {
+            string messageText = $"Public key file not found: {publicKeyPath}";
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - {messageText}");
+            return new SmtpResult(false, EmailAction.PgpSign, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
+        }
+        if (!File.Exists(privateKeyPath)) {
+            string messageText = $"Private key file not found: {privateKeyPath}";
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - {messageText}");
+            return new SmtpResult(false, EmailAction.PgpSign, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
+        }
+
         using (var pub = File.OpenRead(publicKeyPath))
             ctx.Import(pub);
         using (var sec = File.OpenRead(privateKeyPath))
@@ -738,6 +755,17 @@ public class Smtp {
         password = ConvertSecureStringToPlainString(password, isSecureString);
         MimeMessage message = Message;
         using var ctx = new EphemeralOpenPgpContext(password);
+        if (!File.Exists(publicKeyPath)) {
+            string messageText = $"Public key file not found: {publicKeyPath}";
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - {messageText}");
+            return new SmtpResult(false, EmailAction.PgpSignAndEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
+        }
+        if (!File.Exists(privateKeyPath)) {
+            string messageText = $"Private key file not found: {privateKeyPath}";
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - {messageText}");
+            return new SmtpResult(false, EmailAction.PgpSignAndEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
+        }
+
         using (var pub = File.OpenRead(publicKeyPath))
             ctx.Import(pub);
         using (var sec = File.OpenRead(privateKeyPath))

--- a/Tests/Send-EmailMessage.Pgp.Tests.ps1
+++ b/Tests/Send-EmailMessage.Pgp.Tests.ps1
@@ -6,4 +6,16 @@ Describe 'Send-EmailMessage - PGP' {
             -SignOrEncrypt PgpSignAndEncrypt -PublicKeyPath $pub -PrivateKeyPath $sec -PrivateKeyPassword 'no.secret'
         $result.Error | Should -Be 'Email not sent (WhatIf)'
     }
+
+    It 'Returns error when key files are missing' {
+        $smtp = [Mailozaurr.Smtp]::new()
+        $smtp.From = 'a@b.com'
+        $smtp.To = @('c@d.com')
+        $smtp.Subject = 'Test'
+        $smtp.TextBody = 'Body'
+        $smtp.CreateMessage()
+        $result = $smtp.PgpSignAndEncrypt('missing.pub', 'missing.sec', '', $false)
+        $result.Error | Should -Match 'file not found'
+        $result.Status | Should -Be $false
+    }
 }


### PR DESCRIPTION
## Summary
- verify PGP key file paths exist before reading
- test failure path for missing keys

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh ./run-tests.ps1`
- `dotnet test Sources/Mailozaurr.sln -c Debug --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685ae82972c0832eb1db096603521da6