### PR TITLE
Add wildcard support for Send-EmailMessage attachments

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -1049,6 +1049,21 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             };
 
             if (path != null) {
+                if (path.IndexOfAny(new[] { '*', '?' }) >= 0) {
+                    string directory = Path.GetDirectoryName(path) ?? Directory.GetCurrentDirectory();
+                    string pattern = Path.GetFileName(path);
+                    int startCount = valid.Count;
+                    foreach (var file in Directory.GetFiles(directory, pattern)) {
+                        if (File.Exists(file)) {
+                            valid.Add(new FileInfo(file));
+                        }
+                    }
+                    if (valid.Count == startCount) {
+                        WriteWarning($"Send-EmailMessage - No files found for wildcard pattern: {path}. Removing from '{parameterName}'.");
+                    }
+                    continue;
+                }
+
                 if (!File.Exists(path)) {
                     WriteWarning($"Send-EmailMessage - File not found: {path}. Removing from '{parameterName}'.");
                     continue;

--- a/Tests/Send-EmailMessage.WildcardAttachment.Tests.ps1
+++ b/Tests/Send-EmailMessage.WildcardAttachment.Tests.ps1
@@ -1,0 +1,18 @@
+Describe 'Send-EmailMessage - Wildcard Attachments' {
+    It 'Expands wildcard file patterns' {
+        $dir = Join-Path $TestDrive 'wc'
+        New-Item -ItemType Directory -Path $dir | Out-Null
+        $f1 = Join-Path $dir 'file1.txt'
+        $f2 = Join-Path $dir 'file2.txt'
+        'a' | Set-Content -Path $f1
+        'b' | Set-Content -Path $f2
+
+        $cmdlet = [Mailozaurr.PowerShell.CmdletSendEmailMessage]::new()
+        $method = $cmdlet.GetType().GetMethod('FilterExistingPaths', [System.Reflection.BindingFlags] 'NonPublic, Instance')
+        $result = $method.Invoke($cmdlet, @([object[]]@("$dir/*.txt"), 'Attachment'))
+
+        $result.Count | Should -Be 2
+        ($result | ForEach-Object { $_.FullName }) | Should -Contain $f1
+        ($result | ForEach-Object { $_.FullName }) | Should -Contain $f2
+    }
+}


### PR DESCRIPTION
## Summary
- expand Send-EmailMessage `-Attachment` paths that contain wildcards
- test wildcard attachment expansion

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj --configuration Debug`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68643d1882b0832eaabfcafbe029615f