### PR TITLE
Implement refresh token caching

### DIFF
--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -3,6 +3,8 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Auth.OAuth2.Flows;
 using Google.Apis.Util.Store;
 using System.Security.Cryptography.X509Certificates;
+using System.Linq;
+using System;
 
 namespace Mailozaurr;
 
@@ -31,14 +33,27 @@ public static class OAuthHelpers {
             RedirectUri = redirectUri
         };
         var app = PublicClientApplicationBuilder.CreateWithApplicationOptions(options).Build();
+        TokenCacheHelper.RegisterCache(app.UserTokenCache);
         AuthenticationResult result;
+        var accounts = await app.GetAccountsAsync();
+        IAccount? account = null;
         if (!string.IsNullOrEmpty(login)) {
-            result = await app.AcquireTokenInteractive(scopes)
-                .WithLoginHint(login)
-                .ExecuteAsync();
+            account = accounts.FirstOrDefault(a => string.Equals(a.Username, login, StringComparison.OrdinalIgnoreCase));
         } else {
-            result = await app.AcquireTokenInteractive(scopes)
-                .ExecuteAsync();
+            account = accounts.FirstOrDefault();
+        }
+        try {
+            if (account != null) {
+                result = await app.AcquireTokenSilent(scopes, account).ExecuteAsync();
+            } else {
+                throw new MsalUiRequiredException("", "no_account");
+            }
+        } catch (MsalUiRequiredException) {
+            var builder = app.AcquireTokenInteractive(scopes);
+            if (!string.IsNullOrEmpty(login)) {
+                builder = builder.WithLoginHint(login);
+            }
+            result = await builder.ExecuteAsync();
         }
         return new OAuthCredential {
             UserName = result.Account.Username,
@@ -106,7 +121,8 @@ public static class OAuthHelpers {
         var result = await app.AcquireTokenForClient(scopes).ExecuteAsync();
         return new GraphAuthorization {
             AccessToken = result.AccessToken,
-            TokenType = "Bearer"
+            TokenType = "Bearer",
+            ExpiresOn = result.ExpiresOn
         };
     }
 }

--- a/Sources/Mailozaurr/Authentication/TokenCacheHelper.cs
+++ b/Sources/Mailozaurr/Authentication/TokenCacheHelper.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using Microsoft.Identity.Client;
+
+namespace Mailozaurr;
+
+internal static class TokenCacheHelper {
+    private static readonly object FileLock = new();
+    private static readonly string CacheFilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Mailozaurr",
+        "msal_cache.bin");
+
+    public static void RegisterCache(ITokenCache tokenCache) {
+        tokenCache.SetBeforeAccess(BeforeAccessNotification);
+        tokenCache.SetAfterAccess(AfterAccessNotification);
+    }
+
+    private static void BeforeAccessNotification(TokenCacheNotificationArgs args) {
+        lock (FileLock) {
+            if (File.Exists(CacheFilePath)) {
+                var data = File.ReadAllBytes(CacheFilePath);
+                args.TokenCache.DeserializeMsalV3(data, shouldClearExistingCache: true);
+            }
+        }
+    }
+
+    private static void AfterAccessNotification(TokenCacheNotificationArgs args) {
+        if (args.HasStateChanged) {
+            lock (FileLock) {
+                var directory = Path.GetDirectoryName(CacheFilePath);
+                if (!Directory.Exists(directory)) {
+                    Directory.CreateDirectory(directory!);
+                }
+                var data = args.TokenCache.SerializeMsalV3();
+                File.WriteAllBytes(CacheFilePath, data);
+            }
+        }
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAuthorization.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAuthorization.cs
@@ -1,4 +1,6 @@
-﻿namespace Mailozaurr;
+using System.Text.Json.Serialization;
+
+namespace Mailozaurr;
 
 /// <summary>
 /// Result returned when creating an upload session for large attachments.
@@ -19,4 +21,8 @@ public class GraphAuthorization {
     /// <summary>The access token value.</summary>
     [JsonPropertyName("access_token")]
     public string AccessToken { get; set; }
+
+    /// <summary>Time when the access token expires.</summary>
+    [JsonPropertyName("expires_on")]
+    public DateTimeOffset ExpiresOn { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Linq;
 using System.IO;
+using System.Collections.Concurrent;
 
 namespace Mailozaurr {
     /// <summary>
@@ -43,6 +44,7 @@ namespace Mailozaurr {
 
     public static class MicrosoftGraphUtils {
         private static readonly HttpClient HttpClient;
+        private static readonly ConcurrentDictionary<string, GraphAuthorization> TokenCache = new();
 
         static MicrosoftGraphUtils() {
             HttpClient = new HttpClient();
@@ -68,6 +70,10 @@ namespace Mailozaurr {
         /// Connects to O365 Graph and returns the Authorization header value ("Bearer ...").
         /// </summary>
         public static async Task<string> ConnectO365GraphAsync(GraphCredential credential, string tenantDomain, string resource = "https://manage.office.com") {
+            var key = $"{credential.ClientId}|{tenantDomain}|{credential.CertificatePath}|{credential.ClientSecret}|{resource}";
+            if (TokenCache.TryGetValue(key, out var cached) && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
+                return $"{cached.TokenType} {cached.AccessToken}";
+            }
             if (!string.IsNullOrEmpty(credential.CertificatePath)) {
                 var scopes = new[] { $"{resource}/.default" };
                 var auth = await OAuthHelpers.AcquireGraphCertificateTokenAsync(
@@ -76,6 +82,7 @@ namespace Mailozaurr {
                     credential.CertificatePath,
                     credential.CertificatePassword ?? string.Empty,
                     scopes);
+                TokenCache[key] = auth;
                 return $"{auth.TokenType} {auth.AccessToken}";
             }
 
@@ -97,6 +104,16 @@ namespace Mailozaurr {
             var token = System.Text.Json.JsonDocument.Parse(json);
             var accessToken = token.RootElement.GetProperty("access_token").GetString();
             var tokenType = token.RootElement.GetProperty("token_type").GetString();
+            var expiresOn = DateTimeOffset.UtcNow.AddHours(1);
+            if (token.RootElement.TryGetProperty("expires_in", out var expIn)) {
+                expiresOn = DateTimeOffset.UtcNow.AddSeconds(expIn.GetInt32());
+            }
+            if (token.RootElement.TryGetProperty("expires_on", out var expOn)) {
+                if (long.TryParse(expOn.GetString(), out var expSeconds)) {
+                    expiresOn = DateTimeOffset.FromUnixTimeSeconds(expSeconds);
+                }
+            }
+            TokenCache[key] = new GraphAuthorization { AccessToken = accessToken, TokenType = tokenType, ExpiresOn = expiresOn };
             return $"{tokenType} {accessToken}";
         }
 


### PR DESCRIPTION
## Summary
- store MSAL tokens in user cache
- reuse tokens for Graph auth with expiration tracking
- add helper class for token cache persistence

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.sln` *(fails: Could not load file or assembly 'MimeKit')*

------
https://chatgpt.com/codex/tasks/task_e_685cf0918420832ea955b539d76017cb