### PR TITLE
Add Validator email checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Lib/Core/*
 dotnet-install.sh
 packages-microsoft-prod.deb
 
+Sources/*/TestResults/

--- a/Sources/Mailozaurr.Tests/ValidatorTests.cs
+++ b/Sources/Mailozaurr.Tests/ValidatorTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ValidatorTests
+{
+    [Fact]
+    public void ValidateEmail_DisposableDomain_IsMarkedDisposable()
+    {
+        var result = Validator.ValidateEmail("user@example.com");
+        Assert.True(result.IsValid);
+        Assert.True(result.IsDisposable);
+    }
+
+    [Fact]
+    public void ValidateEmail_AllowedDomain_NotDisposable()
+    {
+        var result = Validator.ValidateEmail("user@allowed.example.com");
+        Assert.True(result.IsValid);
+        Assert.False(result.IsDisposable);
+    }
+
+    [Fact]
+    public void ValidateEmail_InvalidEmail_ReturnsFalse()
+    {
+        var result = Validator.ValidateEmail("invalid");
+        Assert.False(result.IsValid);
+    }
+}


### PR DESCRIPTION
## Summary
- add regression tests for `Validator.ValidateEmail`
- ignore test output directories

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --no-build --verbosity minimal`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686958102194832ea1dcbfdec3c27df4