### PR TITLE
Add Disconnect-EmailGraph cmdlet

### DIFF
--- a/Examples/Example-GetEmailMessage.ps1
+++ b/Examples/Example-GetEmailMessage.ps1
@@ -93,3 +93,5 @@ $TenantId = 'your-tenant-id'
 $cred = ConvertTo-GraphCredential -ClientId $ClientId -ClientSecret $ClientSecret -DirectoryId $TenantId
 $graph = Connect-EmailGraph -Credential $cred
 Get-EmailMessage -UserPrincipalName 'user@example.com' -Connection $graph -HasAttachment -Limit 5
+
+Disconnect-EmailGraph -Connection $graph

--- a/Examples/Example-GraphManageMessages.ps1
+++ b/Examples/Example-GraphManageMessages.ps1
@@ -15,3 +15,5 @@ foreach ($m in $messages) {
     Set-MailMessage -UserPrincipalName 'user@example.com' -MessageId $m.Id -Connection $graph -Read
     Move-MailMessage -UserPrincipalName 'user@example.com' -MessageId $m.Id -DestinationFolderId 'Archive' -Connection $graph
 }
+
+Disconnect-EmailGraph -Connection $graph

--- a/Mailozaurr.psd1
+++ b/Mailozaurr.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @('Connect-POP3', 'Disconnect-POP3', 'Get-POP3Message', 'Save-POP3Message')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Connect-EmailGraph', 'Connect-IMAP', 'Connect-OAuthGoogle', 'Connect-OAuthO365', 'Connect-POP', 'ConvertFrom-EmlToMsg', 'ConvertTo-GraphCredential', 'ConvertTo-GraphCertificateCredential', 'ConvertTo-OAuth2Credential', 'ConvertTo-SendGridCredential', 'ConvertTo-MailgunCredential', 'Disconnect-IMAP', 'Disconnect-POP', 'Get-IMAPFolder', 'Get-IMAPMessage', 'Get-EmailMessage', 'Get-MailFolder', 'Get-MailMessageAttachment', 'Get-POPMessage', 'Import-MailFile', 'Move-MailMessage', 'Set-MailMessage', 'Save-MailMessageAttachment', 'Save-MailMessage', 'Save-POPMessage', 'Send-EmailMessage', 'Test-EmailAddress')
+    CmdletsToExport      = @('Connect-EmailGraph', 'Connect-IMAP', 'Connect-OAuthGoogle', 'Connect-OAuthO365', 'Connect-POP', 'ConvertFrom-EmlToMsg', 'ConvertTo-GraphCredential', 'ConvertTo-GraphCertificateCredential', 'ConvertTo-OAuth2Credential', 'ConvertTo-SendGridCredential', 'ConvertTo-MailgunCredential', 'Disconnect-EmailGraph', 'Disconnect-IMAP', 'Disconnect-POP', 'Get-IMAPFolder', 'Get-IMAPMessage', 'Get-EmailMessage', 'Get-MailFolder', 'Get-MailMessageAttachment', 'Get-POPMessage', 'Import-MailFile', 'Move-MailMessage', 'Set-MailMessage', 'Save-MailMessageAttachment', 'Save-MailMessage', 'Save-POPMessage', 'Send-EmailMessage', 'Test-EmailAddress')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -130,7 +130,7 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - [Example-SendEmail-SignEncrypt.ps1](Examples/Example-SendEmail-SignEncrypt.ps1) - sign and encrypt an email using SMTP.
 - [Example-SendEmail-Pgp.ps1](Examples/Example-SendEmail-Pgp.ps1) - send a PGP encrypted email.
 - [Example-GraphManageMessages.ps1](Examples/Example-GraphManageMessages.ps1) - download attachments, set read state and move messages using Microsoft Graph.
-- Use `Connect-EmailGraph` to authenticate with application credentials for Microsoft Graph.
+- Use `Connect-EmailGraph` and `Disconnect-EmailGraph` to authenticate and release application credentials for Microsoft Graph. The connection cmdlet supports both client secret and certificate authentication modes.
 - [Example-SendEmail-Attachments.ps1](Examples/Example-SendEmail-Attachments.ps1) - demonstrate file and in-memory attachments.
 - [PGP documentation](Docs/PGP.md) - overview of OpenPGP support.
 

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -14,6 +14,7 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     public PSCredential? Credential { get; set; }
 
     [Parameter(Mandatory = true, ParameterSetName = "Plain")]
+    [Parameter(Mandatory = true, ParameterSetName = "Certificate")]
     [ValidateNotNullOrEmpty]
     public string? ClientId { get; set; }
 
@@ -22,8 +23,17 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     public string? ClientSecret { get; set; }
 
     [Parameter(Mandatory = true, ParameterSetName = "Plain")]
+    [Parameter(Mandatory = true, ParameterSetName = "Certificate")]
     [ValidateNotNullOrEmpty]
     public string? DirectoryId { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "Certificate")]
+    [ValidateNotNullOrEmpty]
+    public string? CertificatePath { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "Certificate")]
+    [ValidateNotNullOrEmpty]
+    public string? CertificatePassword { get; set; }
 
     protected override async Task ProcessRecordAsync() {
         GraphCredential cred;
@@ -31,8 +41,19 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
             cred = MicrosoftGraphUtils.ConvertFromGraphCredential(
                 Credential!.UserName,
                 Credential.GetNetworkCredential().Password);
+        } else if (ParameterSetName == "Certificate") {
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                DirectoryId = DirectoryId!,
+                CertificatePath = CertificatePath!,
+                CertificatePassword = CertificatePassword!
+            };
         } else {
-            cred = new GraphCredential { ClientId = ClientId!, ClientSecret = ClientSecret!, DirectoryId = DirectoryId! };
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                ClientSecret = ClientSecret!,
+                DirectoryId = DirectoryId!
+            };
         }
 
         bool connected = false;

--- a/Sources/Mailozaurr.PowerShell/CmdletDisconnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletDisconnectEmailGraph.cs
@@ -1,0 +1,42 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// <para type="synopsis">Clears Microsoft Graph credentials created by Connect-EmailGraph.</para>
+/// <para type="description">The <c>Disconnect-EmailGraph</c> cmdlet removes sensitive
+/// information from a <see cref="GraphConnectionInfo"/> object returned by
+/// <c>Connect-EmailGraph</c>. Use it when you no longer need the connection to
+/// ensure credentials are disposed and not kept in memory.</para>
+/// <example>
+///   <summary>Disconnect from Microsoft Graph</summary>
+///   <code>$graph = Connect-EmailGraph ...; Disconnect-EmailGraph -Connection $graph</code>
+/// </example>
+/// <remarks>
+/// This cmdlet does not close any network connections but clears the stored
+/// client secret and marks the connection as disconnected.
+/// </remarks>
+/// <seealso cref="CmdletConnectEmailGraph"/>
+/// </summary>
+[Cmdlet(VerbsCommunications.Disconnect, "EmailGraph")]
+public sealed class CmdletDisconnectEmailGraph : AsyncPSCmdlet {
+    /// <summary>
+    /// <para type="description">The <see cref="GraphConnectionInfo"/> object to clear.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [ValidateNotNull]
+    public GraphConnectionInfo? Connection { get; set; }
+
+    /// <summary>Clears the credential stored in the connection object.</summary>
+    protected override Task ProcessRecordAsync() {
+        if (Connection != null) {
+            var cred = Connection.Credential;
+            if (cred != null) {
+                cred.ClientSecret = string.Empty;
+            }
+            Connection.IsConnected = false;
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -15,7 +15,9 @@ namespace Mailozaurr {
     public class GraphCredential {
         public string ClientId { get; set; }
         public string DirectoryId { get; set; }
-        public string ClientSecret { get; set; }
+        public string? ClientSecret { get; set; }
+        public string? CertificatePath { get; set; }
+        public string? CertificatePassword { get; set; }
     }
 
     /// <summary>
@@ -66,12 +68,23 @@ namespace Mailozaurr {
         /// Connects to O365 Graph and returns the Authorization header value ("Bearer ...").
         /// </summary>
         public static async Task<string> ConnectO365GraphAsync(GraphCredential credential, string tenantDomain, string resource = "https://manage.office.com") {
+            if (!string.IsNullOrEmpty(credential.CertificatePath)) {
+                var scopes = new[] { $"{resource}/.default" };
+                var auth = await OAuthHelpers.AcquireGraphCertificateTokenAsync(
+                    credential.ClientId,
+                    tenantDomain,
+                    credential.CertificatePath,
+                    credential.CertificatePassword ?? string.Empty,
+                    scopes);
+                return $"{auth.TokenType} {auth.AccessToken}";
+            }
+
             var body = new Dictionary<string, string>
             {
-                {"grant_type", "client_credentials"},
-                {"resource", resource},
-                {"client_id", credential.ClientId},
-                {"client_secret", credential.ClientSecret}
+                { "grant_type", "client_credentials" },
+                { "resource", resource },
+                { "client_id", credential.ClientId },
+                { "client_secret", credential.ClientSecret }
             };
             var content = new FormUrlEncodedContent(body);
             var url = $"https://login.microsoftonline.com/{tenantDomain}/oauth2/token";
@@ -81,10 +94,9 @@ namespace Mailozaurr {
                 throw new Exception($"ConnectO365GraphAsync - Error: {error}");
             }
             var json = await response.Content.ReadAsStringAsync();
-                // Parse JSON for access_token and token_type
-                var token = System.Text.Json.JsonDocument.Parse(json);
-                var accessToken = token.RootElement.GetProperty("access_token").GetString();
-                var tokenType = token.RootElement.GetProperty("token_type").GetString();
+            var token = System.Text.Json.JsonDocument.Parse(json);
+            var accessToken = token.RootElement.GetProperty("access_token").GetString();
+            var tokenType = token.RootElement.GetProperty("token_type").GetString();
             return $"{tokenType} {accessToken}";
         }
 


### PR DESCRIPTION
## Summary
- implement Disconnect-EmailGraph cmdlet in C# to clear Graph credentials
- export new cmdlet in module manifest
- document Graph connect/disconnect workflow in README and examples
- support certificate authentication in Connect-EmailGraph

## Testing
- `dotnet restore Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `powershell -NoProfile -ExecutionPolicy Bypass -File run-tests.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfcec4a90832ebdb3a04bb21c9feb