### PR TITLE
Fix cancellation token usage in PostWebhookAsync

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -66,5 +69,16 @@ public class HelpersTests
             .ToArray();
 
         Assert.Equal(new[] { " Test@example.com ", "other@example.com" }, result);
+    }
+
+    [Fact]
+    public async Task PostWebhookAsync_CancellationRequested_ThrowsAsync()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var result = new SmtpResult(true, EmailAction.Send, string.Empty, string.Empty, string.Empty, 0, TimeSpan.Zero);
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+            Mailozaurr.Helpers.PostWebhookAsync("http://localhost", result, cts.Token));
     }
 }

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -151,7 +151,7 @@ public static class Helpers {
             using var client = new HttpClient();
             var json = JsonSerializer.Serialize(result);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
-            using var response = await client.PostAsync(url, content);
+            using var response = await client.PostAsync(url, content, cancellationToken);
         } catch (HttpRequestException ex) {
             LoggingMessages.Logger.WriteWarning($"Failed to post webhook: {ex.Message}");
         }


### PR DESCRIPTION
## Summary
- flow cancellation token through `Helpers.PostWebhookAsync`
- add regression test ensuring cancellation is honored

## Testing
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_6863a5600d44832e90ffe3c11afd52aa