### PR TITLE
Use streaming for attachment uploads

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
@@ -21,8 +21,8 @@ public class GraphUploadRangeTests
             "PrepareByteArrayContentForUpload",
             BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(method);
-        Task<List<ByteArrayContent>> task = (Task<List<ByteArrayContent>>)method!.Invoke(graph, new object[] { tmp, 10, default(System.Threading.CancellationToken) })!;
-        List<ByteArrayContent> chunks = await task;
+        Task<List<StreamContent>> task = (Task<List<StreamContent>>)method!.Invoke(graph, new object[] { tmp, 10, default(System.Threading.CancellationToken) })!;
+        List<StreamContent> chunks = await task;
         File.Delete(tmp);
         Assert.Equal(3, chunks.Count);
         Assert.Equal("bytes 0-9/25", chunks[0].Headers.GetValues("Content-Range").First());
@@ -41,10 +41,10 @@ public class GraphUploadRangeTests
             "PrepareByteArrayContentForUpload",
             BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(method);
-        Task<List<ByteArrayContent>> task = (Task<List<ByteArrayContent>>)method!.Invoke(
+        Task<List<StreamContent>> task = (Task<List<StreamContent>>)method!.Invoke(
             graph,
             new object[] { tmp, 10, default(System.Threading.CancellationToken) })!;
-        List<ByteArrayContent> chunks = await task;
+        List<StreamContent> chunks = await task;
         File.Delete(tmp);
         byte[] chunk0 = await chunks[0].ReadAsByteArrayAsync();
         byte[] chunk1 = await chunks[1].ReadAsByteArrayAsync();

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http.Headers;
+﻿using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 
 namespace Mailozaurr;
@@ -656,25 +657,21 @@ public class Graph : IDisposable {
     /// <param name="filePath"></param>
     /// <param name="chunkSize"></param>
     /// <returns></returns>
-    private async Task<List<ByteArrayContent>> PrepareByteArrayContentForUpload(string filePath, int chunkSize = 9000000, CancellationToken cancellationToken = default) {
-        var fileContents = new List<ByteArrayContent>();
+    private Task<List<StreamContent>> PrepareByteArrayContentForUpload(string filePath, int chunkSize = 9000000, CancellationToken cancellationToken = default) {
+        var fileContents = new List<StreamContent>();
         var fileSize = new FileInfo(filePath).Length;
 
-        using var fileStream = new FileStream(filePath, FileMode.Open);
-        var buffer = new byte[chunkSize];
-        int bytesRead;
         long offset = 0;
-        while ((bytesRead = await fileStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0) {
-            var contentRange = $"bytes {offset}-{offset + bytesRead - 1}/{fileSize}";
-            var chunk = new byte[bytesRead];
-            Array.Copy(buffer, chunk, bytesRead);
-            var byteArrayContent = new ByteArrayContent(chunk);
-            byteArrayContent.Headers.Add("Content-Range", contentRange);
-            fileContents.Add(byteArrayContent);
-            offset += bytesRead;
+        while (offset < fileSize) {
+            var length = Math.Min(chunkSize, fileSize - offset);
+            var stream = new PartialFileStream(filePath, offset, length);
+            var streamContent = new StreamContent(stream);
+            streamContent.Headers.Add("Content-Range", $"bytes {offset}-{offset + length - 1}/{fileSize}");
+            fileContents.Add(streamContent);
+            offset += length;
         }
 
-        return fileContents;
+        return Task.FromResult(fileContents);
     }
 
     /// <summary>
@@ -712,12 +709,11 @@ public class Graph : IDisposable {
     /// </summary>
     /// <param name="uploadUrl">The upload session URL.</param>
     /// <param name="fileChunks">The file chunks to upload.</param>
-    public async Task SendFileChunks(string uploadUrl, List<ByteArrayContent> fileChunks, CancellationToken cancellationToken = default) {
-        var tasks = new List<Task>();
+    public async Task SendFileChunks(string uploadUrl, List<StreamContent> fileChunks, CancellationToken cancellationToken = default) {
         foreach (var chunk in fileChunks) {
-            tasks.Add(SendFile(uploadUrl, chunk, cancellationToken));
+            await SendFile(uploadUrl, chunk, cancellationToken).ConfigureAwait(false);
+            chunk.Dispose();
         }
-        await Task.WhenAll(tasks);
     }
 
     /// <summary>
@@ -725,7 +721,7 @@ public class Graph : IDisposable {
     /// </summary>
     /// <param name="uploadUrl">The upload session URL.</param>
     /// <param name="byteArrayContent">The chunk to send.</param>
-    public async Task SendFile(string uploadUrl, ByteArrayContent byteArrayContent, CancellationToken cancellationToken = default) {
+    public async Task SendFile(string uploadUrl, StreamContent byteArrayContent, CancellationToken cancellationToken = default) {
         using var requestMessage = new HttpRequestMessage(HttpMethod.Put, uploadUrl) {
             Content = byteArrayContent
         };

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentPlaceHolder.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentPlaceHolder.cs
@@ -1,3 +1,5 @@
+using System.Net.Http;
+
 namespace Mailozaurr;
 
 /// <summary>
@@ -7,7 +9,7 @@ public class GraphAttachmentPlaceHolder {
     /// <summary>Serialized attachment metadata.</summary>
     public string Json { get; set; }
     /// <summary>Chunks of the file content.</summary>
-    public List<ByteArrayContent> Content { get; set; }
+    public List<StreamContent> Content { get; set; }
     /// <summary>Size of the file in bytes.</summary>
     public long FileSize { get; set; }
     /// <summary>Name of the file.</summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/PartialFileStream.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/PartialFileStream.cs
@@ -13,7 +13,7 @@ internal sealed class PartialFileStream : Stream
 
     public PartialFileStream(string path, long offset, long length)
     {
-        _stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        _stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
         _stream.Seek(offset, SeekOrigin.Begin);
         _length = length;
         _remaining = length;

--- a/Sources/Mailozaurr/MicrosoftGraph/PartialFileStream.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/PartialFileStream.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr;
+
+internal sealed class PartialFileStream : Stream
+{
+    private readonly FileStream _stream;
+    private readonly long _length;
+    private long _remaining;
+
+    public PartialFileStream(string path, long offset, long length)
+    {
+        _stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        _stream.Seek(offset, SeekOrigin.Begin);
+        _length = length;
+        _remaining = length;
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => _length;
+    public override long Position
+    {
+        get => _length - _remaining;
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        if (_remaining <= 0)
+        {
+            return 0;
+        }
+
+        if (count > _remaining)
+        {
+            count = (int)_remaining;
+        }
+
+        int read = _stream.Read(buffer, offset, count);
+        _remaining -= read;
+        return read;
+    }
+
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        if (_remaining <= 0)
+        {
+            return 0;
+        }
+
+        if (count > _remaining)
+        {
+            count = (int)_remaining;
+        }
+
+        int read = await _stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        _remaining -= read;
+        return read;
+    }
+
+    public override void Flush() => _stream.Flush();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _stream.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}


### PR DESCRIPTION
## Summary
- read attachments in `PrepareByteArrayContentForUpload` using `StreamContent`
- stream chunk uploads sequentially to reduce memory
- update tests for new streaming behavior
- add `PartialFileStream` helper

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6860217be834832ea542ff455f23a8fe