### PR TITLE
Implement refresh token caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Sources/packages/*
 Lib/Default/*
 Lib/Standard/*
 Lib/Core/*
+dotnet-install.sh
+packages-microsoft-prod.deb
+

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
@@ -52,7 +52,7 @@ public class CmdletConnectOAuthGoogle : PSCmdlet {
     protected override void ProcessRecord() {
         OAuthCredential? cred = null;
         try {
-            cred = Task.Run(() => Mailozaurr.OAuthHelpers.AcquireGoogleTokenInteractiveAsync(GmailAccount, ClientID, ClientSecret, Scope)).GetAwaiter().GetResult();
+            cred = Task.Run(() => Mailozaurr.OAuthHelpers.AcquireGoogleTokenCachedAsync(GmailAccount, ClientID, ClientSecret, Scope)).GetAwaiter().GetResult();
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(ex, "OAuthGoogleAuthFailed", ErrorCategory.AuthenticationError, null));
             return;

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthO365.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthO365.cs
@@ -64,7 +64,7 @@ public class CmdletConnectOAuthO365 : PSCmdlet {
     protected override void ProcessRecord() {
         Mailozaurr.OAuthCredential cred = null;
         try {
-            cred = Task.Run(() => Mailozaurr.OAuthHelpers.AcquireO365TokenInteractiveAsync(Login, ClientID, TenantID, RedirectUri, Scopes)).GetAwaiter().GetResult();
+            cred = Task.Run(() => Mailozaurr.OAuthHelpers.AcquireO365TokenCachedAsync(Login, ClientID, TenantID, RedirectUri, Scopes)).GetAwaiter().GetResult();
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(ex, "OAuthO365AuthFailed", ErrorCategory.AuthenticationError, null));
             return;

--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -2,6 +2,7 @@ using Microsoft.Identity.Client;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Auth.OAuth2.Flows;
 using Google.Apis.Util.Store;
+using Google.Apis.Auth.OAuth2.Responses;
 using System.Security.Cryptography.X509Certificates;
 using System.Linq;
 using System;
@@ -55,10 +56,13 @@ public static class OAuthHelpers {
             }
             result = await builder.ExecuteAsync();
         }
-        return new OAuthCredential {
+        var cred = new OAuthCredential {
             UserName = result.Account.Username,
-            AccessToken = result.AccessToken
+            AccessToken = result.AccessToken,
+            ExpiresOn = result.ExpiresOn
         };
+        OAuthTokenCache.Set($"o365:{cred.UserName}", cred);
+        return cred;
     }
 
     /// <summary>
@@ -90,10 +94,75 @@ public static class OAuthHelpers {
         if (credential.Token.IsExpired(Google.Apis.Util.SystemClock.Default)) {
             await credential.RefreshTokenAsync(System.Threading.CancellationToken.None);
         }
-        return new OAuthCredential {
+        var cred = new OAuthCredential {
             UserName = credential.UserId,
-            AccessToken = credential.Token.AccessToken
+            AccessToken = credential.Token.AccessToken,
+            RefreshToken = credential.Token.RefreshToken,
+            ExpiresOn = credential.Token.IssuedUtc + TimeSpan.FromSeconds(credential.Token.ExpiresInSeconds ?? 0)
         };
+        OAuthTokenCache.Set($"google:{cred.UserName}", cred);
+        return cred;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve a cached Office 365 token or acquire a new one if necessary.
+    /// </summary>
+    public static async Task<OAuthCredential> AcquireO365TokenCachedAsync(
+        string login,
+        string clientId,
+        string tenantId,
+        string redirectUri,
+        IEnumerable<string> scopes) {
+        var cacheKey = $"o365:{login}";
+        var cached = OAuthTokenCache.Get(cacheKey);
+        if (cached != null && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
+            return cached;
+        }
+
+        var cred = await AcquireO365TokenInteractiveAsync(login, clientId, tenantId, redirectUri, scopes);
+        OAuthTokenCache.Set(cacheKey, cred);
+        return cred;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve a cached Google token or acquire a new one if necessary.
+    /// </summary>
+    public static async Task<OAuthCredential> AcquireGoogleTokenCachedAsync(
+        string gmailAccount,
+        string clientId,
+        string clientSecret,
+        IEnumerable<string> scopes) {
+        var cacheKey = $"google:{gmailAccount}";
+        var cached = OAuthTokenCache.Get(cacheKey);
+        if (cached != null && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
+            return cached;
+        }
+        if (cached != null && !string.IsNullOrEmpty(cached.RefreshToken)) {
+            var clientSecrets = new ClientSecrets { ClientId = clientId, ClientSecret = clientSecret };
+            var initializer = new GoogleAuthorizationCodeFlow.Initializer {
+                ClientSecrets = clientSecrets,
+                Scopes = scopes,
+                DataStore = new FileDataStore("CredentialCacheFolder", false)
+            };
+            var flow = new GoogleAuthorizationCodeFlow(initializer);
+            var token = new Google.Apis.Auth.OAuth2.Responses.TokenResponse { RefreshToken = cached.RefreshToken };
+            var userCred = new UserCredential(flow, gmailAccount, token);
+            var refreshed = await userCred.RefreshTokenAsync(System.Threading.CancellationToken.None);
+            if (refreshed) {
+                var newCred = new OAuthCredential {
+                    UserName = gmailAccount,
+                    AccessToken = userCred.Token.AccessToken,
+                    RefreshToken = userCred.Token.RefreshToken,
+                    ExpiresOn = userCred.Token.IssuedUtc + TimeSpan.FromSeconds(userCred.Token.ExpiresInSeconds ?? 0)
+                };
+                OAuthTokenCache.Set(cacheKey, newCred);
+                return newCred;
+            }
+        }
+
+        var cred = await AcquireGoogleTokenInteractiveAsync(gmailAccount, clientId, clientSecret, scopes);
+        OAuthTokenCache.Set(cacheKey, cred);
+        return cred;
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace Mailozaurr;
+
+internal static class OAuthTokenCache {
+    private static readonly object LockObj = new();
+    private static readonly string CacheFilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Mailozaurr",
+        "oauth_cache.json");
+
+    private static Dictionary<string, OAuthCredential>? _cache;
+
+    private static Dictionary<string, OAuthCredential> LoadCache() {
+        lock (LockObj) {
+            if (_cache != null) {
+                return _cache;
+            }
+            if (File.Exists(CacheFilePath)) {
+                var json = File.ReadAllText(CacheFilePath);
+                _cache = JsonSerializer.Deserialize<Dictionary<string, OAuthCredential>>(json) ?? new();
+            } else {
+                _cache = new Dictionary<string, OAuthCredential>();
+            }
+            return _cache;
+        }
+    }
+
+    public static OAuthCredential? Get(string key) {
+        var cache = LoadCache();
+        cache.TryGetValue(key, out var cred);
+        return cred;
+    }
+
+    public static void Set(string key, OAuthCredential credential) {
+        var cache = LoadCache();
+        cache[key] = credential;
+        lock (LockObj) {
+            var dir = Path.GetDirectoryName(CacheFilePath);
+            if (!Directory.Exists(dir)) {
+                Directory.CreateDirectory(dir!);
+            }
+            var json = JsonSerializer.Serialize(cache);
+            File.WriteAllText(CacheFilePath, json);
+        }
+    }
+}

--- a/Sources/Mailozaurr/Definitions/OAuthCredential.cs
+++ b/Sources/Mailozaurr/Definitions/OAuthCredential.cs
@@ -12,4 +12,14 @@ public class OAuthCredential {
     /// The access token for the OAuth credential.
     /// </summary>
     public string AccessToken { get; set; }
+
+    /// <summary>
+    /// Time when the access token expires.
+    /// </summary>
+    public DateTimeOffset ExpiresOn { get; set; }
+
+    /// <summary>
+    /// The refresh token, if available.
+    /// </summary>
+    public string? RefreshToken { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -76,6 +76,11 @@ namespace Mailozaurr {
             if (TokenCache.TryGetValue(key, out var cached) && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
                 return $"{cached.TokenType} {cached.AccessToken}";
             }
+            var cachedFile = OAuthTokenCache.Get($"graph:{key}");
+            if (cachedFile != null && cachedFile.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
+                TokenCache[key] = new GraphAuthorization { AccessToken = cachedFile.AccessToken, TokenType = "Bearer", ExpiresOn = cachedFile.ExpiresOn };
+                return $"Bearer {cachedFile.AccessToken}";
+            }
             if (!string.IsNullOrEmpty(credential.CertificatePath)) {
                 var scopes = new[] { $"{resource}/.default" };
                 var auth = await OAuthHelpers.AcquireGraphCertificateTokenAsync(
@@ -135,6 +140,11 @@ namespace Mailozaurr {
                 }
             }
             TokenCache[key] = new GraphAuthorization { AccessToken = accessToken, TokenType = tokenType, ExpiresOn = expiresOn };
+            OAuthTokenCache.Set($"graph:{key}", new OAuthCredential {
+                UserName = credential.ClientId,
+                AccessToken = accessToken,
+                ExpiresOn = expiresOn
+            });
             return $"{tokenType} {accessToken}";
         }
 


### PR DESCRIPTION
## Summary
- add OAuthTokenCache for storing tokens to disk
- extend OAuthCredential with expiry and refresh token
- renew tokens automatically in OAuth helper methods
- use cached token retrieval in Connect-OAuth cmdlets
- persist Graph tokens across runs

## Testing
- `dotnet restore Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet restore Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj`
- `dotnet restore Sources/Mailozaurr.Examples/Mailozaurr.Examples.csproj`
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj --no-restore`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj --no-restore`
- `dotnet build Sources/Mailozaurr.Examples/Mailozaurr.Examples.csproj --no-restore`
- `pwsh -NoProfile -Command ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685db9788378832e9238f727c3b93a40