### PR TITLE
Create directory for saved POP3 message

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSavePOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSavePOP3Message.cs
@@ -51,13 +51,20 @@ public sealed class CmdletSavePOP3Message : AsyncPSCmdlet {
         if (conn != null && conn.Data != null) {
             if (Index < conn.Data.Count) {
                 var message = conn.Data.GetMessage(Index);
-                if (Path != null && Path.EndsWith(".msg", System.StringComparison.OrdinalIgnoreCase)) {
-                    var tempEml = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"{System.Guid.NewGuid()}.eml");
-                    message.WriteTo(tempEml);
-                    EmailMessage.ConvertEmlToMsg(new System.IO.FileInfo(tempEml), new System.IO.FileInfo(Path), true);
-                    System.IO.File.Delete(tempEml);
-                } else {
-                    message.WriteTo(Path);
+                if (Path != null) {
+                    var resolved = System.IO.Path.GetFullPath(Path);
+                    var directory = System.IO.Path.GetDirectoryName(resolved);
+                    if (!string.IsNullOrEmpty(directory) && !System.IO.Directory.Exists(directory)) {
+                        System.IO.Directory.CreateDirectory(directory);
+                    }
+                    if (resolved.EndsWith(".msg", System.StringComparison.OrdinalIgnoreCase)) {
+                        var tempEml = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"{System.Guid.NewGuid()}.eml");
+                        message.WriteTo(tempEml);
+                        EmailMessage.ConvertEmlToMsg(new System.IO.FileInfo(tempEml), new System.IO.FileInfo(resolved), true);
+                        System.IO.File.Delete(tempEml);
+                    } else {
+                        message.WriteTo(resolved);
+                    }
                 }
             } else {
                 WriteWarning($"Save-POP3Message - Index is out of range. Use index less than {conn.Data.Count}.");

--- a/Tests/Save-POP3Message.Tests.ps1
+++ b/Tests/Save-POP3Message.Tests.ps1
@@ -1,0 +1,39 @@
+Describe 'Save-POP3Message' {
+    It 'Creates directory when saving message' {
+        $csc = Get-ChildItem "$HOME/.dotnet/sdk/*/Roslyn/bincore/csc.dll" | Sort-Object FullName -Descending | Select-Object -First 1
+        $csPath = Join-Path $TestDrive 'FakePop3Client.cs'
+        @"
+using MailKit.Net.Pop3;
+using MimeKit;
+public class FakePop3Client : Pop3Client {
+    private readonly MimeMessage _message;
+    public FakePop3Client() {
+        _message = new MimeMessage();
+        _message.From.Add(new MailboxAddress("a", "a@b.com"));
+        _message.To.Add(new MailboxAddress("b", "b@c.com"));
+        _message.Subject = "test";
+        _message.Body = new TextPart("plain") { Text = "body" };
+    }
+    public override int Count => 1;
+    public override MimeMessage GetMessage(int index, System.Threading.CancellationToken cancellationToken = default, MailKit.ITransferProgress? progress = null) {
+        return _message;
+    }
+}
+"@ | Set-Content $csPath
+        $dllPath = Join-Path $TestDrive 'FakePop3Client.dll'
+        $refs = @(
+            "$HOME/.nuget/packages/mailkit/4.12.1/lib/netstandard2.0/MailKit.dll",
+            "$HOME/.nuget/packages/mimekit/4.12.0/lib/netstandard2.0/MimeKit.dll",
+            "$HOME/.dotnet/packs/NETStandard.Library.Ref/2.1.0/ref/netstandard2.1/netstandard.dll"
+        )
+        $refArgs = $refs | ForEach-Object { "-r:" + $_ }
+        & dotnet $csc.FullName $csPath -target:library -out:$dllPath $refArgs | Out-Null
+        Add-Type -Path $dllPath
+
+        $info = [Mailozaurr.PowerShell.PopConnectionInfo]::new()
+        $info.Data = [FakePop3Client]::new()
+        $filePath = Join-Path $TestDrive 'subdir/message.eml'
+        Save-POP3Message -Client $info -Index 0 -Path $filePath
+        Test-Path $filePath | Should -Be $true
+    }
+}


### PR DESCRIPTION
## Summary
- ensure Save-POP3Message creates output directory when needed
- add a Pester test verifying directory creation

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -f net8.0 --no-restore`
- `pwsh -NoLogo -NoProfile -File run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685f10a12888832eb8a8bcbc9a50d16a