### PR TITLE
Add connector retry tests

### DIFF
--- a/Sources/Mailozaurr.Tests/ConnectorTests.cs
+++ b/Sources/Mailozaurr.Tests/ConnectorTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Imap;
+using MailKit.Net.Pop3;
+using MailKit.Security;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ConnectorTests
+{
+    private class FakeImapClient : ImapClient
+    {
+        public int FailuresBeforeSuccess { get; set; }
+        public int ConnectCalls { get; private set; }
+        public new bool Authenticated { get; set; }
+        public override bool IsAuthenticated => Authenticated;
+        public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
+        {
+            ConnectCalls++;
+            if (ConnectCalls <= FailuresBeforeSuccess)
+            {
+                throw new HttpRequestException("fail");
+            }
+            return Task.CompletedTask;
+        }
+        public override Task DisconnectAsync(bool quit, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private class FakePop3Client : Pop3Client
+    {
+        public int FailuresBeforeSuccess { get; set; }
+        public int ConnectCalls { get; private set; }
+        public new bool Authenticated { get; set; }
+        public override bool IsAuthenticated => Authenticated;
+        public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
+        {
+            ConnectCalls++;
+            if (ConnectCalls <= FailuresBeforeSuccess)
+            {
+                throw new HttpRequestException("fail");
+            }
+            return Task.CompletedTask;
+        }
+        public override Task DisconnectAsync(bool quit, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task ImapConnector_RetriesUntilSuccess()
+    {
+        var fake = new FakeImapClient { FailuresBeforeSuccess = 2 };
+        var delays = new List<int>();
+        ImapConnector.ClientFactory = () => fake;
+        ImapConnector.DelayAsync = d => { delays.Add(d); return Task.CompletedTask; };
+        var client = await ImapConnector.ConnectAsync(
+            "s", 1, SecureSocketOptions.Auto, 0, false, false,
+            c => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
+            3, 10, 2);
+        ImapConnector.ClientFactory = () => new ImapClient();
+        ImapConnector.DelayAsync = null;
+        Assert.Same(fake, client);
+        Assert.Equal(3, fake.ConnectCalls);
+        Assert.Equal(new[] { 10, 20 }, delays);
+    }
+
+    [Fact]
+    public async Task ImapConnector_ThrowsAfterRetries()
+    {
+        var fake = new FakeImapClient { FailuresBeforeSuccess = 5 };
+        var delays = new List<int>();
+        ImapConnector.ClientFactory = () => fake;
+        ImapConnector.DelayAsync = d => { delays.Add(d); return Task.CompletedTask; };
+        await Assert.ThrowsAsync<HttpRequestException>(() => ImapConnector.ConnectAsync(
+            "s", 1, SecureSocketOptions.Auto, 0, false, false,
+            c => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
+            2, 10, 2));
+        ImapConnector.ClientFactory = () => new ImapClient();
+        ImapConnector.DelayAsync = null;
+        Assert.Equal(3, fake.ConnectCalls);
+        Assert.Equal(new[] { 10, 20 }, delays);
+    }
+
+    [Fact]
+    public async Task Pop3Connector_RetriesUntilSuccess()
+    {
+        var fake = new FakePop3Client { FailuresBeforeSuccess = 1 };
+        var delays = new List<int>();
+        Pop3Connector.ClientFactory = () => fake;
+        Pop3Connector.DelayAsync = d => { delays.Add(d); return Task.CompletedTask; };
+        var client = await Pop3Connector.ConnectAsync(
+            "s", 1, SecureSocketOptions.Auto, 0, false, false,
+            c => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
+            2, 10, 2);
+        Pop3Connector.ClientFactory = () => new Pop3Client();
+        Pop3Connector.DelayAsync = null;
+        Assert.Same(fake, client);
+        Assert.Equal(2, fake.ConnectCalls);
+        Assert.Equal(new[] { 10 }, delays);
+    }
+
+    [Fact]
+    public async Task Pop3Connector_ThrowsAfterRetries()
+    {
+        var fake = new FakePop3Client { FailuresBeforeSuccess = 4 };
+        var delays = new List<int>();
+        Pop3Connector.ClientFactory = () => fake;
+        Pop3Connector.DelayAsync = d => { delays.Add(d); return Task.CompletedTask; };
+        await Assert.ThrowsAsync<HttpRequestException>(() => Pop3Connector.ConnectAsync(
+            "s", 1, SecureSocketOptions.Auto, 0, false, false,
+            c => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
+            2, 10, 2));
+        Pop3Connector.ClientFactory = () => new Pop3Client();
+        Pop3Connector.DelayAsync = null;
+        Assert.Equal(3, fake.ConnectCalls);
+        Assert.Equal(new[] { 10, 20 }, delays);
+    }
+}

--- a/Sources/Mailozaurr/Connections/ImapConnector.cs
+++ b/Sources/Mailozaurr/Connections/ImapConnector.cs
@@ -9,6 +9,9 @@ namespace Mailozaurr;
 /// Provides helper methods for connecting to IMAP servers with retry logic.
 /// </summary>
 public static class ImapConnector {
+    public static Func<ImapClient> ClientFactory { get; set; } = () => new ImapClient();
+    public static Func<int, Task>? DelayAsync { get; set; }
+
     /// <summary>
     /// Connects and authenticates to an IMAP server with retry support.
     /// </summary>
@@ -37,7 +40,7 @@ public static class ImapConnector {
         int attempts = 0;
         Exception? lastException = null;
         do {
-            var client = new ImapClient();
+            var client = ClientFactory();
             try {
                 await client.ConnectAsync(server, port, options);
                 if (skipCertificateRevocation) {
@@ -67,7 +70,11 @@ public static class ImapConnector {
                 }
                 var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
                 if (delay > 0) {
-                    await Task.Delay(delay);
+                    if (DelayAsync != null) {
+                        await DelayAsync(delay);
+                    } else {
+                        await Task.Delay(delay);
+                    }
                 }
             }
             attempts++;

--- a/Sources/Mailozaurr/Connections/Pop3Connector.cs
+++ b/Sources/Mailozaurr/Connections/Pop3Connector.cs
@@ -9,6 +9,8 @@ namespace Mailozaurr;
 /// Provides helper methods for connecting to POP3 servers with retry logic.
 /// </summary>
 public static class Pop3Connector {
+    public static Func<Pop3Client> ClientFactory { get; set; } = () => new Pop3Client();
+    public static Func<int, Task>? DelayAsync { get; set; }
     /// <summary>
     /// Connects and authenticates to a POP3 server with retry support.
     /// </summary>
@@ -37,7 +39,7 @@ public static class Pop3Connector {
         int attempts = 0;
         Exception? lastException = null;
         do {
-            var client = new Pop3Client();
+            var client = ClientFactory();
             try {
                 await client.ConnectAsync(server, port, options);
                 if (skipCertificateRevocation) {
@@ -67,7 +69,11 @@ public static class Pop3Connector {
                 }
                 var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
                 if (delay > 0) {
-                    await Task.Delay(delay);
+                    if (DelayAsync != null) {
+                        await DelayAsync(delay);
+                    } else {
+                        await Task.Delay(delay);
+                    }
                 }
             }
             attempts++;


### PR DESCRIPTION
## Summary
- add ClientFactory and DelayAsync hooks to `ImapConnector` and `Pop3Connector`
- create `ConnectorTests` verifying retry logic with fake clients

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686795936880832eb02ebd6ee904f03a