### PR TITLE
Add SMTP connection and retry tests

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpSendAsyncTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSendAsyncTests.cs
@@ -1,7 +1,10 @@
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Diagnostics;
 using MailKit;
+using MailKit.Net.Smtp;
+using MailKit.Security;
 using MimeKit;
 using Xunit;
 
@@ -19,13 +22,18 @@ public class SmtpSendAsyncTests
         }
     }
 
+    private static void SetClient(Smtp smtp, ClientSmtp client)
+    {
+        var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(smtp, client);
+    }
+
     [Fact]
     public async Task SendAsync_InvokesClientSendAsync()
     {
         var smtp = new Smtp();
         var fake = new FakeClient();
-        var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        field.SetValue(smtp, fake);
+        SetClient(smtp, fake);
         smtp.From = "a@b.com";
         smtp.To = new object[] { "b@c.com" };
         smtp.Subject = "test";
@@ -37,5 +45,73 @@ public class SmtpSendAsyncTests
 
         Assert.True(fake.Called);
         Assert.True(result.Status);
+    }
+
+    private class FakeConnectClient : ClientSmtp
+    {
+        public SecureSocketOptions? Options;
+        public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
+        {
+            Options = options;
+        }
+    }
+
+    [Fact]
+    public void Connect_UseSslAuto_UsesStartTls()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeConnectClient();
+        SetClient(smtp, fake);
+
+        smtp.Connect("server", 587, SecureSocketOptions.Auto, true);
+
+        Assert.Equal(SecureSocketOptions.StartTls, fake.Options);
+    }
+
+    private class RetryClient : ClientSmtp
+    {
+        private readonly int _failures;
+        public int SendCount;
+        public List<DateTimeOffset> CallTimes { get; } = new();
+
+        public RetryClient(int failures)
+        {
+            _failures = failures;
+        }
+
+        public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken = default, ITransferProgress? progress = null)
+        {
+            SendCount++;
+            CallTimes.Add(DateTimeOffset.UtcNow);
+            if (SendCount <= _failures)
+                throw new SmtpProtocolException("fail");
+            return Task.FromResult(string.Empty);
+        }
+    }
+
+    [Fact]
+    public async Task SendCoreAsync_Retries_WithDelayAndBackoff()
+    {
+        var smtp = new Smtp();
+        var fake = new RetryClient(2);
+        SetClient(smtp, fake);
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "b@c.com" };
+        smtp.Subject = "test";
+        smtp.TextBody = "body";
+        smtp.WebhookUrl = null;
+        smtp.CreateMessage();
+
+        smtp.RetryCount = 2;
+        smtp.RetryDelayMilliseconds = 20;
+        smtp.RetryDelayBackoff = 2.0;
+        smtp.RetryAlways = true;
+
+        var result = await smtp.SendAsync();
+
+        Assert.True(result.Status);
+        Assert.Equal(3, fake.SendCount);
+        Assert.True(fake.CallTimes[1] - fake.CallTimes[0] >= TimeSpan.FromMilliseconds(20));
+        Assert.True(fake.CallTimes[2] - fake.CallTimes[1] >= TimeSpan.FromMilliseconds(40));
     }
 }


### PR DESCRIPTION
## Summary
- extend `SmtpSendAsyncTests` with helpers for faking the underlying SMTP client
- verify `Smtp.Connect` uses StartTls by default when `useSsl` is true
- test `SendCoreAsync` retry logic with delay and backoff

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0 --no-build --verbosity minimal`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net472 --no-build --verbosity minimal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6867c19e7a40832ea904bf752adc87c1