### PR TITLE
Add Graph concurrency control

### DIFF
--- a/Examples/Example-ConnectEmailGraph-DeviceCode.ps1
+++ b/Examples/Example-ConnectEmailGraph-DeviceCode.ps1
@@ -5,5 +5,5 @@ $TenantId = 'Your-Tenant-ID'
 $Scopes = @('Mail.ReadWrite','Mail.Send')
 
 # Authenticate using device code flow
-$graph = Connect-EmailGraph -ClientId $ClientId -DirectoryId $TenantId -DeviceCode -Scopes $Scopes
+$graph = Connect-EmailGraph -ClientId $ClientId -DirectoryId $TenantId -DeviceCode -Scopes $Scopes -MaxConcurrentRequests 10
 $graph

--- a/Examples/Example-SendEmail-GraphDeviceCode.ps1
+++ b/Examples/Example-SendEmail-GraphDeviceCode.ps1
@@ -5,7 +5,7 @@ $TenantId = 'Your-Tenant-ID'
 $Scopes = @('Mail.ReadWrite','Mail.Send')
 
 # Sign in interactively using device code
-$graph = Connect-EmailGraph -ClientId $ClientId -DirectoryId $TenantId -DeviceCode -Scopes $Scopes
+$graph = Connect-EmailGraph -ClientId $ClientId -DirectoryId $TenantId -DeviceCode -Scopes $Scopes -MaxConcurrentRequests 10
 
 $Body = EmailBody {
     EmailText -Text 'Hello from device code authentication!'

--- a/Sources/Mailozaurr.PowerShell/CmdletClearGraphJunk.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletClearGraphJunk.cs
@@ -51,6 +51,9 @@ public sealed class CmdletClearGraphJunk : AsyncPSCmdlet {
     public int TimeoutSeconds { get; set; } = 100;
 
     [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
+    [Parameter]
     public int RetryCount { get; set; } = 0;
 
     [Parameter]
@@ -83,6 +86,7 @@ public sealed class CmdletClearGraphJunk : AsyncPSCmdlet {
     private async Task ProcessGraphAsync(GraphCredential cred) {
         if (!ShouldProcess(UserPrincipalName!, "Clearing Graph junk")) return;
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         int attempts = 0;
         Exception? lastException = null;
         do {

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -86,6 +86,9 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
     protected override async Task ProcessRecordAsync() {
         GraphCredential cred;
         OAuthCredential? oauth = null;
@@ -161,6 +164,7 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
         }
         
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         try {
             var token = await MicrosoftGraphUtils.ConnectO365GraphWithRetryAsync(
                 cred,

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphFolder.cs
@@ -46,6 +46,9 @@ public class CmdletGetEmailGraphFolder : AsyncPSCmdlet {
     public int TimeoutSeconds { get; set; } = 100;
 
     [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
+    [Parameter]
     public int RetryCount { get; set; } = 0;
 
     [Parameter]
@@ -70,6 +73,7 @@ public class CmdletGetEmailGraphFolder : AsyncPSCmdlet {
 
     private async Task ProcessGraphAsync(GraphCredential cred) {
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         int attempts = 0;
         Exception? lastException = null;
         do {

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
@@ -74,6 +74,9 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     public int TimeoutSeconds { get; set; } = 100;
 
     [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
+    [Parameter]
     public int RetryCount { get; set; } = 0;
 
     [Parameter]
@@ -95,6 +98,7 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
 
     private async Task ProcessGraphAsync(GraphCredential cred) {
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         int attempts = 0;
         Exception? lastException = null;
         do {

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessageAttachment.cs
@@ -48,6 +48,9 @@ public class CmdletGetEmailGraphMessageAttachment : AsyncPSCmdlet {
     public int TimeoutSeconds { get; set; } = 100;
 
     [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
+    [Parameter]
     public int RetryCount { get; set; } = 0;
 
     [Parameter]
@@ -70,6 +73,7 @@ public class CmdletGetEmailGraphMessageAttachment : AsyncPSCmdlet {
                 return;
             }
             MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+            MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
             int attempts = 0;
             Exception? lastException = null;
             do {

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveGraphFolder.cs
@@ -45,6 +45,9 @@ public class CmdletMoveGraphFolder : AsyncPSCmdlet {
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
     /// <summary>Number of retries on transient errors.</summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
@@ -76,6 +79,7 @@ public class CmdletMoveGraphFolder : AsyncPSCmdlet {
             return;
         }
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         int attempts = 0;
         Exception? lastException = null;
         do {

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
@@ -50,6 +50,9 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     public int TimeoutSeconds { get; set; } = 100;
 
     [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
+    [Parameter]
     public int RetryCount { get; set; } = 0;
 
     [Parameter]
@@ -82,6 +85,7 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     /// <param name="cred">Credential used to access Graph.</param>
     private async Task ProcessGraphAsync(GraphCredential cred) {
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         int attempts = 0;
         Exception? lastException = null;
         do {

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphFolder.cs
@@ -37,6 +37,9 @@ public class CmdletRemoveGraphFolder : AsyncPSCmdlet {
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
     /// <summary>Number of retries on transient errors.</summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
@@ -67,6 +70,7 @@ public class CmdletRemoveGraphFolder : AsyncPSCmdlet {
             return;
         }
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         int attempts = 0;
         Exception? lastException = null;
         do {

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMessage.cs
@@ -33,6 +33,9 @@ public class CmdletRemoveGraphMessage : AsyncPSCmdlet {
     public int TimeoutSeconds { get; set; } = 100;
 
     [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
+    [Parameter]
     public int RetryCount { get; set; } = 0;
 
     [Parameter]
@@ -61,6 +64,7 @@ public class CmdletRemoveGraphMessage : AsyncPSCmdlet {
             return;
         }
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         int attempts = 0;
         Exception? lastException = null;
         do {

--- a/Sources/Mailozaurr.PowerShell/CmdletRenameGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRenameGraphFolder.cs
@@ -39,6 +39,9 @@ public class CmdletRenameGraphFolder : AsyncPSCmdlet {
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
     /// <summary>Number of retries on transient errors.</summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
@@ -69,6 +72,7 @@ public class CmdletRenameGraphFolder : AsyncPSCmdlet {
             return;
         }
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         int attempts = 0;
         Exception? lastException = null;
         do {

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchGraphMailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchGraphMailbox.cs
@@ -31,6 +31,9 @@ public class CmdletSearchGraphMailbox : AsyncPSCmdlet {
     [ValidateRange(1, int.MaxValue)]
     public int Size { get; set; } = 25;
 
+    [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
     protected override async Task ProcessRecordAsync() {
         var conn = Connection ?? DefaultSessions.GraphSession;
         if (conn == null) {
@@ -38,6 +41,7 @@ public class CmdletSearchGraphMailbox : AsyncPSCmdlet {
             return;
         }
 
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         try {
             var results = await MicrosoftGraphUtils.SearchMailboxesAsync(
                 conn.Credential,

--- a/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
@@ -49,6 +49,9 @@ public class CmdletSetGraphMessage : AsyncPSCmdlet {
     public int TimeoutSeconds { get; set; } = 100;
 
     [Parameter]
+    public int MaxConcurrentRequests { get; set; } = 5;
+
+    [Parameter]
     public int RetryCount { get; set; } = 0;
 
     [Parameter]
@@ -81,6 +84,7 @@ public class CmdletSetGraphMessage : AsyncPSCmdlet {
     /// <param name="cred">Credential used to access Graph.</param>
     private async Task ProcessGraphAsync(GraphCredential cred) {
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         int attempts = 0;
         Exception? lastException = null;
         do {

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -357,20 +357,25 @@ public class Graph : IDisposable {
         //LoggingMessages.Logger.WriteVerbose($"Tenant Domain: {TenantDomain}");
         //LoggingMessages.Logger.WriteVerbose($"Application Key {ApplicationKey}");
         try {
-            using var response = await _client.PostAsync($"https://login.microsoftonline.com/{TenantDomain}/oauth2/token", new FormUrlEncodedContent(body), cancellationToken);
-            var content = await response.Content.ReadAsStringAsync();
-            if (!response.IsSuccessStatusCode) {
-                LogCollector.LogWarning($"Send-EmailMessage - Error during connection using Graph API: {content}");
-                if (ErrorAction == ActionPreference.Stop) {
-                    response.EnsureSuccessStatusCode();
+            await MicrosoftGraphUtils.ConcurrencySemaphore.WaitAsync(cancellationToken);
+            try {
+                using var response = await _client.PostAsync($"https://login.microsoftonline.com/{TenantDomain}/oauth2/token", new FormUrlEncodedContent(body), cancellationToken);
+                var content = await response.Content.ReadAsStringAsync();
+                if (!response.IsSuccessStatusCode) {
+                    LogCollector.LogWarning($"Send-EmailMessage - Error during connection using Graph API: {content}");
+                    if (ErrorAction == ActionPreference.Stop) {
+                        response.EnsureSuccessStatusCode();
+                    }
+                    return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, content, content);
                 }
-                return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, content, content);
-            }
 
-            var authorization = JsonSerializer.Deserialize<GraphAuthorization>(content);
-            AccessToken = authorization.AccessToken;
-            TokenType = authorization.TokenType;
-            return new SmtpResult(true, EmailAction.Connect, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", "");
+                var authorization = JsonSerializer.Deserialize<GraphAuthorization>(content);
+                AccessToken = authorization.AccessToken;
+                TokenType = authorization.TokenType;
+                return new SmtpResult(true, EmailAction.Connect, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", "");
+            } finally {
+                MicrosoftGraphUtils.ConcurrencySemaphore.Release();
+            }
         } catch (TaskCanceledException ex) {
             LogCollector.LogWarning($"Send-EmailMessage - Connection to Graph API cancelled: {ex.Message}");
             return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, string.Empty, ex.Message);
@@ -403,18 +408,23 @@ public class Graph : IDisposable {
                 };
                 request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(TokenType, AccessToken);
 
-                using var response = await _client.SendAsync(request, cancellationToken);
-                var content = await response.Content.ReadAsStringAsync();
-                if (response.IsSuccessStatusCode) {
-                    var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, response.StatusCode.ToString(), "");
-                    await Helpers.PostWebhookAsync(WebhookUrl, okResult, cancellationToken);
-                    return okResult;
+                await MicrosoftGraphUtils.ConcurrencySemaphore.WaitAsync(cancellationToken);
+                try {
+                    using var response = await _client.SendAsync(request, cancellationToken);
+                    var content = await response.Content.ReadAsStringAsync();
+                    if (response.IsSuccessStatusCode) {
+                        var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, response.StatusCode.ToString(), "");
+                        await Helpers.PostWebhookAsync(WebhookUrl, okResult, cancellationToken);
+                        return okResult;
+                    }
+                    var error = JsonSerializer.Deserialize<GraphApiError>(content);
+                    var errorMessage = (error == null || error.Error == null || error.Error.InnerError == null)
+                        ? $"Unknown error: {content}"
+                        : $"Error code: {error.Error.Code}, message: {error.Error.Message}, request ID: {error.Error.InnerError.RequestId}, date: {error.Error.InnerError.Date}";
+                    throw new GraphApiException(response.StatusCode, errorMessage, content);
+                } finally {
+                    MicrosoftGraphUtils.ConcurrencySemaphore.Release();
                 }
-                var error = JsonSerializer.Deserialize<GraphApiError>(content);
-                var errorMessage = (error == null || error.Error == null || error.Error.InnerError == null)
-                    ? $"Unknown error: {content}"
-                    : $"Error code: {error.Error.Code}, message: {error.Error.Message}, request ID: {error.Error.InnerError.RequestId}, date: {error.Error.InnerError.Date}";
-                throw new GraphApiException(response.StatusCode, errorMessage, content);
             } catch (TaskCanceledException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Sending via Graph API cancelled: {ex.Message}");
@@ -517,25 +527,30 @@ public class Graph : IDisposable {
         sendRequest.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(TokenType, AccessToken);
 
         // Send the HTTP request for sending the draft message
-        using var sendResponse = await _client.SendAsync(sendRequest, cancellationToken);
+        await MicrosoftGraphUtils.ConcurrencySemaphore.WaitAsync(cancellationToken);
+        try {
+            using var sendResponse = await _client.SendAsync(sendRequest, cancellationToken);
 
-        // If the status code indicates success, return a successful result
-        if (sendResponse.IsSuccessStatusCode) {
-            var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, sendResponse.StatusCode.ToString(), "");
-            await Helpers.PostWebhookAsync(WebhookUrl, okResult, cancellationToken);
-            return okResult;
+            // If the status code indicates success, return a successful result
+            if (sendResponse.IsSuccessStatusCode) {
+                var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, sendResponse.StatusCode.ToString(), "");
+                await Helpers.PostWebhookAsync(WebhookUrl, okResult, cancellationToken);
+                return okResult;
+            }
+
+            // If the status code indicates an error, throw an exception with the content
+            var sendContent = await sendResponse.Content.ReadAsStringAsync();
+            var sendError = JsonSerializer.Deserialize<GraphApiError>(sendContent);
+            var sendErrorMessage = (sendError == null || sendError.Error == null || sendError.Error.InnerError == null)
+                ? $"Unknown error: {sendContent}"
+                : $"Error code: {sendError.Error.Code}, message: {sendError.Error.Message}, request ID: {sendError.Error.InnerError.RequestId}, date: {sendError.Error.InnerError.Date}";
+            var ex = new GraphApiException(sendResponse.StatusCode, sendErrorMessage, sendContent);
+            var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, sendContent, ex.Message);
+            await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
+            throw ex;
+        } finally {
+            MicrosoftGraphUtils.ConcurrencySemaphore.Release();
         }
-
-        // If the status code indicates an error, throw an exception with the content
-        var sendContent = await sendResponse.Content.ReadAsStringAsync();
-        var sendError = JsonSerializer.Deserialize<GraphApiError>(sendContent);
-        var sendErrorMessage = (sendError == null || sendError.Error == null || sendError.Error.InnerError == null)
-            ? $"Unknown error: {sendContent}"
-            : $"Error code: {sendError.Error.Code}, message: {sendError.Error.Message}, request ID: {sendError.Error.InnerError.RequestId}, date: {sendError.Error.InnerError.Date}";
-        var ex = new GraphApiException(sendResponse.StatusCode, sendErrorMessage, sendContent);
-        var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, sendContent, ex.Message);
-        await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
-        throw ex;
     }
 
     /// <summary>
@@ -597,27 +612,35 @@ public class Graph : IDisposable {
         draftRequest.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(TokenType, AccessToken);
 
         // Send the HTTP request for creating the draft message
-        using var draftResponse = await _client.SendAsync(draftRequest, cancellationToken);
-
-        // Read the response content
-        var draftContent = await draftResponse.Content.ReadAsStringAsync();
-
-        if (!draftResponse.IsSuccessStatusCode) {
-            var error = JsonSerializer.Deserialize<GraphApiError>(draftContent);
-            var errorMessage = (error == null || error.Error == null)
-                ? $"Unknown error: {draftContent}"
-                : $"Error code: {error.Error.Code}, message: {error.Error.Message}";
-            throw new GraphApiException(draftResponse.StatusCode, errorMessage, draftContent);
+        await MicrosoftGraphUtils.ConcurrencySemaphore.WaitAsync(cancellationToken);
+        HttpResponseMessage draftResponse;
+        try {
+            draftResponse = await _client.SendAsync(draftRequest, cancellationToken);
+        } finally {
+            MicrosoftGraphUtils.ConcurrencySemaphore.Release();
         }
 
-        // Deserialize the draft message
-        var draftMessage = JsonSerializer.Deserialize<GraphMessage>(draftContent);
+        using (draftResponse) {
+            // Read the response content
+            var draftContent = await draftResponse.Content.ReadAsStringAsync();
 
-        if (draftMessage == null) {
-            throw new InvalidOperationException("Failed to create draft message.");
+            if (!draftResponse.IsSuccessStatusCode) {
+                var error = JsonSerializer.Deserialize<GraphApiError>(draftContent);
+                var errorMessage = (error == null || error.Error == null)
+                    ? $"Unknown error: {draftContent}"
+                    : $"Error code: {error.Error.Code}, message: {error.Error.Message}";
+                throw new GraphApiException(draftResponse.StatusCode, errorMessage, draftContent);
+            }
+
+            // Deserialize the draft message
+            var draftMessage = JsonSerializer.Deserialize<GraphMessage>(draftContent);
+
+            if (draftMessage == null) {
+                throw new InvalidOperationException("Failed to create draft message.");
+            }
+
+            return draftMessage;
         }
-
-        return draftMessage;
     }
 
     /// <summary>
@@ -686,16 +709,24 @@ public class Graph : IDisposable {
         using var client = new HttpClient();
         client.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
-        using var uploadSessionResponse = await client.PostAsync(
-            uploadSessionUrl,
-            new StringContent(attachmentItemJson, Encoding.UTF8, "application/json"),
-            cancellationToken);
+        await MicrosoftGraphUtils.ConcurrencySemaphore.WaitAsync(cancellationToken);
+        HttpResponseMessage uploadSessionResponse;
+        try {
+            uploadSessionResponse = await client.PostAsync(
+                uploadSessionUrl,
+                new StringContent(attachmentItemJson, Encoding.UTF8, "application/json"),
+                cancellationToken);
+        } finally {
+            MicrosoftGraphUtils.ConcurrencySemaphore.Release();
+        }
 
-        var uploadSessionContent = await uploadSessionResponse.Content.ReadAsStringAsync();
+        using (uploadSessionResponse) {
+            var uploadSessionContent = await uploadSessionResponse.Content.ReadAsStringAsync();
 
-        // {"error":{"code":"InvalidAuthenticationToken","message":"Access token is empty.","innerError":{"date":"2024-06-15T09:51:54","request-id":"4a43e743-e897-4758-8d7d-21858c198e1d","client-request-id":"4a43e743-e897-4758-8d7d-21858c198e1d"}}}
-        //Console.WriteLine(uploadSessionContent);
-        return ParseUploadSessionResult(uploadSessionContent);
+            // {"error":{"code":"InvalidAuthenticationToken","message":"Access token is empty.","innerError":{"date":"2024-06-15T09:51:54","request-id":"4a43e743-e897-4758-8d7d-21858c198e1d","client-request-id":"4a43e743-e897-4758-8d7d-21858c198e1d"}}}
+            //Console.WriteLine(uploadSessionContent);
+            return ParseUploadSessionResult(uploadSessionContent);
+        }
     }
 
     private static string ParseUploadSessionResult(string uploadSessionContent) {
@@ -794,11 +825,16 @@ public class Graph : IDisposable {
         requestMessage.Headers.Add("AnchorMailbox", SentFrom); // This is correctly added to HttpRequestMessage
         using var client = new HttpClient();
         client.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
-        var uploadChunkResponse = await client.SendAsync(requestMessage, cancellationToken);
-        if (!uploadChunkResponse.IsSuccessStatusCode) {
-            // Handle upload error
-            LogCollector.LogWarning(uploadChunkResponse.ToString());
-            return;
+        await MicrosoftGraphUtils.ConcurrencySemaphore.WaitAsync(cancellationToken);
+        try {
+            var uploadChunkResponse = await client.SendAsync(requestMessage, cancellationToken);
+            if (!uploadChunkResponse.IsSuccessStatusCode) {
+                // Handle upload error
+                LogCollector.LogWarning(uploadChunkResponse.ToString());
+                return;
+            }
+        } finally {
+            MicrosoftGraphUtils.ConcurrencySemaphore.Release();
         }
     }
 

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Linq;
 using System.IO;
 using System.Collections.Concurrent;
+using System.Threading;
 
 namespace Mailozaurr {
 
@@ -15,6 +16,23 @@ namespace Mailozaurr {
     public static class MicrosoftGraphUtils {
         private static readonly HttpClient HttpClient;
         private static readonly ConcurrentDictionary<string, GraphAuthorization> TokenCache = new();
+        private static SemaphoreSlim _concurrencySemaphore = new(5, 5);
+        private static int _maxConcurrentRequests = 5;
+
+        public static int MaxConcurrentRequests {
+            get => _maxConcurrentRequests;
+            set {
+                if (value <= 0) {
+                    throw new ArgumentOutOfRangeException(nameof(MaxConcurrentRequests));
+                }
+                var newSem = new SemaphoreSlim(value, value);
+                var old = Interlocked.Exchange(ref _concurrencySemaphore, newSem);
+                old.Dispose();
+                _maxConcurrentRequests = value;
+            }
+        }
+
+        internal static SemaphoreSlim ConcurrencySemaphore => _concurrencySemaphore;
 
         /// <summary>
         /// Timeout for HTTP operations in seconds.
@@ -98,33 +116,38 @@ namespace Mailozaurr {
             };
             var content = new FormUrlEncodedContent(body);
             var url = $"https://login.microsoftonline.com/{tenantDomain}/oauth2/token";
-            using var response = await HttpClient.PostAsync(url, content);
-            var json = await response.Content.ReadAsStringAsync();
-            if (!response.IsSuccessStatusCode) {
-                throw new GraphApiException(
-                    response.StatusCode,
-                    $"ConnectO365GraphAsync - Error: {json}",
-                    json);
-            }
-            var token = System.Text.Json.JsonDocument.Parse(json);
-            var accessToken = token.RootElement.GetProperty("access_token").GetString();
-            var tokenType = token.RootElement.GetProperty("token_type").GetString();
-            var expiresOn = DateTimeOffset.UtcNow.AddHours(1);
-            if (token.RootElement.TryGetProperty("expires_in", out var expIn)) {
-                expiresOn = DateTimeOffset.UtcNow.AddSeconds(expIn.GetInt32());
-            }
-            if (token.RootElement.TryGetProperty("expires_on", out var expOn)) {
-                if (long.TryParse(expOn.GetString(), out var expSeconds)) {
-                    expiresOn = DateTimeOffset.FromUnixTimeSeconds(expSeconds);
+            await ConcurrencySemaphore.WaitAsync();
+            try {
+                using var response = await HttpClient.PostAsync(url, content);
+                var json = await response.Content.ReadAsStringAsync();
+                if (!response.IsSuccessStatusCode) {
+                    throw new GraphApiException(
+                        response.StatusCode,
+                        $"ConnectO365GraphAsync - Error: {json}",
+                        json);
                 }
+                var token = System.Text.Json.JsonDocument.Parse(json);
+                var accessToken = token.RootElement.GetProperty("access_token").GetString();
+                var tokenType = token.RootElement.GetProperty("token_type").GetString();
+                var expiresOn = DateTimeOffset.UtcNow.AddHours(1);
+                if (token.RootElement.TryGetProperty("expires_in", out var expIn)) {
+                    expiresOn = DateTimeOffset.UtcNow.AddSeconds(expIn.GetInt32());
+                }
+                if (token.RootElement.TryGetProperty("expires_on", out var expOn)) {
+                    if (long.TryParse(expOn.GetString(), out var expSeconds)) {
+                        expiresOn = DateTimeOffset.FromUnixTimeSeconds(expSeconds);
+                    }
+                }
+                TokenCache[key] = new GraphAuthorization { AccessToken = accessToken, TokenType = tokenType, ExpiresOn = expiresOn };
+                OAuthTokenCache.Set($"graph:{key}", new OAuthCredential {
+                    UserName = credential.ClientId,
+                    AccessToken = accessToken,
+                    ExpiresOn = expiresOn
+                });
+                return $"{tokenType} {accessToken}";
+            } finally {
+                ConcurrencySemaphore.Release();
             }
-            TokenCache[key] = new GraphAuthorization { AccessToken = accessToken, TokenType = tokenType, ExpiresOn = expiresOn };
-            OAuthTokenCache.Set($"graph:{key}", new OAuthCredential {
-                UserName = credential.ClientId,
-                AccessToken = accessToken,
-                ExpiresOn = expiresOn
-            });
-            return $"{tokenType} {accessToken}";
         }
 
         /// <summary>
@@ -199,15 +222,20 @@ namespace Mailozaurr {
             if (!string.IsNullOrWhiteSpace(body) && (method == "POST" || method == "PUT" || method == "PATCH")) {
                 request.Content = new StringContent(body, Encoding.UTF8, "application/json");
             }
-            using var response = await HttpClient.SendAsync(request);
-            var responseContent = await response.Content.ReadAsStringAsync();
-            if (!response.IsSuccessStatusCode) {
-                throw new GraphApiException(
-                    response.StatusCode,
-                    $"InvokeGraphApiAsync - Error: {response.StatusCode} - {responseContent}",
-                    responseContent);
+            await ConcurrencySemaphore.WaitAsync();
+            try {
+                using var response = await HttpClient.SendAsync(request);
+                var responseContent = await response.Content.ReadAsStringAsync();
+                if (!response.IsSuccessStatusCode) {
+                    throw new GraphApiException(
+                        response.StatusCode,
+                        $"InvokeGraphApiAsync - Error: {response.StatusCode} - {responseContent}",
+                        responseContent);
+                }
+                return JsonDocument.Parse(responseContent);
+            } finally {
+                ConcurrencySemaphore.Release();
             }
-            return JsonDocument.Parse(responseContent);
         }
 
         /// <summary>

--- a/Tests/MaxConcurrentRequests.Tests.ps1
+++ b/Tests/MaxConcurrentRequests.Tests.ps1
@@ -1,0 +1,6 @@
+Describe 'MicrosoftGraphUtils.MaxConcurrentRequests' {
+    It 'Can change concurrency limit' {
+        [Mailozaurr.MicrosoftGraphUtils]::MaxConcurrentRequests = 7
+        [Mailozaurr.MicrosoftGraphUtils]::MaxConcurrentRequests | Should -Be 7
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `MaxConcurrentRequests` in `MicrosoftGraphUtils`
- wrap Graph send operations with semaphore logic
- expose concurrency parameter for Graph cmdlets
- update examples for new parameter
- test new concurrency property

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686a3ee10534832e8f19ba61c8c67470