### PR TITLE
Add Amazon SES client without AWS SDK

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -89,6 +89,7 @@ This will make sure the project has required libraries.
   - [x] SMTP with oAuth2 Google Mail
   - [x] SMTP with SendGrid
   - [x] SendGrid API
+  - [x] Amazon SES API
   - [x] Office 365 Graph API
   - [x] PGP/MIME encryption and signature verification
   - Optional retry logic for `Send-EmailMessage` via `-RetryCount`, `-RetryDelayMilliseconds`, `-RetryDelayBackoff` and `-RetryAlways`.  Retries are only attempted for transient errors by default, but `-RetryAlways` forces retries on all errors.

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -329,6 +329,12 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     public SwitchParameter RetryAlways { get; set; }
 
     /// <summary>
+    /// <para>Specifies the AWS region when using the SES provider.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "EmailProviders")]
+    public string? Region { get; set; }
+
+    /// <summary>
     /// <para>Specifies chunk size in bytes used for Graph attachment uploads. Default is 9MB.</para>
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "Graph")]
@@ -605,6 +611,8 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             ProcessSendGrid(fromEmail, fromName);
         } else if (EmailProvider == EmailProvider.Mailgun) {
             ProcessMailgun(fromEmail, fromName);
+        } else if (EmailProvider == EmailProvider.SES) {
+            ProcessSes(fromEmail, fromName);
         } else if (Graph) {
             ProcessGraph(fromEmail, fromName);
         } else if (MgGraphRequest) {
@@ -683,6 +691,43 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             }
         } else if (!Suppress) {
             WriteObject(new SmtpResult(false, EmailAction.Send, mailgun.SentTo, mailgun.SentFrom, "MailgunApi", 0, mailgun.Stopwatch.Elapsed, "", "Email not sent (WhatIf)"));
+        }
+    }
+
+    private void ProcessSes(string? fromEmail, string? fromName) {
+        var logCollector = new LogCollector();
+        using SesClient ses = new SesClient();
+        ses.LogCollector = logCollector;
+        ses.From = Helpers.GetFromObject(fromEmail, fromName);
+        if (Bcc != null) ses.Bcc = Bcc.ToList();
+        if (Cc != null) ses.Cc = Cc.ToList();
+        if (To != null) ses.To = To.ToList();
+        ses.ReplyTo = ReplyTo;
+        ses.Subject = Subject;
+        if (Text != null) ses.Text = string.Join("", Text);
+        if (HTML != null) ses.Html = string.Join("", HTML);
+        if (Attachment != null) {
+            ses.Attachment = Attachment.Select(a => a?.ToString() ?? string.Empty).ToArray();
+        }
+        if (InlineAttachment != null) {
+            ses.InlineAttachment = InlineAttachment.Select(a => a?.ToString() ?? string.Empty).ToArray();
+        }
+        ses.ErrorAction = errorAction;
+        ses.RetryCount = RetryCount;
+        ses.RetryDelayMilliseconds = RetryDelayMilliseconds;
+        ses.RetryDelayBackoff = RetryDelayBackoff;
+        ses.RetryAlways = RetryAlways.IsPresent;
+        if (!string.IsNullOrEmpty(Region)) ses.Region = Region;
+        NetworkCredential networkCredential = new NetworkCredential(Credential?.UserName, Credential?.Password);
+        ses.Credentials = networkCredential;
+        if (ShouldProcess(ses.SentTo, "Sending email message via SES")) {
+            var result = ses.SendEmailAsync().GetAwaiter().GetResult();
+            LogEmitter.EmitLogs(logCollector, this);
+            if (!Suppress) {
+                WriteObject(result);
+            }
+        } else if (!Suppress) {
+            WriteObject(new SmtpResult(false, EmailAction.Send, ses.SentTo, ses.SentFrom, "SESApi", 0, ses.Stopwatch.Elapsed, "", "Email not sent (WhatIf)"));
         }
     }
 

--- a/Sources/Mailozaurr.Tests/SesClientTests.cs
+++ b/Sources/Mailozaurr.Tests/SesClientTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using MimeKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SesClientTests
+{
+    [Fact]
+    public void BuildMessage_WithValidData_ReturnsMimeMessage()
+    {
+        using var client = new SesClient
+        {
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            Subject = "subject",
+            Text = "text"
+        };
+        MethodInfo? method = typeof(SesClient).GetMethod("BuildMessage", BindingFlags.NonPublic | BindingFlags.Instance);
+        var msg = method!.Invoke(client, null) as MimeMessage;
+        Assert.NotNull(msg);
+        Assert.Equal("subject", msg!.Subject);
+        Assert.Contains("to@example.com", msg.To.ToString());
+    }
+}

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -1,0 +1,183 @@
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Simple client for sending emails using the Amazon SES REST API.
+/// </summary>
+public class SesClient : IDisposable
+{
+    private readonly HttpClient _client;
+    public readonly Stopwatch Stopwatch;
+
+    public ICredentials Credentials { get; set; } = CredentialCache.DefaultNetworkCredentials;
+    public ActionPreference? ErrorAction { get; set; }
+
+    public List<object> To { get; set; } = new();
+    public List<object> Cc { get; set; } = new();
+    public List<object> Bcc { get; set; } = new();
+    public object From { get; set; } = string.Empty;
+    public object? ReplyTo { get; set; }
+    public string? Subject { get; set; }
+    public string Text { get; set; } = string.Empty;
+    public string Html { get; set; } = string.Empty;
+    public string[]? Attachment { get; set; }
+    public string[]? InlineAttachment { get; set; }
+
+    public int RetryCount { get; set; } = 0;
+    public int RetryDelayMilliseconds { get; set; } = 0;
+    public double RetryDelayBackoff { get; set; } = 1.0;
+    public bool RetryAlways { get; set; } = false;
+
+    public string Region { get; set; } = "us-east-1";
+    public string? WebhookUrl { get; set; }
+
+    public LogCollector LogCollector { get; set; } = new();
+
+    public string SentFrom => Helpers.GetEmailAddress(From);
+    public string SentTo
+    {
+        get
+        {
+            HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+            List<string> addresses = new();
+            if (To != null) addresses.AddRange(Helpers.UniqueAddresses(To, seen).Select(Helpers.GetEmailAddress));
+            if (Cc != null) addresses.AddRange(Helpers.UniqueAddresses(Cc, seen).Select(Helpers.GetEmailAddress));
+            if (Bcc != null) addresses.AddRange(Helpers.UniqueAddresses(Bcc, seen).Select(Helpers.GetEmailAddress));
+            return string.Join(",", addresses);
+        }
+    }
+
+    public SesClient()
+    {
+        Stopwatch = Stopwatch.StartNew();
+        _client = new HttpClient();
+    }
+
+    private MimeMessage BuildMessage()
+    {
+        Smtp smtp = new();
+        smtp.From = From;
+        smtp.To = To;
+        smtp.Cc = Cc;
+        smtp.Bcc = Bcc;
+        smtp.ReplyTo = ReplyTo;
+        smtp.Subject = Subject ?? string.Empty;
+        smtp.TextBody = Text;
+        smtp.HtmlBody = Html;
+        if (Attachment != null) smtp.Attachments = Attachment.ToList<object>();
+        if (InlineAttachment != null) smtp.InlineAttachments = InlineAttachment.ToList<object>();
+        smtp.CreateMessage();
+        return smtp.Message;
+    }
+
+    private static byte[] HmacSha256(byte[] key, string data)
+    {
+        using HMACSHA256 hmac = new(key);
+        return hmac.ComputeHash(Encoding.UTF8.GetBytes(data));
+    }
+
+    private static string Sha256Hex(string data)
+    {
+        using SHA256 sha = SHA256.Create();
+        byte[] hash = sha.ComputeHash(Encoding.UTF8.GetBytes(data));
+        return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+    }
+
+    private HttpRequestMessage CreateRequest(string content, DateTime utcNow)
+    {
+        NetworkCredential net = Credentials as NetworkCredential ?? throw new InvalidCastException("Credentials must be NetworkCredential");
+        string accessKey = net.UserName;
+        string secretKey = net.Password;
+        string service = "ses";
+        string region = Region;
+        string amzDate = utcNow.ToString("yyyyMMdd'T'HHmmss'Z'");
+        string dateStamp = utcNow.ToString("yyyyMMdd");
+        string canonicalHeaders = $"content-type:application/x-www-form-urlencoded\nhost:email.{region}.amazonaws.com\nx-amz-date:{amzDate}\n";
+        string signedHeaders = "content-type;host;x-amz-date";
+        string payloadHash = Sha256Hex(content);
+        string canonicalRequest = $"POST\n/\n\n{canonicalHeaders}\n{signedHeaders}\n{payloadHash}";
+        string credentialScope = $"{dateStamp}/{region}/{service}/aws4_request";
+        string stringToSign = $"AWS4-HMAC-SHA256\n{amzDate}\n{credentialScope}\n{Sha256Hex(canonicalRequest)}";
+        byte[] kDate = HmacSha256(Encoding.UTF8.GetBytes("AWS4" + secretKey), dateStamp);
+        byte[] kRegion = HmacSha256(kDate, region);
+        byte[] kService = HmacSha256(kRegion, service);
+        byte[] kSigning = HmacSha256(kService, "aws4_request");
+        byte[] sigBytes = HmacSha256(kSigning, stringToSign);
+        string signature = BitConverter.ToString(sigBytes).Replace("-", string.Empty).ToLowerInvariant();
+        string authorization = $"AWS4-HMAC-SHA256 Credential={accessKey}/{credentialScope}, SignedHeaders={signedHeaders}, Signature={signature}";
+
+        HttpRequestMessage request = new(HttpMethod.Post, $"https://email.{region}.amazonaws.com/");
+        request.Content = new StringContent(content, Encoding.UTF8, "application/x-www-form-urlencoded");
+        request.Headers.TryAddWithoutValidation("x-amz-date", amzDate);
+        request.Headers.TryAddWithoutValidation("Authorization", authorization);
+        return request;
+    }
+
+    /// <summary>
+    /// Sends the email using Amazon SES.
+    /// </summary>
+    public async Task<SmtpResult> SendEmailAsync(CancellationToken cancellationToken = default)
+    {
+        int attempts = 0;
+        Exception? lastException = null;
+        MimeMessage message = BuildMessage();
+        using MemoryStream stream = new();
+        await message.WriteToAsync(stream, cancellationToken);
+        string raw = Convert.ToBase64String(stream.ToArray());
+        string body = $"Action=SendRawEmail&RawMessage.Data={Uri.EscapeDataString(raw)}&Version=2010-12-01";
+        do
+        {
+            try
+            {
+                using HttpRequestMessage request = CreateRequest(body, DateTime.UtcNow);
+                HttpResponseMessage response = await _client.SendAsync(request, cancellationToken);
+                string respContent = await response.Content.ReadAsStringAsync();
+                if (response.IsSuccessStatusCode)
+                {
+                    SmtpResult ok = new(true, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString());
+                    await Helpers.PostWebhookAsync(WebhookUrl, ok, cancellationToken);
+                    return ok;
+                }
+
+                lastException = new HttpRequestException(respContent);
+                LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SES: {respContent}");
+            }
+            catch (HttpRequestException ex)
+            {
+                lastException = ex;
+                LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SES: {ex.Message}");
+            }
+
+            if ((!Helpers.IsTransient(lastException) && !RetryAlways) || attempts >= RetryCount)
+            {
+                if (ErrorAction == ActionPreference.Stop && lastException != null)
+                {
+                    throw lastException;
+                }
+                SmtpResult fail = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message);
+                await Helpers.PostWebhookAsync(WebhookUrl, fail, cancellationToken);
+                return fail;
+            }
+
+            int delay = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+            if (delay > 0)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(delay), cancellationToken);
+            }
+            attempts++;
+        }
+        while (attempts <= RetryCount);
+
+        SmtpResult final = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message);
+        await Helpers.PostWebhookAsync(WebhookUrl, final, cancellationToken);
+        return final;
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+    }
+}

--- a/Sources/Mailozaurr/Enums/EmailProvider.cs
+++ b/Sources/Mailozaurr/Enums/EmailProvider.cs
@@ -17,8 +17,12 @@ public enum EmailProvider {
     /// Use the Mailgun REST API to deliver mail.
     /// </summary>
     Mailgun,
+
+    /// <summary>
+    /// Use the Amazon SES REST API to deliver mail.
+    /// </summary>
+    SES,
     //MailChimp,
-    //AmazonSES,
     //Moosend,
     //Postmark,
     //Brevo (Sendinblue),

--- a/Sources/Mailozaurr/README.md
+++ b/Sources/Mailozaurr/README.md
@@ -1,9 +1,9 @@
 # Mailozaurr
 
-Mailozaurr is a powerful .NET library for sending emails using various providers (SMTP, SendGrid, Mailgun, Microsoft Graph, etc.), supporting advanced features like attachments, HTML bodies, and authentication.
+Mailozaurr is a powerful .NET library for sending emails using various providers (SMTP, SendGrid, Mailgun, Amazon SES, Microsoft Graph, etc.), supporting advanced features like attachments, HTML bodies, and authentication.
 
 ## Features
-- Send emails via SMTP, SendGrid, Mailgun, Microsoft Graph, and more
+- Send emails via SMTP, SendGrid, Mailgun, Amazon SES, Microsoft Graph, and more
 - Support for attachments, HTML, and plain text
 - OAuth2 and basic authentication
 - Delivery notifications and advanced options
@@ -85,6 +85,7 @@ graph.HTML = "<p>Sent via Microsoft Graph!</p>";
 - `Graph` - for Microsoft Graph API
 - `SendGridClient` - for SendGrid
 - `MailgunClient` - for Mailgun
+- `SesClient` - for Amazon SES
 - `SmtpResult` - result object for send operations
 
 ## Building from Source


### PR DESCRIPTION
## Summary
- reimplement SesClient without AWSSDK dependency
- sign requests using AWS Signature v4 via HttpClient
- expose region configuration and update cmdlet integration
- remove AWSSDK.SimpleEmail package

## Testing
- `dotnet test Sources/Mailozaurr.sln --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68643d3ba8d8832ea43f5289bfc78fe5