### PR TITLE
Add Codecov integration

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -52,6 +52,10 @@ jobs:
         with:
           name: coverage-reports-windows
           path: '**/coverage.cobertura.xml'
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: '**/coverage.cobertura.xml'
 
   test-ubuntu:
     name: 'Ubuntu'
@@ -85,6 +89,16 @@ jobs:
         with:
           name: test-results-ubuntu
           path: '**/*.trx'
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-reports-ubuntu
+          path: '**/coverage.cobertura.xml'
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: '**/coverage.cobertura.xml'
 
   test-macos:
     name: 'macOS'
@@ -113,4 +127,14 @@ jobs:
         with:
           name: test-results-macos
           path: '**/*.trx'
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-reports-macos
+          path: '**/coverage.cobertura.xml'
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: '**/coverage.cobertura.xml'
 

--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,6 @@
 <p align="center">
   <a href="https://dev.azure.com/evotecpl/Mailozaurr/_build/results?buildId=latest"><img src="https://dev.azure.com/evotecpl/Mailozaurr/_apis/build/status/EvotecIT.Mailozaurr"></a>
+  <a href="https://codecov.io/gh/EvotecIT/Mailozaurr"><img src="https://codecov.io/gh/EvotecIT/Mailozaurr/branch/v2-speedygonzales/graph/badge.svg"></a>
   <a href="https://www.powershellgallery.com/packages/Mailozaurr"><img src="https://img.shields.io/powershellgallery/v/Mailozaurr.svg"></a>
   <a href="https://www.powershellgallery.com/packages/Mailozaurr"><img src="https://img.shields.io/powershellgallery/vpre/Mailozaurr.svg?label=powershell%20gallery%20preview&colorB=yellow"></a>
   <a href="https://github.com/EvotecIT/Mailozaurr"><img src="https://img.shields.io/github/license/EvotecIT/Mailozaurr.svg"></a>


### PR DESCRIPTION
## Summary
- add Codecov badge to README
- upload coverage to Codecov from GitHub Actions

## Testing
- `dotnet build Sources/Mailozaurr.sln --configuration Debug`
- `dotnet test Sources/Mailozaurr.sln --no-build --logger "trx" --collect:"XPlat Code Coverage"` *(fails: Test host process crashed)*
- `dotnet test Sources/Mailozaurr.sln --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68659c54d23c832e96593914d5aea429