### PR TITLE
Add device code Graph example

### DIFF
--- a/Examples/Example-SendEmail-GraphDeviceCode.ps1
+++ b/Examples/Example-SendEmail-GraphDeviceCode.ps1
@@ -1,0 +1,15 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$ClientId = 'Your-Application-ID'
+$TenantId = 'Your-Tenant-ID'
+$Scopes = @('Mail.ReadWrite','Mail.Send')
+
+# Sign in interactively using device code
+$graph = Connect-EmailGraph -ClientId $ClientId -DirectoryId $TenantId -DeviceCode -Scopes $Scopes
+
+$Body = EmailBody {
+    EmailText -Text 'Hello from device code authentication!'
+} -Online
+
+Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' \
+    -Subject 'Device Code Graph Test' -HTML $Body -Graph -Verbose

--- a/README.MD
+++ b/README.MD
@@ -176,6 +176,7 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - [Example-GetMailFolder.ps1](Examples/Example-GetMailFolder.ps1) - list folders using either `-Connection` or `-MgGraphRequest`.
 - [Example-ConnectEmailGraph-DeviceCode.ps1](Examples/Example-ConnectEmailGraph-DeviceCode.ps1) - authenticate with device code.
 - [Example-ConnectEmailGraph-OnBehalfOf.ps1](Examples/Example-ConnectEmailGraph-OnBehalfOf.ps1) - exchange a user token for Graph access.
+- [Example-SendEmail-GraphDeviceCode.ps1](Examples/Example-SendEmail-GraphDeviceCode.ps1) - interactive device code sign-in and send an email.
 - [Example-SendEmail-GraphWithMgRequest.ps1](Examples/Example-SendEmail-GraphWithMgRequest.ps1) - send mail using Connect-MgGraph and the `-MgGraphRequest` switch.
 - Use `Connect-EmailGraph` and `Disconnect-EmailGraph` to authenticate and release application credentials for Microsoft Graph. The connection cmdlet supports both client secret and certificate authentication modes.
 - `Connect-EmailGraph`, `Connect-IMAP` and `Connect-POP3` store the last successful connection in module variables. Subsequent cmdlets use these defaults when `-Connection` or `-Client` is omitted.


### PR DESCRIPTION
## Summary
- add Example-SendEmail-GraphDeviceCode.ps1 with interactive device code login and email send
- reference the new example in README

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68643cee0428832eb6af15c51222f347