### PR TITLE
Improve UniqueAddresses normalization

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net;
+using System.Linq;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -46,5 +47,24 @@ public class HelpersTests
     public void ConvertFromOAuth2Credential_ThrowsArgumentNullException_WhenCredentialIsNull()
     {
         Assert.Throws<ArgumentNullException>(() => Mailozaurr.Helpers.ConvertFromOAuth2Credential(null!));
+    }
+
+    [Fact]
+    public void UniqueAddresses_RemovesDuplicates_IgnoringCaseAndWhitespace()
+    {
+        var addresses = new object[]
+        {
+            " Test@example.com ",
+            "test@example.com",
+            "other@example.com",
+            "Other@example.com "
+        };
+        var seen = new HashSet<string>();
+        var result = Mailozaurr.Helpers
+            .UniqueAddresses(addresses, seen)
+            .Select(Mailozaurr.Helpers.GetEmailAddress)
+            .ToArray();
+
+        Assert.Equal(new[] { " Test@example.com ", "other@example.com" }, result);
     }
 }

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -5,6 +5,7 @@ using System.Security;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
+using System.Linq;
 
 namespace Mailozaurr;
 
@@ -101,10 +102,14 @@ public static class Helpers {
 
         foreach (var address in addresses) {
             var email = GetEmailAddress(address);
-            if (string.IsNullOrWhiteSpace(email)) continue;
+            if (string.IsNullOrWhiteSpace(email)) {
+                continue;
+            }
 
-            var lowered = email.ToLowerInvariant();
-            if (seen.Add(lowered)) {
+            var normalized = string
+                .Concat(email.Where(c => !char.IsWhiteSpace(c)))
+                .ToLowerInvariant();
+            if (seen.Add(normalized)) {
                 yield return address;
             }
         }


### PR DESCRIPTION
## Summary
- normalize email addresses by removing whitespace and case when deduplicating
- cover deduplication logic with new test

## Testing
- `dotnet restore Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln --no-restore`
- `dotnet test Sources/Mailozaurr.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68614774288c832eaf7cfd3f00418943