### PR TITLE
Fix SSL option override logic

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -209,7 +209,9 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     public MailKit.Security.SecureSocketOptions SecureSocketOptions { get; set; } = MailKit.Security.SecureSocketOptions.Auto;
 
     /// <summary>
-    /// <para>Enables the use of SSL/TLS for the SMTP connection. Recommended to use SecureSocketOptions instead.</para>
+    /// <para>Enables the use of SSL/TLS for the SMTP connection. If
+    /// <see cref="SecureSocketOptions"/> remains <c>Auto</c>, this switch causes
+    /// <c>StartTls</c> to be used automatically.</para>
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
     [Parameter(Mandatory = false, ParameterSetName = "SecureString")]

--- a/Sources/Mailozaurr/README.md
+++ b/Sources/Mailozaurr/README.md
@@ -55,9 +55,15 @@ if (result.Status)
 }
 else
 {
-    Console.WriteLine($"Failed: {result.ErrorMessage}");
+Console.WriteLine($"Failed: {result.ErrorMessage}");
 }
 ```
+
+> **Note**
+> When `Connect` is called with the `useSsl` flag and
+> `SecureSocketOptions` left as `Auto`, the library automatically uses
+> `SecureSocketOptions.StartTls`. Provide an explicit option if a
+> different behaviour is required.
 
 ### Using Microsoft Graph
 

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -211,16 +211,21 @@ public class Smtp {
     /// </summary>
     /// <param name="server"></param>
     /// <param name="port"></param>
-    /// <param name="secureSocketOptions"></param>
-    /// <param name="useSsl"></param>
+    /// <param name="secureSocketOptions">Options controlling SSL/TLS usage. If left
+    /// as <see cref="SecureSocketOptions.Auto"/> and <paramref name="useSsl"/> is
+    /// <c>true</c>, <see cref="SecureSocketOptions.StartTls"/> will be used.</param>
+    /// <param name="useSsl">Compatibility switch. Overrides
+    /// <paramref name="secureSocketOptions"/> only when set to <c>true</c> and the
+    /// option is left as <see cref="SecureSocketOptions.Auto"/>.</param>
     /// <returns></returns>
     public SmtpResult Connect(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false) {
         Server = server;
         Port = port;
         try {
-            if (useSsl) {
-                // If useSsl is true, use SecureSocketOptions.StartTls, otherwise use whatever is passed in secureSocketOptions
-                // Since we are maintaining backwards compatibility with Send-MailMessage, we need to use StartTls if useSsl is true
+            if (useSsl && secureSocketOptions == SecureSocketOptions.Auto) {
+                // Maintain backwards compatibility with Send-MailMessage by
+                // defaulting to StartTls when the UseSsl flag is supplied and
+                // no explicit option was provided.
                 secureSocketOptions = SecureSocketOptions.StartTls;
             }
             Client.Connect(server, port, secureSocketOptions);


### PR DESCRIPTION
## Summary
- default to StartTls only when `UseSsl` is passed and `SecureSocketOptions` is left as `Auto`
- document behaviour in Smtp cmdlet and library README

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685aec1012c0832eaad27c7a949b4e8e