### PR TITLE
Fix disposal of multipart content

### DIFF
--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -147,8 +147,9 @@ public class MailgunClient : IDisposable {
         Exception? lastException = null;
         do {
             try {
+                using var content = CreateContent();
                 using var request = new HttpRequestMessage(HttpMethod.Post, url) {
-                    Content = CreateContent()
+                    Content = content
                 };
                 request.Headers.Authorization = new AuthenticationHeaderValue("Basic", auth);
                 var response = await _client.SendAsync(request);


### PR DESCRIPTION
## Summary
- ensure `MultipartFormDataContent` and nested `ByteArrayContent` are disposed when using Mailgun API

## Testing
- `dotnet build Sources/Mailozaurr.sln --configuration Debug --no-restore`
- `dotnet test Sources/Mailozaurr.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685b9db8698c832e8b5d6a31ca7797c3