### PR TITLE
Add test for GraphUploadSessionResult

### DIFF
--- a/Tests/GraphUploadSessionResult.Tests.ps1
+++ b/Tests/GraphUploadSessionResult.Tests.ps1
@@ -1,0 +1,7 @@
+Describe 'GraphUploadSessionResult' {
+    It 'Deserializes uploadUrl correctly' {
+        $json = '{"uploadUrl":"https://example.com/upload"}'
+        $result = [System.Text.Json.JsonSerializer]::Deserialize($json, [Mailozaurr.GraphUploadSessionResult])
+        $result.UploadUrl | Should -Be 'https://example.com/upload'
+    }
+}


### PR DESCRIPTION
## Summary
- add test verifying uploadUrl deserializes correctly

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug`
- `pwsh -NoProfile -Command "$env:CI='true'; ./Mailozaurr.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_6861476bee28832e97b78477623d08d5