### PR TITLE
Ensure Get-POP3Message checks connection state

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletGetPOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetPOP3Message.cs
@@ -102,6 +102,11 @@ public sealed class CmdletGetPOP3Message : AsyncPSCmdlet {
     protected override Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.Pop3Session;
         if (conn != null && conn.Data != null) {
+            if (!conn.IsConnected) {
+                WriteWarning("Get-POP3Message - Client is not connected.");
+                return Task.CompletedTask;
+            }
+
             var messages = MessageFetcher.Fetch(
                 conn.Data,
                 Subject,


### PR DESCRIPTION
## Summary
- validate `IsConnected` before fetching POP3 messages

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685ce3f85f1c832eaf8d1e27fb18a558