### PR TITLE
Handle invalid base64 attachments

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -198,9 +198,19 @@ public class Graph {
                 }
             }
 
-            if (ConvertedAttachments.Sum(a => string.IsNullOrEmpty(a.ContentBytes)
-                    ? 0
-                    : Convert.FromBase64String(a.ContentBytes).Length) > 4_000_000) {
+            var totalSize = 0;
+            foreach (var a in ConvertedAttachments) {
+                if (string.IsNullOrEmpty(a.ContentBytes)) {
+                    continue;
+                }
+                try {
+                    totalSize += Convert.FromBase64String(a.ContentBytes).Length;
+                } catch (FormatException ex) {
+                    LogCollector.LogError($"Send-EmailMessage - Invalid base64 for attachment '{a.Name}': {ex.Message}");
+                }
+            }
+
+            if (totalSize > 4_000_000) {
                 // Create a draft message if the total size of the attachments is larger than 4MB
                 IsLargerAttachment = true;
             } else {


### PR DESCRIPTION
## Summary
- catch invalid base64 input in Graph attachments

## Testing
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_685cefc02d1c832ea3ec59770c3d563e