### PR TITLE
Add PSD1 refresh step for PowerShell CI

### DIFF
--- a/.github/workflows/powershell-tests-all.yml
+++ b/.github/workflows/powershell-tests-all.yml
@@ -10,12 +10,43 @@ env:
   BUILD_CONFIGURATION: 'Debug'
 
 jobs:
+  refresh-psd1:
+    name: 'Refresh PSD1'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PowerShell modules
+        run: |
+          Install-Module PSPublishModule -Force -Scope CurrentUser -AllowClobber
+        shell: pwsh
+
+      - name: Refresh module manifest
+        env:
+          RefreshPSD1Only: 'true'
+        run: ./Build/Manage-Mailozaurr.ps1
+        shell: pwsh
+
+      - name: Upload refreshed manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: psd1
+          path: Mailozaurr.psd1
+
   test-windows-ps5:
+    needs: refresh-psd1
     name: 'Windows PowerShell 5.1'
     runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -39,11 +70,18 @@ jobs:
         run: .\Mailozaurr.Tests.ps1
 
   test-windows-ps7:
+    needs: refresh-psd1
     name: 'Windows PowerShell 7'
     runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -67,11 +105,18 @@ jobs:
         run: .\Mailozaurr.Tests.ps1
 
   test-ubuntu:
+    needs: refresh-psd1
     name: 'Ubuntu PowerShell 7'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -102,11 +147,18 @@ jobs:
         run: ./Mailozaurr.Tests.ps1
 
   test-macos:
+    needs: refresh-psd1
     name: 'macOS PowerShell 7'
     runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
## Summary
- refresh the module manifest before running PowerShell tests
- download refreshed manifest in each test job

## Testing
- `dotnet build Sources/Mailozaurr.sln --configuration Debug --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685fe960d80c832eaa3eb1800518591a