### PR TITLE
Improve IMAP folder handling

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -1,5 +1,7 @@
 using MailKit.Net.Imap;
 using MailKit.Security;
+using MailKit;
+using Mailozaurr;
 using System.Security;
 
 namespace Mailozaurr.PowerShell;
@@ -173,9 +175,9 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
         }
 
         if (client.IsAuthenticated) {
-            // Open the inbox to get message info
+            // Open the inbox only once and cache it
             try {
-                await client.Inbox.OpenAsync(MailKit.FolderAccess.ReadOnly);
+                client.GetOrOpenFolder(null, FolderAccess.ReadOnly);
             } catch (Exception ex) {
                 var responseText = (ex as ImapCommandException)?.ResponseText;
                 if (!string.IsNullOrEmpty(responseText)) {
@@ -200,7 +202,8 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
                 Data = client,
                 Count = client.Inbox?.Count ?? 0,
                 Messages = client.Inbox,
-                Recent = client.Inbox?.Recent ?? 0
+                Recent = client.Inbox?.Recent ?? 0,
+                Folder = (ImapFolder)client.Inbox
             };
             DefaultSessions.ImapSession = info;
             WriteObject(info);

--- a/Sources/Mailozaurr.PowerShell/CmdletDisconnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletDisconnectIMAP.cs
@@ -1,3 +1,5 @@
+using Mailozaurr;
+
 namespace Mailozaurr.PowerShell;
 
 /// <summary>
@@ -34,6 +36,7 @@ public sealed class CmdletDisconnectIMAP : AsyncPSCmdlet {
                 } catch (System.Exception ex) {
                     WriteWarning($"Disconnect-IMAP - Unable to disconnect: {ex.Message}");
                 }
+                data.ClearFolderCache();
             } else {
                 WriteWarning("Disconnect-IMAP - The provided object does not contain a valid Data property of type ImapClient.");
             }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
@@ -1,6 +1,7 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
 using MailKit;
+using Mailozaurr;
 using Mailozaurr.PowerShell;
 
 namespace Mailozaurr.PowerShell;
@@ -39,12 +40,12 @@ public sealed class CmdletGetIMAPFolder : AsyncPSCmdlet {
     protected override Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null) {
-            var folder = conn.Data.Inbox;
-            folder.Open(FolderAccess);
+            var folder = conn.Data.GetOrOpenFolder(null, FolderAccess);
             WriteVerbose($"Get-IMAPFolder - Total messages {folder.Count}, Recent messages {folder.Recent}");
             conn.Messages = folder;
             conn.Count = folder.Count;
             conn.Recent = folder.Recent;
+            conn.Folder = folder;
             DefaultSessions.ImapSession = conn;
             WriteObject(conn);
         } else {

--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using MailKit;
 using MailKit.Search;
 using MimeKit;
+using Mailozaurr;
 using Mailozaurr.PowerShell;
 
 namespace Mailozaurr.PowerShell;
@@ -130,11 +131,13 @@ public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
     protected override Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null && conn.Data != null) {
-            var folder = conn.Folder?.FullName;
+            var folderName = conn.Folder?.FullName;
+            var folder = conn.Data.GetOrOpenFolder(folderName, Delete.IsPresent ? FolderAccess.ReadWrite : FolderAccess.ReadOnly);
+            conn.Folder = folder;
 
             var messages = MessageFetcher.Fetch(
                 conn.Data,
-                folder,
+                folder.FullName,
                 Subject,
                 FromContains,
                 ToContains,

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPMessage.cs
@@ -1,6 +1,7 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
 using MailKit;
+using Mailozaurr;
 
 namespace Mailozaurr.PowerShell;
 
@@ -52,32 +53,9 @@ public sealed class CmdletMoveIMAPMessage : AsyncPSCmdlet {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null && conn.Data != null) {
             var uid = new UniqueId(Uid);
-            IMailFolder source = conn.Data.Inbox;
-            if (!string.IsNullOrEmpty(SourceFolder)) {
-                try {
-                    source = conn.Data.GetFolder(SourceFolder);
-                } catch {
-                    try {
-                        source = conn.Data.GetFolder(conn.Data.PersonalNamespaces[0]).GetSubfolder(SourceFolder);
-                    } catch {
-                        WriteWarning($"Move-IMAPMessage - Source folder '{SourceFolder}' not found.");
-                        return Task.CompletedTask;
-                    }
-                }
-            }
-            IMailFolder? dest = null;
-            try {
-                dest = conn.Data.GetFolder(DestinationFolder);
-            } catch {
-                try {
-                    dest = conn.Data.GetFolder(conn.Data.PersonalNamespaces[0]).GetSubfolder(DestinationFolder);
-                } catch {
-                    WriteWarning($"Move-IMAPMessage - Destination folder '{DestinationFolder}' not found.");
-                    return Task.CompletedTask;
-                }
-            }
-            source.Open(FolderAccess.ReadWrite);
-            dest.Open(FolderAccess.ReadWrite);
+            var source = conn.Data.GetOrOpenFolder(string.IsNullOrEmpty(SourceFolder) ? conn.Folder?.FullName : SourceFolder, FolderAccess.ReadWrite);
+            var dest = conn.Data.GetOrOpenFolder(DestinationFolder, FolderAccess.ReadWrite);
+            conn.Folder = source;
             source.MoveTo(uid, dest);
         } else {
             WriteWarning("Move-IMAPMessage - Is IMAP connected?");

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveIMAPMessage.cs
@@ -1,6 +1,7 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
 using MailKit;
+using Mailozaurr;
 
 namespace Mailozaurr.PowerShell;
 
@@ -52,20 +53,8 @@ public sealed class CmdletSaveIMAPMessage : AsyncPSCmdlet {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null && conn.Data != null) {
             var uid = new UniqueId(Uid);
-            IMailFolder mailFolder = conn.Data.Inbox;
-            if (!string.IsNullOrEmpty(Folder)) {
-                try {
-                    mailFolder = conn.Data.GetFolder(Folder);
-                } catch {
-                    try {
-                        mailFolder = conn.Data.GetFolder(conn.Data.PersonalNamespaces[0]).GetSubfolder(Folder);
-                    } catch {
-                        WriteWarning($"Save-IMAPMessage - Folder '{Folder}' not found.");
-                        return Task.CompletedTask;
-                    }
-                }
-            }
-            mailFolder.Open(FolderAccess.ReadOnly);
+            var mailFolder = conn.Data.GetOrOpenFolder(string.IsNullOrEmpty(Folder) ? conn.Folder?.FullName : Folder, FolderAccess.ReadOnly);
+            conn.Folder = mailFolder;
             var message = mailFolder.GetMessage(uid);
             message.WriteTo(Path);
         } else {

--- a/Sources/Mailozaurr/Imap/ImapClientFolderCache.cs
+++ b/Sources/Mailozaurr/Imap/ImapClientFolderCache.cs
@@ -1,0 +1,44 @@
+using MailKit;
+using MailKit.Net.Imap;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Mailozaurr;
+
+public static class ImapClientFolderCache
+{
+    private static readonly ConditionalWeakTable<ImapClient, Dictionary<string, ImapFolder>> _cache = new();
+
+    public static ImapFolder GetOrOpenFolder(this ImapClient client, string? folderName, FolderAccess access)
+    {
+        var folders = _cache.GetOrCreateValue(client);
+        var key = string.IsNullOrEmpty(folderName) ? client.Inbox.FullName : folderName!;
+        if (!folders.TryGetValue(key, out var folder))
+        {
+            folder = string.IsNullOrEmpty(folderName) ? (ImapFolder)client.Inbox : GetFolder(client, folderName!);
+            folders[key] = folder;
+        }
+        if (!folder.IsOpen)
+        {
+            folder.Open(access);
+        }
+        return folder;
+    }
+
+    public static void ClearFolderCache(this ImapClient client)
+    {
+        _cache.Remove(client);
+    }
+
+    private static ImapFolder GetFolder(ImapClient client, string folder)
+    {
+        try
+        {
+            return (ImapFolder)client.GetFolder(folder);
+        }
+        catch
+        {
+            return (ImapFolder)client.GetFolder(client.PersonalNamespaces[0]).GetSubfolder(folder);
+        }
+    }
+}

--- a/Sources/Mailozaurr/Receive/MessageFetcher.cs
+++ b/Sources/Mailozaurr/Receive/MessageFetcher.cs
@@ -38,22 +38,7 @@ public static class MessageFetcher {
         bool all = false,
         bool delete = false,
         bool hasAttachment = false) {
-        IMailFolder mailFolder = client.Inbox;
-        if (!string.IsNullOrEmpty(folder)) {
-            try {
-                mailFolder = client.GetFolder(folder);
-            } catch (Exception ex) {
-                LoggingMessages.Logger.WriteError($"Failed to get folder '{folder}': {ex.Message}");
-                try {
-                    mailFolder = client.GetFolder(client.PersonalNamespaces[0]).GetSubfolder(folder);
-                } catch (Exception innerEx) {
-                    LoggingMessages.Logger.WriteError($"Failed to get subfolder '{folder}': {innerEx.Message}");
-                    throw;
-                }
-            }
-        }
-
-        mailFolder.Open(delete ? FolderAccess.ReadWrite : FolderAccess.ReadOnly);
+        var mailFolder = client.GetOrOpenFolder(folder, delete ? FolderAccess.ReadWrite : FolderAccess.ReadOnly);
 
         SearchQuery query = SearchQuery.All;
         if (!all) {


### PR DESCRIPTION
## Summary
- add `ImapClientFolderCache` to cache folders
- use the cache in IMAP cmdlets and MessageFetcher
- keep cache for the duration of the connection

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoProfile -Command ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685d2929ad48832e8bbc41f8c4a12c9d