### PR TITLE
Fix temp dir collisions in PGP context

### DIFF
--- a/Sources/Mailozaurr.Tests/EphemeralOpenPgpContextTests.cs
+++ b/Sources/Mailozaurr.Tests/EphemeralOpenPgpContextTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class EphemeralOpenPgpContextTests
+{
+    [Fact]
+    public async Task CreateTempDirectories_AreUniqueAcrossThreads()
+    {
+        const int count = 20;
+        var bag = new ConcurrentBag<string>();
+        var field = typeof(EphemeralOpenPgpContext).GetField("_tempDirectory", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        var tasks = Enumerable.Range(0, count).Select(_ => Task.Run(() =>
+        {
+            using var ctx = new EphemeralOpenPgpContext();
+            var dir = (string)field.GetValue(ctx)!;
+            bag.Add(dir);
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(count, bag.Distinct(StringComparer.Ordinal).Count());
+        foreach (var dir in bag)
+        {
+            Assert.False(Directory.Exists(dir));
+        }
+    }
+}

--- a/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
+++ b/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
@@ -9,7 +9,7 @@ namespace Mailozaurr;
 /// Provides a <see cref="GnuPGContext"/> that stores keys in a temporary
 /// directory which gets removed when the instance is disposed.
 /// </summary>
-public class EphemeralOpenPgpContext : GnuPGContext {
+public class EphemeralOpenPgpContext : GnuPGContext, IDisposable {
     private readonly string? _password;
     private readonly string _tempDirectory;
 
@@ -28,9 +28,19 @@ public class EphemeralOpenPgpContext : GnuPGContext {
     /// <param name="path">The generated directory path.</param>
     /// <returns>The created path.</returns>
     private static string CreateTempDirectory(out string path) {
-        path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Directory.CreateDirectory(path);
-        return path;
+        var temp = Path.GetTempPath();
+        while (true) {
+            path = Path.Combine(temp, Path.GetRandomFileName());
+            try {
+                using var fs = new FileStream(path, FileMode.CreateNew);
+                fs.Close();
+                File.Delete(path);
+                Directory.CreateDirectory(path);
+                return path;
+            } catch (IOException) {
+                // Collision occurred, retry with a new path
+            }
+        }
     }
 
     /// <summary>
@@ -55,4 +65,5 @@ public class EphemeralOpenPgpContext : GnuPGContext {
             LoggingMessages.Logger.WriteWarning($"Failed to delete temporary directory due to unauthorized access: {ex.Message}");
         }
     }
+    void IDisposable.Dispose() => Dispose();
 }


### PR DESCRIPTION
## Summary
- ensure `EphemeralOpenPgpContext` repeatedly generates a unique temp directory
- implement `IDisposable` so the custom cleanup runs when disposed
- add multithreaded test verifying unique temp directories are created and cleaned up

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68643cc0bd54832e8b5b8855eb8613a3