### PR TITLE
Fix GetEmailAddress fallback

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -20,6 +20,14 @@ public class HelpersTests
         Assert.Equal("dict@example.com", result);
     }
 
+    [Fact]
+    public void GetEmailAddress_ReturnsEmpty_WhenEmailKeyMissing()
+    {
+        var dict = new Dictionary<string, object> { { "Name", "John" } };
+        var result = Mailozaurr.Helpers.GetEmailAddress(dict);
+        Assert.Equal(string.Empty, result);
+    }
+
     private class CustomObject
     {
         public override string ToString() => "Custom";

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -51,8 +51,11 @@ public static class Helpers {
         if (from is string s) {
             return s;
         }
-        if (from is IDictionary<string, object> dict && dict.ContainsKey("Email")) {
-            return dict["Email"]?.ToString();
+        if (from is IDictionary<string, object> dict) {
+            if (dict.TryGetValue("Email", out var emailObj)) {
+                return emailObj?.ToString() ?? string.Empty;
+            }
+            return string.Empty;
         }
         return from?.ToString() ?? string.Empty;
     }


### PR DESCRIPTION
## Summary
- return `string.Empty` when `GetEmailAddress` is passed a dictionary without an `Email` key
- add a unit test for this scenario

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_685e68c6997c832ea738b7bbda37f595