### PR TITLE
Implement disposal for Graph client

### DIFF
--- a/Sources/Mailozaurr.Examples/SendEmailGraphCertificate.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailGraphCertificate.cs
@@ -20,7 +20,7 @@ public static class SendEmailGraphCertificate {
                 certificatePath,
                 certificatePassword);
 
-            var graph = new Graph();
+            using var graph = new Graph();
             graph.From = sender;
             graph.To = new[] { recipient };
             graph.Subject = "Test Email via Microsoft Graph (Certificate)";

--- a/Sources/Mailozaurr.Examples/SendEmailGraphClientSecret.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailGraphClientSecret.cs
@@ -14,7 +14,7 @@ public static class SendEmailGraphClientSecret {
 
         // === EXAMPLE ===
         try {
-            var graph = new Graph();
+            using var graph = new Graph();
             graph.From = sender;
             graph.To = new[] { recipient };
             graph.Subject = "Test Email via Microsoft Graph (Client Secret)";

--- a/Sources/Mailozaurr.Examples/SendEmailMailgun.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailMailgun.cs
@@ -12,7 +12,7 @@ public static class SendEmailMailgun {
 
         // === EXAMPLE ===
         try {
-            var mailgun = new MailgunClient();
+            using var mailgun = new MailgunClient();
             mailgun.From = sender;
             mailgun.To = new[] { recipient }.ToList<object>();
             mailgun.Subject = "Test Email via Mailgun";

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -621,7 +621,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             }
         } else if (EmailProvider == EmailProvider.Mailgun) {
             var logCollector = new LogCollector();
-            MailgunClient mailgun = new MailgunClient();
+            using MailgunClient mailgun = new MailgunClient();
             mailgun.LogCollector = logCollector;
             mailgun.From = Helpers.GetFromObject(fromEmail, fromName);
             if (Bcc != null) mailgun.Bcc = Bcc.ToList();
@@ -656,7 +656,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
                 }
             }
         } else if (Graph) {
-            Graph graph = new Graph();
+            using Graph graph = new Graph();
             graph.ChunkSize = ChunkSize;
             graph.From = Helpers.GetFromObject(fromEmail, fromName);
             graph.To = To;
@@ -706,7 +706,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             }
             LogEmitter.EmitLogs(graph.LogCollector, this);
         } else if (MgGraphRequest) {
-            Graph graph = new Graph();
+            using Graph graph = new Graph();
             graph.ChunkSize = ChunkSize;
             graph.From = Helpers.GetFromObject(fromEmail, fromName);
             graph.To = To;

--- a/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
@@ -9,7 +9,7 @@ public class GraphCreateMessageTests
     [Fact]
     public void CreateMessage_WithValidData_BuildsJson()
     {
-        var graph = new Graph
+        using var graph = new Graph
         {
             From = "from@example.com",
             To = new object[] { "to@example.com" },
@@ -25,7 +25,7 @@ public class GraphCreateMessageTests
     [Fact]
     public void CreateAttachments_WithMissingFile_ThrowsFileNotFoundException()
     {
-        var graph = new Graph
+        using var graph = new Graph
         {
             Attachments = new object[] { "missing.file" }
         };
@@ -37,7 +37,7 @@ public class GraphCreateMessageTests
     {
         string tmp = Path.GetTempFileName();
         File.WriteAllBytes(tmp, new byte[4000001]);
-        var graph = new Graph
+        using var graph = new Graph
         {
             From = "from@example.com",
             To = new object[] { "to@example.com" },

--- a/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
@@ -16,7 +16,7 @@ public class GraphUploadRangeTests
     {
         string tmp = Path.GetTempFileName();
         File.WriteAllBytes(tmp, Enumerable.Range(0, 25).Select(b => (byte)b).ToArray());
-        Graph graph = new Graph();
+        using Graph graph = new Graph();
         MethodInfo? method = typeof(Graph).GetMethod(
             "PrepareByteArrayContentForUpload",
             BindingFlags.NonPublic | BindingFlags.Instance);

--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -9,7 +9,7 @@ public class MailgunClientTests
     [Fact]
     public void EmailDomain_InvalidAddress_ThrowsArgumentException()
     {
-        var client = new MailgunClient { From = "invalid" };
+        using var client = new MailgunClient { From = "invalid" };
         PropertyInfo? prop = typeof(MailgunClient).GetProperty("EmailDomain", BindingFlags.NonPublic | BindingFlags.Instance);
         var ex = Assert.Throws<TargetInvocationException>(() => prop!.GetValue(client));
         Assert.IsType<ArgumentException>(ex.InnerException);

--- a/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
+++ b/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
@@ -47,7 +47,7 @@ namespace Mailozaurr.Tests {
         [Fact(Skip="Requires network access")]
         public async Task SendEmail_Graph_WithValidInput_Succeeds() {
             // Arrange
-            var graph = new Graph();
+            using var graph = new Graph();
             graph.From = "sender@example.com";
             graph.To = new object[] { "recipient@example.com" };
             graph.Subject = "Test Email (Graph)";

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -6,7 +6,7 @@ namespace Mailozaurr;
 /// <summary>
 /// Helper class for sending messages via Microsoft Graph API.
 /// </summary>
-public class Graph {
+public class Graph : IDisposable {
     private readonly HttpClient _client;
     public string MessageJson = string.Empty;
     public GraphMessageContainer MessageContainer;
@@ -681,5 +681,12 @@ public class Graph {
             LogCollector.LogWarning(uploadChunkResponse.ToString());
             return;
         }
+    }
+
+    /// <summary>
+    /// Releases resources used by the Graph client.
+    /// </summary>
+    public void Dispose() {
+        _client.Dispose();
     }
 }

--- a/Sources/Mailozaurr/README.md
+++ b/Sources/Mailozaurr/README.md
@@ -70,7 +70,7 @@ Console.WriteLine($"Failed: {result.ErrorMessage}");
 ```csharp
 using Mailozaurr;
 
-var graph = new Graph();
+using var graph = new Graph();
 graph.From = "sender@example.com";
 graph.To = new[] { "recipient@example.com" };
 graph.Subject = "Graph API Email";


### PR DESCRIPTION
## Summary
- implement `IDisposable` on `Graph` to dispose its `HttpClient`
- use `using` for `Graph` and `MailgunClient` instances in PowerShell cmdlet
- update examples and tests to use `using` statements
- update README example

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release --no-build` *(fails: "The argument ... is invalid")*

------
https://chatgpt.com/codex/tasks/task_e_685d26f40f8c832e84e1e0a65cd838e4