### PR TITLE
Expand Get-IMAPFolder cmdlet

### DIFF
--- a/Examples/Example-ListImapFolderContents.ps1
+++ b/Examples/Example-ListImapFolderContents.ps1
@@ -1,0 +1,23 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+# Authenticate however you like
+$cred = Get-Credential
+$client = Connect-IMAP -Server 'imap.example.com' -Credential $cred -Port 993 -Options Auto
+
+# list inbox messages
+Get-IMAPFolder -Client $client
+Get-IMAPMessage -Client $client | Select-Object -First 10
+
+# open a nested folder
+Get-IMAPFolder -Client $client -Path 'Inbox/Reports/2024'
+Get-IMAPMessage -Client $client | Select-Object -First 10
+
+# sent items
+Get-IMAPFolder -Client $client -Path 'Sent'
+Get-IMAPMessage -Client $client | Select-Object -First 10
+
+# deleted items
+Get-IMAPFolder -Client $client -Path 'Deleted Items'
+Get-IMAPMessage -Client $client | Select-Object -First 10
+
+Disconnect-IMAP -Client $client

--- a/Examples/Example-ListImapRootFolders.ps1
+++ b/Examples/Example-ListImapRootFolders.ps1
@@ -1,0 +1,10 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+# Acquire credentials using your preferred method
+$credential = Get-Credential
+
+# Connect and list root folders
+$client = Connect-IMAP -Server 'imap.example.com' -Credential $credential -Port 993 -Options Auto
+Get-IMAPFolder -Client $client -Root
+
+Disconnect-IMAP -Client $client

--- a/Examples/Example-ListImapRootFoldersOAuth.ps1
+++ b/Examples/Example-ListImapRootFoldersOAuth.ps1
@@ -1,0 +1,10 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+# Acquire OAuth token first
+$token = Connect-OAuthGoogle -ClientId 'id' -ClientSecret 'secret' -GmailAccount 'user@example.com' -Scope https://mail.google.com/
+
+# Connect using the OAuth token and list folders
+$client = Connect-IMAP -Server 'imap.gmail.com' -Port 993 -Credential $token -OAuth2
+Get-IMAPFolder -Client $client -Root
+
+Disconnect-IMAP -Client $client

--- a/README.MD
+++ b/README.MD
@@ -101,6 +101,7 @@ This will make sure the project has required libraries.
 - IMAP
   - [x] Connect to IMAP
   - [x] Get IMAP Folder
+  - [x] List IMAP root folders with `Get-IMAPFolder -Root`
   - [x] Get IMAP Messages
   - [x] Delete IMAP Messages with `Get-IMAPMessage -Delete`
   - [x] Listen for new IMAP messages via `ImapIdleListener`
@@ -136,6 +137,29 @@ $pop3 = Connect-POP3 -Server 'pop.example.com' -Credential $cred
 # OAuth2 token
 $oauth = Connect-OAuthGoogle -ClientId 'id' -ClientSecret 'secret' -GmailAccount 'user@example.com' -Scope https://mail.google.com/
 $imapOAuth = Connect-IMAP -Server 'imap.gmail.com' -Credential $oauth -OAuth2
+```
+
+### Enumerating IMAP folders
+
+After connecting you can list the top-level folders:
+
+```powershell
+$client = Connect-IMAP -Server 'imap.example.com' -Credential $cred
+Get-IMAPFolder -Client $client -Root
+```
+
+Using OAuth tokens works the same:
+
+```powershell
+$token = Connect-OAuthGoogle -ClientId 'id' -ClientSecret 'secret' -GmailAccount 'user@example.com' -Scope https://mail.google.com/
+$client = Connect-IMAP -Server 'imap.gmail.com' -Credential $token -OAuth2
+Get-IMAPFolder -Client $client -Root
+
+You can also open a specific folder by path:
+
+```powershell
+$client = Connect-IMAP -Server 'imap.example.com' -Credential $cred
+Get-IMAPFolder -Client $client -Path 'Inbox/Reports'
 ```
 
 ### Listening for new IMAP mail
@@ -199,6 +223,8 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - [Example-SaveImapMessageAttachment.ps1](Examples/Example-SaveImapMessageAttachment.ps1) - download attachments from an IMAP mailbox.
 - [Example-SavePop3MessageAttachmentFiltered.ps1](Examples/Example-SavePop3MessageAttachmentFiltered.ps1) - search POP3 messages and save matching attachments.
 - [Example-SaveImapMessageAttachmentFiltered.ps1](Examples/Example-SaveImapMessageAttachmentFiltered.ps1) - search IMAP messages and save matching attachments.
+- [Example-ListImapRootFolders.ps1](Examples/Example-ListImapRootFolders.ps1) - list root folders using credentials.
+- [Example-ListImapRootFoldersOAuth.ps1](Examples/Example-ListImapRootFoldersOAuth.ps1) - list root folders using OAuth.
 - [Example-GetMailFolder.ps1](Examples/Example-GetMailFolder.ps1) - list folders using either `-Connection` or `-MgGraphRequest`.
 - [Example-ConnectEmailGraph-DeviceCode.ps1](Examples/Example-ConnectEmailGraph-DeviceCode.ps1) - authenticate with device code.
 - [Example-ConnectEmailGraph-OnBehalfOf.ps1](Examples/Example-ConnectEmailGraph-OnBehalfOf.ps1) - exchange a user token for Graph access.

--- a/README.MD
+++ b/README.MD
@@ -154,12 +154,34 @@ Using OAuth tokens works the same:
 $token = Connect-OAuthGoogle -ClientId 'id' -ClientSecret 'secret' -GmailAccount 'user@example.com' -Scope https://mail.google.com/
 $client = Connect-IMAP -Server 'imap.gmail.com' -Credential $token -OAuth2
 Get-IMAPFolder -Client $client -Root
+```
 
 You can also open a specific folder by path:
 
 ```powershell
 $client = Connect-IMAP -Server 'imap.example.com' -Credential $cred
 Get-IMAPFolder -Client $client -Path 'Inbox/Reports'
+```
+
+### Listing folder contents
+
+Once a folder is opened you can retrieve its messages using `Get-IMAPMessage`.
+
+```powershell
+# Inbox messages
+$client = Connect-IMAP -Server 'imap.example.com' -Credential $cred
+Get-IMAPFolder -Client $client
+Get-IMAPMessage -Client $client
+
+# Nested folder
+Get-IMAPFolder -Client $client -Path 'Inbox/Reports/2024'
+Get-IMAPMessage -Client $client
+
+# Sent and deleted items
+Get-IMAPFolder -Client $client -Path 'Sent'
+Get-IMAPMessage -Client $client
+Get-IMAPFolder -Client $client -Path 'Deleted Items'
+Get-IMAPMessage -Client $client
 ```
 
 ### Listening for new IMAP mail
@@ -225,6 +247,7 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - [Example-SaveImapMessageAttachmentFiltered.ps1](Examples/Example-SaveImapMessageAttachmentFiltered.ps1) - search IMAP messages and save matching attachments.
 - [Example-ListImapRootFolders.ps1](Examples/Example-ListImapRootFolders.ps1) - list root folders using credentials.
 - [Example-ListImapRootFoldersOAuth.ps1](Examples/Example-ListImapRootFoldersOAuth.ps1) - list root folders using OAuth.
+- [Example-ListImapFolderContents.ps1](Examples/Example-ListImapFolderContents.ps1) - open folders by path and list messages.
 - [Example-GetMailFolder.ps1](Examples/Example-GetMailFolder.ps1) - list folders using either `-Connection` or `-MgGraphRequest`.
 - [Example-ConnectEmailGraph-DeviceCode.ps1](Examples/Example-ConnectEmailGraph-DeviceCode.ps1) - authenticate with device code.
 - [Example-ConnectEmailGraph-OnBehalfOf.ps1](Examples/Example-ConnectEmailGraph-OnBehalfOf.ps1) - exchange a user token for Graph access.

--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using MailKit;
 using MailKit.Net.Imap;
 using Mailozaurr;
-using Mailozaurr.PowerShell;
 
 namespace Mailozaurr.PowerShell;
 
@@ -22,6 +21,8 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "IMAPFolder")]
 public sealed class CmdletGetIMAPFolder : AsyncPSCmdlet {
+    private const string OpenParameterSet = "Open";
+    private const string RootParameterSet = "Root";
     /// <summary>
     /// <para type="description">The <see cref="ImapConnectionInfo"/> object representing the active IMAP connection. This is the object returned by <c>Connect-IMAP</c>.</para>
     /// </summary>
@@ -30,29 +31,47 @@ public sealed class CmdletGetIMAPFolder : AsyncPSCmdlet {
     public ImapConnectionInfo? Client { get; set; }
 
     /// <summary>
+    /// <para type="description">When specified, lists only the top-level folders instead of opening one.</para>
+    /// </summary>
+    [Parameter(ParameterSetName = RootParameterSet)]
+    public SwitchParameter Root { get; set; }
+
+    /// <summary>
+    /// <para type="description">Folder path to open. Defaults to the inbox when not provided.</para>
+    /// </summary>
+    [Parameter(ParameterSetName = OpenParameterSet)]
+    public string? Path { get; set; }
+
+    /// <summary>
     /// <para type="description">Specifies the folder access mode (ReadOnly or ReadWrite). Default is ReadOnly.</para>
     /// </summary>
-    [Parameter(Position = 1)]
+    [Parameter(Position = 1, ParameterSetName = OpenParameterSet)]
     public FolderAccess FolderAccess { get; set; } = FolderAccess.ReadOnly;
 
     /// <summary>
     /// Opens the inbox folder, updates message counts, and returns the updated connection info.
     /// </summary>
-    protected override Task ProcessRecordAsync() {
+    protected override async Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
-        if (conn != null) {
-            var folder = (ImapFolder)conn.Data.GetCachedFolder(conn.Folder?.FullName, FolderAccess);
-            WriteVerbose($"Get-IMAPFolder - Total messages {folder.Count}, Recent messages {folder.Recent}");
-            conn.Messages = folder;
-            conn.Count = folder.Count;
-            conn.Recent = folder.Recent;
-            conn.Folder = folder;
-            conn.Folders[folder.FullName] = folder;
-            DefaultSessions.ImapSession = conn;
-            WriteObject(conn);
+        if (conn != null && conn.Data != null) {
+            if (Root) {
+                await foreach (var folder in ImapRootFolderEnumerator.EnumerateAsync(conn.Data, CancelToken)) {
+                    WriteObject(folder);
+                }
+            } else {
+                var name = string.IsNullOrWhiteSpace(Path) ? conn.Folder?.FullName : Path;
+                var folder = (ImapFolder)conn.Data.GetCachedFolder(name, FolderAccess);
+                WriteVerbose($"Get-IMAPFolder - Total messages {folder.Count}, Recent messages {folder.Recent}");
+                conn.Messages = folder;
+                conn.Count = folder.Count;
+                conn.Recent = folder.Recent;
+                conn.Folder = folder;
+                conn.Folders[folder.FullName] = folder;
+                DefaultSessions.ImapSession = conn;
+                WriteObject(conn);
+            }
         } else {
-            WriteVerbose("Get-IMAPFolder - Client not connected?");
+            WriteWarning("Get-IMAPFolder - Is IMAP connected?");
         }
-        return Task.CompletedTask;
     }
 }

--- a/Sources/Mailozaurr/Receive/ImapRootFolderEnumerator.cs
+++ b/Sources/Mailozaurr/Receive/ImapRootFolderEnumerator.cs
@@ -1,0 +1,29 @@
+using MailKit;
+using MailKit.Net.Imap;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Provides helper methods for enumerating top-level IMAP folders.
+/// </summary>
+public static class ImapRootFolderEnumerator {
+    /// <summary>
+    /// Asynchronously enumerates top-level folders for the given IMAP client.
+    /// </summary>
+    /// <param name="client">Connected IMAP client.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static async IAsyncEnumerable<IMailFolder> EnumerateAsync(
+        ImapClient client,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+        var root = client.PersonalNamespaces.Count > 0
+            ? client.GetFolder(client.PersonalNamespaces[0])
+            : client.GetFolder("");
+
+        foreach (var folder in await root.GetSubfoldersAsync(false, cancellationToken).ConfigureAwait(false)) {
+            yield return folder;
+        }
+    }
+}

--- a/Tests/Get-IMAPFolderRoot.Tests.ps1
+++ b/Tests/Get-IMAPFolderRoot.Tests.ps1
@@ -1,0 +1,8 @@
+Describe 'Get-IMAPFolder -Root' {
+    It 'Warns when IMAP connection missing' {
+        $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
+        Get-IMAPFolder -Client $info -Root -WarningVariable warn
+        $warn | Should -Not -BeNullOrEmpty
+        $warn[0] | Should -Be 'Get-IMAPFolder - Is IMAP connected?'
+    }
+}


### PR DESCRIPTION
## Summary
- enhance `Get-IMAPFolder` to list root folders via `-Root` and open arbitrary paths
- drop now redundant `Get-IMAPRootFolder` cmdlet
- update examples, docs and tests for the new switch

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6864e2b17e48832ebdbebed07e870e66