### PR TITLE
Allow null from in graph

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -36,7 +36,7 @@ public class Graph {
     /// Office 365 will use the mailbox's configured display name for the sender, regardless of what is set in the payload.
     /// The email address must be used for API calls and authentication.
     /// </summary>
-    public object From { get; set; }
+    public object? From { get; set; }
 
     /// <summary>
     /// Gets or sets the email address to reply to.
@@ -141,7 +141,7 @@ public class Graph {
     /// <summary>
     /// The email address that the message was sent from.
     /// </summary>
-    public string SentFrom => Helpers.GetEmailAddress(From);
+    public string SentFrom => From == null ? string.Empty : Helpers.GetEmailAddress(From);
 
     /// <summary>
     /// A comma-separated list of email addresses that the message was sent to.


### PR DESCRIPTION
## Summary
- support a null sender for Graph
- guard SentFrom when From is null

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release`
- `dotnet test Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685d26e4df7c832e8fe593bd59188470