### PR TITLE
Handle unauthorized access when deleting PGP temp directory

### DIFF
--- a/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
+++ b/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
@@ -30,6 +30,8 @@ public class EphemeralOpenPgpContext : GnuPGContext {
             Directory.Delete(_tempDirectory, true);
         } catch (IOException ex) {
             LoggingMessages.Logger.WriteWarning($"Failed to delete temporary directory: {ex.Message}");
+        } catch (UnauthorizedAccessException ex) {
+            LoggingMessages.Logger.WriteWarning($"Failed to delete temporary directory due to unauthorized access: {ex.Message}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add extra catch for UnauthorizedAccessException when deleting the PGP temp directory

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685e68b836fc832ea8ae15fd0ec7345f