### PR TITLE
Fix OAuth example params

### DIFF
--- a/Examples/Example-ConnecToImap-03-oAuth.ps1
+++ b/Examples/Example-ConnecToImap-03-oAuth.ps1
@@ -3,10 +3,11 @@ Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 $ClientID = '9393330741'
 $ClientSecret = 'gk2ztAGU'
 
-$oAuth2 = Connect-oAuthGoogle -ClientID $ClientID -ClientSecret $ClientSecret -GmailAccount 'evotectest@gmail.com' -Scope https://mail.google.com/
-$Client = Connect-IMAP -Server 'imap.gmail.com' -Port 993 -Options Auto -Credential $oAuth2 -oAuth2
+$oAuth2 = Connect-OAuthGoogle -ClientID $ClientID -ClientSecret $ClientSecret -GmailAccount 'evotectest@gmail.com' -Scope https://mail.google.com/
+$Client = Connect-IMAP -Server 'imap.gmail.com' -Port 993 -Options Auto -Credential $oAuth2 -OAuth2
 
 Get-IMAPFolder -Client $Client -Verbose
 Get-IMAPMessage -Client $Client -All -Delete
 
 Disconnect-IMAP -Client $Client -Verbose
+

--- a/Examples/Example-ConnecToPop3-03-oAuth.ps1
+++ b/Examples/Example-ConnecToPop3-03-oAuth.ps1
@@ -3,9 +3,10 @@ Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 $ClientID = '93933307418'
 $ClientSecret = 'gk2ztAG'
 
-$oAuth2 = Connect-oAuthGoogle -ClientID $ClientID -ClientSecret $ClientSecret -GmailAccount 'email@gmail.com' -Scope https://mail.google.com/
-$Client = Connect-POP3 -Server 'pop.gmail.com' -Credential $oAuth2 -Port 995 -Options Auto -oAuth2
+$oAuth2 = Connect-OAuthGoogle -ClientID $ClientID -ClientSecret $ClientSecret -GmailAccount 'email@gmail.com' -Scope https://mail.google.com/
+$Client = Connect-POP3 -Server 'pop.gmail.com' -Credential $oAuth2 -Port 995 -Options Auto -OAuth2
 Get-POP3Message -Client $Client -ToContains 'sales@example.com' -HasAttachment | Format-Table
 Save-POP3Message -Client $Client -Index 7 -Path "$Env:UserProfile\Desktop\mail7.eml"
 Save-POP3Message -Client $Client -Index 7 -Path "$Env:UserProfile\Desktop\mail7.msg"
 Disconnect-POP3 -Client $Client -Verbose
+

--- a/Examples/Example-SendEmail-OAuthGmail.ps1
+++ b/Examples/Example-SendEmail-OAuthGmail.ps1
@@ -3,8 +3,9 @@ Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 $ClientID = '939333074185'
 $ClientSecret = 'gk2ztAGU'
 
-$CredentialOAuth2 = Connect-oAuthGoogle -ClientID $ClientID -ClientSecret $ClientSecret -GmailAccount 'evot@gmail.com'
+$CredentialOAuth2 = Connect-OAuthGoogle -ClientID $ClientID -ClientSecret $ClientSecret -GmailAccount 'evot@gmail.com'
 
 Send-EmailMessage -From @{ Name = 'Przemysław Kłys'; Email = 'evot@gmail.com' } -To 'test@evotec.pl' `
     -Server 'smtp.gmail.com' -HTML $Body -Text $Text -DeliveryNotificationOption OnSuccess -Priority High `
-    -Subject 'This is another test email' -SecureSocketOptions Auto -Credential $CredentialOAuth2 -oAuth
+    -Subject 'This is another test email' -SecureSocketOptions Auto -Credential $CredentialOAuth2 -OAuth2
+

--- a/Examples/Example-SendEmail-OAuthO365.ps1
+++ b/Examples/Example-SendEmail-OAuthO365.ps1
@@ -3,8 +3,9 @@ Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 $ClientID = '4c1197dd-53'
 $TenantID = 'ceb371f6-87'
 
-$CredentialOAuth2 = Connect-oAuthO365 -ClientID $ClientID -TenantID $TenantID
+$CredentialOAuth2 = Connect-OAuthO365 -ClientID $ClientID -TenantID $TenantID
 
 Send-EmailMessage -From @{ Name = 'Przemysław Kłys'; Email = 'test@evotec.pl' } -To 'test@evotec.pl' `
     -Server 'smtp.office365.com' -HTML $Body -Text $Text -DeliveryNotificationOption OnSuccess -Priority High `
-    -Subject 'This is another test email' -SecureSocketOptions Auto -Credential $CredentialOAuth2 -oAuth2
+    -Subject 'This is another test email' -SecureSocketOptions Auto -Credential $CredentialOAuth2 -OAuth2
+

--- a/README.MD
+++ b/README.MD
@@ -172,6 +172,8 @@ While I didn't spent much time creating WIKI, working on Get-Help documentation,
 You can also utilize Examples which should help to understand use cases. Of course it would be great having pretty help so if you can help me out feel free to submit PR's.
 - [Example-SendEmail-SignEncrypt.ps1](Examples/Example-SendEmail-SignEncrypt.ps1) - sign and encrypt an email using SMTP.
 - [Example-SendEmail-Pgp.ps1](Examples/Example-SendEmail-Pgp.ps1) - send a PGP encrypted email.
+- [Example-SendEmail-OAuthGmail.ps1](Examples/Example-SendEmail-OAuthGmail.ps1) - send mail through Gmail using OAuth2.
+- [Example-SendEmail-OAuthO365.ps1](Examples/Example-SendEmail-OAuthO365.ps1) - send mail through Office 365 using OAuth2.
 - [Example-GraphManageMessages.ps1](Examples/Example-GraphManageMessages.ps1) - download attachments, set read state and move messages using Microsoft Graph.
 - [Example-GetMailFolder.ps1](Examples/Example-GetMailFolder.ps1) - list folders using either `-Connection` or `-MgGraphRequest`.
 - [Example-ConnectEmailGraph-DeviceCode.ps1](Examples/Example-ConnectEmailGraph-DeviceCode.ps1) - authenticate with device code.


### PR DESCRIPTION
## Summary
- fix parameter names in OAuth example scripts
- mention OAuth Gmail and Office365 examples in README

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `pwsh -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: Send-EmailMessage cmdlet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643cba6e5c832eb3ae8a30ce4c973e