### PR TITLE
Add retry options to connection cmdlets

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -48,6 +48,24 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? CertificatePassword { get; set; }
 
+    /// <summary>
+    /// <para type="description">Number of connection retry attempts.</para>
+    /// </summary>
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Delay in milliseconds between retries.</para>
+    /// </summary>
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Multiplier for increasing retry delay.</para>
+    /// </summary>
+    [Parameter]
+    public double RetryDelayBackoff { get; set; } = 1.0;
+
     protected override async Task ProcessRecordAsync() {
         GraphCredential cred;
         if (ParameterSetName == "Credential") {
@@ -84,7 +102,13 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
 
         bool connected = false;
         try {
-            var token = await MicrosoftGraphUtils.ConnectO365GraphAsync(cred, cred.DirectoryId, "https://graph.microsoft.com");
+            var token = await MicrosoftGraphUtils.ConnectO365GraphWithRetryAsync(
+                cred,
+                cred.DirectoryId!,
+                RetryCount,
+                RetryDelayMilliseconds,
+                RetryDelayBackoff,
+                "https://graph.microsoft.com");
             connected = !string.IsNullOrEmpty(token);
         } catch {
             // ignore errors, return not connected

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -1,7 +1,6 @@
 using MailKit.Net.Imap;
 using MailKit.Security;
 using Mailozaurr;
-using System.IO;
 using System.Security;
 using System.Security.Authentication;
 
@@ -106,6 +105,30 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
     public int TimeOut { get; set; } = 120000;
 
     /// <summary>
+    /// <para type="description">Number of connection retry attempts.</para>
+    /// </summary>
+    [Parameter(ParameterSetName = "OAuth2")]
+    [Parameter(ParameterSetName = "Credential")]
+    [Parameter(ParameterSetName = "ClearText")]
+    public int RetryCount { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Delay in milliseconds between retries.</para>
+    /// </summary>
+    [Parameter(ParameterSetName = "OAuth2")]
+    [Parameter(ParameterSetName = "Credential")]
+    [Parameter(ParameterSetName = "ClearText")]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Multiplier for increasing retry delay.</para>
+    /// </summary>
+    [Parameter(ParameterSetName = "OAuth2")]
+    [Parameter(ParameterSetName = "Credential")]
+    [Parameter(ParameterSetName = "ClearText")]
+    public double RetryDelayBackoff { get; set; } = 1.0;
+
+    /// <summary>
     /// <para type="description">Enables OAuth2 authentication. Use with a PSCredential object containing the access token as the password.</para>
     /// </summary>
     [Parameter(ParameterSetName = "OAuth2")]
@@ -118,78 +141,38 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
     /// Use the returned object with <c>Disconnect-IMAP</c>, <c>Get-IMAPFolder</c>, or <c>Get-IMAPMessage</c> for further operations.
     /// </remarks>
     protected override async Task ProcessRecordAsync() {
-        var client = new ImapClient();
-        try {
-            await client.ConnectAsync(Server, Port, Options);
-        } catch (ImapCommandException ex) {
-            var responseText = ex.ResponseText;
-            if (!string.IsNullOrEmpty(responseText)) {
-                WriteWarning($"Connect-IMAP - Unable to connect: {ex.Message} | Server response: {responseText}");
+        async Task Authenticate(ImapClient c) {
+            if (ParameterSetName == "OAuth2" && OAuth2.IsPresent) {
+                var username = Credential.UserName;
+                var token = new System.Net.NetworkCredential(string.Empty, Credential.Password).Password;
+                var sasl = new MailKit.Security.SaslMechanismOAuth2(username, token);
+                await c.AuthenticateAsync(sasl);
+            } else if (ParameterSetName == "ClearText" && !string.IsNullOrEmpty(UserName) && !string.IsNullOrEmpty(Password)) {
+                await c.AuthenticateAsync(UserName, Password);
+            } else if (Credential != null) {
+                var username = Credential.UserName;
+                var password = Credential.Password is SecureString ss ? new System.Net.NetworkCredential(string.Empty, ss).Password : Credential.GetNetworkCredential().Password;
+                await c.AuthenticateAsync(username, password);
             } else {
-                WriteWarning($"Connect-IMAP - Unable to connect: {ex.Message}");
+                throw new System.Security.Authentication.AuthenticationException("No valid authentication method provided.");
             }
-            return;
-        } catch (ImapProtocolException ex) {
-            WriteWarning($"Connect-IMAP - Protocol error: {ex.Message}");
-            return;
-        } catch (IOException ex) {
-            WriteWarning($"Connect-IMAP - Network error: {ex.Message}");
-            return;
         }
 
-        if (SkipCertificateRevocation) {
-            client.CheckCertificateRevocation = false;
-        }
-        if (SkipCertificateValidation) {
-            client.ServerCertificateValidationCallback = (s, c, h, e) => true;
-        }
-        if (client.Timeout != TimeOut) {
-            client.Timeout = TimeOut;
-        }
-
-        if (client.IsConnected) {
-            try {
-                if (ParameterSetName == "OAuth2" && OAuth2.IsPresent) {
-                    // OAuth2 authentication using SASL
-                    var username = Credential.UserName;
-                    var token = new System.Net.NetworkCredential("", Credential.Password).Password;
-                    var sasl = new MailKit.Security.SaslMechanismOAuth2(username, token);
-                    await client.AuthenticateAsync(sasl);
-                } else if (ParameterSetName == "ClearText" && !string.IsNullOrEmpty(UserName) && !string.IsNullOrEmpty(Password)) {
-                    await client.AuthenticateAsync(UserName, Password);
-                } else if (Credential != null) {
-                    var username = Credential.UserName;
-                    var password = Credential.Password is SecureString ss ? new System.Net.NetworkCredential("", ss).Password : Credential.GetNetworkCredential().Password;
-                    await client.AuthenticateAsync(username, password);
-                } else {
-                    WriteWarning("Connect-IMAP - No valid authentication method provided.");
-                    await client.DisconnectAsync(true);
-                    return;
-                }
-            } catch (System.Security.Authentication.AuthenticationException ex) {
-                WriteWarning($"Connect-IMAP - Authentication error: {ex.Message}");
-                await client.DisconnectAsync(true);
-                return;
-            } catch (ImapCommandException ex) {
-                var responseText = ex.ResponseText;
-                if (!string.IsNullOrEmpty(responseText)) {
-                    WriteWarning($"Connect-IMAP - Unable to authenticate: {ex.Message} | Server response: {responseText}");
-                } else {
-                    WriteWarning($"Connect-IMAP - Unable to authenticate: {ex.Message}");
-                }
-                await client.DisconnectAsync(true);
-                return;
-            } catch (ImapProtocolException ex) {
-                WriteWarning($"Connect-IMAP - Protocol error: {ex.Message}");
-                await client.DisconnectAsync(true);
-                return;
-            } catch (IOException ex) {
-                WriteWarning($"Connect-IMAP - Network error: {ex.Message}");
-                await client.DisconnectAsync(true);
-                return;
-            }
-        } else {
-            WriteWarning("Connect-IMAP - Client is not connected after ConnectAsync.");
+        ImapClient client;
+        try {
+            client = await ImapConnector.ConnectAsync(
+                Server,
+                Port,
+                Options,
+                TimeOut,
+                SkipCertificateRevocation.IsPresent,
+                SkipCertificateValidation.IsPresent,
+                Authenticate,
+                RetryCount,
+                RetryDelayMilliseconds,
+                RetryDelayBackoff);
+        } catch (Exception ex) {
+            WriteWarning($"Connect-IMAP - {ex.Message}");
             return;
         }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -1,6 +1,5 @@
 using MailKit.Net.Pop3;
 using MailKit.Security;
-using System.IO;
 using System.Security;
 using System.Security.Authentication;
 
@@ -104,6 +103,30 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
     public int TimeOut { get; set; } = 120000;
 
     /// <summary>
+    /// <para type="description">Number of connection retry attempts.</para>
+    /// </summary>
+    [Parameter(ParameterSetName = "OAuth2")]
+    [Parameter(ParameterSetName = "Credential")]
+    [Parameter(ParameterSetName = "ClearText")]
+    public int RetryCount { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Delay in milliseconds between retries.</para>
+    /// </summary>
+    [Parameter(ParameterSetName = "OAuth2")]
+    [Parameter(ParameterSetName = "Credential")]
+    [Parameter(ParameterSetName = "ClearText")]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    /// <summary>
+    /// <para type="description">Multiplier for increasing retry delay.</para>
+    /// </summary>
+    [Parameter(ParameterSetName = "OAuth2")]
+    [Parameter(ParameterSetName = "Credential")]
+    [Parameter(ParameterSetName = "ClearText")]
+    public double RetryDelayBackoff { get; set; } = 1.0;
+
+    /// <summary>
     /// <para type="description">Enables OAuth2 authentication. Use with a PSCredential object containing the access token as the password.</para>
     /// </summary>
     [Parameter(ParameterSetName = "OAuth2")]
@@ -116,78 +139,38 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
     /// Use the returned object with <c>Disconnect-POP3</c> or <c>Get-POP3Message</c> for further operations.
     /// </remarks>
     protected override async Task ProcessRecordAsync() {
-        var client = new Pop3Client();
-        try {
-            await client.ConnectAsync(Server, Port, Options);
-        } catch (Pop3CommandException ex) {
-            var statusText = ex.StatusText;
-            if (!string.IsNullOrEmpty(statusText)) {
-                WriteWarning($"Connect-POP3 - Unable to connect: {ex.Message} | Server response: {statusText}");
+        async Task Authenticate(Pop3Client c) {
+            if (ParameterSetName == "OAuth2" && OAuth2.IsPresent) {
+                var username = Credential.UserName;
+                var token = new System.Net.NetworkCredential(string.Empty, Credential.Password).Password;
+                var sasl = new MailKit.Security.SaslMechanismOAuth2(username, token);
+                await c.AuthenticateAsync(sasl);
+            } else if (ParameterSetName == "ClearText" && !string.IsNullOrEmpty(UserName) && !string.IsNullOrEmpty(Password)) {
+                await c.AuthenticateAsync(UserName, Password);
+            } else if (Credential != null) {
+                var username = Credential.UserName;
+                var password = Credential.Password is SecureString ss ? new System.Net.NetworkCredential(string.Empty, ss).Password : Credential.GetNetworkCredential().Password;
+                await c.AuthenticateAsync(username, password);
             } else {
-                WriteWarning($"Connect-POP3 - Unable to connect: {ex.Message}");
+                throw new System.Security.Authentication.AuthenticationException("No valid authentication method provided.");
             }
-            return;
-        } catch (Pop3ProtocolException ex) {
-            WriteWarning($"Connect-POP3 - Protocol error: {ex.Message}");
-            return;
-        } catch (IOException ex) {
-            WriteWarning($"Connect-POP3 - Network error: {ex.Message}");
-            return;
         }
 
-        if (SkipCertificateRevocation) {
-            client.CheckCertificateRevocation = false;
-        }
-        if (SkipCertificateValidation) {
-            client.ServerCertificateValidationCallback = (s, c, h, e) => true;
-        }
-        if (client.Timeout != TimeOut) {
-            client.Timeout = TimeOut;
-        }
-
-        if (client.IsConnected) {
-            try {
-                if (ParameterSetName == "OAuth2" && OAuth2.IsPresent) {
-                    // OAuth2 authentication using SASL
-                    var username = Credential.UserName;
-                    var token = new System.Net.NetworkCredential("", Credential.Password).Password;
-                    var sasl = new MailKit.Security.SaslMechanismOAuth2(username, token);
-                    await client.AuthenticateAsync(sasl);
-                } else if (ParameterSetName == "ClearText" && !string.IsNullOrEmpty(UserName) && !string.IsNullOrEmpty(Password)) {
-                    await client.AuthenticateAsync(UserName, Password);
-                } else if (Credential != null) {
-                    var username = Credential.UserName;
-                    var password = Credential.Password is SecureString ss ? new System.Net.NetworkCredential("", ss).Password : Credential.GetNetworkCredential().Password;
-                    await client.AuthenticateAsync(username, password);
-                } else {
-                    WriteWarning("Connect-POP3 - No valid authentication method provided.");
-                    await client.DisconnectAsync(true);
-                    return;
-                }
-            } catch (System.Security.Authentication.AuthenticationException ex) {
-                WriteWarning($"Connect-POP3 - Authentication error: {ex.Message}");
-                await client.DisconnectAsync(true);
-                return;
-            } catch (Pop3CommandException ex) {
-                var statusText = ex.StatusText;
-                if (!string.IsNullOrEmpty(statusText)) {
-                    WriteWarning($"Connect-POP3 - Unable to authenticate: {ex.Message} | Server response: {statusText}");
-                } else {
-                    WriteWarning($"Connect-POP3 - Unable to authenticate: {ex.Message}");
-                }
-                await client.DisconnectAsync(true);
-                return;
-            } catch (Pop3ProtocolException ex) {
-                WriteWarning($"Connect-POP3 - Protocol error: {ex.Message}");
-                await client.DisconnectAsync(true);
-                return;
-            } catch (IOException ex) {
-                WriteWarning($"Connect-POP3 - Network error: {ex.Message}");
-                await client.DisconnectAsync(true);
-                return;
-            }
-        } else {
-            WriteWarning("Connect-POP3 - Client is not connected after ConnectAsync.");
+        Pop3Client client;
+        try {
+            client = await Pop3Connector.ConnectAsync(
+                Server,
+                Port,
+                Options,
+                TimeOut,
+                SkipCertificateRevocation.IsPresent,
+                SkipCertificateValidation.IsPresent,
+                Authenticate,
+                RetryCount,
+                RetryDelayMilliseconds,
+                RetryDelayBackoff);
+        } catch (Exception ex) {
+            WriteWarning($"Connect-POP3 - {ex.Message}");
             return;
         }
 

--- a/Sources/Mailozaurr/Connections/ImapConnector.cs
+++ b/Sources/Mailozaurr/Connections/ImapConnector.cs
@@ -1,0 +1,77 @@
+using MailKit.Net.Imap;
+using MailKit.Security;
+using System;
+using System.Threading.Tasks;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Provides helper methods for connecting to IMAP servers with retry logic.
+/// </summary>
+public static class ImapConnector {
+    /// <summary>
+    /// Connects and authenticates to an IMAP server with retry support.
+    /// </summary>
+    /// <param name="server">Server hostname.</param>
+    /// <param name="port">Server port.</param>
+    /// <param name="options">Secure socket options.</param>
+    /// <param name="timeout">Connection timeout.</param>
+    /// <param name="skipCertificateRevocation">Skip certificate revocation check.</param>
+    /// <param name="skipCertificateValidation">Skip certificate validation.</param>
+    /// <param name="authenticateAsync">Delegate performing authentication.</param>
+    /// <param name="retryCount">Number of retry attempts.</param>
+    /// <param name="retryDelayMilliseconds">Initial delay between retries.</param>
+    /// <param name="retryDelayBackoff">Multiplier for delay backoff.</param>
+    /// <returns>Authenticated <see cref="ImapClient"/> instance.</returns>
+    public static async Task<ImapClient> ConnectAsync(
+        string server,
+        int port,
+        SecureSocketOptions options,
+        int timeout,
+        bool skipCertificateRevocation,
+        bool skipCertificateValidation,
+        Func<ImapClient, Task> authenticateAsync,
+        int retryCount,
+        int retryDelayMilliseconds,
+        double retryDelayBackoff) {
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            var client = new ImapClient();
+            try {
+                await client.ConnectAsync(server, port, options);
+                if (skipCertificateRevocation) {
+                    client.CheckCertificateRevocation = false;
+                }
+                if (skipCertificateValidation) {
+                    client.ServerCertificateValidationCallback = (s, c, h, e) => true;
+                }
+                if (client.Timeout != timeout) {
+                    client.Timeout = timeout;
+                }
+                await authenticateAsync(client);
+                if (!client.IsAuthenticated) {
+                    throw new InvalidOperationException("Authentication failed.");
+                }
+                return client;
+            } catch (Exception ex) {
+                lastException = ex;
+                LoggingMessages.Logger.WriteWarning($"Connect-IMAP - {ex.Message}");
+                try {
+                    if (client.IsConnected) {
+                        await client.DisconnectAsync(true);
+                    }
+                } catch { }
+                if ((!Helpers.IsTransient(ex)) || attempts >= retryCount) {
+                    throw;
+                }
+                var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
+                if (delay > 0) {
+                    await Task.Delay(delay);
+                }
+            }
+            attempts++;
+        } while (attempts <= retryCount);
+        throw lastException!;
+    }
+}

--- a/Sources/Mailozaurr/Connections/Pop3Connector.cs
+++ b/Sources/Mailozaurr/Connections/Pop3Connector.cs
@@ -1,0 +1,77 @@
+using MailKit.Net.Pop3;
+using MailKit.Security;
+using System;
+using System.Threading.Tasks;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Provides helper methods for connecting to POP3 servers with retry logic.
+/// </summary>
+public static class Pop3Connector {
+    /// <summary>
+    /// Connects and authenticates to a POP3 server with retry support.
+    /// </summary>
+    /// <param name="server">Server hostname.</param>
+    /// <param name="port">Server port.</param>
+    /// <param name="options">Secure socket options.</param>
+    /// <param name="timeout">Connection timeout.</param>
+    /// <param name="skipCertificateRevocation">Skip certificate revocation check.</param>
+    /// <param name="skipCertificateValidation">Skip certificate validation.</param>
+    /// <param name="authenticateAsync">Delegate performing authentication.</param>
+    /// <param name="retryCount">Number of retry attempts.</param>
+    /// <param name="retryDelayMilliseconds">Initial delay between retries.</param>
+    /// <param name="retryDelayBackoff">Multiplier for delay backoff.</param>
+    /// <returns>Authenticated <see cref="Pop3Client"/> instance.</returns>
+    public static async Task<Pop3Client> ConnectAsync(
+        string server,
+        int port,
+        SecureSocketOptions options,
+        int timeout,
+        bool skipCertificateRevocation,
+        bool skipCertificateValidation,
+        Func<Pop3Client, Task> authenticateAsync,
+        int retryCount,
+        int retryDelayMilliseconds,
+        double retryDelayBackoff) {
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            var client = new Pop3Client();
+            try {
+                await client.ConnectAsync(server, port, options);
+                if (skipCertificateRevocation) {
+                    client.CheckCertificateRevocation = false;
+                }
+                if (skipCertificateValidation) {
+                    client.ServerCertificateValidationCallback = (s, c, h, e) => true;
+                }
+                if (client.Timeout != timeout) {
+                    client.Timeout = timeout;
+                }
+                await authenticateAsync(client);
+                if (!client.IsAuthenticated) {
+                    throw new InvalidOperationException("Authentication failed.");
+                }
+                return client;
+            } catch (Exception ex) {
+                lastException = ex;
+                LoggingMessages.Logger.WriteWarning($"Connect-POP3 - {ex.Message}");
+                try {
+                    if (client.IsConnected) {
+                        await client.DisconnectAsync(true);
+                    }
+                } catch { }
+                if ((!Helpers.IsTransient(ex)) || attempts >= retryCount) {
+                    throw;
+                }
+                var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
+                if (delay > 0) {
+                    await Task.Delay(delay);
+                }
+            }
+            attempts++;
+        } while (attempts <= retryCount);
+        throw lastException!;
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -139,6 +139,37 @@ namespace Mailozaurr {
         }
 
         /// <summary>
+        /// Connects to O365 Graph with retry logic and returns the Authorization header value.
+        /// </summary>
+        public static async Task<string> ConnectO365GraphWithRetryAsync(
+            GraphCredential credential,
+            string tenantDomain,
+            int retryCount,
+            int retryDelayMilliseconds,
+            double retryDelayBackoff,
+            string resource = "https://manage.office.com") {
+            int attempts = 0;
+            Exception? lastException = null;
+            do {
+                try {
+                    return await ConnectO365GraphAsync(credential, tenantDomain, resource);
+                } catch (Exception ex) {
+                    lastException = ex;
+                    LoggingMessages.Logger.WriteWarning($"Connect-EmailGraph - {ex.Message}");
+                    if ((!Helpers.IsTransient(ex)) || attempts >= retryCount) {
+                        throw;
+                    }
+                    var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
+                    if (delay > 0) {
+                        await Task.Delay(delay);
+                    }
+                }
+                attempts++;
+            } while (attempts <= retryCount);
+            throw lastException!;
+        }
+
+        /// <summary>
         /// Builds a full URI from base, path, and query parameters.
         /// </summary>
         public static string BuildGraphUri(string baseUri, string path, IDictionary<string, string> queryParameters = null) {


### PR DESCRIPTION
## Summary
- add `ImapConnector` and `Pop3Connector` with retry logic
- expose `ConnectO365GraphWithRetryAsync` for Graph authentication retries
- update `Connect-IMAP`, `Connect-POP3`, and `Connect-EmailGraph` cmdlets with `-RetryCount`, `-RetryDelayMilliseconds`, and `-RetryDelayBackoff`
- hook cmdlets to new connector utilities

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685d85f7f330832e849ee5383ae30b83