### PR TITLE
Document AllowUnsafeBlocks usage

### DIFF
--- a/Sources/Mailozaurr/Mailozaurr.csproj
+++ b/Sources/Mailozaurr/Mailozaurr.csproj
@@ -10,6 +10,7 @@
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <!-- Required for pointer operations in Helpers/SecureStringHelper.cs -->
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RepositoryUrl>https://github.com/EvotecIT/Mailozaurr</RepositoryUrl>
     <PackageTags>Windows;MacOS;Linux;Mail;Email;MX;SPF;DMARC;DKIM;GraphApi;SendGrid;Graph;IMAP;POP3</PackageTags>


### PR DESCRIPTION
## Summary
- explain why AllowUnsafeBlocks is enabled

## Testing
- `dotnet build Sources/Mailozaurr.sln --configuration Debug --no-restore`
- `dotnet test Sources/Mailozaurr.sln --configuration Debug --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_685b9bb4c218832eb95f65948e248065