### PR TITLE
Fix SaveMessage directory handling

### DIFF
--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -207,6 +207,10 @@ public partial class ClientSmtp : SmtpClient {
     /// </summary>
     /// <param name="path">Destination file path.</param>
     public void SaveMessage(string path) {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory)) {
+            Directory.CreateDirectory(directory);
+        }
         Message.WriteTo(path);
     }
 


### PR DESCRIPTION
## Summary
- ensure directory exists before writing the message

## Testing
- `dotnet build Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --no-restore`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685aee69584c832eb980e90e1dffb7de