### PR TITLE
Standardize POP3 cmdlet names

### DIFF
--- a/Mailozaurr.psd1
+++ b/Mailozaurr.psd1
@@ -1,7 +1,7 @@
 ﻿@{
-    AliasesToExport      = @('Connect-POP3', 'Disconnect-POP3', 'Get-POP3Message', 'Save-POP3Message')
+    AliasesToExport      = @('Connect-POP', 'Disconnect-POP', 'Get-POPMessage', 'Save-POPMessage')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Connect-EmailGraph', 'Connect-IMAP', 'Connect-OAuthGoogle', 'Connect-OAuthO365', 'Connect-POP', 'ConvertFrom-EmlToMsg', 'ConvertTo-GraphCredential', 'ConvertTo-GraphCertificateCredential', 'ConvertTo-OAuth2Credential', 'ConvertTo-SendGridCredential', 'ConvertTo-MailgunCredential', 'Disconnect-IMAP', 'Disconnect-POP', 'Get-IMAPFolder', 'Get-IMAPMessage', 'Get-EmailMessage', 'Get-MailFolder', 'Get-MailMessageAttachment', 'Get-POPMessage', 'Import-MailFile', 'Move-MailMessage', 'Set-MailMessage', 'Save-MailMessageAttachment', 'Save-MailMessage', 'Save-POPMessage', 'Send-EmailMessage', 'Test-EmailAddress')
+    CmdletsToExport      = @('Connect-EmailGraph', 'Connect-IMAP', 'Connect-OAuthGoogle', 'Connect-OAuthO365', 'Connect-POP3', 'ConvertFrom-EmlToMsg', 'ConvertTo-GraphCredential', 'ConvertTo-GraphCertificateCredential', 'ConvertTo-OAuth2Credential', 'ConvertTo-SendGridCredential', 'ConvertTo-MailgunCredential', 'Disconnect-IMAP', 'Disconnect-POP3', 'Get-IMAPFolder', 'Get-IMAPMessage', 'Get-EmailMessage', 'Get-MailFolder', 'Get-MailMessageAttachment', 'Get-POP3Message', 'Import-MailFile', 'Move-MailMessage', 'Set-MailMessage', 'Save-MailMessageAttachment', 'Save-MailMessage', 'Save-POP3Message', 'Send-EmailMessage', 'Test-EmailAddress')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -6,31 +6,31 @@ namespace Mailozaurr.PowerShell;
 
 /// <summary>
 /// <para type="synopsis">Connects to a POP3 server and authenticates using credentials, OAuth2, or clear text.</para>
-/// <para type="description">The <c>Connect-POP</c> cmdlet establishes a connection to a POP3 server using MailKit. It supports multiple authentication methods, including OAuth2, PSCredential, and clear text username/password. The cmdlet returns a <see cref="PopConnectionInfo"/> object containing connection details and the authenticated client for further use in subsequent cmdlets.</para>
+/// <para type="description">The <c>Connect-POP3</c> cmdlet establishes a connection to a POP3 server using MailKit. It supports multiple authentication methods, including OAuth2, PSCredential, and clear text username/password. The cmdlet returns a <see cref="PopConnectionInfo"/> object containing connection details and the authenticated client for further use in subsequent cmdlets.</para>
 /// <para type="description">Supports advanced options such as certificate validation skipping, custom timeouts, and secure socket options. Designed for secure, flexible, and scriptable POP3 connectivity in PowerShell automation scenarios.</para>
 /// <example>
 ///   <summary>Connect to a POP3 server using credentials</summary>
-///   <code>Connect-POP -Server "pop.example.com" -Credential (Get-Credential)</code>
+///   <code>Connect-POP3 -Server "pop.example.com" -Credential (Get-Credential)</code>
 /// </example>
 /// <example>
 ///   <summary>Connect to Gmail POP3 using OAuth2</summary>
 ///   <code>$cred = Connect-OAuthGoogle -GmailAccount "user@gmail.com" -ClientID "id" -ClientSecret "secret"
-/// Connect-POP -Server "pop.gmail.com" -Credential $cred -oAuth2</code>
+/// Connect-POP3 -Server "pop.gmail.com" -Credential $cred -oAuth2</code>
 /// </example>
 /// <example>
 ///   <summary>Connect to a POP3 server with clear text username and password</summary>
-///   <code>Connect-POP -Server "pop.example.com" -UserName "user" -Password "pass"</code>
+///   <code>Connect-POP3 -Server "pop.example.com" -UserName "user" -Password "pass"</code>
 /// </example>
 /// <remarks>
 /// For OAuth2, use the <c>Connect-OAuthGoogle</c> or <c>Connect-OAuthO365</c> cmdlets to obtain a credential object.
 /// </remarks>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>
-/// <seealso cref="CmdletDisconnectPOP"/>
-/// <seealso cref="CmdletGetPOPMessage"/>
+/// <seealso cref="CmdletDisconnectPOP3"/>
+/// <seealso cref="CmdletGetPOP3Message"/>
 /// </summary>
-[Cmdlet(VerbsCommunications.Connect, "POP")]
-[Alias("Connect-POP3")]
-public sealed class CmdletConnectPOP : AsyncPSCmdlet {
+[Cmdlet(VerbsCommunications.Connect, "POP3")]
+[Alias("Connect-POP")]
+public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
     /// <summary>
     /// <para type="description">Specifies the POP3 server hostname or IP address to connect to.</para>
     /// </summary>
@@ -112,14 +112,14 @@ public sealed class CmdletConnectPOP : AsyncPSCmdlet {
     /// Connects to the POP3 server and returns a <see cref="PopConnectionInfo"/> object with connection and client details.
     /// </summary>
     /// <remarks>
-    /// Use the returned object with <c>Disconnect-POP</c> or <c>Get-POPMessage</c> for further operations.
+    /// Use the returned object with <c>Disconnect-POP3</c> or <c>Get-POP3Message</c> for further operations.
     /// </remarks>
     protected override async Task ProcessRecordAsync() {
         var client = new Pop3Client();
         try {
             await client.ConnectAsync(Server, Port, Options);
         } catch (Exception ex) {
-            WriteWarning($"Connect-POP - Unable to connect: {ex.Message}");
+            WriteWarning($"Connect-POP3 - Unable to connect: {ex.Message}");
             return;
         }
 
@@ -148,17 +148,17 @@ public sealed class CmdletConnectPOP : AsyncPSCmdlet {
                     var password = Credential.Password is SecureString ss ? new System.Net.NetworkCredential("", ss).Password : Credential.GetNetworkCredential().Password;
                     await client.AuthenticateAsync(username, password);
                 } else {
-                    WriteWarning("Connect-POP - No valid authentication method provided.");
+                    WriteWarning("Connect-POP3 - No valid authentication method provided.");
                     await client.DisconnectAsync(true);
                     return;
                 }
             } catch (Exception ex) {
-                WriteWarning($"Connect-POP - Unable to authenticate: {ex.Message}");
+                WriteWarning($"Connect-POP3 - Unable to authenticate: {ex.Message}");
                 await client.DisconnectAsync(true);
                 return;
             }
         } else {
-            WriteWarning("Connect-POP - Client is not connected after ConnectAsync.");
+            WriteWarning("Connect-POP3 - Client is not connected after ConnectAsync.");
             return;
         }
 
@@ -183,7 +183,7 @@ public sealed class CmdletConnectPOP : AsyncPSCmdlet {
             };
             WriteObject(info);
         } else {
-            WriteWarning("Connect-POP - Authentication failed.");
+            WriteWarning("Connect-POP3 - Authentication failed.");
             await client.DisconnectAsync(true);
         }
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletDisconnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletDisconnectPOP3.cs
@@ -5,23 +5,23 @@ using MailKit.Net.Pop3;
 namespace Mailozaurr.PowerShell;
 
 /// <summary>
-/// <para type="synopsis">Disconnects an active POP3 connection previously established with Connect-POP.</para>
-/// <para type="description">The <c>Disconnect-POP</c> cmdlet disconnects an active MailKit POP3 client session. Pass the <see cref="PopConnectionInfo"/> object returned by <c>Connect-POP</c> to this cmdlet to safely close the connection and release resources.</para>
+/// <para type="synopsis">Disconnects an active POP3 connection previously established with Connect-POP3.</para>
+/// <para type="description">The <c>Disconnect-POP3</c> cmdlet disconnects an active MailKit POP3 client session. Pass the <see cref="PopConnectionInfo"/> object returned by <c>Connect-POP3</c> to this cmdlet to safely close the connection and release resources.</para>
 /// <example>
 ///   <summary>Disconnect a POP3 client</summary>
-///   <code>$client = Connect-POP ...; Disconnect-POP -Client $client</code>
+///   <code>$client = Connect-POP3 ...; Disconnect-POP3 -Client $client</code>
 /// </example>
 /// <remarks>
 /// Always disconnect POP3 sessions to avoid resource leaks and server-side session limits.
 /// </remarks>
-/// <seealso cref="CmdletConnectPOP"/>
+/// <seealso cref="CmdletConnectPOP3"/>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>
 /// </summary>
-[Cmdlet(VerbsCommunications.Disconnect, "POP")]
-[Alias("Disconnect-POP3")]
-public sealed class CmdletDisconnectPOP : AsyncPSCmdlet {
+[Cmdlet(VerbsCommunications.Disconnect, "POP3")]
+[Alias("Disconnect-POP")]
+public sealed class CmdletDisconnectPOP3 : AsyncPSCmdlet {
     /// <summary>
-    /// <para type="description">The <see cref="PopConnectionInfo"/> object containing the MailKit POP3 client instance to disconnect. This is the object returned by <c>Connect-POP</c>.</para>
+    /// <para type="description">The <see cref="PopConnectionInfo"/> object containing the MailKit POP3 client instance to disconnect. This is the object returned by <c>Connect-POP3</c>.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
     [ValidateNotNull]
@@ -37,10 +37,10 @@ public sealed class CmdletDisconnectPOP : AsyncPSCmdlet {
                 try {
                     data.Disconnect(true);
                 } catch (System.Exception ex) {
-                    WriteWarning($"Disconnect-POP - Unable to disconnect: {ex.Message}");
+                    WriteWarning($"Disconnect-POP3 - Unable to disconnect: {ex.Message}");
                 }
             } else {
-                WriteWarning("Disconnect-POP - The provided object does not contain a valid Data property of type Pop3Client.");
+                WriteWarning("Disconnect-POP3 - The provided object does not contain a valid Data property of type Pop3Client.");
             }
         }
         return Task.CompletedTask;

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailMessage.cs
@@ -18,13 +18,13 @@ namespace Mailozaurr.PowerShell;
 /// </example>
 /// <example>
 ///   <summary>Get POP3 messages received today</summary>
-///   <code>$pop = Connect-POP ...; Get-EmailMessage -PopClient $pop -Since (Get-Date).Date</code>
+///   <code>$pop = Connect-POP3 ...; Get-EmailMessage -PopClient $pop -Since (Get-Date).Date</code>
 /// </example>
 /// <remarks>
 /// Use this cmdlet to retrieve and filter messages from IMAP or POP3 servers for automation or archiving tasks.
 /// </remarks>
 /// <seealso cref="CmdletConnectIMAP"/>
-/// <seealso cref="CmdletConnectPOP"/>
+/// <seealso cref="CmdletConnectPOP3"/>
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "EmailMessage")]
 [OutputType(typeof(MimeMessage))]
@@ -37,7 +37,7 @@ public sealed class CmdletGetEmailMessage : AsyncPSCmdlet {
     public ImapConnectionInfo? ImapClient { get; set; }
 
     /// <summary>
-    /// <para type="description">Active POP3 connection object returned by <c>Connect-POP</c>.</para>
+    /// <para type="description">Active POP3 connection object returned by <c>Connect-POP3</c>.</para>
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "POP", ValueFromPipeline = true)]
     [ValidateNotNull]

--- a/Sources/Mailozaurr.PowerShell/CmdletGetPOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetPOP3Message.cs
@@ -6,26 +6,26 @@ namespace Mailozaurr.PowerShell;
 
 /// <summary>
 /// <para type="synopsis">Retrieves messages from a POP3 mailbox using an active POP3 connection.</para>
-/// <para type="description">The <c>Get-POPMessage</c> cmdlet retrieves one or more messages from a POP3 mailbox using the provided <see cref="PopConnectionInfo"/> object (from <c>Connect-POP</c>). You can specify the message index, count, or use <c>-All</c> to retrieve all messages. Returns message objects for further automation or archiving.</para>
+/// <para type="description">The <c>Get-POP3Message</c> cmdlet retrieves one or more messages from a POP3 mailbox using the provided <see cref="PopConnectionInfo"/> object (from <c>Connect-POP3</c>). You can specify the message index, count, or use <c>-All</c> to retrieve all messages. Returns message objects for further automation or archiving.</para>
 /// <example>
 ///   <summary>Get the first message from a POP3 mailbox</summary>
-///   <code>$client = Connect-POP ...; Get-POPMessage -Client $client -Index 0</code>
+///   <code>$client = Connect-POP3 ...; Get-POP3Message -Client $client -Index 0</code>
 /// </example>
 /// <example>
 ///   <summary>Get all messages from a POP3 mailbox</summary>
-///   <code>$client = Connect-POP ...; Get-POPMessage -Client $client -All</code>
+///   <code>$client = Connect-POP3 ...; Get-POP3Message -Client $client -All</code>
 /// </example>
 /// <remarks>
 /// Use this cmdlet to enumerate or download messages from a POP3 mailbox for backup, migration, or processing.
 /// </remarks>
-/// <seealso cref="CmdletConnectPOP"/>
+/// <seealso cref="CmdletConnectPOP3"/>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "POPMessage")]
-[Alias("Get-POP3Message")]
-public sealed class CmdletGetPOPMessage : AsyncPSCmdlet {
+[Cmdlet(VerbsCommon.Get, "POP3Message")]
+[Alias("Get-POPMessage")]
+public sealed class CmdletGetPOP3Message : AsyncPSCmdlet {
     /// <summary>
-    /// <para type="description">The <see cref="PopConnectionInfo"/> object representing the active POP3 connection. This is the object returned by <c>Connect-POP</c>.</para>
+    /// <para type="description">The <see cref="PopConnectionInfo"/> object representing the active POP3 connection. This is the object returned by <c>Connect-POP3</c>.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
     [ValidateNotNull]

--- a/Sources/Mailozaurr.PowerShell/CmdletSavePOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSavePOP3Message.cs
@@ -6,22 +6,22 @@ namespace Mailozaurr.PowerShell;
 
 /// <summary>
 /// <para type="synopsis">Saves a POP3 message to disk at the specified path.</para>
-/// <para type="description">The <c>Save-POPMessage</c> cmdlet saves a message from a POP3 mailbox (using a <see cref="PopConnectionInfo"/> object from <c>Connect-POP</c>) to disk at the specified path. Use this to archive, export, or process messages retrieved from a POP3 server.</para>
+/// <para type="description">The <c>Save-POP3Message</c> cmdlet saves a message from a POP3 mailbox (using a <see cref="PopConnectionInfo"/> object from <c>Connect-POP3</c>) to disk at the specified path. Use this to archive, export, or process messages retrieved from a POP3 server.</para>
 /// <example>
 ///   <summary>Save a POP3 message to a file</summary>
-///   <code>$client = Connect-POP ...; Save-POPMessage -Client $client -Index 0 -Path "C:\Mail\message.eml"</code>
+///   <code>$client = Connect-POP3 ...; Save-POP3Message -Client $client -Index 0 -Path "C:\Mail\message.eml"</code>
 /// </example>
 /// <remarks>
 /// Use this cmdlet to export or archive messages for backup, migration, or compliance scenarios.
 /// </remarks>
-/// <seealso cref="CmdletConnectPOP"/>
+/// <seealso cref="CmdletConnectPOP3"/>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>
 /// </summary>
-[Cmdlet(VerbsData.Save, "POPMessage")]
-[Alias("Save-POP3Message")]
-public sealed class CmdletSavePOPMessage : AsyncPSCmdlet {
+[Cmdlet(VerbsData.Save, "POP3Message")]
+[Alias("Save-POPMessage")]
+public sealed class CmdletSavePOP3Message : AsyncPSCmdlet {
     /// <summary>
-    /// <para type="description">The <see cref="PopConnectionInfo"/> object representing the active POP3 connection. This is the object returned by <c>Connect-POP</c>.</para>
+    /// <para type="description">The <see cref="PopConnectionInfo"/> object representing the active POP3 connection. This is the object returned by <c>Connect-POP3</c>.</para>
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
     [ValidateNotNull]


### PR DESCRIPTION
## Summary
- rename POP cmdlets to POP3 form
- keep compatibility aliases for previous names
- update module manifest entries
- refresh documentation comments

## Testing
- `MSBUILDDISABLENODEREUSE=1 dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug -p:TargetFramework=net8.0` *(fails: TerminalLogger WrapText out of range)*

------
https://chatgpt.com/codex/tasks/task_e_685bfcd27a60832e8a3d9946f7dcc3d3