### PR TITLE
Fix attachment decode errors

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -321,8 +321,11 @@ namespace Mailozaurr {
                     try {
                         var bytes = Convert.FromBase64String(att.ContentBytes);
                         File.WriteAllBytes(filePath, bytes);
+                    } catch (FormatException fex) {
+                        // Invalid Base64 content
+                        LoggingMessages.Logger.WriteWarning($"SaveAttachment - Invalid base64 content for {att.Name}. Error: {fex.Message}");
                     } catch (Exception ex) {
-                        // Log or handle error
+                        // Log or handle other errors
                         LoggingMessages.Logger.WriteWarning($"SaveAttachment - Couldn't save file to {filePath}. Error: {ex.Message}");
                     }
                 }


### PR DESCRIPTION
## Summary
- catch `FormatException` when converting attachment content
- warn about invalid base64 data by attachment name

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685aec059b14832ea2ff4b11250f0eca