### PR TITLE
Add default connection sessions

### DIFF
--- a/Examples/Example-GetEmailMessage.ps1
+++ b/Examples/Example-GetEmailMessage.ps1
@@ -1,19 +1,19 @@
 Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
 # Example 1: Retrieve messages from an IMAP folder with subject filter
-$imap = Connect-IMAP -Server 'imap.example.com' -UserName 'user@example.com' -Password 'Pa55w0rd' -Port 993 -Options Auto
-Get-EmailMessage -ImapClient $imap -Folder 'Inbox/Reports' -Subject 'Monthly' -Since (Get-Date).AddDays(-7)
-Disconnect-IMAP -Client $imap
+Connect-IMAP -Server 'imap.example.com' -UserName 'user@example.com' -Password 'Pa55w0rd' -Port 993 -Options Auto | Out-Null
+Get-EmailMessage -Folder 'Inbox/Reports' -Subject 'Monthly' -Since (Get-Date).AddDays(-7)
+Disconnect-IMAP
 
 # Example 2: Retrieve today's POP3 messages
-$pop = Connect-POP3 -Server 'pop.example.com' -UserName 'user@example.com' -Password 'Pa55w0rd' -Port 995 -Options Auto
-Get-EmailMessage -PopClient $pop -Since (Get-Date).Date
-Disconnect-POP3 -Client $pop
+Connect-POP3 -Server 'pop.example.com' -UserName 'user@example.com' -Password 'Pa55w0rd' -Port 995 -Options Auto | Out-Null
+Get-POP3Message -Since (Get-Date).Date
+Disconnect-POP3
 
 # Example 3: Retrieve all POP3 messages and delete them
-$pop = Connect-POP3 -Server 'pop.example.com' -UserName 'user@example.com' -Password 'Pa55w0rd' -Port 995 -Options Auto
-Get-EmailMessage -PopClient $pop -All -Delete
-Disconnect-POP3 -Client $pop
+Connect-POP3 -Server 'pop.example.com' -UserName 'user@example.com' -Password 'Pa55w0rd' -Port 995 -Options Auto | Out-Null
+Get-POP3Message -All -Delete
+Disconnect-POP3
 
 # Example 4: Retrieve high priority messages from a specific domain via IMAP
 $imap = Connect-IMAP -Server 'imap.example.com' -UserName 'user@example.com' -Password 'Pa55w0rd' -Port 993 -Options Auto
@@ -91,7 +91,7 @@ $ClientId = 'your-client-id'
 $ClientSecret = 'your-client-secret'
 $TenantId = 'your-tenant-id'
 $cred = ConvertTo-GraphCredential -ClientId $ClientId -ClientSecret $ClientSecret -DirectoryId $TenantId
-$graph = Connect-EmailGraph -Credential $cred
-Get-GraphMessage -UserPrincipalName 'user@example.com' -Connection $graph -HasAttachment -Limit 5
+Connect-EmailGraph -Credential $cred | Out-Null
+Get-GraphMessage -UserPrincipalName 'user@example.com' -HasAttachment -Limit 5
 
-Disconnect-EmailGraph -Connection $graph
+Disconnect-EmailGraph

--- a/Examples/Example-GetMailFolder.ps1
+++ b/Examples/Example-GetMailFolder.ps1
@@ -5,9 +5,9 @@ $ClientId = 'your-client-id'
 $ClientSecret = 'your-client-secret'
 $TenantId = 'your-tenant-id'
 $cred = ConvertTo-GraphCredential -ClientId $ClientId -ClientSecret $ClientSecret -DirectoryId $TenantId
-$graph = Connect-EmailGraph -Credential $cred
-Get-MailFolder -UserPrincipalName 'user@example.com' -Connection $graph
-Disconnect-EmailGraph -Connection $graph
+Connect-EmailGraph -Credential $cred | Out-Null
+Get-MailFolder -UserPrincipalName 'user@example.com'
+Disconnect-EmailGraph
 
 # using Connect-MgGraph
 Import-Module Microsoft.Graph.Authentication -Force

--- a/Examples/Example-GraphManageMessages.ps1
+++ b/Examples/Example-GraphManageMessages.ps1
@@ -6,14 +6,13 @@ $ClientSecret = 'your-client-secret'
 $TenantId = 'your-tenant-id'
 
 $cred = ConvertTo-GraphCredential -ClientId $ClientId -ClientSecret $ClientSecret -DirectoryId $TenantId
-$graph = Connect-EmailGraph -Credential $cred
+Connect-EmailGraph -Credential $cred | Out-Null
 
-$messages = Get-GraphMessage -UserPrincipalName 'user@example.com' -Connection $graph -Filter "hasAttachments eq true" -Limit 5
+$messages = Get-GraphMessage -UserPrincipalName 'user@example.com' -Filter "hasAttachments eq true" -Limit 5
 foreach ($m in $messages) {
-    Get-MailMessageAttachment -UserPrincipalName 'user@example.com' -MessageId $m.Id -Connection $graph |
+    Get-MailMessageAttachment -UserPrincipalName 'user@example.com' -MessageId $m.Id |
         Save-GraphMessageAttachment -Path 'C:\Temp\Attachments'
-    Set-GraphMessage -UserPrincipalName 'user@example.com' -MessageId $m.Id -Connection $graph -Read
-    Move-GraphMessage -UserPrincipalName 'user@example.com' -MessageId $m.Id -DestinationFolderId 'Archive' -Connection $graph
+    Set-GraphMessage -UserPrincipalName 'user@example.com' -MessageId $m.Id -Read
+    Move-GraphMessage -UserPrincipalName 'user@example.com' -MessageId $m.Id -DestinationFolderId 'Archive'
 }
-
-Disconnect-EmailGraph -Connection $graph
+Disconnect-EmailGraph

--- a/README.MD
+++ b/README.MD
@@ -132,6 +132,7 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - [Example-GraphManageMessages.ps1](Examples/Example-GraphManageMessages.ps1) - download attachments, set read state and move messages using Microsoft Graph.
 - [Example-GetMailFolder.ps1](Examples/Example-GetMailFolder.ps1) - list folders using either `-Connection` or `-MgGraphRequest`.
 - Use `Connect-EmailGraph` and `Disconnect-EmailGraph` to authenticate and release application credentials for Microsoft Graph. The connection cmdlet supports both client secret and certificate authentication modes.
+- `Connect-EmailGraph`, `Connect-IMAP` and `Connect-POP3` store the last successful connection in module variables. Subsequent cmdlets use these defaults when `-Connection` or `-Client` is omitted.
 - [Example-SendEmail-Attachments.ps1](Examples/Example-SendEmail-Attachments.ps1) - demonstrate file and in-memory attachments.
 - [PGP documentation](Docs/PGP.md) - overview of OpenPGP support.
 

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -65,6 +65,7 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
         }
 
         var info = new GraphConnectionInfo { Credential = cred, IsConnected = connected };
+        DefaultSessions.GraphSession = info;
         WriteObject(info);
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -187,6 +187,7 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
                 Messages = client.Inbox,
                 Recent = client.Inbox?.Recent ?? 0
             };
+            DefaultSessions.ImapSession = info;
             WriteObject(info);
         } else {
             WriteWarning("Connect-IMAP - Authentication failed.");

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -181,6 +181,7 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
                 Messages = null, // Not directly available
                 Recent = 0 // Not directly available
             };
+            DefaultSessions.Pop3Session = info;
             WriteObject(info);
         } else {
             WriteWarning("Connect-POP3 - Authentication failed.");

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailMessage.cs
@@ -29,14 +29,14 @@ public sealed class CmdletGetEmailMessage : AsyncPSCmdlet {
     /// <summary>
     /// <para type="description">Active IMAP connection object returned by <c>Connect-IMAP</c>.</para>
     /// </summary>
-    [Parameter(Mandatory = true, ParameterSetName = "IMAP", ValueFromPipeline = true)]
+    [Parameter(ParameterSetName = "IMAP", ValueFromPipeline = true)]
     [ValidateNotNull]
     public ImapConnectionInfo? ImapClient { get; set; }
 
     /// <summary>
     /// <para type="description">Active POP3 connection object returned by <c>Connect-POP3</c>.</para>
     /// </summary>
-    [Parameter(Mandatory = true, ParameterSetName = "POP", ValueFromPipeline = true)]
+    [Parameter(ParameterSetName = "POP", ValueFromPipeline = true)]
     [ValidateNotNull]
     public PopConnectionInfo? PopClient { get; set; }
 
@@ -112,13 +112,14 @@ public sealed class CmdletGetEmailMessage : AsyncPSCmdlet {
     }
 
     private Task ProcessImapAsync() {
-        if (ImapClient == null || ImapClient.Data == null) {
+        var imap = ImapClient ?? DefaultSessions.ImapSession;
+        if (imap == null || imap.Data == null) {
             WriteWarning("Get-EmailMessage - Is IMAP connected?");
             return Task.CompletedTask;
         }
 
         var messages = MessageFetcher.Fetch(
-            ImapClient.Data,
+            imap.Data,
             Folder,
             Subject,
             FromContains,
@@ -135,13 +136,14 @@ public sealed class CmdletGetEmailMessage : AsyncPSCmdlet {
     }
 
     private Task ProcessPopAsync() {
-        if (PopClient == null || PopClient.Data == null) {
+        var pop = PopClient ?? DefaultSessions.Pop3Session;
+        if (pop == null || pop.Data == null) {
             WriteWarning("Get-EmailMessage - Is POP3 connected?");
             return Task.CompletedTask;
         }
 
         var messages = MessageFetcher.Fetch(
-            PopClient.Data,
+            pop.Data,
             Subject,
             FromContains,
             ToContains,

--- a/Sources/Mailozaurr.PowerShell/CmdletGetGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetGraphMessage.cs
@@ -19,7 +19,7 @@ public sealed class CmdletGetGraphMessage : AsyncPSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
-    [Parameter(Mandatory = true, ParameterSetName = "Graph")]
+    [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
@@ -66,11 +66,17 @@ public sealed class CmdletGetGraphMessage : AsyncPSCmdlet {
     public SwitchParameter MgGraphRequest { get; set; }
 
     protected override Task ProcessRecordAsync() {
-        return ParameterSetName switch {
-            "Graph" => ProcessGraphAsync(Connection!.Credential),
-            "MgGraphRequest" => ProcessMgGraph(),
-            _ => Task.CompletedTask,
-        };
+        if (ParameterSetName == "MgGraphRequest") {
+            return ProcessMgGraph();
+        }
+
+        var conn = Connection ?? DefaultSessions.GraphSession;
+        if (conn == null) {
+            WriteWarning("Get-GraphMessage - Connection not provided and no default session available.");
+            return Task.CompletedTask;
+        }
+
+        return ProcessGraphAsync(conn.Credential);
     }
 
     private async Task ProcessGraphAsync(GraphCredential cred) {

--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
@@ -23,7 +23,7 @@ public sealed class CmdletGetIMAPFolder : AsyncPSCmdlet {
     /// <summary>
     /// <para type="description">The <see cref="ImapConnectionInfo"/> object representing the active IMAP connection. This is the object returned by <c>Connect-IMAP</c>.</para>
     /// </summary>
-    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [Parameter(Position = 0, ValueFromPipeline = true)]
     [ValidateNotNull]
     public ImapConnectionInfo? Client { get; set; }
 
@@ -37,14 +37,16 @@ public sealed class CmdletGetIMAPFolder : AsyncPSCmdlet {
     /// Opens the inbox folder, updates message counts, and returns the updated connection info.
     /// </summary>
     protected override Task ProcessRecordAsync() {
-        if (Client != null) {
-            var folder = Client.Data.Inbox;
+        var conn = Client ?? DefaultSessions.ImapSession;
+        if (conn != null) {
+            var folder = conn.Data.Inbox;
             folder.Open(FolderAccess);
             WriteVerbose($"Get-IMAPFolder - Total messages {folder.Count}, Recent messages {folder.Recent}");
-            Client.Messages = folder;
-            Client.Count = folder.Count;
-            Client.Recent = folder.Recent;
-            WriteObject(Client);
+            conn.Messages = folder;
+            conn.Count = folder.Count;
+            conn.Recent = folder.Recent;
+            DefaultSessions.ImapSession = conn;
+            WriteObject(conn);
         } else {
             WriteVerbose("Get-IMAPFolder - Client not connected?");
         }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
@@ -30,7 +30,7 @@ public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
     /// <summary>
     /// <para type="description">The <see cref="ImapConnectionInfo"/> object representing the active IMAP connection. This is the object returned by <c>Connect-IMAP</c>.</para>
     /// </summary>
-    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [Parameter(Position = 0, ValueFromPipeline = true)]
     [ValidateNotNull]
     public ImapConnectionInfo? Client { get; set; }
 
@@ -128,11 +128,12 @@ public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
     /// Opens the inbox folder and retrieves messages if message parameters are specified.
     /// </summary>
     protected override Task ProcessRecordAsync() {
-        if (Client != null && Client.Data != null) {
-            var folder = Client.Folder?.FullName;
+        var conn = Client ?? DefaultSessions.ImapSession;
+        if (conn != null && conn.Data != null) {
+            var folder = conn.Folder?.FullName;
 
             var messages = MessageFetcher.Fetch(
-                Client.Data,
+                conn.Data,
                 folder,
                 Subject,
                 FromContains,

--- a/Sources/Mailozaurr.PowerShell/CmdletGetMailFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetMailFolder.cs
@@ -35,7 +35,7 @@ public class CmdletGetMailFolder : AsyncPSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
-    [Parameter(Mandatory = true, ParameterSetName = "Graph")]
+    [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
@@ -46,11 +46,17 @@ public class CmdletGetMailFolder : AsyncPSCmdlet {
     /// Retrieves mail folders for the specified user via Microsoft Graph API.
     /// </summary>
     protected override Task ProcessRecordAsync() {
-        return ParameterSetName switch {
-            "Graph" => ProcessGraphAsync(Connection!.Credential),
-            "MgGraphRequest" => ProcessMgGraph(),
-            _ => Task.CompletedTask,
-        };
+        if (ParameterSetName == "MgGraphRequest") {
+            return ProcessMgGraph();
+        }
+
+        var conn = Connection ?? DefaultSessions.GraphSession;
+        if (conn == null) {
+            WriteWarning("Get-MailFolder - Connection not provided and no default session available.");
+            return Task.CompletedTask;
+        }
+
+        return ProcessGraphAsync(conn.Credential);
     }
 
     private async Task ProcessGraphAsync(GraphCredential cred) {

--- a/Sources/Mailozaurr.PowerShell/CmdletGetMailMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetMailMessageAttachment.cs
@@ -36,7 +36,7 @@ public class CmdletGetMailMessageAttachment : AsyncPSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? MessageId { get; set; }
     /// <summary>
-    [Parameter(Mandatory = true, ParameterSetName = "Graph")]
+    [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
@@ -55,7 +55,12 @@ public class CmdletGetMailMessageAttachment : AsyncPSCmdlet {
     /// </summary>
     protected override async Task ProcessRecordAsync() {
         if (ParameterSetName == "Graph") {
-            var attachments = await MicrosoftGraphUtils.GetMailMessageAttachmentsAsync(Connection!.Credential, UserPrincipalName!, MessageId!, Property);
+            var conn = Connection ?? DefaultSessions.GraphSession;
+            if (conn == null) {
+                WriteWarning("Get-MailMessageAttachment - Connection not provided and no default session available.");
+                return;
+            }
+            var attachments = await MicrosoftGraphUtils.GetMailMessageAttachmentsAsync(conn.Credential, UserPrincipalName!, MessageId!, Property);
             foreach (var att in attachments) {
                 WriteObject(att);
             }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetPOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetPOP3Message.cs
@@ -27,7 +27,7 @@ public sealed class CmdletGetPOP3Message : AsyncPSCmdlet {
     /// <summary>
     /// <para type="description">The <see cref="PopConnectionInfo"/> object representing the active POP3 connection. This is the object returned by <c>Connect-POP3</c>.</para>
     /// </summary>
-    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [Parameter(Position = 0, ValueFromPipeline = true)]
     [ValidateNotNull]
     public PopConnectionInfo? Client { get; set; }
 
@@ -101,9 +101,10 @@ public sealed class CmdletGetPOP3Message : AsyncPSCmdlet {
     /// Retrieves one or more messages from the POP3 mailbox.
     /// </summary>
     protected override Task ProcessRecordAsync() {
-        if (Client != null && Client.Data != null) {
+        var conn = Client ?? DefaultSessions.Pop3Session;
+        if (conn != null && conn.Data != null) {
             var messages = MessageFetcher.Fetch(
-                Client.Data,
+                conn.Data,
                 Subject,
                 FromContains,
                 ToContains,

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
@@ -21,7 +21,7 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? DestinationFolderId { get; set; }
 
-    [Parameter(Mandatory = true, ParameterSetName = "Graph")]
+    [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
@@ -32,7 +32,12 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     protected override Task ProcessRecordAsync() {
         switch (ParameterSetName) {
             case "Graph":
-                return ProcessGraphAsync(Connection!.Credential);
+                var conn = Connection ?? DefaultSessions.GraphSession;
+                if (conn == null) {
+                    WriteWarning("Move-GraphMessage - Connection not provided and no default session available.");
+                    return Task.CompletedTask;
+                }
+                return ProcessGraphAsync(conn.Credential);
             case "MgGraphRequest":
                 ProcessMgGraph();
                 return Task.CompletedTask;

--- a/Sources/Mailozaurr.PowerShell/CmdletSavePOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSavePOP3Message.cs
@@ -23,7 +23,7 @@ public sealed class CmdletSavePOP3Message : AsyncPSCmdlet {
     /// <summary>
     /// <para type="description">The <see cref="PopConnectionInfo"/> object representing the active POP3 connection. This is the object returned by <c>Connect-POP3</c>.</para>
     /// </summary>
-    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [Parameter(Position = 0, ValueFromPipeline = true)]
     [ValidateNotNull]
     public PopConnectionInfo? Client { get; set; }
 
@@ -44,12 +44,13 @@ public sealed class CmdletSavePOP3Message : AsyncPSCmdlet {
     /// Saves the specified POP3 message to disk at the given path.
     /// </summary>
     protected override Task ProcessRecordAsync() {
-        if (Client != null && Client.Data != null) {
-            if (Index < Client.Data.Count) {
-                var message = Client.Data.GetMessage(Index);
+        var conn = Client ?? DefaultSessions.Pop3Session;
+        if (conn != null && conn.Data != null) {
+            if (Index < conn.Data.Count) {
+                var message = conn.Data.GetMessage(Index);
                 message.WriteTo(Path);
             } else {
-                WriteWarning($"Save-POP3Message - Index is out of range. Use index less than {Client.Data.Count}.");
+                WriteWarning($"Save-POP3Message - Index is out of range. Use index less than {conn.Data.Count}.");
             }
         } else {
             WriteWarning("Save-POP3Message - Is POP3 connected?");

--- a/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
@@ -20,7 +20,7 @@ public class CmdletSetGraphMessage : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Read { get; set; }
 
-    [Parameter(Mandatory = true, ParameterSetName = "Graph")]
+    [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
@@ -31,7 +31,12 @@ public class CmdletSetGraphMessage : AsyncPSCmdlet {
     protected override Task ProcessRecordAsync() {
         switch (ParameterSetName) {
             case "Graph":
-                return ProcessGraphAsync(Connection!.Credential);
+                var conn = Connection ?? DefaultSessions.GraphSession;
+                if (conn == null) {
+                    WriteWarning("Set-GraphMessage - Connection not provided and no default session available.");
+                    return Task.CompletedTask;
+                }
+                return ProcessGraphAsync(conn.Credential);
             case "MgGraphRequest":
                 ProcessMgGraph();
                 return Task.CompletedTask;

--- a/Sources/Mailozaurr.PowerShell/Definitions/DefaultSessions.cs
+++ b/Sources/Mailozaurr.PowerShell/Definitions/DefaultSessions.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// Provides access to the last successful connection objects used by the module.
+/// These are automatically updated by Connect-EmailGraph, Connect-IMAP and
+/// Connect-POP3 and consumed by other cmdlets when a connection is not
+/// explicitly provided.
+/// </summary>
+public static class DefaultSessions {
+    /// <summary>Last Microsoft Graph connection.</summary>
+    public static GraphConnectionInfo? GraphSession { get; set; }
+
+    /// <summary>Last IMAP connection.</summary>
+    public static ImapConnectionInfo? ImapSession { get; set; }
+
+    /// <summary>Last POP3 connection.</summary>
+    public static PopConnectionInfo? Pop3Session { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `DefaultSessions` to hold last used connection objects
- persist sessions in Connect-EmailGraph/IMAP/POP3
- use default sessions in graph, IMAP and POP3 cmdlets when connection not specified
- document default session behavior
- update examples

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1` *(fails: Compiled module not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c518dec08832e936be4f1fbd826a3