### PR TITLE
Add signing and secure string tests

### DIFF
--- a/Sources/Mailozaurr.Tests/ConvertSecureStringToPlainStringTests.cs
+++ b/Sources/Mailozaurr.Tests/ConvertSecureStringToPlainStringTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ConvertSecureStringToPlainStringTests
+{
+    [Fact]
+    public void ReturnsPlainPassword_WhenNotSecure()
+    {
+        var smtp = new Smtp();
+        var result = smtp.ConvertSecureStringToPlainString("secret", false);
+        Assert.Equal("secret", result);
+    }
+
+    [Fact]
+    public void ReturnsDecryptedPassword_WhenSecure()
+    {
+        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) return;
+        var smtp = new Smtp();
+        byte[] bytes = Encoding.Unicode.GetBytes("secret");
+        string protectedStr = string.Concat(bytes.Select(b => b.ToString("x2", CultureInfo.InvariantCulture)));
+
+        var result = smtp.ConvertSecureStringToPlainString(protectedStr, true);
+
+        Assert.Equal("secret", result);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ConvertSecureStringToPlainStringTests.cs
+++ b/Sources/Mailozaurr.Tests/ConvertSecureStringToPlainStringTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
-using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 using Xunit;
 
@@ -19,10 +20,20 @@ public class ConvertSecureStringToPlainStringTests
     [Fact]
     public void ReturnsDecryptedPassword_WhenSecure()
     {
-        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) return;
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
         var smtp = new Smtp();
-        byte[] bytes = Encoding.Unicode.GetBytes("secret");
-        string protectedStr = string.Concat(bytes.Select(b => b.ToString("x2", CultureInfo.InvariantCulture)));
+
+        static string ProtectString(string value)
+        {
+            byte[] bytes = Encoding.Unicode.GetBytes(value);
+            byte[] protectedBytes = ProtectedData.Protect(bytes, null, DataProtectionScope.CurrentUser);
+            var sb = new StringBuilder(protectedBytes.Length * 2);
+            foreach (byte b in protectedBytes)
+                sb.Append(b.ToString("x2", CultureInfo.InvariantCulture));
+            return sb.ToString();
+        }
+
+        string protectedStr = ProtectString("secret");
 
         var result = smtp.ConvertSecureStringToPlainString(protectedStr, true);
 

--- a/Sources/Mailozaurr.Tests/SmtpSmimeSignTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSmimeSignTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+#if NETFRAMEWORK
+using Xunit;
+namespace Mailozaurr.Tests;
+public class SmtpSmimeSignTests
+{
+    [Fact(Skip = "Self-signed certificate generation not supported on .NET Framework.")]
+    public void Sign_ChangesMessageBodyAndReturnsSuccess() { }
+
+    [Fact(Skip = "Self-signed certificate generation not supported on .NET Framework.")]
+    public void Pkcs7Sign_ChangesMessageBodyAndReturnsSuccess() { }
+}
+#else
+using MimeKit;
+using MimeKit.Cryptography;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpSmimeSignTests
+{
+    private static X509Certificate2 CreateSelfSignedCert()
+    {
+        using RSA rsa = RSA.Create(2048);
+        var req = new CertificateRequest("CN=Test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+        return new X509Certificate2(cert.Export(X509ContentType.Pfx));
+    }
+
+    [Fact]
+    public void Sign_ChangesMessageBodyAndReturnsSuccess()
+    {
+        using var cert = CreateSelfSignedCert();
+        var smtp = new Smtp();
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "c@d.com" };
+        smtp.Subject = "test";
+        smtp.TextBody = "body";
+        smtp.CreateMessage();
+        var originalType = smtp.Message.Body.GetType();
+
+        var result = smtp.Sign(cert);
+
+        Assert.True(result.Status);
+        Assert.NotEqual(originalType, smtp.Message.Body.GetType());
+        Assert.IsType<MultipartSigned>(smtp.Message.Body);
+    }
+
+    [Fact]
+    public void Pkcs7Sign_ChangesMessageBodyAndReturnsSuccess()
+    {
+        using var cert = CreateSelfSignedCert();
+        var smtp = new Smtp();
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "c@d.com" };
+        smtp.Subject = "test";
+        smtp.TextBody = "body";
+        smtp.CreateMessage();
+        var originalType = smtp.Message.Body.GetType();
+
+        var result = smtp.Pkcs7Sign(cert);
+
+        Assert.True(result.Status);
+        Assert.NotEqual(originalType, smtp.Message.Body.GetType());
+        Assert.IsType<ApplicationPkcs7Mime>(smtp.Message.Body);
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- test ConvertSecureStringToPlainString with plain and secure inputs
- add S/MIME signing tests using self-signed certs

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6867959be904832eb984c8856db33b89