### PR TITLE
Add Graph API exception handling

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using Mailozaurr;
 
 namespace Mailozaurr.PowerShell;
 
@@ -110,8 +111,8 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
                 RetryDelayBackoff,
                 "https://graph.microsoft.com");
             connected = !string.IsNullOrWhiteSpace(token);
-        } catch {
-            // ignore errors, return not connected
+        } catch (GraphApiException ex) {
+            WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
         }
 
         var info = new GraphConnectionInfo { Credential = cred, IsConnected = connected };

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphFolder.cs
@@ -60,9 +60,13 @@ public class CmdletGetEmailGraphFolder : AsyncPSCmdlet {
     }
 
     private async Task ProcessGraphAsync(GraphCredential cred) {
-        var folders = await MicrosoftGraphUtils.GetMailFoldersAsync(cred, UserPrincipalName!);
-        foreach (var folder in folders) {
-            WriteObject(folder);
+        try {
+            var folders = await MicrosoftGraphUtils.GetMailFoldersAsync(cred, UserPrincipalName!);
+            foreach (var folder in folders) {
+                WriteObject(folder);
+            }
+        } catch (GraphApiException ex) {
+            WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
         }
     }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
+using Mailozaurr;
 using System.Threading.Tasks;
 
 namespace Mailozaurr.PowerShell;
@@ -84,19 +85,23 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     }
 
     private async Task ProcessGraphAsync(GraphCredential cred) {
-        var filter = BuildFilter(Filter);
-        var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(
-            cred,
-            UserPrincipalName!,
-            Property,
-            filter,
-            Limit);
+        try {
+            var filter = BuildFilter(Filter);
+            var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(
+                cred,
+                UserPrincipalName!,
+                Property,
+                filter,
+                Limit);
 
-        foreach (var msg in messages) {
-            WriteObject(PSObject.AsPSObject(msg));
-            if (Delete.IsPresent && msg.TryGetValue("id", out var idObj) && idObj is string id) {
-                await MicrosoftGraphUtils.DeleteMailMessageAsync(cred, UserPrincipalName!, id);
+            foreach (var msg in messages) {
+                WriteObject(PSObject.AsPSObject(msg));
+                if (Delete.IsPresent && msg.TryGetValue("id", out var idObj) && idObj is string id) {
+                    await MicrosoftGraphUtils.DeleteMailMessageAsync(cred, UserPrincipalName!, id);
+                }
             }
+        } catch (GraphApiException ex) {
+            WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
         }
     }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessageAttachment.cs
@@ -60,9 +60,13 @@ public class CmdletGetEmailGraphMessageAttachment : AsyncPSCmdlet {
                 WriteWarning("Get-EmailGraphMessageAttachment - Connection not provided and no default session available.");
                 return;
             }
-            var attachments = await MicrosoftGraphUtils.GetMailMessageAttachmentsAsync(conn.Credential, UserPrincipalName!, MessageId!, Property);
-            foreach (var att in attachments) {
-                WriteObject(att);
+            try {
+                var attachments = await MicrosoftGraphUtils.GetMailMessageAttachmentsAsync(conn.Credential, UserPrincipalName!, MessageId!, Property);
+                foreach (var att in attachments) {
+                    WriteObject(att);
+                }
+            } catch (GraphApiException ex) {
+                WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
             }
         } else {
             var query = new Dictionary<string, object>();

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
@@ -72,7 +72,11 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     /// </summary>
     /// <param name="cred">Credential used to access Graph.</param>
     private async Task ProcessGraphAsync(GraphCredential cred) {
-        await MicrosoftGraphUtils.MoveMailMessageAsync(cred, UserPrincipalName!, MessageId!, DestinationFolderId!);
+        try {
+            await MicrosoftGraphUtils.MoveMailMessageAsync(cred, UserPrincipalName!, MessageId!, DestinationFolderId!);
+        } catch (GraphApiException ex) {
+            WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+        }
     }
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -1,5 +1,6 @@
 ﻿using System.Management.Automation;
 using System.IO;
+using Mailozaurr;
 
 namespace Mailozaurr.PowerShell;
 
@@ -718,19 +719,26 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
 
         NetworkCredential networkCredential = new NetworkCredential(Credential?.UserName, Credential?.Password);
         graph.Authenticate(networkCredential);
-        var status = graph.ConnectO365GraphAsync().GetAwaiter().GetResult();
-        if (!status.Status) {
+        try {
+            var status = graph.ConnectO365GraphAsync().GetAwaiter().GetResult();
+            if (!status.Status) {
+                if (!Suppress) {
+                    WriteObject(status);
+                }
+                LogEmitter.EmitLogs(graph.LogCollector, this);
+                return;
+            }
+
+            status = graph.IsLargerAttachment
+                ? graph.SendMessageDraftAsync().GetAwaiter().GetResult()
+                : graph.SendMessageAsync().GetAwaiter().GetResult();
             if (!Suppress) {
                 WriteObject(status);
             }
-            LogEmitter.EmitLogs(graph.LogCollector, this);
-            return;
+        } catch (GraphApiException ex) {
+            WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
         }
 
-        status = graph.IsLargerAttachment ? graph.SendMessageDraftAsync().GetAwaiter().GetResult() : graph.SendMessageAsync().GetAwaiter().GetResult();
-        if (!Suppress) {
-            WriteObject(status);
-        }
         LogEmitter.EmitLogs(graph.LogCollector, this);
     }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
@@ -71,7 +71,11 @@ public class CmdletSetGraphMessage : AsyncPSCmdlet {
     /// </summary>
     /// <param name="cred">Credential used to access Graph.</param>
     private async Task ProcessGraphAsync(GraphCredential cred) {
-        await MicrosoftGraphUtils.SetMailMessageAsync(cred, UserPrincipalName!, MessageId!, Read.IsPresent);
+        try {
+            await MicrosoftGraphUtils.SetMailMessageAsync(cred, UserPrincipalName!, MessageId!, Read.IsPresent);
+        } catch (GraphApiException ex) {
+            WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+        }
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -404,7 +404,7 @@ public class Graph : IDisposable {
                 var errorMessage = (error == null || error.Error == null || error.Error.InnerError == null)
                     ? $"Unknown error: {content}"
                     : $"Error code: {error.Error.Code}, message: {error.Error.Message}, request ID: {error.Error.InnerError.RequestId}, date: {error.Error.InnerError.Date}";
-                throw new HttpRequestException(errorMessage);
+                throw new GraphApiException(response.StatusCode, errorMessage, content);
             } catch (TaskCanceledException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Sending via Graph API cancelled: {ex.Message}");
@@ -522,7 +522,7 @@ public class Graph : IDisposable {
         var sendErrorMessage = (sendError == null || sendError.Error == null || sendError.Error.InnerError == null)
             ? $"Unknown error: {sendContent}"
             : $"Error code: {sendError.Error.Code}, message: {sendError.Error.Message}, request ID: {sendError.Error.InnerError.RequestId}, date: {sendError.Error.InnerError.Date}";
-        var ex = new HttpRequestException(sendErrorMessage);
+        var ex = new GraphApiException(sendResponse.StatusCode, sendErrorMessage, sendContent);
         var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, sendContent, ex.Message);
         await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
         throw ex;
@@ -564,7 +564,7 @@ public class Graph : IDisposable {
             var errorMessage = (error == null || error.Error == null)
                 ? $"Unknown error: {draftContent}"
                 : $"Error code: {error.Error.Code}, message: {error.Error.Message}";
-            throw new HttpRequestException(errorMessage);
+            throw new GraphApiException(draftResponse.StatusCode, errorMessage, draftContent);
         }
 
         // Deserialize the draft message

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiException.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiException.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Net;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Exception thrown when Microsoft Graph API returns an error.
+/// </summary>
+public class GraphApiException : Exception {
+    /// <summary>
+    /// HTTP status code returned by the Graph API.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// Raw response content returned by the Graph API.
+    /// </summary>
+    public string ResponseContent { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GraphApiException"/> class.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <param name="message">The error message.</param>
+    /// <param name="responseContent">Raw response content from the server.</param>
+    public GraphApiException(HttpStatusCode statusCode, string message, string responseContent)
+        : base(message) {
+        StatusCode = statusCode;
+        ResponseContent = responseContent;
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -90,11 +90,13 @@ namespace Mailozaurr {
             var content = new FormUrlEncodedContent(body);
             var url = $"https://login.microsoftonline.com/{tenantDomain}/oauth2/token";
             using var response = await HttpClient.PostAsync(url, content);
-            if (!response.IsSuccessStatusCode) {
-                var error = await response.Content.ReadAsStringAsync();
-                throw new Exception($"ConnectO365GraphAsync - Error: {error}");
-            }
             var json = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode) {
+                throw new GraphApiException(
+                    response.StatusCode,
+                    $"ConnectO365GraphAsync - Error: {json}",
+                    json);
+            }
             var token = System.Text.Json.JsonDocument.Parse(json);
             var accessToken = token.RootElement.GetProperty("access_token").GetString();
             var tokenType = token.RootElement.GetProperty("token_type").GetString();
@@ -191,7 +193,10 @@ namespace Mailozaurr {
             using var response = await HttpClient.SendAsync(request);
             var responseContent = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode) {
-                throw new Exception($"InvokeGraphApiAsync - Error: {response.StatusCode} - {responseContent}");
+                throw new GraphApiException(
+                    response.StatusCode,
+                    $"InvokeGraphApiAsync - Error: {response.StatusCode} - {responseContent}",
+                    responseContent);
             }
             return JsonDocument.Parse(responseContent);
         }


### PR DESCRIPTION
## Summary
- add `GraphApiException`
- throw `GraphApiException` in Graph API helpers
- catch Graph API errors in PowerShell cmdlets and emit `Write-Error`

## Testing
- `dotnet restore Sources/Mailozaurr/Mailozaurr.csproj` *(fails: NuGet config)*
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj --no-restore` *(fails: unresolved packages)*
- `pwsh -NoLogo -File run-tests.ps1` *(fails: compiled module not found)*

------
https://chatgpt.com/codex/tasks/task_e_686191754414832ebb2932a51b93ea3a