### PR TITLE
Check Graph.From before building message

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
@@ -52,4 +52,18 @@ public class GraphCreateMessageTests
         Assert.True(graph.IsLargerAttachment);
         Assert.Null(graph.MessageContainer.Message.Attachments);
     }
+
+    [Fact]
+    public void CreateMessage_WithoutFrom_ThrowsInvalidOperationException()
+    {
+        using var graph = new Graph
+        {
+            To = new object[] { "to@example.com" },
+            Subject = "subject",
+            HTML = "body",
+            ContentType = "HTML"
+        };
+
+        Assert.Throws<InvalidOperationException>(() => graph.CreateMessage());
+    }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -246,6 +246,9 @@ public class Graph : IDisposable {
                 ConvertedAttachments.Add(att);
             }
         }
+        if (From is null) {
+            throw new InvalidOperationException("From address must be specified.");
+        }
         // Note: The display name for the sender is controlled by Office 365 and may not reflect the value you provide here.
         // Office 365 will use the mailbox's configured display name for the sender, regardless of what is set in the payload.
         // Always use the email address for API calls and authentication.


### PR DESCRIPTION
## Summary
- validate `Graph.From` is not null in `CreateMessage`
- test that `CreateMessage` throws when `From` isn't set

## Testing
- `dotnet test Sources/Mailozaurr.sln --framework net8.0 --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685f98346214832eab5575618fc09e31