### PR TITLE
Fix disposal of HttpRequestMessage

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -341,21 +341,18 @@ public class Graph {
         // create message
         CreateMessage();
         LogCollector.LogVerbose("Send-EmailMessage - Sending email via Graph API");
-        // Create the HTTP request.
+        // Create the request URI outside the loop.
         var requestUri = "https://graph.microsoft.com/v1.0/users/" + MessageContainer.Message.From.Email.Address + "/sendMail";
-        var request = new HttpRequestMessage(HttpMethod.Post, requestUri) {
-            Content = new StringContent(MessageJson, Encoding.UTF8, "application/json")
-        };
-        //LoggingMessages.Logger.WriteVerbose($"Url: {requestUri}");
-        //LoggingMessages.Logger.WriteVerbose($"AccessToken Before Sent: {TokenType} {AccessToken}");
-
-        // Add the authorization header.
-        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(TokenType, AccessToken);
 
         int attempts = 0;
         Exception? lastException = null;
         do {
             try {
+                using var request = new HttpRequestMessage(HttpMethod.Post, requestUri) {
+                    Content = new StringContent(MessageJson, Encoding.UTF8, "application/json")
+                };
+                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(TokenType, AccessToken);
+
                 using var response = await _client.SendAsync(request);
                 var content = await response.Content.ReadAsStringAsync();
                 if (response.IsSuccessStatusCode) {
@@ -440,7 +437,7 @@ public class Graph {
     public async Task<SmtpResult> SendDraftMessage(GraphMessage draftMessage) {
         // Send the draft message
         var sendRequestUri = $"https://graph.microsoft.com/v1.0/users/{MessageContainer.Message.From.Email.Address}/messages/{draftMessage.Id}/send";
-        var sendRequest = new HttpRequestMessage(HttpMethod.Post, sendRequestUri);
+        using var sendRequest = new HttpRequestMessage(HttpMethod.Post, sendRequestUri);
 
         // Add the authorization header
         sendRequest.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(TokenType, AccessToken);

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -240,10 +240,6 @@ public class SendGridClient {
     /// </summary>
     /// <returns>A Task that represents the asynchronous operation. The task result contains the result of the email sending operation.</returns>
     public async Task<SmtpResult> SendEmailAsync() {
-        var request = new HttpRequestMessage(HttpMethod.Post, "https://api.sendgrid.com/v3/mail/send") {
-            Content = new StringContent(MessageJson, Encoding.UTF8, "application/json")
-        };
-
         string apiKey;
         try {
             var networkCredential = Credentials as NetworkCredential;
@@ -258,14 +254,17 @@ public class SendGridClient {
             return credFail;
         }
 
-        request.Headers.Add("Authorization", $"Bearer {apiKey}");
-
         int attempts = 0;
         Exception? lastException = null;
         string? lastContent = null;
         do {
             try {
-                var response = await _client.SendAsync(request);
+                using var request = new HttpRequestMessage(HttpMethod.Post, "https://api.sendgrid.com/v3/mail/send") {
+                    Content = new StringContent(MessageJson, Encoding.UTF8, "application/json")
+                };
+                request.Headers.Add("Authorization", $"Bearer {apiKey}");
+
+                using var response = await _client.SendAsync(request);
                 lastContent = await response.Content.ReadAsStringAsync();
                 LogCollector.LogVerbose($"Send-EmailMessage - Sent email to {SentTo} using SendGrid");
 


### PR DESCRIPTION
## Summary
- ensure Graph API requests are created inside the retry loop
- dispose draft send requests
- create SendGrid API requests per attempt and dispose properly

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685aebda927c832eb6db862cc38a2836