### PR TITLE
Fix missing personal namespace check

### DIFF
--- a/Sources/Mailozaurr/Receive/ImapClientFolderCache.cs
+++ b/Sources/Mailozaurr/Receive/ImapClientFolderCache.cs
@@ -29,6 +29,10 @@ public static class ImapClientFolderCache {
                 try {
                     mailFolder = client.GetFolder(name);
                 } catch (FolderNotFoundException) {
+                    if (client.PersonalNamespaces.Count == 0) {
+                        throw;
+                    }
+
                     mailFolder = client.GetFolder(client.PersonalNamespaces[0]).GetSubfolder(name);
                 }
             }


### PR DESCRIPTION
## Summary
- prevent `IndexOutOfRangeException` when the IMAP client has no personal namespaces

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --nologo`
- `pwsh run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685d85a09544832eb98ee4685be1521f