### PR TITLE
Update Graph ReplyTo property

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -41,7 +41,7 @@ public class Graph {
     /// <summary>
     /// Gets or sets the email address to reply to.
     /// </summary>
-    public string ReplyTo { get; set; }
+    public string? ReplyTo { get; set; }
 
     /// <summary>
     /// Gets or sets the email addresses of the recipients.
@@ -225,7 +225,9 @@ public class Graph {
                 To = ConvertToGraphEmailAddressUnique(To, seen),
                 Cc = ConvertToGraphEmailAddressUnique(Cc, seen),
                 Bcc = ConvertToGraphEmailAddressUnique(Bcc, seen),
-                ReplyTo = string.IsNullOrEmpty(ReplyTo) ? null : new List<GraphEmailAddress> { ConvertToGraphEmailAddress(ReplyTo)! },
+                ReplyTo = string.IsNullOrWhiteSpace(ReplyTo)
+                    ? null
+                    : new List<GraphEmailAddress> { ConvertToGraphEmailAddress(ReplyTo)! },
                 Subject = Subject,
                 Body = new GraphContent { Content = HTML, Type = ContentType },
                 IsDeliveryReceiptRequested = RequestDeliveryReceipt,


### PR DESCRIPTION
## Summary
- make `ReplyTo` nullable
- guard `ReplyTo` when building Graph messages

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Debug`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug`
- `pwsh ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685cdca44124832e9e07a7dcf6a0f62c