### PR TITLE
Add XML documentation for public members

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
@@ -11,23 +11,38 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsCommon.Move, "GraphMessage")]
 public class CmdletMoveGraphMessage : AsyncPSCmdlet {
+    /// <summary>
+    /// UPN of the mailbox owner containing the message.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Identifier of the message to move.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? MessageId { get; set; }
 
+    /// <summary>
+    /// Target folder identifier where the message will be moved.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? DestinationFolderId { get; set; }
 
+    /// <summary>
+    /// Optional Graph connection used when moving the message.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
 
+    /// <summary>
+    /// Indicates that the message should be moved using Invoke-MgGraphRequest.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveGraphMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveGraphMessageAttachment.cs
@@ -11,10 +11,16 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsData.Save, "GraphMessageAttachment")]
 public class CmdletSaveGraphMessageAttachment : PSCmdlet {
+    /// <summary>
+    /// Attachments to save from the message.
+    /// </summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
     [ValidateNotNullOrEmpty]
     public PSObject[]? Attachment { get; set; }
 
+    /// <summary>
+    /// Destination path for saved attachments.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? Path { get; set; }

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -528,24 +528,36 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "Compatibility")]
     public string? CertificateThumbprint { get; set; }
 
+    /// <summary>
+    /// Path to the recipient's public key used for PGP operations.
+    /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
     [Parameter(Mandatory = false, ParameterSetName = "SecureString")]
     [Parameter(Mandatory = false, ParameterSetName = "oAuth")]
     [Parameter(Mandatory = false, ParameterSetName = "Compatibility")]
     public string? PublicKeyPath { get; set; }
 
+    /// <summary>
+    /// Path to the sender's private key used for PGP signing.
+    /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
     [Parameter(Mandatory = false, ParameterSetName = "SecureString")]
     [Parameter(Mandatory = false, ParameterSetName = "oAuth")]
     [Parameter(Mandatory = false, ParameterSetName = "Compatibility")]
     public string? PrivateKeyPath { get; set; }
 
+    /// <summary>
+    /// Password for the private key when required.
+    /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
     [Parameter(Mandatory = false, ParameterSetName = "SecureString")]
     [Parameter(Mandatory = false, ParameterSetName = "oAuth")]
     [Parameter(Mandatory = false, ParameterSetName = "Compatibility")]
     public string? PrivateKeyPassword { get; set; }
 
+    /// <summary>
+    /// Indicates that <see cref="PrivateKeyPassword"/> is provided as a secure string.
+    /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
     [Parameter(Mandatory = false, ParameterSetName = "SecureString")]
     [Parameter(Mandatory = false, ParameterSetName = "oAuth")]

--- a/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
@@ -11,22 +11,37 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsCommon.Set, "GraphMessage")]
 public class CmdletSetGraphMessage : AsyncPSCmdlet {
+    /// <summary>
+    /// UPN of the mailbox owner containing the message.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Identifier of the message to modify.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? MessageId { get; set; }
 
+    /// <summary>
+    /// Marks the message as read when set.
+    /// </summary>
     [Parameter]
     public SwitchParameter Read { get; set; }
 
+    /// <summary>
+    /// Optional Graph connection used when updating the message.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
 
+    /// <summary>
+    /// Indicates that the message should be updated using Invoke-MgGraphRequest.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 

--- a/Sources/Mailozaurr/Attachment.cs
+++ b/Sources/Mailozaurr/Attachment.cs
@@ -4,7 +4,14 @@ namespace Mailozaurr;
 /// Represents a file attachment from Microsoft Graph.
 /// </summary>
 public class Attachment {
+    /// <summary>
+    /// Gets or sets the attachment file name.
+    /// </summary>
     public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Base64-encoded file content.
+    /// </summary>
     public string ContentBytes { get; set; }
     // Add more properties as needed
 }

--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -230,6 +230,15 @@ public static class OAuthHelpers {
         return await AcquireGraphCertificateTokenInternal(clientId, tenantId, certificate, scopes);
     }
 
+    /// <summary>
+    /// Acquires an app-only token using a certificate provided as a byte array.
+    /// </summary>
+    /// <param name="clientId">The application (client) identifier.</param>
+    /// <param name="tenantId">The tenant identifier.</param>
+    /// <param name="certificateBytes">Certificate bytes in PFX format.</param>
+    /// <param name="certificatePassword">Password for the certificate.</param>
+    /// <param name="scopes">Optional scopes to request.</param>
+    /// <returns>The authorization information including access token.</returns>
     public static async Task<GraphAuthorization> AcquireGraphCertificateTokenAsync(
         string clientId,
         string tenantId,
@@ -240,6 +249,14 @@ public static class OAuthHelpers {
         return await AcquireGraphCertificateTokenInternal(clientId, tenantId, certificate, scopes);
     }
 
+    /// <summary>
+    /// Acquires an app-only token using a PEM encoded certificate file.
+    /// </summary>
+    /// <param name="clientId">The application (client) identifier.</param>
+    /// <param name="tenantId">The tenant identifier.</param>
+    /// <param name="pemPath">Path to the PEM certificate file.</param>
+    /// <param name="scopes">Optional scopes to request.</param>
+    /// <returns>The authorization information including access token.</returns>
     public static async Task<GraphAuthorization> AcquireGraphCertificatePemTokenAsync(
         string clientId,
         string tenantId,

--- a/Sources/Mailozaurr/EmailGraphMessage.cs
+++ b/Sources/Mailozaurr/EmailGraphMessage.cs
@@ -4,10 +4,29 @@ namespace Mailozaurr;
 /// Simplified representation of an email message returned from Graph.
 /// </summary>
 public class EmailGraphMessage {
+    /// <summary>
+    /// Gets or sets the unique identifier of the message.
+    /// </summary>
     public string Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subject line of the message.
+    /// </summary>
     public string Subject { get; set; }
+
+    /// <summary>
+    /// Gets or sets the preview text of the message body.
+    /// </summary>
     public string BodyPreview { get; set; }
+
+    /// <summary>
+    /// Gets or sets the full body content of the message.
+    /// </summary>
     public object Body { get; set; }
+
+    /// <summary>
+    /// Gets or sets the change key used for concurrency checks.
+    /// </summary>
     public string ChangeKey { get; set; }
     // Add more properties as needed
 }

--- a/Sources/Mailozaurr/Enums/ActionPreference.cs
+++ b/Sources/Mailozaurr/Enums/ActionPreference.cs
@@ -4,9 +4,28 @@ namespace Mailozaurr;
 /// Specifies how the client should react when an error occurs.
 /// </summary>
 public enum ActionPreference {
+    /// <summary>
+    /// Stop execution when an error occurs.
+    /// </summary>
     Stop,
+
+    /// <summary>
+    /// Continue execution regardless of errors.
+    /// </summary>
     Continue,
+
+    /// <summary>
+    /// Ask the user whether to continue when an error occurs.
+    /// </summary>
     Inquire,
+
+    /// <summary>
+    /// Ignore errors and continue without notification.
+    /// </summary>
     SilentlyContinue,
+
+    /// <summary>
+    /// Pause execution for further action.
+    /// </summary>
     Suspend
 }

--- a/Sources/Mailozaurr/Enums/AuthenticationMechanism.cs
+++ b/Sources/Mailozaurr/Enums/AuthenticationMechanism.cs
@@ -4,7 +4,18 @@
 /// Supported SASL authentication mechanisms.
 /// </summary>
 public enum AuthenticationMechanism {
+    /// <summary>
+    /// Plain text authentication mechanism.
+    /// </summary>
     Plain,
+
+    /// <summary>
+    /// LOGIN authentication mechanism.
+    /// </summary>
     Login,
+
+    /// <summary>
+    /// Challenge-response authentication using CRAM-MD5.
+    /// </summary>
     CramMd5
 }

--- a/Sources/Mailozaurr/Enums/DeliveryNotification.cs
+++ b/Sources/Mailozaurr/Enums/DeliveryNotification.cs
@@ -4,9 +4,28 @@
 /// Delivery status notification options.
 /// </summary>
 public enum DeliveryNotification {
+    /// <summary>
+    /// No delivery status notifications are requested.
+    /// </summary>
     None,
+
+    /// <summary>
+    /// Notify when delivery is delayed.
+    /// </summary>
     Delay,
+
+    /// <summary>
+    /// Suppress all delivery notifications.
+    /// </summary>
     Never,
+
+    /// <summary>
+    /// Notify on delivery failure.
+    /// </summary>
     OnFailure,
+
+    /// <summary>
+    /// Notify on successful delivery.
+    /// </summary>
     OnSuccess,
 }

--- a/Sources/Mailozaurr/Enums/EmailAction.cs
+++ b/Sources/Mailozaurr/Enums/EmailAction.cs
@@ -4,16 +4,63 @@
 /// Represents actions performed when sending or preparing an email.
 /// </summary>
 public enum EmailAction {
+    /// <summary>
+    /// Authenticate with the mail server or provider.
+    /// </summary>
     Authenticate,
+
+    /// <summary>
+    /// Establish a connection to the mail server.
+    /// </summary>
     Connect,
+
+    /// <summary>
+    /// Sign the message using S/MIME.
+    /// </summary>
     SMimeSignature,
+
+    /// <summary>
+    /// Sign the message using S/MIME in PKCS#7 format.
+    /// </summary>
     SMimeSignaturePKCS7,
+
+    /// <summary>
+    /// Encrypt the message using S/MIME.
+    /// </summary>
     SMimeEncrypt,
+
+    /// <summary>
+    /// Sign and encrypt the message using S/MIME.
+    /// </summary>
     SMimeSignAndEncrypt,
+
+    /// <summary>
+    /// Sign the message using PGP.
+    /// </summary>
     PgpSign,
+
+    /// <summary>
+    /// Encrypt the message using PGP.
+    /// </summary>
     PgpEncrypt,
+
+    /// <summary>
+    /// Sign and encrypt the message using PGP.
+    /// </summary>
     PgpSignAndEncrypt,
+
+    /// <summary>
+    /// Send the message via the configured provider.
+    /// </summary>
     Send,
+
+    /// <summary>
+    /// Send the message as a draft.
+    /// </summary>
     SendDraftMessage,
+
+    /// <summary>
+    /// Send message attachments only.
+    /// </summary>
     SendAttachment
 }

--- a/Sources/Mailozaurr/Enums/EmailActionEncryption.cs
+++ b/Sources/Mailozaurr/Enums/EmailActionEncryption.cs
@@ -4,13 +4,44 @@
 /// Specifies encryption or signing actions for S/MIME operations.
 /// </summary>
 public enum EmailActionEncryption {
+    /// <summary>
+    /// No signing or encryption is applied.
+    /// </summary>
     None,
+
+    /// <summary>
+    /// Sign the message using an S/MIME certificate.
+    /// </summary>
     SMIMESign,
+
+    /// <summary>
+    /// Sign the message using an S/MIME certificate in PKCS#7 format.
+    /// </summary>
     SMIMESignPkcs7,
+
+    /// <summary>
+    /// Encrypt the message using S/MIME.
+    /// </summary>
     SMIMEEncrypt,
+
+    /// <summary>
+    /// Sign and encrypt the message using S/MIME.
+    /// </summary>
     SMIMESignAndEncrypt,
+
+    /// <summary>
+    /// Sign the message using a PGP key.
+    /// </summary>
     PGPSign,
+
+    /// <summary>
+    /// Encrypt the message using a PGP key.
+    /// </summary>
     PGPEncrypt,
+
+    /// <summary>
+    /// Sign and encrypt the message using a PGP key.
+    /// </summary>
     PGPSignAndEncrypt,
 }
 

--- a/Sources/Mailozaurr/Enums/EmailProvider.cs
+++ b/Sources/Mailozaurr/Enums/EmailProvider.cs
@@ -3,8 +3,19 @@
 /// Supported external email providers.
 /// </summary>
 public enum EmailProvider {
+    /// <summary>
+    /// Use the built-in SMTP client.
+    /// </summary>
     None,
+
+    /// <summary>
+    /// Use the SendGrid REST API to deliver mail.
+    /// </summary>
     SendGrid,
+
+    /// <summary>
+    /// Use the Mailgun REST API to deliver mail.
+    /// </summary>
     Mailgun,
     //MailChimp,
     //AmazonSES,

--- a/Sources/Mailozaurr/Enums/MessagePriority.cs
+++ b/Sources/Mailozaurr/Enums/MessagePriority.cs
@@ -4,7 +4,18 @@
 /// Indicates the priority of an email message.
 /// </summary>
 public enum MessagePriority {
+    /// <summary>
+    /// High priority message.
+    /// </summary>
     High,
+
+    /// <summary>
+    /// Low priority message.
+    /// </summary>
     Low,
+
+    /// <summary>
+    /// Normal priority message.
+    /// </summary>
     Normal
 }


### PR DESCRIPTION
## Summary
- revert prior suppression of CS1591 warnings
- add XML comments to attachment types, Graph message model, and enums
- document parameters for Graph cmdlets
- add summaries for OAuth helper methods

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685feb2de904832e9e49bd471263a3d2