### PR TITLE
Fix attachment size check for Graph

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -197,7 +197,9 @@ public class Graph {
                 }
             }
 
-            if (ConvertedAttachments.Sum(a => a.ContentBytes.Length) > 4000000) {
+            if (ConvertedAttachments.Sum(a => string.IsNullOrEmpty(a.ContentBytes)
+                    ? 0
+                    : Convert.FromBase64String(a.ContentBytes).Length) > 4 * 1024 * 1024) {
                 // Create a draft message if the total size of the attachments is larger than 4MB
                 IsLargerAttachment = true;
             } else {

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -199,7 +199,7 @@ public class Graph {
 
             if (ConvertedAttachments.Sum(a => string.IsNullOrEmpty(a.ContentBytes)
                     ? 0
-                    : Convert.FromBase64String(a.ContentBytes).Length) > 4 * 1024 * 1024) {
+                    : Convert.FromBase64String(a.ContentBytes).Length) > 4_000_000) {
                 // Create a draft message if the total size of the attachments is larger than 4MB
                 IsLargerAttachment = true;
             } else {


### PR DESCRIPTION
## Summary
- decode `ContentBytes` to bytes when calculating total attachment size

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -File run-tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_685aebcb8564832e849e56dbe6720c04