### PR TITLE
Add sender address validation for Mailgun

### DIFF
--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class MailgunClientTests
+{
+    [Fact]
+    public void EmailDomain_InvalidAddress_ThrowsArgumentException()
+    {
+        var client = new MailgunClient { From = "invalid" };
+        PropertyInfo? prop = typeof(MailgunClient).GetProperty("EmailDomain", BindingFlags.NonPublic | BindingFlags.Instance);
+        var ex = Assert.Throws<TargetInvocationException>(() => prop!.GetValue(client));
+        Assert.IsType<ArgumentException>(ex.InnerException);
+        Assert.Contains("invalid", ex.InnerException!.Message, StringComparison.Ordinal);
+    }
+}

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -11,7 +11,15 @@ public class MailgunClient : IDisposable {
     public readonly Stopwatch Stopwatch;
 
     private string ApiKey => Helpers.CredentialToApiKey(Credentials);
-    private string EmailDomain => Helpers.GetEmailAddress(From).Split('@')[1];
+    private string EmailDomain {
+        get {
+            var address = Helpers.GetEmailAddress(From);
+            if (!address.Contains('@')) {
+                throw new ArgumentException($"Invalid email address: {address}", nameof(From));
+            }
+            return address.Split('@')[1];
+        }
+    }
 
     /// <summary>Credentials used to authenticate to the API.</summary>
     public ICredentials Credentials { get; set; }


### PR DESCRIPTION
## Summary
- validate that sender address contains '@' before deriving domain
- add tests for invalid Mailgun sender address

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685ae81598a0832ebed2df102e12ae66