### PR TITLE
Handle null input in ToSecureString

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CredentialHelpers.cs
+++ b/Sources/Mailozaurr.PowerShell/CredentialHelpers.cs
@@ -12,8 +12,10 @@ public static class CredentialHelpers {
     /// </summary>
     /// <param name="s"></param>
     /// <returns></returns>
-    public static SecureString ToSecureString(string s) {
-        if (string.IsNullOrEmpty(s))
+    public static SecureString ToSecureString(string? s) {
+        if (s is null)
+            return new SecureString();
+        if (s.Length == 0)
             return new SecureString();
         // Try to convert from encrypted string, fallback to plain text
         try {

--- a/Sources/Mailozaurr.Tests/CredentialHelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/CredentialHelpersTests.cs
@@ -1,0 +1,13 @@
+using System.Security;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class CredentialHelpersTests {
+    [Fact]
+    public void ToSecureString_ReturnsEmpty_WhenInputIsNull() {
+        SecureString result = Mailozaurr.PowerShell.CredentialHelpers.ToSecureString(null);
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Length);
+    }
+}


### PR DESCRIPTION
## Summary
- handle `null` input in `ToSecureString`
- add regression test for null argument

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug`
- `dotnet build Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Debug`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Debug --no-build`
- `pwsh -NoLogo -Command ./run-tests.ps1 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685e68ae8e34832eb023c50c64a86811