### PR TITLE
Handle null credential in helper

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Net;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -31,5 +32,11 @@ public class HelpersTests
         var obj = new CustomObject();
         var result = Mailozaurr.Helpers.GetEmailAddress(obj);
         Assert.Equal("Custom", result);
+    }
+
+    [Fact]
+    public void ConvertFromOAuth2Credential_ThrowsArgumentNullException_WhenCredentialIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => Mailozaurr.Helpers.ConvertFromOAuth2Credential(null!));
     }
 }

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System;
 using System.Net.Http;
 using System.Security;
 using System.Text;
@@ -15,6 +16,9 @@ public static class Helpers {
     /// <param name="credential">The credential containing the token.</param>
     /// <returns>The username and token.</returns>
     public static (string UserName, string Token) ConvertFromOAuth2Credential(NetworkCredential credential) {
+        if (credential is null) {
+            throw new ArgumentNullException(nameof(credential));
+        }
         return (credential.UserName, credential.Password);
     }
 


### PR DESCRIPTION
## Summary
- validate credential in `ConvertFromOAuth2Credential`
- test null credential throws `ArgumentNullException`

## Testing
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_685e68a4fec8832eafbaac2d79b30905