### PR TITLE
Implement parameter set support for Get-MailFolder

### DIFF
--- a/Examples/Example-GetMailFolder.ps1
+++ b/Examples/Example-GetMailFolder.ps1
@@ -1,0 +1,15 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+# using application permissions
+$ClientId = 'your-client-id'
+$ClientSecret = 'your-client-secret'
+$TenantId = 'your-tenant-id'
+$cred = ConvertTo-GraphCredential -ClientId $ClientId -ClientSecret $ClientSecret -DirectoryId $TenantId
+$graph = Connect-EmailGraph -Credential $cred
+Get-MailFolder -UserPrincipalName 'user@example.com' -Connection $graph
+Disconnect-EmailGraph -Connection $graph
+
+# using Connect-MgGraph
+Import-Module Microsoft.Graph.Authentication -Force
+Connect-MgGraph -Scopes Mail.Read -NoWelcome
+Get-MailFolder -UserPrincipalName 'user@example.com' -MgGraphRequest

--- a/README.MD
+++ b/README.MD
@@ -101,7 +101,7 @@ This will make sure the project has required libraries.
   - [x] Get IMAP Folder
   - [x] Get IMAP Messages
 - Office 365 Graph API
-  - [x] Get Mail Folders
+  - [x] Get Mail Folders via `Get-MailFolder` with `-Connection` or `-MgGraphRequest`
   - [x] Get Mail Messages
   - [x] Save Mail Messages
 - DNS and email validation functionality is now provided by [DomainDetective](https://github.com/EvotecIT/DomainDetective)
@@ -130,6 +130,7 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - [Example-SendEmail-SignEncrypt.ps1](Examples/Example-SendEmail-SignEncrypt.ps1) - sign and encrypt an email using SMTP.
 - [Example-SendEmail-Pgp.ps1](Examples/Example-SendEmail-Pgp.ps1) - send a PGP encrypted email.
 - [Example-GraphManageMessages.ps1](Examples/Example-GraphManageMessages.ps1) - download attachments, set read state and move messages using Microsoft Graph.
+- [Example-GetMailFolder.ps1](Examples/Example-GetMailFolder.ps1) - list folders using either `-Connection` or `-MgGraphRequest`.
 - Use `Connect-EmailGraph` and `Disconnect-EmailGraph` to authenticate and release application credentials for Microsoft Graph. The connection cmdlet supports both client secret and certificate authentication modes.
 - [Example-SendEmail-Attachments.ps1](Examples/Example-SendEmail-Attachments.ps1) - demonstrate file and in-memory attachments.
 - [PGP documentation](Docs/PGP.md) - overview of OpenPGP support.

--- a/Sources/Mailozaurr.PowerShell/CmdletGetMailFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetMailFolder.cs
@@ -1,14 +1,23 @@
 using System.Management.Automation;
+using System.Management.Automation.Runspaces;
 using Mailozaurr;
+using System.Threading.Tasks;
 
 namespace Mailozaurr.PowerShell;
 
 /// <summary>
 /// <para type="synopsis">Retrieves mail folders for a user via Microsoft Graph API.</para>
-/// <para type="description">The <c>Get-MailFolder</c> cmdlet retrieves mail folders for the specified user principal name (email address) using Microsoft Graph API. You can specify client credentials directly or use a PSCredential object. Returns folder objects for use in further automation or reporting.</para>
+/// <para type="description">The <c>Get-MailFolder</c> cmdlet retrieves mail folders for the specified user principal name using Microsoft Graph API. Provide a <see cref="GraphConnectionInfo"/> object created with <c>Connect-EmailGraph</c> or authenticate via <c>Connect-MgGraph</c>.</para>
 /// <example>
-///   <summary>Get mail folders for a user</summary>
-///   <code>Get-MailFolder -UserPrincipalName "user@domain.com" -ClientId "id" -ClientSecret "secret" -DirectoryId "tenant"</code>
+///   <summary>Get mail folders using application permissions</summary>
+///   <code>$cred = ConvertTo-GraphCredential -ClientId "id" -ClientSecret "secret" -DirectoryId "tenant"
+///   $graph = Connect-EmailGraph -Credential $cred
+///   Get-MailFolder -UserPrincipalName "user@domain.com" -Connection $graph</code>
+/// </example>
+/// <example>
+///   <summary>Get mail folders using Connect-MgGraph</summary>
+///   <code>Connect-MgGraph -Scopes Mail.Read -NoWelcome
+///   Get-MailFolder -UserPrincipalName "user@domain.com" -MgGraphRequest</code>
 /// </example>
 /// <remarks>
 /// Use this cmdlet to enumerate mail folders for mailbox management, reporting, or migration scenarios.
@@ -17,38 +26,48 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "MailFolder")]
 [OutputType(typeof(object))]
-public class CmdletGetMailFolder : PSCmdlet {
+public class CmdletGetMailFolder : AsyncPSCmdlet {
     /// <summary>
     /// <para type="description">Specifies the user principal name (email address) whose mail folders will be retrieved.</para>
     /// </summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = "Graph")]
+    [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
-    /// <summary>
-    /// <para type="description">Specifies the client ID for Microsoft Graph authentication.</para>
-    /// </summary>
-    [Parameter]
-    public string? ClientId { get; set; }
-    /// <summary>
-    /// <para type="description">Specifies the client secret for Microsoft Graph authentication.</para>
-    /// </summary>
-    [Parameter]
-    public string? ClientSecret { get; set; }
-    /// <summary>
-    /// <para type="description">Specifies the directory (tenant) ID for Microsoft Graph authentication.</para>
-    /// </summary>
-    [Parameter]
-    public string? DirectoryId { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "Graph")]
+    [ValidateNotNull]
+    public GraphConnectionInfo? Connection { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
+    public SwitchParameter MgGraphRequest { get; set; }
 
     /// <summary>
     /// Retrieves mail folders for the specified user via Microsoft Graph API.
     /// </summary>
-    protected override void ProcessRecord() {
-        var cred = new GraphCredential { ClientId = ClientId, ClientSecret = ClientSecret, DirectoryId = DirectoryId };
-        var task = MicrosoftGraphUtils.GetMailFoldersAsync(cred, UserPrincipalName);
-        task.Wait();
-        foreach (var folder in task.Result) {
+    protected override Task ProcessRecordAsync() {
+        return ParameterSetName switch {
+            "Graph" => ProcessGraphAsync(Connection!.Credential),
+            "MgGraphRequest" => ProcessMgGraph(),
+            _ => Task.CompletedTask,
+        };
+    }
+
+    private async Task ProcessGraphAsync(GraphCredential cred) {
+        var folders = await MicrosoftGraphUtils.GetMailFoldersAsync(cred, UserPrincipalName!);
+        foreach (var folder in folders) {
             WriteObject(folder);
         }
+    }
+
+    private Task ProcessMgGraph() {
+        var uri = $"https://graph.microsoft.com/v1.0/users/{UserPrincipalName}/mailFolders";
+        var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
+        ps.AddCommand("Invoke-MgGraphRequest")
+            .AddParameter("Method", "GET")
+            .AddParameter("Uri", uri);
+        var results = ps.Invoke();
+        foreach (var res in results) WriteObject(res);
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- add GraphConnectionInfo and MgGraphRequest parameter sets to `Get-MailFolder`
- provide MgGraph pipeline example
- document Get-MailFolder connection usage in README

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685c24ff9eec832ebd394300b650fb02