### PR TITLE
Add typed message wrappers for IMAP and POP3

### DIFF
--- a/Sources/Mailozaurr/ImapEmailMessage.cs
+++ b/Sources/Mailozaurr/ImapEmailMessage.cs
@@ -1,0 +1,27 @@
+using MailKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents an IMAP email message along with its unique identifier.
+/// </summary>
+public class ImapEmailMessage {
+    /// <summary>
+    /// Creates a new instance of <see cref="ImapEmailMessage"/>.
+    /// </summary>
+    /// <param name="uid">Unique identifier of the message.</param>
+    /// <param name="message">The actual MIME message.</param>
+    public ImapEmailMessage(UniqueId uid, MimeMessage message) {
+        Uid = uid;
+        Message = message;
+    }
+
+    /// <summary>Unique identifier of the message.</summary>
+    public UniqueId Uid { get; }
+
+    /// <summary>The underlying <see cref="MimeMessage"/>.</summary>
+    public MimeMessage Message { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Message.Subject ?? base.ToString();
+}

--- a/Sources/Mailozaurr/Pop3EmailMessage.cs
+++ b/Sources/Mailozaurr/Pop3EmailMessage.cs
@@ -1,0 +1,25 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents a POP3 email message along with its index.
+/// </summary>
+public class Pop3EmailMessage {
+    /// <summary>
+    /// Creates a new instance of <see cref="Pop3EmailMessage"/>.
+    /// </summary>
+    /// <param name="index">Index of the message within the mailbox.</param>
+    /// <param name="message">The actual MIME message.</param>
+    public Pop3EmailMessage(int index, MimeMessage message) {
+        Index = index;
+        Message = message;
+    }
+
+    /// <summary>Index of the message within the mailbox.</summary>
+    public int Index { get; }
+
+    /// <summary>The underlying <see cref="MimeMessage"/>.</summary>
+    public MimeMessage Message { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Message.Subject ?? base.ToString();
+}

--- a/Sources/Mailozaurr/Receive/MessageFetcher.cs
+++ b/Sources/Mailozaurr/Receive/MessageFetcher.cs
@@ -26,7 +26,7 @@ public static class MessageFetcher {
     /// <param name="all">If set, ignores other filters.</param>
     /// <param name="delete">If set, messages are deleted after fetching.</param>
     /// <returns>Collection of matching messages.</returns>
-    public static IEnumerable<MimeMessage> Fetch(
+    public static IEnumerable<ImapEmailMessage> Fetch(
         ImapClient client,
         string? folder = null,
         string? subject = null,
@@ -83,7 +83,7 @@ public static class MessageFetcher {
             if (priority.HasValue && msg.Priority != ConvertPriority(priority.Value)) {
                 continue;
             }
-            yield return msg;
+            yield return new ImapEmailMessage(uid, msg);
             if (delete) {
                 mailFolder.AddFlags(uid, MessageFlags.Deleted, true);
             }
@@ -106,7 +106,7 @@ public static class MessageFetcher {
     /// <param name="all">If set, ignores other filters.</param>
     /// <param name="delete">If set, messages are deleted after fetching.</param>
     /// <returns>Collection of matching messages.</returns>
-    public static IEnumerable<MimeMessage> Fetch(
+    public static IEnumerable<Pop3EmailMessage> Fetch(
         Pop3Client client,
         string? subject = null,
         string? fromContains = null,
@@ -146,7 +146,7 @@ public static class MessageFetcher {
                 continue;
             }
 
-            yield return message;
+            yield return new Pop3EmailMessage(i, message);
             if (delete) {
                 client.DeleteMessage(i);
             }

--- a/Tests/MessageTypes.Tests.ps1
+++ b/Tests/MessageTypes.Tests.ps1
@@ -1,0 +1,9 @@
+Describe 'Message wrapper types' {
+    It 'Pop3EmailMessage type is available' {
+        [Mailozaurr.Pop3EmailMessage] | Should -Not -BeNullOrEmpty
+    }
+
+    It 'ImapEmailMessage type is available' {
+        [Mailozaurr.ImapEmailMessage] | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Pop3EmailMessage` and `ImapEmailMessage` wrappers
- emit these types from `MessageFetcher.Fetch`
- add simple unit test for the new types

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685c6a8136b4832e88b9cfa34cc97123