### PR TITLE
Embed images referenced in HTML

### DIFF
--- a/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Linq;
+using MimeKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class HtmlAutoEmbedImageTests {
+    [Fact]
+    public void Smtp_CreateMessage_AutoEmbedsImages() {
+        var tmp = Path.GetTempFileName();
+        File.WriteAllText(tmp, "data");
+        var smtp = new Smtp { AutoEmbedImages = true };
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "c@d.com" };
+        smtp.Subject = "test";
+        smtp.HtmlBody = $"<img src=\"{tmp}\">";
+        smtp.CreateMessage();
+        var body = (MultipartRelated)smtp.Message.Body;
+        var inline = body.OfType<MimePart>().FirstOrDefault(p => p.ContentDisposition?.Disposition == ContentDisposition.Inline);
+        File.Delete(tmp);
+        Assert.NotNull(inline);
+        Assert.Contains("cid:" + Path.GetFileName(tmp), smtp.HtmlBody);
+    }
+
+    [Fact]
+    public void Graph_CreateMessage_AutoEmbedsImages() {
+        var tmp = Path.GetTempFileName();
+        File.WriteAllText(tmp, "data");
+        using var graph = new Graph {
+            From = "from@example.com",
+            To = new object[] { "to@example.com" },
+            Subject = "subject",
+            HTML = $"<img src=\"{tmp}\">",
+            ContentType = "HTML",
+            AutoEmbedImages = true
+        };
+        graph.CreateMessage();
+        File.Delete(tmp);
+        var attachment = Assert.Single(graph.MessageContainer.Message.Attachments);
+        Assert.True(attachment.IsInline);
+        Assert.Contains("cid:" + attachment.ContentId, graph.HTML);
+    }
+}

--- a/Sources/Mailozaurr/Helpers/HtmlUtils.cs
+++ b/Sources/Mailozaurr/Helpers/HtmlUtils.cs
@@ -1,0 +1,27 @@
+using System.Text.RegularExpressions;
+
+namespace Mailozaurr;
+
+public static class HtmlUtils {
+    public static (string Html, List<string> Paths) ExtractLocalImagePaths(string html) {
+        var paths = new List<string>();
+        if (string.IsNullOrEmpty(html)) return (html, paths);
+
+        string pattern = "<img[^>]+src=[\"']([^\"']+)[\"']";
+        foreach (Match match in Regex.Matches(html, pattern, RegexOptions.IgnoreCase)) {
+            var path = match.Groups[1].Value;
+            if (string.IsNullOrEmpty(path)) continue;
+            if (path.StartsWith("http", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith("cid:", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (File.Exists(path)) {
+                var fileName = Path.GetFileName(path);
+                html = html.Replace(path, $"cid:{fileName}");
+                paths.Add(path);
+            }
+        }
+        return (html, paths);
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -119,6 +119,8 @@ public class Graph : IDisposable {
     /// </summary>
     public double RetryDelayBackoff { get; set; } = 1.0;
 
+    public bool AutoEmbedImages { get; set; } = false;
+
     /// <summary>
     /// Forces retries even when the encountered error is not classified as
     /// transient.
@@ -188,6 +190,7 @@ public class Graph : IDisposable {
     /// Converts the <see cref="Attachments"/> collection into <see cref="GraphAttachment"/> instances.
     /// </summary>
     public void CreateAttachments() {
+        ConvertedAttachments.Clear();
         if (Attachments != null && Attachments.Any()) {
             // Convert provided attachments into GraphAttachment objects
             foreach (var item in Attachments) {
@@ -224,6 +227,17 @@ public class Graph : IDisposable {
     /// Builds the <see cref="GraphMessageContainer"/> object that represents the email.
     /// </summary>
     public void CreateMessage() {
+        CreateAttachments();
+        if (AutoEmbedImages) {
+            var (html, paths) = HtmlUtils.ExtractLocalImagePaths(HTML);
+            HTML = html;
+            foreach (var p in paths) {
+                var att = GraphAttachment.FromFile(p);
+                att.IsInline = true;
+                att.ContentId = Path.GetFileName(p);
+                ConvertedAttachments.Add(att);
+            }
+        }
         // Note: The display name for the sender is controlled by Office 365 and may not reflect the value you provide here.
         // Office 365 will use the mailbox's configured display name for the sender, regardless of what is set in the payload.
         // Always use the email address for API calls and authentication.

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachment.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachment.cs
@@ -65,6 +65,12 @@ public class GraphAttachment {
     [JsonPropertyName("contentBytes")]
     public string ContentBytes { get; set; }
 
+    [JsonPropertyName("isInline")]
+    public bool IsInline { get; set; }
+
+    [JsonPropertyName("contentId")]
+    public string? ContentId { get; set; }
+
     /// <summary>
     /// Creates a <see cref="GraphAttachment"/> from a local file path.
     /// </summary>

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -98,6 +98,8 @@ public class Smtp {
 
     public double RetryDelayBackoff { get; set; } = 1.0;
 
+    public bool AutoEmbedImages { get; set; } = false;
+
     /// <summary>
     /// Forces retries even when the encountered error is not considered
     /// transient. By default retries occur only for transient failures.
@@ -193,6 +195,18 @@ public class Smtp {
     /// Creates the MIME message using the current property values.
     /// </summary>
     public void CreateMessage() {
+        if (AutoEmbedImages) {
+            var (html, paths) = HtmlUtils.ExtractLocalImagePaths(HtmlBody);
+            HtmlBody = html;
+            if (paths.Count > 0) {
+                InlineAttachments ??= new List<object>();
+                foreach (var p in paths) {
+                    if (!InlineAttachments.Contains(p)) {
+                        InlineAttachments.Add(p);
+                    }
+                }
+            }
+        }
         Client.CreateMessage();
     }
 


### PR DESCRIPTION
## Summary
- add `HtmlUtils.ExtractLocalImagePaths` helper
- allow automatically embedding images when building SMTP messages
- support automatic inline images for Graph messages
- include tests for the new `AutoEmbedImages` feature

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.sln -v minimal` *(fails: Restore canceled)*

------
https://chatgpt.com/codex/tasks/task_e_685dba32a690832eb659cc5a2b921369