### PR TITLE
Ensure unique email recipients

### DIFF
--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -83,6 +83,26 @@ public static class Helpers {
     }
 
     /// <summary>
+    /// Enumerates unique address objects based on email value using the provided hash set to track seen addresses.
+    /// </summary>
+    /// <param name="addresses">Collection of address objects.</param>
+    /// <param name="seen">Hash set tracking emails that were already yielded.</param>
+    /// <returns>Unique address objects.</returns>
+    public static IEnumerable<object> UniqueAddresses(IEnumerable<object>? addresses, HashSet<string> seen) {
+        if (addresses == null) yield break;
+
+        foreach (var address in addresses) {
+            var email = GetEmailAddress(address);
+            if (string.IsNullOrEmpty(email)) continue;
+
+            var lowered = email.ToLowerInvariant();
+            if (seen.Add(lowered)) {
+                yield return address;
+            }
+        }
+    }
+
+    /// <summary>
     /// Determines whether the specified exception represents a transient error
     /// that can be retried safely.
     /// </summary>

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -56,10 +56,11 @@ public class MailgunClient : IDisposable {
     public string SentFrom => Helpers.GetEmailAddress(From);
     public string SentTo {
         get {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var addresses = new List<string>();
-            if (To != null) addresses.AddRange(To.Select(Helpers.GetEmailAddress));
-            if (Cc != null) addresses.AddRange(Cc.Select(Helpers.GetEmailAddress));
-            if (Bcc != null) addresses.AddRange(Bcc.Select(Helpers.GetEmailAddress));
+            if (To != null) addresses.AddRange(Helpers.UniqueAddresses(To, seen).Select(Helpers.GetEmailAddress));
+            if (Cc != null) addresses.AddRange(Helpers.UniqueAddresses(Cc, seen).Select(Helpers.GetEmailAddress));
+            if (Bcc != null) addresses.AddRange(Helpers.UniqueAddresses(Bcc, seen).Select(Helpers.GetEmailAddress));
             return string.Join(",", addresses);
         }
     }
@@ -89,9 +90,10 @@ public class MailgunClient : IDisposable {
     private MultipartFormDataContent CreateContent() {
         var content = new MultipartFormDataContent();
         content.Add(new StringContent(ConvertAddress(From)), "from");
-        foreach (var t in To) content.Add(new StringContent(ConvertAddress(t)), "to");
-        foreach (var c in Cc) content.Add(new StringContent(ConvertAddress(c)), "cc");
-        foreach (var b in Bcc) content.Add(new StringContent(ConvertAddress(b)), "bcc");
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var t in Helpers.UniqueAddresses(To, seen)) content.Add(new StringContent(ConvertAddress(t)), "to");
+        foreach (var c in Helpers.UniqueAddresses(Cc, seen)) content.Add(new StringContent(ConvertAddress(c)), "cc");
+        foreach (var b in Helpers.UniqueAddresses(Bcc, seen)) content.Add(new StringContent(ConvertAddress(b)), "bcc");
         if (ReplyTo != null) content.Add(new StringContent(ConvertAddress(ReplyTo)), "h:Reply-To");
         if (!string.IsNullOrEmpty(Subject)) content.Add(new StringContent(Subject), "subject");
         if (!string.IsNullOrEmpty(Text)) content.Add(new StringContent(Text), "text");

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -147,15 +147,16 @@ public class Graph {
     /// </summary>
     public string SentTo {
         get {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var addresses = new List<string>();
             if (To != null) {
-                addresses.AddRange(To.Select(email => email.ToString()));
+                addresses.AddRange(Helpers.UniqueAddresses(To, seen).Select(obj => Helpers.GetEmailAddress(obj)));
             }
             if (Cc != null) {
-                addresses.AddRange(Cc.Select(email => email.ToString()));
+                addresses.AddRange(Helpers.UniqueAddresses(Cc, seen).Select(obj => Helpers.GetEmailAddress(obj)));
             }
             if (Bcc != null) {
-                addresses.AddRange(Bcc.Select(email => email.ToString()));
+                addresses.AddRange(Helpers.UniqueAddresses(Bcc, seen).Select(obj => Helpers.GetEmailAddress(obj)));
             }
             return string.Join(",", addresses);
         }
@@ -213,12 +214,14 @@ public class Graph {
         // Note: The display name for the sender is controlled by Office 365 and may not reflect the value you provide here.
         // Office 365 will use the mailbox's configured display name for the sender, regardless of what is set in the payload.
         // Always use the email address for API calls and authentication.
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         MessageContainer = new GraphMessageContainer {
             Message = new GraphMessage {
                 From = ConvertToGraphEmailAddress(From),
-                To = ConvertToGraphEmailAddress(To),
-                Cc = ConvertToGraphEmailAddress(Cc),
-                Bcc = ConvertToGraphEmailAddress(Bcc),
+                To = ConvertToGraphEmailAddressUnique(To, seen),
+                Cc = ConvertToGraphEmailAddressUnique(Cc, seen),
+                Bcc = ConvertToGraphEmailAddressUnique(Bcc, seen),
                 ReplyTo = string.IsNullOrEmpty(ReplyTo) ? null : new List<GraphEmailAddress> { ConvertToGraphEmailAddress(ReplyTo)! },
                 Subject = Subject,
                 Body = new GraphContent { Content = HTML, Type = ContentType },
@@ -266,6 +269,19 @@ public class Graph {
             return null;
         }
         return emails.Select(email => new GraphEmailAddress { Email = new GraphEmail { Address = Helpers.GetEmailAddress(email) } }).ToList();
+    }
+
+    private List<GraphEmailAddress>? ConvertToGraphEmailAddressUnique(object[]? emails, HashSet<string> seen) {
+        if (emails == null) {
+            return null;
+        }
+
+        var list = new List<GraphEmailAddress>();
+        foreach (var email in Helpers.UniqueAddresses(emails, seen)) {
+            var address = Helpers.GetEmailAddress(email);
+            list.Add(new GraphEmailAddress { Email = new GraphEmail { Address = address } });
+        }
+        return list.Count == 0 ? null : list;
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -113,15 +113,16 @@ public class SendGridClient {
     /// </summary>
     public string SentTo {
         get {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var addresses = new List<string>();
             if (To != null) {
-                addresses.AddRange(To.Select(ConvertToEmailObject).Where(x => x != null).Select(x => x.Email));
+                addresses.AddRange(To.Select(ConvertToEmailObject).Where(x => x != null && seen.Add(x.Email)).Select(x => x.Email));
             }
             if (Cc != null) {
-                addresses.AddRange(Cc.Select(ConvertToEmailObject).Where(x => x != null).Select(x => x.Email));
+                addresses.AddRange(Cc.Select(ConvertToEmailObject).Where(x => x != null && seen.Add(x.Email)).Select(x => x.Email));
             }
             if (Bcc != null) {
-                addresses.AddRange(Bcc.Select(ConvertToEmailObject).Where(x => x != null).Select(x => x.Email));
+                addresses.AddRange(Bcc.Select(ConvertToEmailObject).Where(x => x != null && seen.Add(x.Email)).Select(x => x.Email));
             }
             return string.Join(",", addresses);
         }
@@ -188,13 +189,28 @@ public class SendGridClient {
             }
         }
 
-        var personalizations = new List<SendGridPersonalization> {
-                new SendGridPersonalization {
-                    To = To?.Where(t => t != null).Select(ConvertToEmailObject).ToList(),
-                    Cc = Cc?.Where(c => c != null).Select(ConvertToEmailObject).ToList(),
-                    Bcc = Bcc?.Where(b => b != null).Select(ConvertToEmailObject).ToList()
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var personalizations = new List<SendGridPersonalization>
+            {
+                new SendGridPersonalization
+                {
+                    To = To?.Where(t => t != null)
+                        .Select(ConvertToEmailObject)
+                        .Where(x => x != null && seen.Add(x.Email))
+                        .ToList(),
+                    Cc = Cc?.Where(c => c != null)
+                        .Select(ConvertToEmailObject)
+                        .Where(x => x != null && seen.Add(x.Email))
+                        .ToList(),
+                    Bcc = Bcc?.Where(b => b != null)
+                        .Select(ConvertToEmailObject)
+                        .Where(x => x != null && seen.Add(x.Email))
+                        .ToList()
                 }
-            }.Where(p => p.To != null || p.Cc != null || p.Bcc != null).ToList();
+            }
+            .Where(p => p.To != null || p.Cc != null || p.Bcc != null)
+            .ToList();
 
         var content = new List<SendGridContent> {
                 new SendGridContent { Type = "text/plain", Value = Text },

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -35,15 +35,16 @@ public partial class ClientSmtp : SmtpClient {
     /// <summary>Comma separated list of all recipients.</summary>
     public string SentTo {
         get {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var addresses = new List<string>();
             if (To != null) {
-                addresses.AddRange(To.Select(ConvertToMailboxAddress).SelectMany(x => x).Select(x => x.Address));
+                addresses.AddRange(ConvertToMailboxAddressesUnique(To, seen).Select(x => x.Address));
             }
             if (Cc != null) {
-                addresses.AddRange(Cc.Select(ConvertToMailboxAddress).SelectMany(x => x).Select(x => x.Address));
+                addresses.AddRange(ConvertToMailboxAddressesUnique(Cc, seen).Select(x => x.Address));
             }
             if (Bcc != null) {
-                addresses.AddRange(Bcc.Select(ConvertToMailboxAddress).SelectMany(x => x).Select(x => x.Address));
+                addresses.AddRange(ConvertToMailboxAddressesUnique(Bcc, seen).Select(x => x.Address));
             }
             return string.Join(",", addresses);
         }
@@ -111,16 +112,18 @@ public partial class ClientSmtp : SmtpClient {
             message.From.Add(fromAddresses.First());
         }
 
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         if (To != null && To.Any()) {
-            message.To.AddRange(To.SelectMany(ConvertToMailboxAddress));
+            message.To.AddRange(ConvertToMailboxAddressesUnique(To, seen));
         }
 
         if (Cc != null && Cc.Any()) {
-            message.Cc.AddRange(Cc.SelectMany(ConvertToMailboxAddress));
+            message.Cc.AddRange(ConvertToMailboxAddressesUnique(Cc, seen));
         }
 
         if (Bcc != null && Bcc.Any()) {
-            message.Bcc.AddRange(Bcc.SelectMany(ConvertToMailboxAddress));
+            message.Bcc.AddRange(ConvertToMailboxAddressesUnique(Bcc, seen));
         }
 
         if (ReplyTo != null) {
@@ -205,6 +208,18 @@ public partial class ClientSmtp : SmtpClient {
     /// <param name="path">Destination file path.</param>
     public void SaveMessage(string path) {
         Message.WriteTo(path);
+    }
+
+    private IEnumerable<MailboxAddress> ConvertToMailboxAddressesUnique(IEnumerable<object>? inputs, HashSet<string> seen) {
+        if (inputs == null) yield break;
+        foreach (var input in inputs) {
+            foreach (var address in ConvertToMailboxAddress(input)) {
+                var lowered = address.Address.ToLowerInvariant();
+                if (seen.Add(lowered)) {
+                    yield return address;
+                }
+            }
+        }
     }
 
     private IEnumerable<MailboxAddress> ConvertToMailboxAddress(object input) {


### PR DESCRIPTION
## Summary
- prevent duplicate addresses across To/Cc/Bcc when building messages
- expose helper `UniqueAddresses`
- update SendGrid, Mailgun, Graph and SMTP clients to use deduplication

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj`
- `pwsh -File run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685ae845f9b4832e8cd7a06e38bee6da