### PR TITLE
Improve exception handling

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -1,6 +1,8 @@
 using MailKit.Net.Imap;
 using MailKit.Security;
+using System.IO;
 using System.Security;
+using System.Security.Authentication;
 
 namespace Mailozaurr.PowerShell;
 
@@ -118,13 +120,19 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
         var client = new ImapClient();
         try {
             await client.ConnectAsync(Server, Port, Options);
-        } catch (Exception ex) {
-            var responseText = (ex as ImapCommandException)?.ResponseText;
+        } catch (ImapCommandException ex) {
+            var responseText = ex.ResponseText;
             if (!string.IsNullOrEmpty(responseText)) {
                 WriteWarning($"Connect-IMAP - Unable to connect: {ex.Message} | Server response: {responseText}");
             } else {
                 WriteWarning($"Connect-IMAP - Unable to connect: {ex.Message}");
             }
+            return;
+        } catch (ImapProtocolException ex) {
+            WriteWarning($"Connect-IMAP - Protocol error: {ex.Message}");
+            return;
+        } catch (IOException ex) {
+            WriteWarning($"Connect-IMAP - Network error: {ex.Message}");
             return;
         }
 
@@ -157,13 +165,25 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
                     await client.DisconnectAsync(true);
                     return;
                 }
-            } catch (Exception ex) {
-                var responseText = (ex as ImapCommandException)?.ResponseText;
+            } catch (System.Security.Authentication.AuthenticationException ex) {
+                WriteWarning($"Connect-IMAP - Authentication error: {ex.Message}");
+                await client.DisconnectAsync(true);
+                return;
+            } catch (ImapCommandException ex) {
+                var responseText = ex.ResponseText;
                 if (!string.IsNullOrEmpty(responseText)) {
                     WriteWarning($"Connect-IMAP - Unable to authenticate: {ex.Message} | Server response: {responseText}");
                 } else {
                     WriteWarning($"Connect-IMAP - Unable to authenticate: {ex.Message}");
                 }
+                await client.DisconnectAsync(true);
+                return;
+            } catch (ImapProtocolException ex) {
+                WriteWarning($"Connect-IMAP - Protocol error: {ex.Message}");
+                await client.DisconnectAsync(true);
+                return;
+            } catch (IOException ex) {
+                WriteWarning($"Connect-IMAP - Network error: {ex.Message}");
                 await client.DisconnectAsync(true);
                 return;
             }
@@ -176,8 +196,8 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
             // Open the inbox to get message info
             try {
                 await client.Inbox.OpenAsync(MailKit.FolderAccess.ReadOnly);
-            } catch (Exception ex) {
-                var responseText = (ex as ImapCommandException)?.ResponseText;
+            } catch (ImapCommandException ex) {
+                var responseText = ex.ResponseText;
                 if (!string.IsNullOrEmpty(responseText)) {
                     LoggingMessages.Logger.WriteWarning($"Connect-IMAP - Failed to open inbox: {ex.Message} | Server response: {responseText}");
                 } else {

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -1,6 +1,8 @@
 using MailKit.Net.Pop3;
 using MailKit.Security;
+using System.IO;
 using System.Security;
+using System.Security.Authentication;
 
 namespace Mailozaurr.PowerShell;
 
@@ -117,13 +119,19 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
         var client = new Pop3Client();
         try {
             await client.ConnectAsync(Server, Port, Options);
-        } catch (Exception ex) {
-            var statusText = (ex as Pop3CommandException)?.StatusText;
+        } catch (Pop3CommandException ex) {
+            var statusText = ex.StatusText;
             if (!string.IsNullOrEmpty(statusText)) {
                 WriteWarning($"Connect-POP3 - Unable to connect: {ex.Message} | Server response: {statusText}");
             } else {
                 WriteWarning($"Connect-POP3 - Unable to connect: {ex.Message}");
             }
+            return;
+        } catch (Pop3ProtocolException ex) {
+            WriteWarning($"Connect-POP3 - Protocol error: {ex.Message}");
+            return;
+        } catch (IOException ex) {
+            WriteWarning($"Connect-POP3 - Network error: {ex.Message}");
             return;
         }
 
@@ -156,13 +164,25 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
                     await client.DisconnectAsync(true);
                     return;
                 }
-            } catch (Exception ex) {
-                var statusText = (ex as Pop3CommandException)?.StatusText;
+            } catch (System.Security.Authentication.AuthenticationException ex) {
+                WriteWarning($"Connect-POP3 - Authentication error: {ex.Message}");
+                await client.DisconnectAsync(true);
+                return;
+            } catch (Pop3CommandException ex) {
+                var statusText = ex.StatusText;
                 if (!string.IsNullOrEmpty(statusText)) {
                     WriteWarning($"Connect-POP3 - Unable to authenticate: {ex.Message} | Server response: {statusText}");
                 } else {
                     WriteWarning($"Connect-POP3 - Unable to authenticate: {ex.Message}");
                 }
+                await client.DisconnectAsync(true);
+                return;
+            } catch (Pop3ProtocolException ex) {
+                WriteWarning($"Connect-POP3 - Protocol error: {ex.Message}");
+                await client.DisconnectAsync(true);
+                return;
+            } catch (IOException ex) {
+                WriteWarning($"Connect-POP3 - Network error: {ex.Message}");
                 await client.DisconnectAsync(true);
                 return;
             }

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -1,4 +1,6 @@
-﻿namespace Mailozaurr.PowerShell;
+﻿using System.Management.Automation;
+
+namespace Mailozaurr.PowerShell;
 
 /// <summary>
 /// <para type="synopsis">Sends an email message using SMTP, SendGrid, or Microsoft Graph from within PowerShell. Replaces the deprecated Send-MailMessage.</para>
@@ -883,7 +885,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             if (!Suppress) {
                 WriteObject(new SmtpResult(true, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ""));
             }
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
             LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
             if (errorAction == ActionPreference.Stop) {
                 throw;
@@ -913,7 +915,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             powerShell.AddParameters(parameters);
             try {
                 var results = powerShell.Invoke();
-            } catch (Exception ex) {
+            } catch (RuntimeException ex) {
                 LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
                 if (errorAction == ActionPreference.Stop) {
                     throw;
@@ -954,7 +956,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
                 // Handle the case where no results were returned
                 throw new InvalidOperationException("No results were returned from the Invoke-MgGraphRequest command.");
             }
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
             LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
             if (errorAction == ActionPreference.Stop) {
                 throw;
@@ -992,7 +994,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
                 // Handle the case where no results were returned
                 throw new InvalidOperationException("No results were returned from the Invoke-MgGraphRequest command.");
             }
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
             LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
             if (errorAction == ActionPreference.Stop) {
                 throw;

--- a/Sources/Mailozaurr.PowerShell/CredentialHelpers.cs
+++ b/Sources/Mailozaurr.PowerShell/CredentialHelpers.cs
@@ -18,7 +18,7 @@ public static class CredentialHelpers {
         // Try to convert from encrypted string, fallback to plain text
         try {
             return new NetworkCredential("", s).SecurePassword;
-        } catch (Exception ex) {
+        } catch (ArgumentException ex) {
             LoggingMessages.Logger.WriteWarning($"Failed to convert to SecureString: {ex.Message}");
             var ss = new SecureString();
             foreach (char c in s) ss.AppendChar(c);

--- a/Sources/Mailozaurr.PowerShell/OnImportAndRemove.cs
+++ b/Sources/Mailozaurr.PowerShell/OnImportAndRemove.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reflection;
 
@@ -47,7 +48,7 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
             if (File.Exists(assemblyPath)) {
                 try {
                     return Assembly.LoadFrom(assemblyPath);
-                } catch (Exception ex) {
+                } catch (BadImageFormatException ex) {
                     Console.WriteLine($"Failed to load assembly from {assemblyPath}: {ex.Message}");
                 }
             }

--- a/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
+++ b/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
@@ -28,7 +28,7 @@ public class EphemeralOpenPgpContext : GnuPGContext {
         base.Dispose();
         try {
             Directory.Delete(_tempDirectory, true);
-        } catch (Exception ex) {
+        } catch (IOException ex) {
             LoggingMessages.Logger.WriteWarning($"Failed to delete temporary directory: {ex.Message}");
         }
     }

--- a/Sources/Mailozaurr/EmailMessage.cs
+++ b/Sources/Mailozaurr/EmailMessage.cs
@@ -1,4 +1,5 @@
 ﻿using MsgKit;
+using System.IO;
 
 namespace Mailozaurr;
 
@@ -45,7 +46,7 @@ public static class EmailMessage {
                     Converter.ConvertEmlToMsg(emlFile.FullName, msgFile.FullName);
                     return new EmlConversionResult() { EmlFile = emlFile.FullName, MsgFile = msgFile.FullName, Status = true };
                 }
-            } catch (Exception ex) {
+            } catch (IOException ex) {
                 LoggingMessages.Logger.WriteWarning("Error converting EML to MSG: {0}", ex.Message);
                 return new EmlConversionResult() { EmlFile = emlFile.FullName, MsgFile = msgFile.FullName, Status = false, Error = ex.Message };
             }

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -38,8 +38,8 @@ public static class Helpers {
         try {
             var networkCredential = credentials as NetworkCredential;
             apiKey = networkCredential.Password;
-        } catch (Exception ex) {
-            apiKey = "";
+        } catch (InvalidCastException) {
+            apiKey = string.Empty;
         }
         return apiKey;
     }
@@ -140,7 +140,7 @@ public static class Helpers {
             var json = JsonSerializer.Serialize(result);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
             using var response = await client.PostAsync(url, content);
-        } catch (Exception ex) {
+        } catch (HttpRequestException ex) {
             LoggingMessages.Logger.WriteWarning($"Failed to post webhook: {ex.Message}");
         }
     }

--- a/Sources/Mailozaurr/Logging/LoggingConfigurator.cs
+++ b/Sources/Mailozaurr/Logging/LoggingConfigurator.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace Mailozaurr;
 
 /// <summary>
@@ -54,7 +56,7 @@ public class LoggingConfigurator {
             if (!string.IsNullOrEmpty(logPath)) {
                 try {
                     protocolLogger = new ProtocolLogger(logPath, logOverwrite);
-                } catch (Exception ex) {
+                } catch (IOException ex) {
                     LoggingMessages.Logger.WriteWarning($"Couldn't create protocol logger with {logPath}: {ex.Message}. Using console output instead.");
                     protocolLogger = new ProtocolLogger(Console.OpenStandardOutput());
                 }

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -161,7 +161,7 @@ public class MailgunClient : IDisposable {
                 }
                 var error = await response.Content.ReadAsStringAsync();
                 throw new HttpRequestException(error);
-            } catch (Exception ex) {
+            } catch (HttpRequestException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Mailgun: {ex.Message}");
                 if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -351,7 +351,7 @@ namespace Mailozaurr {
                     try {
                         var content = m.Body is JsonElement je && je.TryGetProperty("Content", out var c) ? c.GetString() : m.Body.ToString();
                         File.WriteAllText(filePath, content);
-                    } catch (Exception ex) {
+                    } catch (IOException ex) {
                         // Log or handle error
                         LoggingMessages.Logger.WriteWarning($"SaveMailMessage - Couldn't save file to {filePath}. Error: {ex.Message}");
                     }
@@ -374,7 +374,7 @@ namespace Mailozaurr {
                     } catch (FormatException fex) {
                         // Invalid Base64 content
                         LoggingMessages.Logger.WriteWarning($"SaveAttachment - Invalid base64 content for {att.Name}. Error: {fex.Message}");
-                    } catch (Exception ex) {
+                    } catch (IOException ex) {
                         // Log or handle other errors
                         LoggingMessages.Logger.WriteWarning($"SaveAttachment - Couldn't save file to {filePath}. Error: {ex.Message}");
                     }

--- a/Sources/Mailozaurr/Receive/MessageFetcher.cs
+++ b/Sources/Mailozaurr/Receive/MessageFetcher.cs
@@ -42,11 +42,11 @@ public static class MessageFetcher {
         if (!string.IsNullOrEmpty(folder)) {
             try {
                 mailFolder = client.GetFolder(folder);
-            } catch (Exception ex) {
+            } catch (FolderNotFoundException ex) {
                 LoggingMessages.Logger.WriteError($"Failed to get folder '{folder}': {ex.Message}");
                 try {
                     mailFolder = client.GetFolder(client.PersonalNamespaces[0]).GetSubfolder(folder);
-                } catch (Exception innerEx) {
+                } catch (FolderNotFoundException innerEx) {
                     LoggingMessages.Logger.WriteError($"Failed to get subfolder '{folder}': {innerEx.Message}");
                     throw;
                 }
@@ -79,7 +79,7 @@ public static class MessageFetcher {
             MimeMessage msg;
             try {
                 msg = mailFolder.GetMessage(uid);
-            } catch (Exception ex) {
+            } catch (MessageNotFoundException ex) {
                 LoggingMessages.Logger.WriteError($"Failed to get message UID {uid}: {ex.Message}");
                 throw;
             }
@@ -127,7 +127,7 @@ public static class MessageFetcher {
             MimeMessage message;
             try {
                 message = client.GetMessage(i);
-            } catch (Exception ex) {
+            } catch (Pop3CommandException ex) {
                 LoggingMessages.Logger.WriteError($"Failed to get message index {i}: {ex.Message}");
                 throw;
             }

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -246,7 +246,7 @@ public class SendGridClient {
         try {
             var networkCredential = Credentials as NetworkCredential;
             apiKey = networkCredential.Password;
-        } catch (Exception ex) {
+        } catch (InvalidCastException ex) {
             LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SendGrid: {ex.Message}");
             if (ErrorAction == ActionPreference.Stop) {
                 throw;
@@ -279,9 +279,9 @@ public class SendGridClient {
                 var message = $"Status code {response.StatusCode}: {lastContent}";
                 lastException = new HttpRequestException(message);
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SendGrid: {message}");
-            } catch (Exception ex) {
+            } catch (HttpRequestException ex) {
                 lastException = ex;
-                LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SendGrid: {ex.Message}");
+                LogCollector.LogWarning($"Send-EmailMessage - HTTP error during sending using SendGrid: {ex.Message}");
                 if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
                     if (ErrorAction == ActionPreference.Stop && lastException != null) {
                         throw lastException;
@@ -294,6 +294,21 @@ public class SendGridClient {
                 var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
                 if (delayMilliseconds > 0) {
                     await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken);
+                }
+            } catch (TaskCanceledException ex) {
+                lastException = ex;
+                LogCollector.LogWarning($"Send-EmailMessage - Request canceled: {ex.Message}");
+                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
+                    if (ErrorAction == ActionPreference.Stop && lastException != null) {
+                        throw lastException;
+                    }
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
+                    await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
+                    return failResult;
+                }
+                var delayMs = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (delayMs > 0) {
+                    await Task.Delay(TimeSpan.FromMilliseconds(delayMs), cancellationToken);
                 }
             }
             attempts++;

--- a/Sources/Mailozaurr/Validator.cs
+++ b/Sources/Mailozaurr/Validator.cs
@@ -3810,7 +3810,7 @@ public static class Validator {
                 ReasonErrorIndex = errorReason.ErrorIndex,
                 Error = ""
             };
-        } catch (Exception ex) {
+        } catch (FormatException ex) {
             return new ValidatedEmail {
                 EmailAddress = emailAddress,
                 IsValid = false,


### PR DESCRIPTION
## Summary
- use specific exceptions in POP3 connection and authentication flows
- use specific exceptions when fetching messages
- tighten SendGrid and logging error handling
- refine various helper methods to catch targeted exceptions

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685d27432a70832eb2e1b174d65dd7ce