### PR TITLE
Include auth failure details in SmtpResult

### DIFF
--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -287,7 +287,7 @@ public class Smtp {
             if (ErrorAction == ActionPreference.Stop) {
                 throw;
             }
-            return new SmtpResult(false, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", "Could not authenticate using default credentials.");
+            return new SmtpResult(false, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message);
         }
     }
 


### PR DESCRIPTION
## Summary
- capture the authentication failure message when default credentials are used

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_685b9dd12218832eb7fc8d1209bac50d