### PR TITLE
Improve attachment path warnings

### DIFF
--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -111,6 +111,7 @@ public class MailgunClient : IDisposable {
             foreach (var path in Attachment) {
                 if (!File.Exists(path)) {
                     LogCollector.LogWarning($"Send-EmailMessage - Attachment file not found: {path}");
+                    LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{path}' is invalid. Verify the file exists and the path is correct.");
                     continue;
                 }
 
@@ -124,6 +125,7 @@ public class MailgunClient : IDisposable {
             foreach (var path in InlineAttachment) {
                 if (!File.Exists(path)) {
                     LogCollector.LogWarning($"Send-EmailMessage - Inline attachment file not found: {path}");
+                    LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{path}' is invalid. Verify the file exists and the path is correct.");
                     continue;
                 }
 

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -192,6 +192,11 @@ public class Graph : IDisposable {
             // Convert provided attachments into GraphAttachment objects
             foreach (var item in Attachments) {
                 if (item is string path) {
+                    if (!File.Exists(path)) {
+                        LogCollector.LogWarning($"Send-EmailMessage - Attachment file not found: {path}");
+                        LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{path}' is invalid. Verify the file exists and the path is correct.");
+                        continue;
+                    }
                     ConvertedAttachments.Add(GraphAttachment.FromFile(path));
                 } else if (item is GraphAttachment ga) {
                     ConvertedAttachments.Add(ga);

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -195,7 +195,6 @@ public class Graph : IDisposable {
                     if (!File.Exists(path)) {
                         LogCollector.LogWarning($"Send-EmailMessage - Attachment file not found: {path}");
                         LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{path}' is invalid. Verify the file exists and the path is correct.");
-                        continue;
                     }
                     ConvertedAttachments.Add(GraphAttachment.FromFile(path));
                 } else if (item is GraphAttachment ga) {

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -385,6 +385,7 @@ namespace Mailozaurr {
                     } catch (IOException ex) {
                         // Log or handle error
                         LoggingMessages.Logger.WriteWarning($"SaveMailMessage - Couldn't save file to {filePath}. Error: {ex.Message}");
+                        LoggingMessages.Logger.WriteWarning($"SaveMailMessage - Possible issue: Ensure the directory '{resolvedPath}' exists and you have write permissions.");
                     }
                 }
             }
@@ -405,9 +406,11 @@ namespace Mailozaurr {
                     } catch (FormatException fex) {
                         // Invalid Base64 content
                         LoggingMessages.Logger.WriteWarning($"SaveAttachment - Invalid base64 content for {att.Name}. Error: {fex.Message}");
+                        LoggingMessages.Logger.WriteWarning($"SaveAttachment - Possible issue: The attachment '{att.Name}' may be corrupted.");
                     } catch (IOException ex) {
                         // Log or handle other errors
                         LoggingMessages.Logger.WriteWarning($"SaveAttachment - Couldn't save file to {filePath}. Error: {ex.Message}");
+                        LoggingMessages.Logger.WriteWarning($"SaveAttachment - Possible issue: Verify the path '{filePath}' exists and you have write permissions.");
                     }
                 }
             }

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -704,6 +704,7 @@ public class Smtp {
         if (!File.Exists(publicKeyPath)) {
             string messageText = $"Public key file not found: {publicKeyPath}";
             LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - {messageText}");
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Possible issue: Path '{publicKeyPath}' is invalid. Verify the file exists and the path is correct.");
             return new SmtpResult(false, EmailAction.PgpEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
         }
 
@@ -731,11 +732,13 @@ public class Smtp {
         if (!File.Exists(publicKeyPath)) {
             string messageText = $"Public key file not found: {publicKeyPath}";
             LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - {messageText}");
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Possible issue: Path '{publicKeyPath}' is invalid. Verify the file exists and the path is correct.");
             return new SmtpResult(false, EmailAction.PgpSign, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
         }
         if (!File.Exists(privateKeyPath)) {
             string messageText = $"Private key file not found: {privateKeyPath}";
             LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - {messageText}");
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Possible issue: Path '{privateKeyPath}' is invalid. Verify the file exists and the path is correct.");
             return new SmtpResult(false, EmailAction.PgpSign, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
         }
 
@@ -775,11 +778,13 @@ public class Smtp {
         if (!File.Exists(publicKeyPath)) {
             string messageText = $"Public key file not found: {publicKeyPath}";
             LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - {messageText}");
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Possible issue: Path '{publicKeyPath}' is invalid. Verify the file exists and the path is correct.");
             return new SmtpResult(false, EmailAction.PgpSignAndEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
         }
         if (!File.Exists(privateKeyPath)) {
             string messageText = $"Private key file not found: {privateKeyPath}";
             LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - {messageText}");
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Possible issue: Path '{privateKeyPath}' is invalid. Verify the file exists and the path is correct.");
             return new SmtpResult(false, EmailAction.PgpSignAndEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
         }
 


### PR DESCRIPTION
## Summary
- add detailed attachment path warnings for Mailgun
- show recommended actions when PG encryption files are missing
- capture missing attachments in Graph helper methods
- log extra guidance when saving Graph artifacts fails

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685db99cca1c832ea1f3a11c11b133c1