### PR TITLE
Fix Graph chunk buffer reuse

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
@@ -29,4 +29,28 @@ public class GraphUploadRangeTests
         Assert.Equal("bytes 10-19/25", chunks[1].Headers.GetValues("Content-Range").First());
         Assert.Equal("bytes 20-24/25", chunks[2].Headers.GetValues("Content-Range").First());
     }
+
+    [Fact]
+    public async Task PrepareByteArrayContentForUpload_CreatesIndependentBuffers()
+    {
+        string tmp = Path.GetTempFileName();
+        byte[] allBytes = Enumerable.Range(0, 25).Select(b => (byte)b).ToArray();
+        File.WriteAllBytes(tmp, allBytes);
+        using Graph graph = new Graph();
+        MethodInfo? method = typeof(Graph).GetMethod(
+            "PrepareByteArrayContentForUpload",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        Task<List<ByteArrayContent>> task = (Task<List<ByteArrayContent>>)method!.Invoke(
+            graph,
+            new object[] { tmp, 10, default(System.Threading.CancellationToken) })!;
+        List<ByteArrayContent> chunks = await task;
+        File.Delete(tmp);
+        byte[] chunk0 = await chunks[0].ReadAsByteArrayAsync();
+        byte[] chunk1 = await chunks[1].ReadAsByteArrayAsync();
+        byte[] chunk2 = await chunks[2].ReadAsByteArrayAsync();
+        Assert.Equal(allBytes.Take(10), chunk0);
+        Assert.Equal(allBytes.Skip(10).Take(10), chunk1);
+        Assert.Equal(allBytes.Skip(20).Take(5), chunk2);
+    }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -663,7 +663,9 @@ public class Graph : IDisposable {
         long offset = 0;
         while ((bytesRead = await fileStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0) {
             var contentRange = $"bytes {offset}-{offset + bytesRead - 1}/{fileSize}";
-            var byteArrayContent = new ByteArrayContent(buffer, 0, bytesRead);
+            var chunk = new byte[bytesRead];
+            Array.Copy(buffer, chunk, bytesRead);
+            var byteArrayContent = new ByteArrayContent(chunk);
             byteArrayContent.Headers.Add("Content-Range", contentRange);
             fileContents.Add(byteArrayContent);
             offset += bytesRead;


### PR DESCRIPTION
## Summary
- avoid reusing the same byte buffer when creating upload chunks in `Graph`
- test that each chunk retains correct data

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net472 --no-build -v minimal`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_685e689e7c24832ebb7eef935c53eede