### PR TITLE
Add warning logs for swallowed exceptions

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -166,7 +166,9 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
             // Open the inbox to get message info
             try {
                 await client.Inbox.OpenAsync(MailKit.FolderAccess.ReadOnly);
-            } catch { /* ignore if fails */ }
+            } catch (Exception ex) {
+                LoggingMessages.Logger.WriteWarning($"Connect-IMAP - Failed to open inbox: {ex.Message}");
+            }
             var info = new ImapConnectionInfo {
                 Uri = $"imaps://{Server}:{Port}/",
                 AuthenticationMechanisms = client.AuthenticationMechanisms,

--- a/Sources/Mailozaurr.PowerShell/CredentialHelpers.cs
+++ b/Sources/Mailozaurr.PowerShell/CredentialHelpers.cs
@@ -18,7 +18,8 @@ public static class CredentialHelpers {
         // Try to convert from encrypted string, fallback to plain text
         try {
             return new NetworkCredential("", s).SecurePassword;
-        } catch {
+        } catch (Exception ex) {
+            LoggingMessages.Logger.WriteWarning($"Failed to convert to SecureString: {ex.Message}");
             var ss = new SecureString();
             foreach (char c in s) ss.AppendChar(c);
             ss.MakeReadOnly();

--- a/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
+++ b/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
@@ -28,8 +28,8 @@ public class EphemeralOpenPgpContext : GnuPGContext {
         base.Dispose();
         try {
             Directory.Delete(_tempDirectory, true);
-        } catch {
-            // ignore cleanup errors
+        } catch (Exception ex) {
+            LoggingMessages.Logger.WriteWarning($"Failed to delete temporary directory: {ex.Message}");
         }
     }
 }

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -139,7 +139,8 @@ public static class Helpers {
             var json = JsonSerializer.Serialize(result);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
             await client.PostAsync(url, content);
-        } catch {
+        } catch (Exception ex) {
+            LoggingMessages.Logger.WriteWarning($"Failed to post webhook: {ex.Message}");
         }
     }
 }

--- a/Sources/Mailozaurr/Logging/LoggingConfigurator.cs
+++ b/Sources/Mailozaurr/Logging/LoggingConfigurator.cs
@@ -54,9 +54,8 @@ public class LoggingConfigurator {
             if (!string.IsNullOrEmpty(logPath)) {
                 try {
                     protocolLogger = new ProtocolLogger(logPath, logOverwrite);
-                } catch {
-                    //Console.WriteLine($"Couldn't create protocol logger with {logPath}. Using console output instead.");
-                    // TODO: add logging
+                } catch (Exception ex) {
+                    LoggingMessages.Logger.WriteWarning($"Couldn't create protocol logger with {logPath}: {ex.Message}. Using console output instead.");
                     protocolLogger = new ProtocolLogger(Console.OpenStandardOutput());
                 }
             } else if (logConsole) {

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -323,8 +323,8 @@ public class Graph {
             if (response != null) {
                 try {
                     errorContent = await response.Content.ReadAsStringAsync();
-                } catch {
-                    // ignored
+                } catch (Exception innerEx) {
+                    LoggingMessages.Logger.WriteWarning($"Failed to read error response: {innerEx.Message}");
                 }
             }
 

--- a/Sources/Mailozaurr/Receive/MessageFetcher.cs
+++ b/Sources/Mailozaurr/Receive/MessageFetcher.cs
@@ -41,10 +41,12 @@ public static class MessageFetcher {
         if (!string.IsNullOrEmpty(folder)) {
             try {
                 mailFolder = client.GetFolder(folder);
-            } catch {
+            } catch (Exception ex) {
+                LoggingMessages.Logger.WriteWarning($"Failed to get folder '{folder}': {ex.Message}");
                 try {
                     mailFolder = client.GetFolder(client.PersonalNamespaces[0]).GetSubfolder(folder);
-                } catch {
+                } catch (Exception innerEx) {
+                    LoggingMessages.Logger.WriteWarning($"Failed to get subfolder '{folder}': {innerEx.Message}");
                     mailFolder = client.Inbox;
                 }
             }


### PR DESCRIPTION
## Summary
- add warning logs when deleting temp PGP directory fails
- log failure to create protocol log file
- improve folder error handling in MessageFetcher
- log webhook posting errors
- log Graph API error response read errors
- warn if IMAP inbox fails to open
- warn if secure string conversion fails

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj` *(fails: NuGet.Config is not valid XML)*
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj` *(fails: NuGet.Config is not valid XML)*

------
https://chatgpt.com/codex/tasks/task_e_685b9da7fc1c832ea1642ed9b69660f9