### PR TITLE
Implement IMAP folder caching

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -1,5 +1,6 @@
 using MailKit.Net.Imap;
 using MailKit.Security;
+using Mailozaurr;
 using System.IO;
 using System.Security;
 using System.Security.Authentication;
@@ -193,9 +194,9 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
         }
 
         if (client.IsAuthenticated) {
-            // Open the inbox to get message info
+            // Open the inbox once and cache folder reference
             try {
-                await client.Inbox.OpenAsync(MailKit.FolderAccess.ReadOnly);
+                _ = client.GetCachedFolder(null, MailKit.FolderAccess.ReadOnly);
             } catch (ImapCommandException ex) {
                 var responseText = ex.ResponseText;
                 if (!string.IsNullOrEmpty(responseText)) {
@@ -204,6 +205,7 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
                     LoggingMessages.Logger.WriteWarning($"Connect-IMAP - Failed to open inbox: {ex.Message}");
                 }
             }
+            var inbox = (ImapFolder)client.GetCachedFolder(null, MailKit.FolderAccess.ReadOnly);
             var info = new ImapConnectionInfo {
                 Uri = $"imaps://{Server}:{Port}/",
                 AuthenticationMechanisms = client.AuthenticationMechanisms,
@@ -218,10 +220,12 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
                 IsAuthenticated = client.IsAuthenticated,
                 IsSecure = client.IsSecure,
                 Data = client,
-                Count = client.Inbox?.Count ?? 0,
-                Messages = client.Inbox,
-                Recent = client.Inbox?.Recent ?? 0
+                Count = inbox.Count,
+                Messages = inbox,
+                Recent = inbox.Recent,
+                Folder = inbox
             };
+            info.Folders[inbox.FullName] = inbox;
             DefaultSessions.ImapSession = info;
             WriteObject(info);
         } else {

--- a/Sources/Mailozaurr.PowerShell/CmdletDisconnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletDisconnectIMAP.cs
@@ -1,3 +1,5 @@
+using Mailozaurr;
+
 namespace Mailozaurr.PowerShell;
 
 /// <summary>
@@ -31,6 +33,7 @@ public sealed class CmdletDisconnectIMAP : AsyncPSCmdlet {
             if (data != null) {
                 try {
                     data.Disconnect(true);
+                    data.ClearFolderCache();
                 } catch (System.Exception ex) {
                     WriteWarning($"Disconnect-IMAP - Unable to disconnect: {ex.Message}");
                 }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
@@ -1,6 +1,8 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
 using MailKit;
+using MailKit.Net.Imap;
+using Mailozaurr;
 using Mailozaurr.PowerShell;
 
 namespace Mailozaurr.PowerShell;
@@ -39,12 +41,13 @@ public sealed class CmdletGetIMAPFolder : AsyncPSCmdlet {
     protected override Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null) {
-            var folder = conn.Data.Inbox;
-            folder.Open(FolderAccess);
+            var folder = (ImapFolder)conn.Data.GetCachedFolder(conn.Folder?.FullName, FolderAccess);
             WriteVerbose($"Get-IMAPFolder - Total messages {folder.Count}, Recent messages {folder.Recent}");
             conn.Messages = folder;
             conn.Count = folder.Count;
             conn.Recent = folder.Recent;
+            conn.Folder = folder;
+            conn.Folders[folder.FullName] = folder;
             DefaultSessions.ImapSession = conn;
             WriteObject(conn);
         } else {

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPMessage.cs
@@ -1,6 +1,8 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
 using MailKit;
+using MailKit.Net.Imap;
+using Mailozaurr;
 
 namespace Mailozaurr.PowerShell;
 
@@ -52,32 +54,10 @@ public sealed class CmdletMoveIMAPMessage : AsyncPSCmdlet {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null && conn.Data != null) {
             var uid = new UniqueId(Uid);
-            IMailFolder source = conn.Data.Inbox;
-            if (!string.IsNullOrEmpty(SourceFolder)) {
-                try {
-                    source = conn.Data.GetFolder(SourceFolder);
-                } catch {
-                    try {
-                        source = conn.Data.GetFolder(conn.Data.PersonalNamespaces[0]).GetSubfolder(SourceFolder);
-                    } catch {
-                        WriteWarning($"Move-IMAPMessage - Source folder '{SourceFolder}' not found.");
-                        return Task.CompletedTask;
-                    }
-                }
-            }
-            IMailFolder? dest = null;
-            try {
-                dest = conn.Data.GetFolder(DestinationFolder);
-            } catch {
-                try {
-                    dest = conn.Data.GetFolder(conn.Data.PersonalNamespaces[0]).GetSubfolder(DestinationFolder);
-                } catch {
-                    WriteWarning($"Move-IMAPMessage - Destination folder '{DestinationFolder}' not found.");
-                    return Task.CompletedTask;
-                }
-            }
-            source.Open(FolderAccess.ReadWrite);
-            dest.Open(FolderAccess.ReadWrite);
+            var source = conn.Data.GetCachedFolder(SourceFolder ?? conn.Folder?.FullName, FolderAccess.ReadWrite);
+            var dest = conn.Data.GetCachedFolder(DestinationFolder!, FolderAccess.ReadWrite);
+            conn.Folders[source.FullName] = (ImapFolder)source;
+            conn.Folders[dest.FullName] = (ImapFolder)dest;
             source.MoveTo(uid, dest);
         } else {
             WriteWarning("Move-IMAPMessage - Is IMAP connected?");

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveIMAPMessage.cs
@@ -1,6 +1,8 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
 using MailKit;
+using MailKit.Net.Imap;
+using Mailozaurr;
 
 namespace Mailozaurr.PowerShell;
 
@@ -52,20 +54,8 @@ public sealed class CmdletSaveIMAPMessage : AsyncPSCmdlet {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null && conn.Data != null) {
             var uid = new UniqueId(Uid);
-            IMailFolder mailFolder = conn.Data.Inbox;
-            if (!string.IsNullOrEmpty(Folder)) {
-                try {
-                    mailFolder = conn.Data.GetFolder(Folder);
-                } catch {
-                    try {
-                        mailFolder = conn.Data.GetFolder(conn.Data.PersonalNamespaces[0]).GetSubfolder(Folder);
-                    } catch {
-                        WriteWarning($"Save-IMAPMessage - Folder '{Folder}' not found.");
-                        return Task.CompletedTask;
-                    }
-                }
-            }
-            mailFolder.Open(FolderAccess.ReadOnly);
+            var mailFolder = conn.Data.GetCachedFolder(Folder ?? conn.Folder?.FullName, FolderAccess.ReadOnly);
+            conn.Folders[mailFolder.FullName] = (ImapFolder)mailFolder;
             var message = mailFolder.GetMessage(uid);
             message.WriteTo(Path);
         } else {

--- a/Sources/Mailozaurr.PowerShell/Definitions/ImapConnectionInfo.cs
+++ b/Sources/Mailozaurr.PowerShell/Definitions/ImapConnectionInfo.cs
@@ -1,4 +1,5 @@
 using MailKit.Net.Imap;
+using System.Collections.Generic;
 
 namespace Mailozaurr.PowerShell;
 
@@ -42,4 +43,8 @@ public class ImapConnectionInfo {
     /// IMAP folder.
     /// </summary>
     public ImapFolder Folder { get; set; }
+    /// <summary>
+    /// Cached folders for this connection.
+    /// </summary>
+    public Dictionary<string, ImapFolder> Folders { get; } = new();
 }

--- a/Sources/Mailozaurr/Receive/ImapClientFolderCache.cs
+++ b/Sources/Mailozaurr/Receive/ImapClientFolderCache.cs
@@ -1,0 +1,50 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using MailKit;
+using MailKit.Net.Imap;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Provides folder caching for <see cref="ImapClient"/> instances.
+/// </summary>
+public static class ImapClientFolderCache {
+    private static readonly ConditionalWeakTable<ImapClient, ConcurrentDictionary<string, IMailFolder>> Cache = new();
+
+    /// <summary>
+    /// Retrieves a folder, caching it on first access and ensuring it is opened with the specified access.
+    /// </summary>
+    /// <param name="client">IMAP client instance.</param>
+    /// <param name="folder">Folder name or null for the inbox.</param>
+    /// <param name="access">Folder access mode.</param>
+    /// <returns>The opened folder.</returns>
+    public static IMailFolder GetCachedFolder(this ImapClient client, string? folder, FolderAccess access) {
+        var map = Cache.GetOrCreateValue(client);
+        var name = string.IsNullOrEmpty(folder) ? client.Inbox.FullName : folder;
+
+        if (!map.TryGetValue(name, out var mailFolder)) {
+            if (name.Equals(client.Inbox.FullName, System.StringComparison.OrdinalIgnoreCase)) {
+                mailFolder = client.Inbox;
+            } else {
+                try {
+                    mailFolder = client.GetFolder(name);
+                } catch (FolderNotFoundException) {
+                    mailFolder = client.GetFolder(client.PersonalNamespaces[0]).GetSubfolder(name);
+                }
+            }
+            map[name] = mailFolder;
+        }
+
+        if (!mailFolder.IsOpen || mailFolder.Access != access) {
+            mailFolder.Open(access);
+        }
+
+        return mailFolder;
+    }
+
+    /// <summary>
+    /// Clears cached folders for the specified client.
+    /// </summary>
+    /// <param name="client">IMAP client instance.</param>
+    public static void ClearFolderCache(this ImapClient client) => Cache.Remove(client);
+}

--- a/Sources/Mailozaurr/Receive/MessageFetcher.cs
+++ b/Sources/Mailozaurr/Receive/MessageFetcher.cs
@@ -40,22 +40,13 @@ public static class MessageFetcher {
         bool delete = false,
         bool hasAttachment = false,
         IEnumerable<SearchQuery>? additionalQueries = null) {
-        IMailFolder mailFolder = client.Inbox;
-        if (!string.IsNullOrEmpty(folder)) {
-            try {
-                mailFolder = client.GetFolder(folder);
-            } catch (FolderNotFoundException ex) {
-                LoggingMessages.Logger.WriteError($"Failed to get folder '{folder}': {ex.Message}");
-                try {
-                    mailFolder = client.GetFolder(client.PersonalNamespaces[0]).GetSubfolder(folder);
-                } catch (FolderNotFoundException innerEx) {
-                    LoggingMessages.Logger.WriteError($"Failed to get subfolder '{folder}': {innerEx.Message}");
-                    throw;
-                }
-            }
+        IMailFolder mailFolder;
+        try {
+            mailFolder = client.GetCachedFolder(folder, delete ? FolderAccess.ReadWrite : FolderAccess.ReadOnly);
+        } catch (FolderNotFoundException ex) {
+            LoggingMessages.Logger.WriteError($"Failed to get folder '{folder}': {ex.Message}");
+            throw;
         }
-
-        mailFolder.Open(delete ? FolderAccess.ReadWrite : FolderAccess.ReadOnly);
 
         SearchQuery query = SearchQuery.All;
         if (!all) {


### PR DESCRIPTION
## Summary
- cache IMAP folders on the client and reuse them
- open Inbox once during Connect-IMAP and store in connection info
- track cached folders and reuse in Get-IMAPFolder, Save-IMAPMessage and Move-IMAPMessage
- clear cached folders on disconnect

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_685d2e65925c832e973d86d96782f160