### PR TITLE
Handle invalid attachment paths

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Management.Automation;
+using System.IO;
 
 namespace Mailozaurr.PowerShell;
 
@@ -583,6 +584,8 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     /// Process the record.
     /// </summary>
     protected override void ProcessRecord() {
+        Attachment = FilterExistingPaths(Attachment, nameof(Attachment));
+        InlineAttachment = FilterExistingPaths(InlineAttachment, nameof(InlineAttachment));
         var (fromEmail, fromName) = Helpers.GetEmailAndName(From);
         if (SendGrid || EmailProvider == EmailProvider.SendGrid) {
             var logCollector = new LogCollector();
@@ -1005,5 +1008,34 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
         }
 
         return "";
+    }
+
+    private object[]? FilterExistingPaths(object[]? paths, string parameterName) {
+        if (paths == null) {
+            return null;
+        }
+
+        List<object> valid = new();
+
+        foreach (var item in paths) {
+            string? path = item switch {
+                string s => s,
+                FileInfo fi => fi.FullName,
+                _ => null
+            };
+
+            if (path != null) {
+                if (!File.Exists(path)) {
+                    WriteWarning($"Send-EmailMessage - File not found: {path}. Removing from '{parameterName}'.");
+                    continue;
+                }
+            }
+
+            if (item != null) {
+                valid.Add(item);
+            }
+        }
+
+        return valid.Count > 0 ? valid.ToArray() : null;
     }
 }

--- a/Tests/Send-EmailMessage.Attachments.Tests.ps1
+++ b/Tests/Send-EmailMessage.Attachments.Tests.ps1
@@ -1,0 +1,13 @@
+Describe 'Send-EmailMessage - Attachment Cleanup' {
+    It 'Warns and skips missing attachment paths' {
+        $missing1 = 'mailozaurr_missing1.txt'
+        $missing2 = 'mailozaurr_missing2.txt'
+        if (Test-Path $missing1) { Remove-Item $missing1 -Force }
+        if (Test-Path $missing2) { Remove-Item $missing2 -Force }
+        $result = Send-EmailMessage -From 'a@b.com' -To 'c@d.com' -Subject 'x' -Body 'y' -Server 'smtp.example.com' -Port 25 -Attachment $missing1 -InlineAttachment $missing2 -WarningAction Continue -WhatIf 3>&1
+        $warnings = $result | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
+        $warnings.Count | Should -Be 2
+        ($warnings[0].Message + $warnings[1].Message) | Should -Match 'mailozaurr_missing1.txt'
+        ($warnings[0].Message + $warnings[1].Message) | Should -Match 'mailozaurr_missing2.txt'
+    }
+}


### PR DESCRIPTION
## Summary
- warn and drop missing attachment paths in `Send-EmailMessage`
- cover attachment cleanup with test

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685f10eacd44832ea4c5fa38d679b993