### PR TITLE
Add retry options to connect cmdlets

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -11,6 +11,7 @@
 * Fix SMTP auth optional by @PrzemyslawKlys in https://github.com/EvotecIT/Mailozaurr/pull/76
 * feat: add `RetryCount` parameter to `Send-EmailMessage` allowing optional retries
 * feat: support configurable delay and exponential backoff via `RetryDelayMilliseconds` and `RetryDelayBackoff`
+* feat: add connection retry parameters to `Connect-IMAP`, `Connect-POP3` and `Connect-EmailGraph`
 
 **Full Changelog**: https://github.com/EvotecIT/Mailozaurr/compare/v2.0.0-Preview5...v2.0.0-Preview6
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -11,7 +11,6 @@
 * Fix SMTP auth optional by @PrzemyslawKlys in https://github.com/EvotecIT/Mailozaurr/pull/76
 * feat: add `RetryCount` parameter to `Send-EmailMessage` allowing optional retries
 * feat: support configurable delay and exponential backoff via `RetryDelayMilliseconds` and `RetryDelayBackoff`
-* feat: add connection retry parameters to `Connect-IMAP`, `Connect-POP3` and `Connect-EmailGraph`
 
 **Full Changelog**: https://github.com/EvotecIT/Mailozaurr/compare/v2.0.0-Preview5...v2.0.0-Preview6
 

--- a/README.MD
+++ b/README.MD
@@ -134,6 +134,7 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - [Example-GetMailFolder.ps1](Examples/Example-GetMailFolder.ps1) - list folders using either `-Connection` or `-MgGraphRequest`.
 - Use `Connect-EmailGraph` and `Disconnect-EmailGraph` to authenticate and release application credentials for Microsoft Graph. The connection cmdlet supports both client secret and certificate authentication modes.
 - `Connect-EmailGraph`, `Connect-IMAP` and `Connect-POP3` store the last successful connection in module variables. Subsequent cmdlets use these defaults when `-Connection` or `-Client` is omitted.
+- Connection cmdlets also accept `-RetryCount`, `-RetryDelayMilliseconds` and `-RetryDelayBackoff` to control how many times they retry establishing sessions and how long they wait between attempts.
 - [Example-SendEmail-Attachments.ps1](Examples/Example-SendEmail-Attachments.ps1) - demonstrate file and in-memory attachments.
 - [PGP documentation](Docs/PGP.md) - overview of OpenPGP support.
 

--- a/README.MD
+++ b/README.MD
@@ -92,6 +92,7 @@ This will make sure the project has required libraries.
   - [x] Office 365 Graph API
   - [x] PGP/MIME encryption and signature verification
   - Optional retry logic for `Send-EmailMessage` via `-RetryCount`, `-RetryDelayMilliseconds`, `-RetryDelayBackoff` and `-RetryAlways`.  Retries are only attempted for transient errors by default, but `-RetryAlways` forces retries on all errors.
+  - Connection cmdlets support the same retry parameters for establishing sessions.
 - POP3
   - [x] Connect to POP3
   - [x] Get POP3 Emails

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -74,28 +74,18 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
             };
         }
 
-        var delay = RetryDelayMilliseconds;
         bool connected = false;
-        Exception? lastError = null;
-
-        for (var attempt = 0; attempt <= RetryCount; attempt++) {
-            try {
-                var token = await MicrosoftGraphUtils.ConnectO365GraphAsync(cred, cred.DirectoryId, "https://graph.microsoft.com");
-                connected = !string.IsNullOrEmpty(token);
-                break;
-            } catch (Exception ex) {
-                lastError = ex;
-                WriteWarning($"Connect-EmailGraph - Attempt {attempt + 1} failed: {ex.Message}");
-            }
-
-            if (attempt < RetryCount) {
-                if (delay > 0) await Task.Delay(delay);
-                delay = (int)(delay * RetryDelayBackoff);
-            }
-        }
-
-        if (!connected) {
-            WriteWarning($"Connect-EmailGraph - Unable to obtain token after {RetryCount + 1} attempts: {lastError?.Message}");
+        try {
+            var token = await MicrosoftGraphUtils.ConnectO365GraphAsync(
+                cred,
+                cred.DirectoryId,
+                "https://graph.microsoft.com",
+                RetryCount,
+                RetryDelayMilliseconds,
+                RetryDelayBackoff);
+            connected = !string.IsNullOrEmpty(token);
+        } catch (Exception ex) {
+            WriteWarning($"Connect-EmailGraph - {ex.Message}");
         }
 
         var info = new GraphConnectionInfo { Credential = cred, IsConnected = connected };

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -35,6 +35,24 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? CertificatePassword { get; set; }
 
+    /// <summary>
+    /// <para type="description">Specifies how many times the cmdlet should retry when obtaining the access token. Default is 0 (no retries).</para>
+    /// </summary>
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Delay in milliseconds between retry attempts.</para>
+    /// </summary>
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Multiplicative backoff applied to the retry delay. Value of 1 disables backoff.</para>
+    /// </summary>
+    [Parameter]
+    public double RetryDelayBackoff { get; set; } = 1.0;
+
     protected override async Task ProcessRecordAsync() {
         GraphCredential cred;
         if (ParameterSetName == "Credential") {

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -74,12 +74,28 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
             };
         }
 
+        var delay = RetryDelayMilliseconds;
         bool connected = false;
-        try {
-            var token = await MicrosoftGraphUtils.ConnectO365GraphAsync(cred, cred.DirectoryId, "https://graph.microsoft.com");
-            connected = !string.IsNullOrEmpty(token);
-        } catch {
-            // ignore errors, return not connected
+        Exception? lastError = null;
+
+        for (var attempt = 0; attempt <= RetryCount; attempt++) {
+            try {
+                var token = await MicrosoftGraphUtils.ConnectO365GraphAsync(cred, cred.DirectoryId, "https://graph.microsoft.com");
+                connected = !string.IsNullOrEmpty(token);
+                break;
+            } catch (Exception ex) {
+                lastError = ex;
+                WriteWarning($"Connect-EmailGraph - Attempt {attempt + 1} failed: {ex.Message}");
+            }
+
+            if (attempt < RetryCount) {
+                if (delay > 0) await Task.Delay(delay);
+                delay = (int)(delay * RetryDelayBackoff);
+            }
+        }
+
+        if (!connected) {
+            WriteWarning($"Connect-EmailGraph - Unable to obtain token after {RetryCount + 1} attempts: {lastError?.Message}");
         }
 
         var info = new GraphConnectionInfo { Credential = cred, IsConnected = connected };

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -133,89 +133,54 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
     /// Use the returned object with <c>Disconnect-IMAP</c>, <c>Get-IMAPFolder</c>, or <c>Get-IMAPMessage</c> for further operations.
     /// </remarks>
     protected override async Task ProcessRecordAsync() {
-        var delay = RetryDelayMilliseconds;
-        ImapClient? client = null;
-        Exception? lastError = null;
-
-        for (var attempt = 0; attempt <= RetryCount; attempt++) {
-            client = new ImapClient();
-            try {
-                await client.ConnectAsync(Server, Port, Options);
-
-                if (SkipCertificateRevocation) {
-                    client.CheckCertificateRevocation = false;
-                }
-                if (SkipCertificateValidation) {
-                    client.ServerCertificateValidationCallback = (s, c, h, e) => true;
-                }
-                if (client.Timeout != TimeOut) {
-                    client.Timeout = TimeOut;
-                }
-
-                if (!client.IsConnected) {
-                    throw new InvalidOperationException("Client is not connected after ConnectAsync.");
-                }
-
-                if (ParameterSetName == "OAuth2" && OAuth2.IsPresent) {
-                    var username = Credential.UserName;
-                    var token = new System.Net.NetworkCredential("", Credential.Password).Password;
-                    var sasl = new MailKit.Security.SaslMechanismOAuth2(username, token);
-                    await client.AuthenticateAsync(sasl);
-                } else if (ParameterSetName == "ClearText" && !string.IsNullOrEmpty(UserName) && !string.IsNullOrEmpty(Password)) {
-                    await client.AuthenticateAsync(UserName, Password);
-                } else if (Credential != null) {
-                    var username = Credential.UserName;
-                    var password = Credential.Password is SecureString ss ? new System.Net.NetworkCredential("", ss).Password : Credential.GetNetworkCredential().Password;
-                    await client.AuthenticateAsync(username, password);
-                } else {
-                    throw new InvalidOperationException("No valid authentication method provided.");
-                }
-
-                if (!client.IsAuthenticated) {
-                    throw new InvalidOperationException("Authentication failed.");
-                }
-
-                try {
-                    await client.Inbox.OpenAsync(MailKit.FolderAccess.ReadOnly);
-                } catch (Exception ex) {
-                    LoggingMessages.Logger.WriteWarning($"Connect-IMAP - Failed to open inbox: {ex.Message}");
-                }
-
-                var info = new ImapConnectionInfo {
-                    Uri = $"imaps://{Server}:{Port}/",
-                    AuthenticationMechanisms = client.AuthenticationMechanisms,
-                    Capabilities = client.Capabilities,
-                    Stream = null, // Not exposed
-                    State = null, // Not exposed
-                    IsConnected = client.IsConnected,
-                    ApopToken = null,
-                    ExpirePolicy = null,
-                    Implementation = null,
-                    LoginDelay = null,
-                    IsAuthenticated = client.IsAuthenticated,
-                    IsSecure = client.IsSecure,
-                    Data = client,
-                    Count = client.Inbox?.Count ?? 0,
-                    Messages = client.Inbox,
-                    Recent = client.Inbox?.Recent ?? 0
-                };
-                DefaultSessions.ImapSession = info;
-                WriteObject(info);
-                return;
-            } catch (Exception ex) {
-                lastError = ex;
-                WriteWarning($"Connect-IMAP - Attempt {attempt + 1} failed: {ex.Message}");
-                if (client.IsConnected) {
-                    try { await client.DisconnectAsync(true); } catch { /* ignore */ }
-                }
-            }
-
-            if (attempt < RetryCount) {
-                if (delay > 0) await Task.Delay(delay);
-                delay = (int)(delay * RetryDelayBackoff);
-            }
+        NetworkCredential? cred = null;
+        var useOAuth = false;
+        if (ParameterSetName == "OAuth2" && Credential != null) {
+            var token = new System.Net.NetworkCredential("", Credential.Password).Password;
+            cred = new NetworkCredential(Credential.UserName, token);
+            useOAuth = true;
+        } else if (ParameterSetName == "ClearText") {
+            cred = new NetworkCredential(UserName, Password);
+        } else if (Credential != null) {
+            cred = Credential.GetNetworkCredential();
         }
 
-        WriteWarning($"Connect-IMAP - Unable to connect after {RetryCount + 1} attempts: {lastError?.Message}");
+        try {
+            var client = await ConnectionHelpers.ConnectImapAsync(
+                Server,
+                Port,
+                Options,
+                SkipCertificateRevocation.IsPresent,
+                SkipCertificateValidation.IsPresent,
+                TimeOut,
+                cred,
+                useOAuth,
+                RetryCount,
+                RetryDelayMilliseconds,
+                RetryDelayBackoff);
+
+            var info = new ImapConnectionInfo {
+                Uri = $"imaps://{Server}:{Port}/",
+                AuthenticationMechanisms = client.AuthenticationMechanisms,
+                Capabilities = client.Capabilities,
+                Stream = null,
+                State = null,
+                IsConnected = client.IsConnected,
+                ApopToken = null,
+                ExpirePolicy = null,
+                Implementation = null,
+                LoginDelay = null,
+                IsAuthenticated = client.IsAuthenticated,
+                IsSecure = client.IsSecure,
+                Data = client,
+                Count = client.Inbox?.Count ?? 0,
+                Messages = client.Inbox,
+                Recent = client.Inbox?.Recent ?? 0
+            };
+            DefaultSessions.ImapSession = info;
+            WriteObject(info);
+        } catch (Exception ex) {
+            WriteWarning($"Connect-IMAP - {ex.Message}");
+        }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -133,28 +133,30 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
     /// Use the returned object with <c>Disconnect-IMAP</c>, <c>Get-IMAPFolder</c>, or <c>Get-IMAPMessage</c> for further operations.
     /// </remarks>
     protected override async Task ProcessRecordAsync() {
-        var client = new ImapClient();
-        try {
-            await client.ConnectAsync(Server, Port, Options);
-        } catch (Exception ex) {
-            WriteWarning($"Connect-IMAP - Unable to connect: {ex.Message}");
-            return;
-        }
+        var delay = RetryDelayMilliseconds;
+        ImapClient? client = null;
+        Exception? lastError = null;
 
-        if (SkipCertificateRevocation) {
-            client.CheckCertificateRevocation = false;
-        }
-        if (SkipCertificateValidation) {
-            client.ServerCertificateValidationCallback = (s, c, h, e) => true;
-        }
-        if (client.Timeout != TimeOut) {
-            client.Timeout = TimeOut;
-        }
-
-        if (client.IsConnected) {
+        for (var attempt = 0; attempt <= RetryCount; attempt++) {
+            client = new ImapClient();
             try {
+                await client.ConnectAsync(Server, Port, Options);
+
+                if (SkipCertificateRevocation) {
+                    client.CheckCertificateRevocation = false;
+                }
+                if (SkipCertificateValidation) {
+                    client.ServerCertificateValidationCallback = (s, c, h, e) => true;
+                }
+                if (client.Timeout != TimeOut) {
+                    client.Timeout = TimeOut;
+                }
+
+                if (!client.IsConnected) {
+                    throw new InvalidOperationException("Client is not connected after ConnectAsync.");
+                }
+
                 if (ParameterSetName == "OAuth2" && OAuth2.IsPresent) {
-                    // OAuth2 authentication using SASL
                     var username = Credential.UserName;
                     var token = new System.Net.NetworkCredential("", Credential.Password).Password;
                     var sasl = new MailKit.Security.SaslMechanismOAuth2(username, token);
@@ -166,50 +168,54 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
                     var password = Credential.Password is SecureString ss ? new System.Net.NetworkCredential("", ss).Password : Credential.GetNetworkCredential().Password;
                     await client.AuthenticateAsync(username, password);
                 } else {
-                    WriteWarning("Connect-IMAP - No valid authentication method provided.");
-                    await client.DisconnectAsync(true);
-                    return;
+                    throw new InvalidOperationException("No valid authentication method provided.");
                 }
-            } catch (Exception ex) {
-                WriteWarning($"Connect-IMAP - Unable to authenticate: {ex.Message}");
-                await client.DisconnectAsync(true);
+
+                if (!client.IsAuthenticated) {
+                    throw new InvalidOperationException("Authentication failed.");
+                }
+
+                try {
+                    await client.Inbox.OpenAsync(MailKit.FolderAccess.ReadOnly);
+                } catch (Exception ex) {
+                    LoggingMessages.Logger.WriteWarning($"Connect-IMAP - Failed to open inbox: {ex.Message}");
+                }
+
+                var info = new ImapConnectionInfo {
+                    Uri = $"imaps://{Server}:{Port}/",
+                    AuthenticationMechanisms = client.AuthenticationMechanisms,
+                    Capabilities = client.Capabilities,
+                    Stream = null, // Not exposed
+                    State = null, // Not exposed
+                    IsConnected = client.IsConnected,
+                    ApopToken = null,
+                    ExpirePolicy = null,
+                    Implementation = null,
+                    LoginDelay = null,
+                    IsAuthenticated = client.IsAuthenticated,
+                    IsSecure = client.IsSecure,
+                    Data = client,
+                    Count = client.Inbox?.Count ?? 0,
+                    Messages = client.Inbox,
+                    Recent = client.Inbox?.Recent ?? 0
+                };
+                DefaultSessions.ImapSession = info;
+                WriteObject(info);
                 return;
+            } catch (Exception ex) {
+                lastError = ex;
+                WriteWarning($"Connect-IMAP - Attempt {attempt + 1} failed: {ex.Message}");
+                if (client.IsConnected) {
+                    try { await client.DisconnectAsync(true); } catch { /* ignore */ }
+                }
             }
-        } else {
-            WriteWarning("Connect-IMAP - Client is not connected after ConnectAsync.");
-            return;
+
+            if (attempt < RetryCount) {
+                if (delay > 0) await Task.Delay(delay);
+                delay = (int)(delay * RetryDelayBackoff);
+            }
         }
 
-        if (client.IsAuthenticated) {
-            // Open the inbox to get message info
-            try {
-                await client.Inbox.OpenAsync(MailKit.FolderAccess.ReadOnly);
-            } catch (Exception ex) {
-                LoggingMessages.Logger.WriteWarning($"Connect-IMAP - Failed to open inbox: {ex.Message}");
-            }
-            var info = new ImapConnectionInfo {
-                Uri = $"imaps://{Server}:{Port}/",
-                AuthenticationMechanisms = client.AuthenticationMechanisms,
-                Capabilities = client.Capabilities,
-                Stream = null, // Not exposed
-                State = null, // Not exposed
-                IsConnected = client.IsConnected,
-                ApopToken = null, // Not applicable for IMAP
-                ExpirePolicy = null, // Not applicable for IMAP
-                Implementation = null, // Not directly available
-                LoginDelay = null, // Not directly available
-                IsAuthenticated = client.IsAuthenticated,
-                IsSecure = client.IsSecure,
-                Data = client,
-                Count = client.Inbox?.Count ?? 0,
-                Messages = client.Inbox,
-                Recent = client.Inbox?.Recent ?? 0
-            };
-            DefaultSessions.ImapSession = info;
-            WriteObject(info);
-        } else {
-            WriteWarning("Connect-IMAP - Authentication failed.");
-            await client.DisconnectAsync(true);
-        }
+        WriteWarning($"Connect-IMAP - Unable to connect after {RetryCount + 1} attempts: {lastError?.Message}");
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -103,6 +103,24 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
     public int TimeOut { get; set; } = 120000;
 
     /// <summary>
+    /// <para type="description">Specifies how many times the cmdlet should retry when connecting or authenticating. Default is 0 (no retries).</para>
+    /// </summary>
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Delay in milliseconds between retry attempts.</para>
+    /// </summary>
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Multiplicative backoff applied to the retry delay. Value of 1 disables backoff.</para>
+    /// </summary>
+    [Parameter]
+    public double RetryDelayBackoff { get; set; } = 1.0;
+
+    /// <summary>
     /// <para type="description">Enables OAuth2 authentication. Use with a PSCredential object containing the access token as the password.</para>
     /// </summary>
     [Parameter(ParameterSetName = "OAuth2")]

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -132,83 +132,54 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
     /// Use the returned object with <c>Disconnect-POP3</c> or <c>Get-POP3Message</c> for further operations.
     /// </remarks>
     protected override async Task ProcessRecordAsync() {
-        var delay = RetryDelayMilliseconds;
-        Pop3Client? client = null;
-        Exception? lastError = null;
-
-        for (var attempt = 0; attempt <= RetryCount; attempt++) {
-            client = new Pop3Client();
-            try {
-                await client.ConnectAsync(Server, Port, Options);
-
-                if (SkipCertificateRevocation) {
-                    client.CheckCertificateRevocation = false;
-                }
-                if (SkipCertificateValidation) {
-                    client.ServerCertificateValidationCallback = (s, c, h, e) => true;
-                }
-                if (client.Timeout != TimeOut) {
-                    client.Timeout = TimeOut;
-                }
-
-                if (!client.IsConnected) {
-                    throw new InvalidOperationException("Client is not connected after ConnectAsync.");
-                }
-
-                if (ParameterSetName == "OAuth2" && OAuth2.IsPresent) {
-                    var username = Credential.UserName;
-                    var token = new System.Net.NetworkCredential("", Credential.Password).Password;
-                    var sasl = new MailKit.Security.SaslMechanismOAuth2(username, token);
-                    await client.AuthenticateAsync(sasl);
-                } else if (ParameterSetName == "ClearText" && !string.IsNullOrEmpty(UserName) && !string.IsNullOrEmpty(Password)) {
-                    await client.AuthenticateAsync(UserName, Password);
-                } else if (Credential != null) {
-                    var username = Credential.UserName;
-                    var password = Credential.Password is SecureString ss ? new System.Net.NetworkCredential("", ss).Password : Credential.GetNetworkCredential().Password;
-                    await client.AuthenticateAsync(username, password);
-                } else {
-                    throw new InvalidOperationException("No valid authentication method provided.");
-                }
-
-                if (!client.IsAuthenticated) {
-                    throw new InvalidOperationException("Authentication failed.");
-                }
-
-                var info = new PopConnectionInfo {
-                    Uri = $"pops://{Server}:{Port}/",
-                    AuthenticationMechanisms = client.AuthenticationMechanisms,
-                    Capabilities = client.Capabilities,
-                    Stream = null, // Not exposed
-                    State = null, // Not exposed
-                    IsConnected = client.IsConnected,
-                    ApopToken = null,
-                    ExpirePolicy = null,
-                    Implementation = null,
-                    LoginDelay = null,
-                    IsAuthenticated = client.IsAuthenticated,
-                    IsSecure = client.IsSecure,
-                    Data = client,
-                    Count = client.Count,
-                    Messages = null,
-                    Recent = 0
-                };
-                DefaultSessions.Pop3Session = info;
-                WriteObject(info);
-                return;
-            } catch (Exception ex) {
-                lastError = ex;
-                WriteWarning($"Connect-POP3 - Attempt {attempt + 1} failed: {ex.Message}");
-                if (client.IsConnected) {
-                    try { await client.DisconnectAsync(true); } catch { /* ignore */ }
-                }
-            }
-
-            if (attempt < RetryCount) {
-                if (delay > 0) await Task.Delay(delay);
-                delay = (int)(delay * RetryDelayBackoff);
-            }
+        NetworkCredential? cred = null;
+        var useOAuth = false;
+        if (ParameterSetName == "OAuth2" && Credential != null) {
+            var token = new System.Net.NetworkCredential("", Credential.Password).Password;
+            cred = new NetworkCredential(Credential.UserName, token);
+            useOAuth = true;
+        } else if (ParameterSetName == "ClearText") {
+            cred = new NetworkCredential(UserName, Password);
+        } else if (Credential != null) {
+            cred = Credential.GetNetworkCredential();
         }
 
-        WriteWarning($"Connect-POP3 - Unable to connect after {RetryCount + 1} attempts: {lastError?.Message}");
+        try {
+            var client = await ConnectionHelpers.ConnectPop3Async(
+                Server,
+                Port,
+                Options,
+                SkipCertificateRevocation.IsPresent,
+                SkipCertificateValidation.IsPresent,
+                TimeOut,
+                cred,
+                useOAuth,
+                RetryCount,
+                RetryDelayMilliseconds,
+                RetryDelayBackoff);
+
+            var info = new PopConnectionInfo {
+                Uri = $"pops://{Server}:{Port}/",
+                AuthenticationMechanisms = client.AuthenticationMechanisms,
+                Capabilities = client.Capabilities,
+                Stream = null,
+                State = null,
+                IsConnected = client.IsConnected,
+                ApopToken = null,
+                ExpirePolicy = null,
+                Implementation = null,
+                LoginDelay = null,
+                IsAuthenticated = client.IsAuthenticated,
+                IsSecure = client.IsSecure,
+                Data = client,
+                Count = client.Count,
+                Messages = null,
+                Recent = 0
+            };
+            DefaultSessions.Pop3Session = info;
+            WriteObject(info);
+        } catch (Exception ex) {
+            WriteWarning($"Connect-POP3 - {ex.Message}");
+        }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -132,28 +132,30 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
     /// Use the returned object with <c>Disconnect-POP3</c> or <c>Get-POP3Message</c> for further operations.
     /// </remarks>
     protected override async Task ProcessRecordAsync() {
-        var client = new Pop3Client();
-        try {
-            await client.ConnectAsync(Server, Port, Options);
-        } catch (Exception ex) {
-            WriteWarning($"Connect-POP3 - Unable to connect: {ex.Message}");
-            return;
-        }
+        var delay = RetryDelayMilliseconds;
+        Pop3Client? client = null;
+        Exception? lastError = null;
 
-        if (SkipCertificateRevocation) {
-            client.CheckCertificateRevocation = false;
-        }
-        if (SkipCertificateValidation) {
-            client.ServerCertificateValidationCallback = (s, c, h, e) => true;
-        }
-        if (client.Timeout != TimeOut) {
-            client.Timeout = TimeOut;
-        }
-
-        if (client.IsConnected) {
+        for (var attempt = 0; attempt <= RetryCount; attempt++) {
+            client = new Pop3Client();
             try {
+                await client.ConnectAsync(Server, Port, Options);
+
+                if (SkipCertificateRevocation) {
+                    client.CheckCertificateRevocation = false;
+                }
+                if (SkipCertificateValidation) {
+                    client.ServerCertificateValidationCallback = (s, c, h, e) => true;
+                }
+                if (client.Timeout != TimeOut) {
+                    client.Timeout = TimeOut;
+                }
+
+                if (!client.IsConnected) {
+                    throw new InvalidOperationException("Client is not connected after ConnectAsync.");
+                }
+
                 if (ParameterSetName == "OAuth2" && OAuth2.IsPresent) {
-                    // OAuth2 authentication using SASL
                     var username = Credential.UserName;
                     var token = new System.Net.NetworkCredential("", Credential.Password).Password;
                     var sasl = new MailKit.Security.SaslMechanismOAuth2(username, token);
@@ -165,44 +167,48 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
                     var password = Credential.Password is SecureString ss ? new System.Net.NetworkCredential("", ss).Password : Credential.GetNetworkCredential().Password;
                     await client.AuthenticateAsync(username, password);
                 } else {
-                    WriteWarning("Connect-POP3 - No valid authentication method provided.");
-                    await client.DisconnectAsync(true);
-                    return;
+                    throw new InvalidOperationException("No valid authentication method provided.");
                 }
-            } catch (Exception ex) {
-                WriteWarning($"Connect-POP3 - Unable to authenticate: {ex.Message}");
-                await client.DisconnectAsync(true);
+
+                if (!client.IsAuthenticated) {
+                    throw new InvalidOperationException("Authentication failed.");
+                }
+
+                var info = new PopConnectionInfo {
+                    Uri = $"pops://{Server}:{Port}/",
+                    AuthenticationMechanisms = client.AuthenticationMechanisms,
+                    Capabilities = client.Capabilities,
+                    Stream = null, // Not exposed
+                    State = null, // Not exposed
+                    IsConnected = client.IsConnected,
+                    ApopToken = null,
+                    ExpirePolicy = null,
+                    Implementation = null,
+                    LoginDelay = null,
+                    IsAuthenticated = client.IsAuthenticated,
+                    IsSecure = client.IsSecure,
+                    Data = client,
+                    Count = client.Count,
+                    Messages = null,
+                    Recent = 0
+                };
+                DefaultSessions.Pop3Session = info;
+                WriteObject(info);
                 return;
+            } catch (Exception ex) {
+                lastError = ex;
+                WriteWarning($"Connect-POP3 - Attempt {attempt + 1} failed: {ex.Message}");
+                if (client.IsConnected) {
+                    try { await client.DisconnectAsync(true); } catch { /* ignore */ }
+                }
             }
-        } else {
-            WriteWarning("Connect-POP3 - Client is not connected after ConnectAsync.");
-            return;
+
+            if (attempt < RetryCount) {
+                if (delay > 0) await Task.Delay(delay);
+                delay = (int)(delay * RetryDelayBackoff);
+            }
         }
 
-        if (client.IsAuthenticated) {
-            var info = new PopConnectionInfo {
-                Uri = $"pops://{Server}:{Port}/",
-                AuthenticationMechanisms = client.AuthenticationMechanisms,
-                Capabilities = client.Capabilities,
-                Stream = null, // Not exposed
-                State = null, // Not exposed
-                IsConnected = client.IsConnected,
-                ApopToken = null, // Not directly available
-                ExpirePolicy = null, // Not directly available
-                Implementation = null, // Not directly available
-                LoginDelay = null, // Not directly available
-                IsAuthenticated = client.IsAuthenticated,
-                IsSecure = client.IsSecure,
-                Data = client,
-                Count = client.Count,
-                Messages = null, // Not directly available
-                Recent = 0 // Not directly available
-            };
-            DefaultSessions.Pop3Session = info;
-            WriteObject(info);
-        } else {
-            WriteWarning("Connect-POP3 - Authentication failed.");
-            await client.DisconnectAsync(true);
-        }
+        WriteWarning($"Connect-POP3 - Unable to connect after {RetryCount + 1} attempts: {lastError?.Message}");
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -102,6 +102,24 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
     public int TimeOut { get; set; } = 120000;
 
     /// <summary>
+    /// <para type="description">Specifies how many times the cmdlet should retry when connecting or authenticating. Default is 0 (no retries).</para>
+    /// </summary>
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Delay in milliseconds between retry attempts.</para>
+    /// </summary>
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Multiplicative backoff applied to the retry delay. Value of 1 disables backoff.</para>
+    /// </summary>
+    [Parameter]
+    public double RetryDelayBackoff { get; set; } = 1.0;
+
+    /// <summary>
     /// <para type="description">Enables OAuth2 authentication. Use with a PSCredential object containing the access token as the password.</para>
     /// </summary>
     [Parameter(ParameterSetName = "OAuth2")]

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -67,37 +67,56 @@ namespace Mailozaurr {
         /// <summary>
         /// Connects to O365 Graph and returns the Authorization header value ("Bearer ...").
         /// </summary>
-        public static async Task<string> ConnectO365GraphAsync(GraphCredential credential, string tenantDomain, string resource = "https://manage.office.com") {
-            if (!string.IsNullOrEmpty(credential.CertificatePath)) {
-                var scopes = new[] { $"{resource}/.default" };
-                var auth = await OAuthHelpers.AcquireGraphCertificateTokenAsync(
-                    credential.ClientId,
-                    tenantDomain,
-                    credential.CertificatePath,
-                    credential.CertificatePassword ?? string.Empty,
-                    scopes);
-                return $"{auth.TokenType} {auth.AccessToken}";
-            }
+        public static async Task<string> ConnectO365GraphAsync(
+            GraphCredential credential,
+            string tenantDomain,
+            string resource = "https://manage.office.com",
+            int retryCount = 0,
+            int retryDelayMilliseconds = 0,
+            double retryDelayBackoff = 1.0) {
+            var delay = retryDelayMilliseconds;
+            Exception? lastError = null;
+            for (var attempt = 0; attempt <= retryCount; attempt++) {
+                try {
+                    if (!string.IsNullOrEmpty(credential.CertificatePath)) {
+                        var scopes = new[] { $"{resource}/.default" };
+                        var auth = await OAuthHelpers.AcquireGraphCertificateTokenAsync(
+                            credential.ClientId,
+                            tenantDomain,
+                            credential.CertificatePath,
+                            credential.CertificatePassword ?? string.Empty,
+                            scopes);
+                        return $"{auth.TokenType} {auth.AccessToken}";
+                    }
 
-            var body = new Dictionary<string, string>
-            {
-                { "grant_type", "client_credentials" },
-                { "resource", resource },
-                { "client_id", credential.ClientId },
-                { "client_secret", credential.ClientSecret }
-            };
-            var content = new FormUrlEncodedContent(body);
-            var url = $"https://login.microsoftonline.com/{tenantDomain}/oauth2/token";
-            using var response = await HttpClient.PostAsync(url, content);
-            if (!response.IsSuccessStatusCode) {
-                var error = await response.Content.ReadAsStringAsync();
-                throw new Exception($"ConnectO365GraphAsync - Error: {error}");
+                    var body = new Dictionary<string, string> {
+                        { "grant_type", "client_credentials" },
+                        { "resource", resource },
+                        { "client_id", credential.ClientId },
+                        { "client_secret", credential.ClientSecret }
+                    };
+                    using var content = new FormUrlEncodedContent(body);
+                    var url = $"https://login.microsoftonline.com/{tenantDomain}/oauth2/token";
+                    using var response = await HttpClient.PostAsync(url, content);
+                    if (!response.IsSuccessStatusCode) {
+                        var error = await response.Content.ReadAsStringAsync();
+                        throw new Exception($"ConnectO365GraphAsync - Error: {error}");
+                    }
+                    var json = await response.Content.ReadAsStringAsync();
+                    var token = System.Text.Json.JsonDocument.Parse(json);
+                    var accessToken = token.RootElement.GetProperty("access_token").GetString();
+                    var tokenType = token.RootElement.GetProperty("token_type").GetString();
+                    return $"{tokenType} {accessToken}";
+                } catch (Exception ex) {
+                    lastError = ex;
+                }
+
+                if (attempt < retryCount) {
+                    if (delay > 0) await Task.Delay(delay);
+                    delay = (int)(delay * retryDelayBackoff);
+                }
             }
-            var json = await response.Content.ReadAsStringAsync();
-            var token = System.Text.Json.JsonDocument.Parse(json);
-            var accessToken = token.RootElement.GetProperty("access_token").GetString();
-            var tokenType = token.RootElement.GetProperty("token_type").GetString();
-            return $"{tokenType} {accessToken}";
+            throw lastError ?? new Exception("Unable to obtain Graph token.");
         }
 
         /// <summary>

--- a/Sources/Mailozaurr/Receive/ConnectionHelpers.cs
+++ b/Sources/Mailozaurr/Receive/ConnectionHelpers.cs
@@ -1,0 +1,135 @@
+using MailKit.Net.Imap;
+using MailKit.Net.Pop3;
+using MailKit.Security;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Utility methods for establishing IMAP and POP3 connections with optional retry logic.
+/// </summary>
+public static class ConnectionHelpers {
+    /// <summary>
+    /// Connects and authenticates an <see cref="ImapClient"/> with retry logic.
+    /// </summary>
+    public static async Task<ImapClient> ConnectImapAsync(
+        string server,
+        int port,
+        SecureSocketOptions options,
+        bool skipCertificateRevocation,
+        bool skipCertificateValidation,
+        int timeout,
+        NetworkCredential? credential,
+        bool oauth2,
+        int retryCount,
+        int retryDelayMilliseconds,
+        double retryDelayBackoff) {
+        var delay = retryDelayMilliseconds;
+        Exception? lastError = null;
+        for (var attempt = 0; attempt <= retryCount; attempt++) {
+            var client = new ImapClient();
+            try {
+                await client.ConnectAsync(server, port, options);
+                if (skipCertificateRevocation) {
+                    client.CheckCertificateRevocation = false;
+                }
+                if (skipCertificateValidation) {
+                    client.ServerCertificateValidationCallback = (s, c, h, e) => true;
+                }
+                if (client.Timeout != timeout) {
+                    client.Timeout = timeout;
+                }
+                if (!client.IsConnected) {
+                    throw new InvalidOperationException("Client is not connected after ConnectAsync.");
+                }
+                if (credential != null) {
+                    if (oauth2) {
+                        var sasl = new MailKit.Security.SaslMechanismOAuth2(credential.UserName, credential.Password);
+                        await client.AuthenticateAsync(sasl);
+                    } else {
+                        await client.AuthenticateAsync(credential);
+                    }
+                    if (!client.IsAuthenticated) {
+                        throw new InvalidOperationException("Authentication failed.");
+                    }
+                }
+                try {
+                    await client.Inbox.OpenAsync(MailKit.FolderAccess.ReadOnly);
+                } catch (Exception ex) {
+                    LoggingMessages.Logger.WriteWarning($"Connect-IMAP - Failed to open inbox: {ex.Message}");
+                }
+                return client;
+            } catch (Exception ex) {
+                lastError = ex;
+                if (client.IsConnected) {
+                    try { await client.DisconnectAsync(true); } catch { }
+                }
+            }
+            if (attempt < retryCount) {
+                if (delay > 0) await Task.Delay(delay);
+                delay = (int)(delay * retryDelayBackoff);
+            }
+        }
+        throw lastError ?? new Exception("Unable to connect to IMAP server.");
+    }
+
+    /// <summary>
+    /// Connects and authenticates a <see cref="Pop3Client"/> with retry logic.
+    /// </summary>
+    public static async Task<Pop3Client> ConnectPop3Async(
+        string server,
+        int port,
+        SecureSocketOptions options,
+        bool skipCertificateRevocation,
+        bool skipCertificateValidation,
+        int timeout,
+        NetworkCredential? credential,
+        bool oauth2,
+        int retryCount,
+        int retryDelayMilliseconds,
+        double retryDelayBackoff) {
+        var delay = retryDelayMilliseconds;
+        Exception? lastError = null;
+        for (var attempt = 0; attempt <= retryCount; attempt++) {
+            var client = new Pop3Client();
+            try {
+                await client.ConnectAsync(server, port, options);
+                if (skipCertificateRevocation) {
+                    client.CheckCertificateRevocation = false;
+                }
+                if (skipCertificateValidation) {
+                    client.ServerCertificateValidationCallback = (s, c, h, e) => true;
+                }
+                if (client.Timeout != timeout) {
+                    client.Timeout = timeout;
+                }
+                if (!client.IsConnected) {
+                    throw new InvalidOperationException("Client is not connected after ConnectAsync.");
+                }
+                if (credential != null) {
+                    if (oauth2) {
+                        var sasl = new MailKit.Security.SaslMechanismOAuth2(credential.UserName, credential.Password);
+                        await client.AuthenticateAsync(sasl);
+                    } else {
+                        await client.AuthenticateAsync(credential);
+                    }
+                    if (!client.IsAuthenticated) {
+                        throw new InvalidOperationException("Authentication failed.");
+                    }
+                }
+                return client;
+            } catch (Exception ex) {
+                lastError = ex;
+                if (client.IsConnected) {
+                    try { await client.DisconnectAsync(true); } catch { }
+                }
+            }
+            if (attempt < retryCount) {
+                if (delay > 0) await Task.Delay(delay);
+                delay = (int)(delay * retryDelayBackoff);
+            }
+        }
+        throw lastError ?? new Exception("Unable to connect to POP3 server.");
+    }
+}


### PR DESCRIPTION
## Summary
- add `RetryCount`, `RetryDelayMilliseconds`, and `RetryDelayBackoff` parameters to connection cmdlets
- document new retry options in README and CHANGELOG

## Testing
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_685cf31c85ec832e8d109785c9e963f3