### PR TITLE
Fix credential parsing in Graph

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -250,6 +250,12 @@ public class Graph {
         var networkCredential = Credentials as NetworkCredential;
         if (networkCredential != null) {
             var userSplit = networkCredential.UserName.Split('@');
+            if (userSplit.Length != 2) {
+                throw new ArgumentException(
+                    "Credential.UserName must be in the format 'clientid@directoryid'",
+                    nameof(Credentials));
+            }
+
             ApplicationID = userSplit[0];
             ApplicationKey = networkCredential.Password;
             TenantDomain = userSplit[1];


### PR DESCRIPTION
## Summary
- validate credential format in `Authenticate`

## Testing
- `dotnet restore Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln --configuration Release --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685aebd361e4832e8d73034ef8722cdc