### PR TITLE
Add raw OData filter option

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -179,6 +179,16 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - `Sources/Mailozaurr.Examples/AcquireGoogleTokenInteractive.cs` – C# sample for `OAuthHelpers.AcquireGoogleTokenInteractiveAsync`.
 - `Sources/Mailozaurr.Examples/SendEmailAttachments.cs` – C# sample demonstrating attachments and inline resources.
 
+### Filtering Graph messages
+
+`Get-EmailGraphMessage` supports the `-Filter` parameter for raw OData queries. This value is passed directly to Microsoft Graph's `$filter` option.
+
+```powershell
+Get-EmailGraphMessage -UserPrincipalName 'user@example.com' -Filter "receivedDateTime ge 2024-01-01T00:00:00Z and contains(subject,'Invoice')"
+```
+
+See the [Microsoft Graph query parameters documentation](https://learn.microsoft.com/en-us/graph/query-parameters#filter-parameter) for details.
+
 Keep in mind PSSharedGoods is only required for development. When you use this module from PowerShellGallery it's not installed as everything is merged.
 
 ### Limiting access to mailboxes (Microsoft Graph API)

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
@@ -27,8 +27,12 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     [Parameter(ParameterSetName = "MgGraphRequest")]
     public string[]? Property { get; set; }
 
+    /// <summary>
+    /// <para type="description">Raw OData filter passed directly to Microsoft Graph.</para>
+    /// </summary>
     [Parameter(ParameterSetName = "Graph")]
     [Parameter(ParameterSetName = "MgGraphRequest")]
+    [Alias("ODataFilter")]
     public string? Filter { get; set; }
 
     [Parameter(ParameterSetName = "Graph")]
@@ -80,7 +84,7 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     }
 
     private async Task ProcessGraphAsync(GraphCredential cred) {
-        var filter = BuildFilter();
+        var filter = BuildFilter(Filter);
         var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(
             cred,
             UserPrincipalName!,
@@ -97,7 +101,7 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     }
 
     private Task ProcessMgGraph() {
-        var filter = BuildFilter();
+        var filter = BuildFilter(Filter);
         var query = new Dictionary<string, object>();
         if (!string.IsNullOrWhiteSpace(filter)) query["$filter"] = filter;
         if (Property != null && Property.Length > 0) query["$select"] = string.Join(",", Property);
@@ -115,7 +119,10 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
         return Task.CompletedTask;
     }
 
-    private string BuildFilter() {
+    /// <summary>
+    /// Combines built-in conditions with a raw OData filter.
+    /// </summary>
+    private string BuildFilter(string? rawFilter) {
         var filters = new List<string>();
         if (!All.IsPresent) {
             if (!string.IsNullOrWhiteSpace(Subject)) {
@@ -138,8 +145,8 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
             filters.Add("hasAttachments eq true");
         }
         var filter = string.Join(" and ", filters);
-        if (!string.IsNullOrWhiteSpace(Filter)) {
-            filter = string.IsNullOrWhiteSpace(filter) ? Filter : $"{filter} and {Filter}";
+        if (!string.IsNullOrWhiteSpace(rawFilter)) {
+            filter = string.IsNullOrWhiteSpace(filter) ? rawFilter : $"{filter} and {rawFilter}";
         }
         return filter;
     }


### PR DESCRIPTION
## Summary
- expose `-Filter` as raw OData filter in `Get-EmailGraphMessage`
- pass provided filter when building Graph message queries
- document filter usage in README

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -File run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686021a01e84832e881de0cd37478f61