### PR TITLE
Use AsyncLocal for session storage

### DIFF
--- a/Sources/Mailozaurr.PowerShell/Definitions/DefaultSessions.cs
+++ b/Sources/Mailozaurr.PowerShell/Definitions/DefaultSessions.cs
@@ -1,5 +1,7 @@
 namespace Mailozaurr.PowerShell;
 
+using System.Threading;
+
 /// <summary>
 /// Provides access to the last successful connection objects used by the module.
 /// These are automatically updated by Connect-EmailGraph, Connect-IMAP and
@@ -7,12 +9,25 @@ namespace Mailozaurr.PowerShell;
 /// explicitly provided.
 /// </summary>
 public static class DefaultSessions {
+    private static readonly AsyncLocal<GraphConnectionInfo?> _graphSession = new();
+    private static readonly AsyncLocal<ImapConnectionInfo?> _imapSession = new();
+    private static readonly AsyncLocal<PopConnectionInfo?> _pop3Session = new();
+
     /// <summary>Last Microsoft Graph connection.</summary>
-    public static GraphConnectionInfo? GraphSession { get; set; }
+    public static GraphConnectionInfo? GraphSession {
+        get => _graphSession.Value;
+        set => _graphSession.Value = value;
+    }
 
     /// <summary>Last IMAP connection.</summary>
-    public static ImapConnectionInfo? ImapSession { get; set; }
+    public static ImapConnectionInfo? ImapSession {
+        get => _imapSession.Value;
+        set => _imapSession.Value = value;
+    }
 
     /// <summary>Last POP3 connection.</summary>
-    public static PopConnectionInfo? Pop3Session { get; set; }
+    public static PopConnectionInfo? Pop3Session {
+        get => _pop3Session.Value;
+        set => _pop3Session.Value = value;
+    }
 }


### PR DESCRIPTION
## Summary
- wrap session properties in `AsyncLocal<T>` for thread-safety

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1` *(fails: Write-Color not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce3ed3f24832e9aea234843b7d10e