### PR TITLE
Extend MessageFetcher search filters

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
@@ -65,10 +65,10 @@ public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
     public uint? UidEnd { get; set; }
 
     /// <summary>
-    /// <para type="description">Search query used to match messages to retrieve.</para>
+    /// <para type="description">Search queries used to match messages to retrieve.</para>
     /// </summary>
     [Parameter]
-    public SearchQuery? SearchQuery { get; set; }
+    public SearchQuery[]? SearchQuery { get; set; }
 
     /// <summary>
     /// <para type="description">Only return messages containing this text in the subject.</para>
@@ -143,7 +143,8 @@ public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
                 Before,
                 All.IsPresent,
                 Delete.IsPresent,
-                HasAttachment.IsPresent);
+                HasAttachment.IsPresent,
+                SearchQuery);
 
             WriteObject(messages, true);
         } else {

--- a/Sources/Mailozaurr/Receive/MessageFetcher.cs
+++ b/Sources/Mailozaurr/Receive/MessageFetcher.cs
@@ -25,6 +25,7 @@ public static class MessageFetcher {
     /// <param name="before">Latest delivery date.</param>
     /// <param name="all">If set, ignores other filters.</param>
     /// <param name="delete">If set, messages are deleted after fetching.</param>
+    /// <param name="additionalQueries">Additional <see cref="SearchQuery"/> filters.</param>
     /// <returns>Collection of matching messages.</returns>
     public static IEnumerable<ImapEmailMessage> Fetch(
         ImapClient client,
@@ -37,7 +38,8 @@ public static class MessageFetcher {
         DateTime? before = null,
         bool all = false,
         bool delete = false,
-        bool hasAttachment = false) {
+        bool hasAttachment = false,
+        IEnumerable<SearchQuery>? additionalQueries = null) {
         IMailFolder mailFolder = client.Inbox;
         if (!string.IsNullOrEmpty(folder)) {
             try {
@@ -71,6 +73,14 @@ public static class MessageFetcher {
             }
             if (before.HasValue) {
                 query = query.And(SearchQuery.DeliveredBefore(before.Value));
+            }
+        }
+
+        if (additionalQueries != null) {
+            foreach (var q in additionalQueries) {
+                if (q != null) {
+                    query = query.And(q);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- allow `MessageFetcher.Fetch` to accept extra `SearchQuery` filters
- support passing arrays of queries from `Get-IMAPMessage`

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685d2988e9f8832e8d1ead39f73fd4d9