### PR TITLE
Improve XML docs on several models

### DIFF
--- a/Sources/Mailozaurr/Attachment.cs
+++ b/Sources/Mailozaurr/Attachment.cs
@@ -4,7 +4,14 @@ namespace Mailozaurr;
 /// Represents a file attachment from Microsoft Graph.
 /// </summary>
 public class Attachment {
+    /// <summary>
+    /// Gets or sets the file name of the attachment.
+    /// </summary>
     public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the attachment content encoded as a Base64 string.
+    /// </summary>
     public string ContentBytes { get; set; }
     // Add more properties as needed
 }

--- a/Sources/Mailozaurr/EmailGraphMessage.cs
+++ b/Sources/Mailozaurr/EmailGraphMessage.cs
@@ -4,10 +4,29 @@ namespace Mailozaurr;
 /// Simplified representation of an email message returned from Graph.
 /// </summary>
 public class EmailGraphMessage {
+    /// <summary>
+    /// Gets or sets the unique identifier of the message.
+    /// </summary>
     public string Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message subject.
+    /// </summary>
     public string Subject { get; set; }
+
+    /// <summary>
+    /// Gets or sets a short preview of the message body.
+    /// </summary>
     public string BodyPreview { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message body content.
+    /// </summary>
     public object Body { get; set; }
+
+    /// <summary>
+    /// Gets or sets the change key for the message.
+    /// </summary>
     public string ChangeKey { get; set; }
     // Add more properties as needed
 }

--- a/Sources/Mailozaurr/GraphCredential.cs
+++ b/Sources/Mailozaurr/GraphCredential.cs
@@ -4,11 +4,38 @@ namespace Mailozaurr;
 /// Represents credentials required for Microsoft Graph authentication.
 /// </summary>
 public class GraphCredential {
+    /// <summary>
+    /// Gets or sets the application (client) identifier.
+    /// </summary>
     public string ClientId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the directory (tenant) identifier.
+    /// </summary>
     public string DirectoryId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client secret if using secret-based auth.
+    /// </summary>
     public string? ClientSecret { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to a certificate used for authentication.
+    /// </summary>
     public string? CertificatePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the certificate password.
+    /// </summary>
     public string? CertificatePassword { get; set; }
+
+    /// <summary>
+    /// Gets or sets certificate bytes when provided programmatically.
+    /// </summary>
     public byte[]? CertificateBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the PEM certificate path, if applicable.
+    /// </summary>
     public string? CertificatePemPath { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorDetail.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorDetail.cs
@@ -4,12 +4,21 @@ namespace Mailozaurr;
 /// Detailed information about a Graph API error.
 /// </summary>
 public class GraphApiErrorDetail {
+    /// <summary>
+    /// Gets or sets the error code returned by the API.
+    /// </summary>
     [JsonPropertyName("code")]
     public string Code { get; set; }
 
+    /// <summary>
+    /// Gets or sets the human readable error message.
+    /// </summary>
     [JsonPropertyName("message")]
     public string Message { get; set; }
 
+    /// <summary>
+    /// Gets or sets additional error details.
+    /// </summary>
     [JsonPropertyName("innerError")]
     public GraphApiInnerError InnerError { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiInnerError.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiInnerError.cs
@@ -4,12 +4,21 @@ namespace Mailozaurr;
 /// Additional error details returned by the Graph API.
 /// </summary>
 public class GraphApiInnerError {
+    /// <summary>
+    /// Gets or sets the request identifier associated with the error.
+    /// </summary>
     [JsonPropertyName("request-id")]
     public string RequestId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the client request identifier associated with the error.
+    /// </summary>
     [JsonPropertyName("client-request-id")]
     public string ClientRequestId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the timestamp of when the error occurred.
+    /// </summary>
     [JsonPropertyName("date")]
     public DateTime Date { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachment.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachment.cs
@@ -4,27 +4,36 @@
 /// Represents a simple file attachment used when sending messages.
 /// </summary>
 public class GraphAttachment {
+    /// <summary>
+    /// Gets or sets the Graph type of the attachment.
+    /// </summary>
     [JsonPropertyName("@odata.type")]
     public string ODataType { get; set; } = "#microsoft.graph.fileAttachment";
 
+    /// <summary>
+    /// Gets or sets the attachment file name.
+    /// </summary>
     [JsonPropertyName("name")]
     public string Name { get; set; }
 
+    /// <summary>
+    /// Gets or sets the file content encoded as a Base64 string.
+    /// </summary>
     [JsonPropertyName("contentBytes")]
     public string ContentBytes { get; set; }
 
-    [JsonPropertyName("isInline")]
     /// <summary>
     /// Indicates whether this attachment should be rendered inline in the
     /// message body.
     /// </summary>
+    [JsonPropertyName("isInline")]
     public bool IsInline { get; set; }
 
-    [JsonPropertyName("contentId")]
     /// <summary>
     /// Optional identifier used to reference the attachment via a <c>cid:</c>
     /// URL within the HTML body.
     /// </summary>
+    [JsonPropertyName("contentId")]
     public string? ContentId { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentItem.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentItem.cs
@@ -4,12 +4,21 @@ namespace Mailozaurr;
 /// Metadata describing an attachment for upload.
 /// </summary>
 public class GraphAttachmentItem {
+    /// <summary>
+    /// Gets or sets the type of the attachment being uploaded.
+    /// </summary>
     [JsonPropertyName("attachmentType")]
     public string AttachmentType { get; set; }
 
+    /// <summary>
+    /// Gets or sets the file name of the attachment.
+    /// </summary>
     [JsonPropertyName("name")]
     public string Name { get; set; }
 
+    /// <summary>
+    /// Gets or sets the size of the attachment in bytes.
+    /// </summary>
     [JsonPropertyName("size")]
     public long Size { get; set; }
 

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphContent.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphContent.cs
@@ -4,9 +4,15 @@ namespace Mailozaurr;
 /// Body content for a message.
 /// </summary>
 public class GraphContent {
+    /// <summary>
+    /// Gets or sets the content type, such as "Text" or "HTML".
+    /// </summary>
     [JsonPropertyName("contentType")]
     public string Type { get; set; } = "Text";
 
+    /// <summary>
+    /// Gets or sets the content value.
+    /// </summary>
     [JsonPropertyName("content")]
     public string Content { get; set; } = "";
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphEmail.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphEmail.cs
@@ -4,6 +4,9 @@ namespace Mailozaurr;
 /// Simple email address container.
 /// </summary>
 public class GraphEmail {
+    /// <summary>
+    /// Gets or sets the email address value.
+    /// </summary>
     [JsonPropertyName("address")]
     public string Address { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphEmailAddress.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphEmailAddress.cs
@@ -4,6 +4,9 @@ namespace Mailozaurr;
 /// Represents an email address object for Graph API payloads.
 /// </summary>
 public class GraphEmailAddress {
+    /// <summary>
+    /// Gets or sets the email details.
+    /// </summary>
     [JsonPropertyName("emailAddress")]
     public GraphEmail Email { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMessage.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMessage.cs
@@ -4,44 +4,80 @@
 /// Represents an email message for use with the Graph API.
 /// </summary>
 public class GraphMessage {
+    /// <summary>
+    /// Gets or sets the message identifier.
+    /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("id")]
     public string Id { get; set; }
+    /// <summary>
+    /// Gets or sets the sender address.
+    /// </summary>
     [JsonPropertyName("from")]
     public GraphEmailAddress From { get; set; }
 
+    /// <summary>
+    /// Gets or sets the primary recipients of the message.
+    /// </summary>
     [JsonPropertyName("toRecipients")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<GraphEmailAddress>? To { get; set; }
 
+    /// <summary>
+    /// Gets or sets the CC recipients of the message.
+    /// </summary>
     [JsonPropertyName("ccRecipients")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<GraphEmailAddress>? Cc { get; set; }
 
+    /// <summary>
+    /// Gets or sets the BCC recipients of the message.
+    /// </summary>
     [JsonPropertyName("bccRecipients")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<GraphEmailAddress>? Bcc { get; set; }
 
+    /// <summary>
+    /// Gets or sets reply-to addresses for the message.
+    /// </summary>
     [JsonPropertyName("replyTo")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<GraphEmailAddress>? ReplyTo { get; set; }
 
+    /// <summary>
+    /// Gets or sets the subject line of the message.
+    /// </summary>
     [JsonPropertyName("subject")]
     public string Subject { get; set; }
 
+    /// <summary>
+    /// Gets or sets the message body.
+    /// </summary>
     [JsonPropertyName("body")]
     public GraphContent Body { get; set; }
 
+    /// <summary>
+    /// Gets or sets the importance of the message.
+    /// </summary>
     [JsonPropertyName("importance")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Importance { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a read receipt is requested.
+    /// </summary>
     [JsonPropertyName("isReadReceiptRequested")]
     public bool IsReadReceiptRequested { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a delivery receipt is requested.
+    /// </summary>
     [JsonPropertyName("isDeliveryReceiptRequested")]
     public bool IsDeliveryReceiptRequested { get; set; }
 
+    /// <summary>
+    /// Gets or sets attachments included with the message.
+    /// </summary>
     [JsonPropertyName("attachments")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<GraphAttachment>? Attachments { get; set; }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMessageContainer.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMessageContainer.cs
@@ -4,8 +4,15 @@ namespace Mailozaurr;
 /// Wrapper used when serializing a message for Graph API calls.
 /// </summary>
 public class GraphMessageContainer {
+    /// <summary>
+    /// Gets or sets the message payload.
+    /// </summary>
     [JsonPropertyName("message")]
     public GraphMessage Message { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the message should be saved to the Sent Items folder.
+    /// </summary>
     [JsonPropertyName("saveToSentItems")]
     public bool SaveToSentItems { get; set; }
 }


### PR DESCRIPTION
## Summary
- add XML comments to graph-related model properties
- document message details properties
- clarify attachment fields

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_685ff20fff8c832e8a68d754cc4205a3