### PR TITLE
Fix personal namespaces usage

### DIFF
--- a/Sources/Mailozaurr/Receive/MessageFetcher.cs
+++ b/Sources/Mailozaurr/Receive/MessageFetcher.cs
@@ -45,7 +45,12 @@ public static class MessageFetcher {
             } catch (Exception ex) {
                 LoggingMessages.Logger.WriteError($"Failed to get folder '{folder}': {ex.Message}");
                 try {
-                    mailFolder = client.GetFolder(client.PersonalNamespaces[0]).GetSubfolder(folder);
+                    if (client.PersonalNamespaces.Count > 0) {
+                        mailFolder = client.GetFolder(client.PersonalNamespaces[0]).GetSubfolder(folder);
+                    } else {
+                        LoggingMessages.Logger.WriteError("Personal namespaces list is empty. Unable to access subfolder.");
+                        throw;
+                    }
                 } catch (Exception innerEx) {
                     LoggingMessages.Logger.WriteError($"Failed to get subfolder '{folder}': {innerEx.Message}");
                     throw;


### PR DESCRIPTION
## Summary
- ensure PersonalNamespaces has items before using index 0

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685d26ec1688832e8a82faa265f47bc2