### PR TITLE
Add SesClient HTTP injection and tests

### DIFF
--- a/Sources/Mailozaurr.Tests/RecordingHandler.cs
+++ b/Sources/Mailozaurr.Tests/RecordingHandler.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.Tests;
+
+public class RecordingHandler : HttpMessageHandler
+{
+    public List<HttpRequestMessage> Requests { get; } = new();
+    private readonly Queue<HttpResponseMessage> _responses;
+
+    public RecordingHandler(params HttpResponseMessage[] responses)
+    {
+        _responses = new Queue<HttpResponseMessage>(responses);
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        HttpRequestMessage copy = new(request.Method, request.RequestUri);
+        foreach (var header in request.Headers)
+        {
+            copy.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+        if (request.Content != null)
+        {
+            byte[] bytes = await request.Content.ReadAsByteArrayAsync();
+            copy.Content = new ByteArrayContent(bytes);
+            foreach (var header in request.Content.Headers)
+            {
+                copy.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+        Requests.Add(copy);
+        HttpResponseMessage response = _responses.Count > 0 ? _responses.Dequeue() : new HttpResponseMessage(HttpStatusCode.OK);
+        return response;
+    }
+}

--- a/Sources/Mailozaurr.Tests/SesClientSendEmailAsyncTests.cs
+++ b/Sources/Mailozaurr.Tests/SesClientSendEmailAsyncTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SesClientSendEmailAsyncTests
+{
+    private static byte[] HmacSha256(byte[] key, string data)
+    {
+        using HMACSHA256 hmac = new(key);
+        return hmac.ComputeHash(Encoding.UTF8.GetBytes(data));
+    }
+
+    private static string Sha256Hex(string data)
+    {
+        using SHA256 sha = SHA256.Create();
+        byte[] hash = sha.ComputeHash(Encoding.UTF8.GetBytes(data));
+        return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+    }
+
+    private static string ExpectedAuthorization(string accessKey, string secretKey, string region, string amzDate, string body)
+    {
+        string service = "ses";
+        string dateStamp = amzDate.Substring(0, 8);
+        string canonicalHeaders = $"content-type:application/x-www-form-urlencoded\nhost:email.{region}.amazonaws.com\nx-amz-date:{amzDate}\n";
+        string signedHeaders = "content-type;host;x-amz-date";
+        string payloadHash = Sha256Hex(body);
+        string canonicalRequest = $"POST\n/\n\n{canonicalHeaders}\n{signedHeaders}\n{payloadHash}";
+        string credentialScope = $"{dateStamp}/{region}/{service}/aws4_request";
+        string stringToSign = $"AWS4-HMAC-SHA256\n{amzDate}\n{credentialScope}\n{Sha256Hex(canonicalRequest)}";
+        byte[] kDate = HmacSha256(Encoding.UTF8.GetBytes("AWS4" + secretKey), dateStamp);
+        byte[] kRegion = HmacSha256(kDate, region);
+        byte[] kService = HmacSha256(kRegion, service);
+        byte[] kSigning = HmacSha256(kService, "aws4_request");
+        byte[] sigBytes = HmacSha256(kSigning, stringToSign);
+        string signature = BitConverter.ToString(sigBytes).Replace("-", string.Empty).ToLowerInvariant();
+        return $"AWS4-HMAC-SHA256 Credential={accessKey}/{credentialScope}, SignedHeaders={signedHeaders}, Signature={signature}";
+    }
+
+    private static SesClient CreateClient(HttpMessageHandler handler)
+    {
+        return new SesClient(handler)
+        {
+            Credentials = new NetworkCredential("AKID", "SECRET"),
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            Subject = "subject",
+            Text = "body",
+            RetryDelayMilliseconds = 0,
+            Region = "us-east-1"
+        };
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_ComputesSignature()
+    {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+        using var client = CreateClient(handler);
+        client.WebhookUrl = null;
+
+        var result = await client.SendEmailAsync();
+
+        Assert.True(result.Status);
+        var request = Assert.Single(handler.Requests);
+        string amzDate = request.Headers.GetValues("x-amz-date").Single();
+        string auth = request.Headers.GetValues("Authorization").Single();
+        string body = await request.Content!.ReadAsStringAsync();
+        string expected = ExpectedAuthorization("AKID", "SECRET", "us-east-1", amzDate, body);
+        Assert.Equal(expected, auth);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_RetriesFailedRequest()
+    {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("fail") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+        using var client = CreateClient(handler);
+        client.RetryCount = 1;
+        client.WebhookUrl = null;
+
+        var result = await client.SendEmailAsync();
+
+        Assert.True(result.Status);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_PostsWebhook_OnSuccess()
+    {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+        using var client = CreateClient(handler);
+        client.WebhookUrl = "http://localhost";
+
+        await client.SendEmailAsync();
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains(handler.Requests, r => r.RequestUri!.ToString() == "http://localhost/");
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_PostsWebhook_OnFailure()
+    {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent("bad") });
+        using var client = CreateClient(handler);
+        client.WebhookUrl = "http://localhost";
+        client.RetryCount = 0;
+
+        await client.SendEmailAsync();
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains(handler.Requests, r => r.RequestUri!.ToString() == "http://localhost/");
+    }
+}

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -56,6 +56,12 @@ public class SesClient : IDisposable
         _client = new HttpClient();
     }
 
+    public SesClient(HttpMessageHandler handler)
+    {
+        Stopwatch = Stopwatch.StartNew();
+        _client = new HttpClient(handler);
+    }
+
     private MimeMessage BuildMessage()
     {
         Smtp smtp = new();
@@ -138,7 +144,7 @@ public class SesClient : IDisposable
                 if (response.IsSuccessStatusCode)
                 {
                     SmtpResult ok = new(true, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString());
-                    await Helpers.PostWebhookAsync(WebhookUrl, ok, cancellationToken);
+                    await Helpers.PostWebhookAsync(WebhookUrl, ok, cancellationToken, _client);
                     return ok;
                 }
 
@@ -158,7 +164,7 @@ public class SesClient : IDisposable
                     throw lastException;
                 }
                 SmtpResult fail = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message);
-                await Helpers.PostWebhookAsync(WebhookUrl, fail, cancellationToken);
+                await Helpers.PostWebhookAsync(WebhookUrl, fail, cancellationToken, _client);
                 return fail;
             }
 
@@ -172,7 +178,7 @@ public class SesClient : IDisposable
         while (attempts <= RetryCount);
 
         SmtpResult final = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message);
-        await Helpers.PostWebhookAsync(WebhookUrl, final, cancellationToken);
+        await Helpers.PostWebhookAsync(WebhookUrl, final, cancellationToken, _client);
         return final;
     }
 


### PR DESCRIPTION
## Summary
- allow injecting custom HttpMessageHandler into `SesClient`
- send webhooks through injected client
- record HTTP calls in tests
- verify SES signature, retry logic and webhook posting

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68684a839874832e9cd970e741844579