### PR TITLE
Stream graph attachments

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
@@ -21,8 +21,7 @@ public class GraphUploadRangeTests
             "PrepareByteArrayContentForUpload",
             BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(method);
-        Task<List<ByteArrayContent>> task = (Task<List<ByteArrayContent>>)method!.Invoke(graph, new object[] { tmp, 10, default(System.Threading.CancellationToken) })!;
-        List<ByteArrayContent> chunks = await task;
+        List<StreamContent> chunks = (List<StreamContent>)method!.Invoke(graph, new object[] { tmp, 10, default(System.Threading.CancellationToken) })!;
         File.Delete(tmp);
         Assert.Equal(3, chunks.Count);
         Assert.Equal("bytes 0-9/25", chunks[0].Headers.GetValues("Content-Range").First());
@@ -41,10 +40,9 @@ public class GraphUploadRangeTests
             "PrepareByteArrayContentForUpload",
             BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(method);
-        Task<List<ByteArrayContent>> task = (Task<List<ByteArrayContent>>)method!.Invoke(
+        List<StreamContent> chunks = (List<StreamContent>)method!.Invoke(
             graph,
             new object[] { tmp, 10, default(System.Threading.CancellationToken) })!;
-        List<ByteArrayContent> chunks = await task;
         File.Delete(tmp);
         byte[] chunk0 = await chunks[0].ReadAsByteArrayAsync();
         byte[] chunk1 = await chunks[1].ReadAsByteArrayAsync();

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -610,7 +610,7 @@ public class Graph : IDisposable {
     /// </summary>
     /// <param name="attachmentPath">Path to the attachment file.</param>
     /// <returns>The placeholder representing the attachment.</returns>
-    public async Task<GraphAttachmentPlaceHolder> CreateGraphAttachment(string attachmentPath, CancellationToken cancellationToken = default) {
+    public Task<GraphAttachmentPlaceHolder> CreateGraphAttachment(string attachmentPath, CancellationToken cancellationToken = default) {
         var fileName = Path.GetFileName(attachmentPath);
         var fileSize = new FileInfo(attachmentPath).Length;
 
@@ -619,14 +619,17 @@ public class Graph : IDisposable {
         var attachmentItemWrapper = new GraphAttachmentItemWrapper(attachmentItem);
         var attachmentItemJson = JsonSerializer.Serialize(attachmentItemWrapper);
 
-        var content = await PrepareByteArrayContentForUpload(attachmentPath, ChunkSize, cancellationToken);
+        List<StreamContent> content = PrepareByteArrayContentForUpload(attachmentPath, ChunkSize, cancellationToken);
 
-        return new GraphAttachmentPlaceHolder() {
+        var placeholder = new GraphAttachmentPlaceHolder {
             Json = attachmentItemJson,
             Content = content,
+            FilePath = attachmentPath,
             FileSize = fileSize,
             FileName = fileName
         };
+
+        return Task.FromResult(placeholder);
     }
 
     /// <summary>
@@ -656,21 +659,26 @@ public class Graph : IDisposable {
     /// <param name="filePath"></param>
     /// <param name="chunkSize"></param>
     /// <returns></returns>
-    private async Task<List<ByteArrayContent>> PrepareByteArrayContentForUpload(string filePath, int chunkSize = 9000000, CancellationToken cancellationToken = default) {
-        var fileContents = new List<ByteArrayContent>();
+    private List<StreamContent> PrepareByteArrayContentForUpload(string filePath, int chunkSize = 9000000, CancellationToken cancellationToken = default) {
+        var fileContents = new List<StreamContent>();
         var fileSize = new FileInfo(filePath).Length;
 
-        using var fileStream = new FileStream(filePath, FileMode.Open);
+        using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
         var buffer = new byte[chunkSize];
         int bytesRead;
         long offset = 0;
-        while ((bytesRead = await fileStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0) {
-            var contentRange = $"bytes {offset}-{offset + bytesRead - 1}/{fileSize}";
+        while ((bytesRead = fileStream.Read(buffer, 0, buffer.Length)) > 0) {
+            if (cancellationToken.IsCancellationRequested) {
+                return fileContents;
+            }
+
             var chunk = new byte[bytesRead];
             Array.Copy(buffer, chunk, bytesRead);
-            var byteArrayContent = new ByteArrayContent(chunk);
-            byteArrayContent.Headers.Add("Content-Range", contentRange);
-            fileContents.Add(byteArrayContent);
+            var memoryStream = new MemoryStream(chunk, writable: false);
+            var contentRange = $"bytes {offset}-{offset + bytesRead - 1}/{fileSize}";
+            var streamContent = new StreamContent(memoryStream);
+            streamContent.Headers.Add("Content-Range", contentRange);
+            fileContents.Add(streamContent);
             offset += bytesRead;
         }
 
@@ -712,12 +720,10 @@ public class Graph : IDisposable {
     /// </summary>
     /// <param name="uploadUrl">The upload session URL.</param>
     /// <param name="fileChunks">The file chunks to upload.</param>
-    public async Task SendFileChunks(string uploadUrl, List<ByteArrayContent> fileChunks, CancellationToken cancellationToken = default) {
-        var tasks = new List<Task>();
+    public async Task SendFileChunks(string uploadUrl, IEnumerable<StreamContent> fileChunks, CancellationToken cancellationToken = default) {
         foreach (var chunk in fileChunks) {
-            tasks.Add(SendAttachmentChunk(uploadUrl, chunk, cancellationToken));
+            await SendAttachmentChunk(uploadUrl, chunk, cancellationToken);
         }
-        await Task.WhenAll(tasks);
     }
 
     /// <summary>
@@ -725,7 +731,7 @@ public class Graph : IDisposable {
     /// </summary>
     /// <param name="uploadUrl">The upload session URL.</param>
     /// <param name="byteArrayContent">The chunk to send.</param>
-    public async Task SendAttachmentChunk(string uploadUrl, ByteArrayContent byteArrayContent, CancellationToken cancellationToken = default) {
+    public async Task SendAttachmentChunk(string uploadUrl, StreamContent byteArrayContent, CancellationToken cancellationToken = default) {
         using var requestMessage = new HttpRequestMessage(HttpMethod.Put, uploadUrl) {
             Content = byteArrayContent
         };

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentPlaceHolder.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentPlaceHolder.cs
@@ -7,7 +7,9 @@ public class GraphAttachmentPlaceHolder {
     /// <summary>Serialized attachment metadata.</summary>
     public string Json { get; set; }
     /// <summary>Chunks of the file content.</summary>
-    public List<ByteArrayContent> Content { get; set; }
+    public List<StreamContent> Content { get; set; }
+    /// <summary>Path to the file.</summary>
+    public string FilePath { get; set; }
     /// <summary>Size of the file in bytes.</summary>
     public long FileSize { get; set; }
     /// <summary>Name of the file.</summary>


### PR DESCRIPTION
## Summary
- use `StreamContent` when preparing attachment chunks
- stream sequential chunks in `UploadAttachmentsAsync`
- adjust tests for new streaming approach

## Testing
- `dotnet build Sources/Mailozaurr.sln --no-restore`
- `dotnet test Sources/Mailozaurr.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686157119aa4832ea8d99f9a07f5dbc9