### PR TITLE
Improve IMAP/POP3 connection warnings

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -119,7 +119,12 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
         try {
             await client.ConnectAsync(Server, Port, Options);
         } catch (Exception ex) {
-            WriteWarning($"Connect-IMAP - Unable to connect: {ex.Message}");
+            var responseText = (ex as ImapCommandException)?.ResponseText;
+            if (!string.IsNullOrEmpty(responseText)) {
+                WriteWarning($"Connect-IMAP - Unable to connect: {ex.Message} | Server response: {responseText}");
+            } else {
+                WriteWarning($"Connect-IMAP - Unable to connect: {ex.Message}");
+            }
             return;
         }
 
@@ -153,7 +158,12 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
                     return;
                 }
             } catch (Exception ex) {
-                WriteWarning($"Connect-IMAP - Unable to authenticate: {ex.Message}");
+                var responseText = (ex as ImapCommandException)?.ResponseText;
+                if (!string.IsNullOrEmpty(responseText)) {
+                    WriteWarning($"Connect-IMAP - Unable to authenticate: {ex.Message} | Server response: {responseText}");
+                } else {
+                    WriteWarning($"Connect-IMAP - Unable to authenticate: {ex.Message}");
+                }
                 await client.DisconnectAsync(true);
                 return;
             }
@@ -167,7 +177,12 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
             try {
                 await client.Inbox.OpenAsync(MailKit.FolderAccess.ReadOnly);
             } catch (Exception ex) {
-                LoggingMessages.Logger.WriteWarning($"Connect-IMAP - Failed to open inbox: {ex.Message}");
+                var responseText = (ex as ImapCommandException)?.ResponseText;
+                if (!string.IsNullOrEmpty(responseText)) {
+                    LoggingMessages.Logger.WriteWarning($"Connect-IMAP - Failed to open inbox: {ex.Message} | Server response: {responseText}");
+                } else {
+                    LoggingMessages.Logger.WriteWarning($"Connect-IMAP - Failed to open inbox: {ex.Message}");
+                }
             }
             var info = new ImapConnectionInfo {
                 Uri = $"imaps://{Server}:{Port}/",

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -118,7 +118,12 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
         try {
             await client.ConnectAsync(Server, Port, Options);
         } catch (Exception ex) {
-            WriteWarning($"Connect-POP3 - Unable to connect: {ex.Message}");
+            var statusText = (ex as Pop3CommandException)?.StatusText;
+            if (!string.IsNullOrEmpty(statusText)) {
+                WriteWarning($"Connect-POP3 - Unable to connect: {ex.Message} | Server response: {statusText}");
+            } else {
+                WriteWarning($"Connect-POP3 - Unable to connect: {ex.Message}");
+            }
             return;
         }
 
@@ -152,7 +157,12 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
                     return;
                 }
             } catch (Exception ex) {
-                WriteWarning($"Connect-POP3 - Unable to authenticate: {ex.Message}");
+                var statusText = (ex as Pop3CommandException)?.StatusText;
+                if (!string.IsNullOrEmpty(statusText)) {
+                    WriteWarning($"Connect-POP3 - Unable to authenticate: {ex.Message} | Server response: {statusText}");
+                } else {
+                    WriteWarning($"Connect-POP3 - Unable to authenticate: {ex.Message}");
+                }
                 await client.DisconnectAsync(true);
                 return;
             }


### PR DESCRIPTION
## Summary
- include server response text in IMAP/POP3 connection warnings

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Release`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug`
- `pwsh ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685cf2ed29c0832e89a989cac82e0dea