### PR TITLE
Add missing XML docs

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace Mailozaurr.PowerShell;
 
+/// <summary>
+/// Moves a Microsoft Graph message to a different folder.
+/// </summary>
 [Cmdlet(VerbsCommon.Move, "GraphMessage")]
 public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true)]
@@ -28,6 +31,10 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Processes the cmdlet invocation.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         switch (ParameterSetName) {
             case "Graph":
@@ -45,10 +52,17 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
         }
     }
 
+    /// <summary>
+    /// Executes the move operation using the Graph SDK.
+    /// </summary>
+    /// <param name="cred">Credential used to access Graph.</param>
     private async Task ProcessGraphAsync(GraphCredential cred) {
         await MicrosoftGraphUtils.MoveMailMessageAsync(cred, UserPrincipalName!, MessageId!, DestinationFolderId!);
     }
 
+    /// <summary>
+    /// Executes the move operation using the <c>Invoke-MgGraphRequest</c> cmdlet.
+    /// </summary>
     private void ProcessMgGraph() {
         var uri = $"https://graph.microsoft.com/v1.0/users/{UserPrincipalName}/messages/{MessageId}/move";
         var body = System.Text.Json.JsonSerializer.Serialize(new { destinationId = DestinationFolderId });

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveGraphMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveGraphMessageAttachment.cs
@@ -6,6 +6,9 @@ using Mailozaurr;
 
 namespace Mailozaurr.PowerShell;
 
+/// <summary>
+/// Saves attachments from Microsoft Graph message objects.
+/// </summary>
 [Cmdlet(VerbsData.Save, "GraphMessageAttachment")]
 public class CmdletSaveGraphMessageAttachment : PSCmdlet {
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
@@ -16,6 +19,9 @@ public class CmdletSaveGraphMessageAttachment : PSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? Path { get; set; }
 
+    /// <summary>
+    /// Processes the cmdlet invocation.
+    /// </summary>
     protected override void ProcessRecord() {
         var graphAttachments = new List<Attachment>();
         var mimeAttachments = new List<MimeEntity>();

--- a/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace Mailozaurr.PowerShell;
 
+/// <summary>
+/// Updates properties of an existing Microsoft Graph message.
+/// </summary>
 [Cmdlet(VerbsCommon.Set, "GraphMessage")]
 public class CmdletSetGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true)]
@@ -27,6 +30,10 @@ public class CmdletSetGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Processes the cmdlet invocation.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         switch (ParameterSetName) {
             case "Graph":
@@ -44,10 +51,17 @@ public class CmdletSetGraphMessage : AsyncPSCmdlet {
         }
     }
 
+    /// <summary>
+    /// Executes the update operation using the Graph SDK.
+    /// </summary>
+    /// <param name="cred">Credential used to access Graph.</param>
     private async Task ProcessGraphAsync(GraphCredential cred) {
         await MicrosoftGraphUtils.SetMailMessageAsync(cred, UserPrincipalName!, MessageId!, Read.IsPresent);
     }
 
+    /// <summary>
+    /// Executes the update operation using the <c>Invoke-MgGraphRequest</c> cmdlet.
+    /// </summary>
     private void ProcessMgGraph() {
         var uri = $"https://graph.microsoft.com/v1.0/users/{UserPrincipalName}/messages/{MessageId}";
         var body = JsonSerializer.Serialize(new { isRead = Read.IsPresent });

--- a/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
+++ b/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
@@ -5,25 +5,46 @@ using MimeKit.Cryptography;
 
 namespace Mailozaurr;
 
+/// <summary>
+/// Provides a <see cref="GnuPGContext"/> that stores keys in a temporary
+/// directory which gets removed when the instance is disposed.
+/// </summary>
 public class EphemeralOpenPgpContext : GnuPGContext {
     private readonly string? _password;
     private readonly string _tempDirectory;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EphemeralOpenPgpContext"/> class.
+    /// </summary>
+    /// <param name="password">Optional passphrase used when unlocking private keys.</param>
     public EphemeralOpenPgpContext(string? password = null) : base(CreateTempDirectory(out var dir)) {
         _password = password;
         _tempDirectory = dir;
     }
 
+    /// <summary>
+    /// Creates a temporary directory for the OpenPGP keyring.
+    /// </summary>
+    /// <param name="path">The generated directory path.</param>
+    /// <returns>The created path.</returns>
     private static string CreateTempDirectory(out string path) {
         path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         Directory.CreateDirectory(path);
         return path;
     }
 
+    /// <summary>
+    /// Retrieves the passphrase for the specified secret key.
+    /// </summary>
+    /// <param name="key">The secret key requiring a passphrase.</param>
+    /// <returns>The passphrase to use.</returns>
     protected override string GetPasswordForKey(PgpSecretKey key) {
         return _password ?? string.Empty;
     }
 
+    /// <summary>
+    /// Releases the resources used by the context and deletes the temporary directory.
+    /// </summary>
     public new void Dispose() {
         base.Dispose();
         try {

--- a/Sources/Mailozaurr/Mailozaurr.csproj
+++ b/Sources/Mailozaurr/Mailozaurr.csproj
@@ -10,6 +10,7 @@
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- Required for pointer operations in Helpers/SecureStringHelper.cs -->
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RepositoryUrl>https://github.com/EvotecIT/Mailozaurr</RepositoryUrl>


### PR DESCRIPTION
## Summary
- document EphemeralOpenPgpContext usage
- document Graph cmdlets
- enable XML documentation generation for Mailozaurr

## Testing
- `dotnet restore Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln --no-restore`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685f110ce290832ea3cbdb3afda62f37