### PR TITLE
Add timeout and retry options for Graph operations

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -67,6 +67,9 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     [Parameter]
     public double RetryDelayBackoff { get; set; } = 1.0;
 
+    [Parameter]
+    public int TimeoutSeconds { get; set; } = 100;
+
     protected override async Task ProcessRecordAsync() {
         GraphCredential cred;
         if (ParameterSetName == "Credential") {
@@ -102,6 +105,7 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
         }
 
         bool connected = false;
+        MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
         try {
             var token = await MicrosoftGraphUtils.ConnectO365GraphWithRetryAsync(
                 cred,

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphFolder.cs
@@ -42,6 +42,15 @@ public class CmdletGetEmailGraphFolder : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    [Parameter]
+    public int TimeoutSeconds { get; set; } = 100;
+
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
     /// <summary>
     /// Retrieves mail folders for the specified user via Microsoft Graph API.
     /// </summary>
@@ -60,13 +69,35 @@ public class CmdletGetEmailGraphFolder : AsyncPSCmdlet {
     }
 
     private async Task ProcessGraphAsync(GraphCredential cred) {
-        try {
-            var folders = await MicrosoftGraphUtils.GetMailFoldersAsync(cred, UserPrincipalName!);
-            foreach (var folder in folders) {
-                WriteObject(folder);
+        MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            try {
+                var folders = await MicrosoftGraphUtils.GetMailFoldersAsync(cred, UserPrincipalName!);
+                foreach (var folder in folders) {
+                    WriteObject(folder);
+                }
+                return;
+            } catch (Exception ex) {
+                lastException = ex;
+                WriteWarning($"Get-EmailGraphFolder - {ex.Message}");
+                if (!Helpers.IsTransient(ex) || attempts >= RetryCount) {
+                    if (ex is GraphApiException gex) {
+                        WriteError(new ErrorRecord(gex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+                    } else {
+                        WriteError(new ErrorRecord(ex, "GraphError", ErrorCategory.InvalidOperation, null));
+                    }
+                    return;
+                }
+                if (RetryDelayMilliseconds > 0) {
+                    await Task.Delay(RetryDelayMilliseconds);
+                }
             }
-        } catch (GraphApiException ex) {
-            WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+            attempts++;
+        } while (attempts <= RetryCount);
+        if (lastException is not null) {
+            WriteError(new ErrorRecord(lastException, "GraphError", ErrorCategory.InvalidOperation, null));
         }
     }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
@@ -70,6 +70,15 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    [Parameter]
+    public int TimeoutSeconds { get; set; } = 100;
+
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
     protected override Task ProcessRecordAsync() {
         if (ParameterSetName == "MgGraphRequest") {
             return ProcessMgGraph();
@@ -85,23 +94,45 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     }
 
     private async Task ProcessGraphAsync(GraphCredential cred) {
-        try {
-            var filter = BuildFilter(Filter);
-            var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(
-                cred,
-                UserPrincipalName!,
-                Property,
-                filter,
-                Limit);
+        MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            try {
+                var filter = BuildFilter(Filter);
+                var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(
+                    cred,
+                    UserPrincipalName!,
+                    Property,
+                    filter,
+                    Limit);
 
-            foreach (var msg in messages) {
-                WriteObject(PSObject.AsPSObject(msg));
-                if (Delete.IsPresent && msg.TryGetValue("id", out var idObj) && idObj is string id) {
-                    await MicrosoftGraphUtils.DeleteMailMessageAsync(cred, UserPrincipalName!, id);
+                foreach (var msg in messages) {
+                    WriteObject(PSObject.AsPSObject(msg));
+                    if (Delete.IsPresent && msg.TryGetValue("id", out var idObj) && idObj is string id) {
+                        await MicrosoftGraphUtils.DeleteMailMessageAsync(cred, UserPrincipalName!, id);
+                    }
+                }
+                return;
+            } catch (Exception ex) {
+                lastException = ex;
+                WriteWarning($"Get-EmailGraphMessage - {ex.Message}");
+                if (!Helpers.IsTransient(ex) || attempts >= RetryCount) {
+                    if (ex is GraphApiException gex) {
+                        WriteError(new ErrorRecord(gex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+                    } else {
+                        WriteError(new ErrorRecord(ex, "GraphError", ErrorCategory.InvalidOperation, null));
+                    }
+                    return;
+                }
+                if (RetryDelayMilliseconds > 0) {
+                    await Task.Delay(RetryDelayMilliseconds);
                 }
             }
-        } catch (GraphApiException ex) {
-            WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+            attempts++;
+        } while (attempts <= RetryCount);
+        if (lastException is not null) {
+            WriteError(new ErrorRecord(lastException, "GraphError", ErrorCategory.InvalidOperation, null));
         }
     }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessageAttachment.cs
@@ -43,6 +43,15 @@ public class CmdletGetEmailGraphMessageAttachment : AsyncPSCmdlet {
 
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
+
+    [Parameter]
+    public int TimeoutSeconds { get; set; } = 100;
+
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
     /// <summary>
     /// <para type="description">Specifies the properties to retrieve for each attachment.</para>
     /// </summary>
@@ -60,13 +69,35 @@ public class CmdletGetEmailGraphMessageAttachment : AsyncPSCmdlet {
                 WriteWarning("Get-EmailGraphMessageAttachment - Connection not provided and no default session available.");
                 return;
             }
-            try {
-                var attachments = await MicrosoftGraphUtils.GetMailMessageAttachmentsAsync(conn.Credential, UserPrincipalName!, MessageId!, Property);
-                foreach (var att in attachments) {
-                    WriteObject(att);
+            MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+            int attempts = 0;
+            Exception? lastException = null;
+            do {
+                try {
+                    var attachments = await MicrosoftGraphUtils.GetMailMessageAttachmentsAsync(conn.Credential, UserPrincipalName!, MessageId!, Property);
+                    foreach (var att in attachments) {
+                        WriteObject(att);
+                    }
+                    return;
+                } catch (Exception ex) {
+                    lastException = ex;
+                    WriteWarning($"Get-EmailGraphMessageAttachment - {ex.Message}");
+                    if (!Helpers.IsTransient(ex) || attempts >= RetryCount) {
+                        if (ex is GraphApiException gex) {
+                            WriteError(new ErrorRecord(gex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+                        } else {
+                            WriteError(new ErrorRecord(ex, "GraphError", ErrorCategory.InvalidOperation, null));
+                        }
+                        return;
+                    }
+                    if (RetryDelayMilliseconds > 0) {
+                        await Task.Delay(RetryDelayMilliseconds);
+                    }
                 }
-            } catch (GraphApiException ex) {
-                WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+                attempts++;
+            } while (attempts <= RetryCount);
+            if (lastException is not null) {
+                WriteError(new ErrorRecord(lastException, "GraphError", ErrorCategory.InvalidOperation, null));
             }
         } else {
             var query = new Dictionary<string, object>();

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
@@ -46,6 +46,15 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    [Parameter]
+    public int TimeoutSeconds { get; set; } = 100;
+
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
     /// <summary>
     /// Processes the cmdlet invocation.
     /// </summary>
@@ -72,10 +81,32 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     /// </summary>
     /// <param name="cred">Credential used to access Graph.</param>
     private async Task ProcessGraphAsync(GraphCredential cred) {
-        try {
-            await MicrosoftGraphUtils.MoveMailMessageAsync(cred, UserPrincipalName!, MessageId!, DestinationFolderId!);
-        } catch (GraphApiException ex) {
-            WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+        MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            try {
+                await MicrosoftGraphUtils.MoveMailMessageAsync(cred, UserPrincipalName!, MessageId!, DestinationFolderId!);
+                return;
+            } catch (Exception ex) {
+                lastException = ex;
+                WriteWarning($"Move-GraphMessage - {ex.Message}");
+                if (!Helpers.IsTransient(ex) || attempts >= RetryCount) {
+                    if (ex is GraphApiException gex) {
+                        WriteError(new ErrorRecord(gex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+                    } else {
+                        WriteError(new ErrorRecord(ex, "GraphError", ErrorCategory.InvalidOperation, null));
+                    }
+                    return;
+                }
+                if (RetryDelayMilliseconds > 0) {
+                    await Task.Delay(RetryDelayMilliseconds);
+                }
+            }
+            attempts++;
+        } while (attempts <= RetryCount);
+        if (lastException is not null) {
+            WriteError(new ErrorRecord(lastException, "GraphError", ErrorCategory.InvalidOperation, null));
         }
     }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
@@ -45,6 +45,15 @@ public class CmdletSetGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    [Parameter]
+    public int TimeoutSeconds { get; set; } = 100;
+
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
     /// <summary>
     /// Processes the cmdlet invocation.
     /// </summary>
@@ -71,10 +80,32 @@ public class CmdletSetGraphMessage : AsyncPSCmdlet {
     /// </summary>
     /// <param name="cred">Credential used to access Graph.</param>
     private async Task ProcessGraphAsync(GraphCredential cred) {
-        try {
-            await MicrosoftGraphUtils.SetMailMessageAsync(cred, UserPrincipalName!, MessageId!, Read.IsPresent);
-        } catch (GraphApiException ex) {
-            WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+        MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            try {
+                await MicrosoftGraphUtils.SetMailMessageAsync(cred, UserPrincipalName!, MessageId!, Read.IsPresent);
+                return;
+            } catch (Exception ex) {
+                lastException = ex;
+                WriteWarning($"Set-GraphMessage - {ex.Message}");
+                if (!Helpers.IsTransient(ex) || attempts >= RetryCount) {
+                    if (ex is GraphApiException gex) {
+                        WriteError(new ErrorRecord(gex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+                    } else {
+                        WriteError(new ErrorRecord(ex, "GraphError", ErrorCategory.InvalidOperation, null));
+                    }
+                    return;
+                }
+                if (RetryDelayMilliseconds > 0) {
+                    await Task.Delay(RetryDelayMilliseconds);
+                }
+            }
+            attempts++;
+        } while (attempts <= RetryCount);
+        if (lastException is not null) {
+            WriteError(new ErrorRecord(lastException, "GraphError", ErrorCategory.InvalidOperation, null));
         }
     }
 

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -1,3 +1,4 @@
+using System;
 ﻿using System.Net.Http.Headers;
 using System.Threading;
 
@@ -120,6 +121,14 @@ public class Graph : IDisposable {
     public double RetryDelayBackoff { get; set; } = 1.0;
 
     /// <summary>
+    /// Timeout for HTTP operations in seconds.
+    /// </summary>
+    public int TimeoutSeconds {
+        get => (int)_client.Timeout.TotalSeconds;
+        set => _client.Timeout = TimeSpan.FromSeconds(value);
+    }
+
+    /// <summary>
     /// When enabled, scans the HTML body for local image references and embeds
     /// them as inline attachments.
     /// </summary>
@@ -187,6 +196,7 @@ public class Graph : IDisposable {
     public Graph() {
         Stopwatch = Stopwatch.StartNew();
         _client = new HttpClient();
+        _client.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
         if (LogCollector == null) LogCollector = new();
     }
 
@@ -641,6 +651,7 @@ public class Graph : IDisposable {
     public async Task<string> CreateUploadSession(GraphMessage draftMessage, string attachmentItemJson, CancellationToken cancellationToken = default) {
         var uploadSessionUrl = $"https://graph.microsoft.com/v1.0/users('{SentFrom}')/messages/{draftMessage.Id}/attachments/createUploadSession";
         using var client = new HttpClient();
+        client.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
         using var uploadSessionResponse = await client.PostAsync(uploadSessionUrl, new StringContent(attachmentItemJson, Encoding.UTF8, "application/json"), cancellationToken);
         var uploadSessionContent = await uploadSessionResponse.Content.ReadAsStringAsync();
@@ -737,6 +748,7 @@ public class Graph : IDisposable {
         };
         requestMessage.Headers.Add("AnchorMailbox", SentFrom); // This is correctly added to HttpRequestMessage
         using var client = new HttpClient();
+        client.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
         var uploadChunkResponse = await client.SendAsync(requestMessage, cancellationToken);
         if (!uploadChunkResponse.IsSuccessStatusCode) {
             // Handle upload error

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -16,8 +16,17 @@ namespace Mailozaurr {
         private static readonly HttpClient HttpClient;
         private static readonly ConcurrentDictionary<string, GraphAuthorization> TokenCache = new();
 
+        /// <summary>
+        /// Timeout for HTTP operations in seconds.
+        /// </summary>
+        public static int TimeoutSeconds {
+            get => (int)HttpClient.Timeout.TotalSeconds;
+            set => HttpClient.Timeout = TimeSpan.FromSeconds(value);
+        }
+
         static MicrosoftGraphUtils() {
             HttpClient = new HttpClient();
+            HttpClient.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
             AppDomain.CurrentDomain.ProcessExit += (_, _) => HttpClient.Dispose();
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- expose timeout options in MicrosoftGraphUtils and Graph
- add timeout/retry parameters to Graph-related cmdlets
- honor the timeout when making HTTP requests

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6863a4f4e208832ea9dcacbbad446d88