### PR TITLE
Extend Graph connection cmdlet

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -15,6 +15,8 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
 
     [Parameter(Mandatory = true, ParameterSetName = "Plain")]
     [Parameter(Mandatory = true, ParameterSetName = "Certificate")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytes")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificatePem")]
     [ValidateNotNullOrEmpty]
     public string? ClientId { get; set; }
 
@@ -24,6 +26,8 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
 
     [Parameter(Mandatory = true, ParameterSetName = "Plain")]
     [Parameter(Mandatory = true, ParameterSetName = "Certificate")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytes")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificatePem")]
     [ValidateNotNullOrEmpty]
     public string? DirectoryId { get; set; }
 
@@ -31,7 +35,16 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? CertificatePath { get; set; }
 
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytes")]
+    [ValidateNotNull]
+    public byte[]? CertificateBytes { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "CertificatePem")]
+    [ValidateNotNullOrEmpty]
+    public string? CertificatePemPath { get; set; }
+
     [Parameter(Mandatory = true, ParameterSetName = "Certificate")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytes")]
     [ValidateNotNullOrEmpty]
     public string? CertificatePassword { get; set; }
 
@@ -47,6 +60,19 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
                 DirectoryId = DirectoryId!,
                 CertificatePath = CertificatePath!,
                 CertificatePassword = CertificatePassword!
+            };
+        } else if (ParameterSetName == "CertificateBytes") {
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                DirectoryId = DirectoryId!,
+                CertificateBytes = CertificateBytes!,
+                CertificatePassword = CertificatePassword!
+            };
+        } else if (ParameterSetName == "CertificatePem") {
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                DirectoryId = DirectoryId!,
+                CertificatePemPath = CertificatePemPath!
             };
         } else {
             cred = new GraphCredential {

--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -97,6 +97,37 @@ public static class OAuthHelpers {
         string certificatePassword,
         IEnumerable<string>? scopes = null) {
         var certificate = new X509Certificate2(certificatePath, certificatePassword);
+        return await AcquireGraphCertificateTokenInternal(clientId, tenantId, certificate, scopes);
+    }
+
+    public static async Task<GraphAuthorization> AcquireGraphCertificateTokenAsync(
+        string clientId,
+        string tenantId,
+        byte[] certificateBytes,
+        string certificatePassword,
+        IEnumerable<string>? scopes = null) {
+        var certificate = new X509Certificate2(certificateBytes, certificatePassword);
+        return await AcquireGraphCertificateTokenInternal(clientId, tenantId, certificate, scopes);
+    }
+
+    public static async Task<GraphAuthorization> AcquireGraphCertificatePemTokenAsync(
+        string clientId,
+        string tenantId,
+        string pemPath,
+        IEnumerable<string>? scopes = null) {
+#if NET5_0_OR_GREATER
+        var certificate = X509Certificate2.CreateFromPemFile(pemPath);
+        return await AcquireGraphCertificateTokenInternal(clientId, tenantId, certificate, scopes);
+#else
+        throw new NotSupportedException("PEM certificates are not supported on this framework.");
+#endif
+    }
+
+    private static async Task<GraphAuthorization> AcquireGraphCertificateTokenInternal(
+        string clientId,
+        string tenantId,
+        X509Certificate2 certificate,
+        IEnumerable<string>? scopes) {
         var app = ConfidentialClientApplicationBuilder
             .Create(clientId)
             .WithTenantId(tenantId)

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -18,6 +18,8 @@ namespace Mailozaurr {
         public string? ClientSecret { get; set; }
         public string? CertificatePath { get; set; }
         public string? CertificatePassword { get; set; }
+        public byte[]? CertificateBytes { get; set; }
+        public string? CertificatePemPath { get; set; }
     }
 
     /// <summary>
@@ -75,6 +77,25 @@ namespace Mailozaurr {
                     tenantDomain,
                     credential.CertificatePath,
                     credential.CertificatePassword ?? string.Empty,
+                    scopes);
+                return $"{auth.TokenType} {auth.AccessToken}";
+            }
+            if (credential.CertificateBytes != null) {
+                var scopes = new[] { $"{resource}/.default" };
+                var auth = await OAuthHelpers.AcquireGraphCertificateTokenAsync(
+                    credential.ClientId,
+                    tenantDomain,
+                    credential.CertificateBytes,
+                    credential.CertificatePassword ?? string.Empty,
+                    scopes);
+                return $"{auth.TokenType} {auth.AccessToken}";
+            }
+            if (!string.IsNullOrEmpty(credential.CertificatePemPath)) {
+                var scopes = new[] { $"{resource}/.default" };
+                var auth = await OAuthHelpers.AcquireGraphCertificatePemTokenAsync(
+                    credential.ClientId,
+                    tenantDomain,
+                    credential.CertificatePemPath,
                     scopes);
                 return $"{auth.TokenType} {auth.AccessToken}";
             }


### PR DESCRIPTION
## Summary
- add cert byte and PEM path support in `CmdletConnectEmailGraph`
- extend `GraphCredential` with new certificate properties
- update graph auth helper to handle byte arrays and PEM files

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685cf0a60b04832eaa0a567af2a9619e