### PR TITLE
Fix certificate validation reset on disconnect

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletDisconnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletDisconnectIMAP.cs
@@ -33,6 +33,8 @@ public sealed class CmdletDisconnectIMAP : AsyncPSCmdlet {
                     data.Disconnect(true);
                 } catch (System.Exception ex) {
                     WriteWarning($"Disconnect-IMAP - Unable to disconnect: {ex.Message}");
+                } finally {
+                    data.ServerCertificateValidationCallback = null;
                 }
             } else {
                 WriteWarning("Disconnect-IMAP - The provided object does not contain a valid Data property of type ImapClient.");

--- a/Sources/Mailozaurr.PowerShell/CmdletDisconnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletDisconnectPOP3.cs
@@ -37,6 +37,8 @@ public sealed class CmdletDisconnectPOP3 : AsyncPSCmdlet {
                     data.Disconnect(true);
                 } catch (System.Exception ex) {
                     WriteWarning($"Disconnect-POP3 - Unable to disconnect: {ex.Message}");
+                } finally {
+                    data.ServerCertificateValidationCallback = null;
                 }
             } else {
                 WriteWarning("Disconnect-POP3 - The provided object does not contain a valid Data property of type Pop3Client.");


### PR DESCRIPTION
## Summary
- clear validation callback on POP3 disconnect
- clear validation callback on IMAP disconnect

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685d271931cc832e9f6b92bec456bbd4