### PR TITLE
Refactor Google OAuth cmdlet

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 
 namespace Mailozaurr.PowerShell;
 
@@ -17,7 +18,7 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsCommunications.Connect, "OAuthGoogle")]
 [OutputType(typeof(PSCredential))]
-public class CmdletConnectOAuthGoogle : PSCmdlet {
+public sealed class CmdletConnectOAuthGoogle : AsyncPSCmdlet {
     /// <summary>
     /// <para type="description">Specifies the Gmail account (email address) to authenticate.</para>
     /// </summary>
@@ -48,13 +49,11 @@ public class CmdletConnectOAuthGoogle : PSCmdlet {
     /// <summary>
     /// Performs the interactive OAuth2 authentication and returns a PSCredential with the access token.
     /// </summary>
-    protected override void ProcessRecord() {
+    protected override async Task ProcessRecordAsync() {
         OAuthCredential? cred = null;
         try {
-            cred = Mailozaurr.OAuthHelpers
-                .AcquireGoogleTokenCachedAsync(GmailAccount, ClientID, ClientSecret, Scope)
-                .GetAwaiter()
-                .GetResult();
+            cred = await Mailozaurr.OAuthHelpers
+                .AcquireGoogleTokenCachedAsync(GmailAccount, ClientID, ClientSecret, Scope);
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(ex, "OAuthGoogleAuthFailed", ErrorCategory.AuthenticationError, null));
             return;

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
@@ -1,5 +1,4 @@
 using System.Management.Automation;
-using System.Threading.Tasks;
 
 namespace Mailozaurr.PowerShell;
 
@@ -52,7 +51,10 @@ public class CmdletConnectOAuthGoogle : PSCmdlet {
     protected override void ProcessRecord() {
         OAuthCredential? cred = null;
         try {
-            cred = Task.Run(() => Mailozaurr.OAuthHelpers.AcquireGoogleTokenCachedAsync(GmailAccount, ClientID, ClientSecret, Scope)).GetAwaiter().GetResult();
+            cred = Mailozaurr.OAuthHelpers
+                .AcquireGoogleTokenCachedAsync(GmailAccount, ClientID, ClientSecret, Scope)
+                .GetAwaiter()
+                .GetResult();
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(ex, "OAuthGoogleAuthFailed", ErrorCategory.AuthenticationError, null));
             return;

--- a/Tests/Connect-OAuthGoogle.Tests.ps1
+++ b/Tests/Connect-OAuthGoogle.Tests.ps1
@@ -1,0 +1,6 @@
+Describe 'Connect-OAuthGoogle cmdlet' {
+    It 'Cmdlet derives from AsyncPSCmdlet' {
+        $base = [Mailozaurr.PowerShell.CmdletConnectOAuthGoogle].BaseType
+        $base.FullName | Should -Be 'Mailozaurr.PowerShell.AsyncPSCmdlet'
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `CmdletConnectOAuthGoogle` to call `OAuthHelpers.AcquireGoogleTokenCachedAsync` without `Task.Run`
- use `.GetAwaiter().GetResult()` directly

## Testing
- `dotnet restore Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685f10c59bc8832e8b0829eac4390deb