### PR TITLE
Add ShouldProcess support for move and delete operations

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
@@ -25,7 +25,7 @@ namespace Mailozaurr.PowerShell;
 /// <seealso cref="CmdletConnectIMAP"/>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "IMAPMessage")]
+[Cmdlet(VerbsCommon.Get, "IMAPMessage", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
 [OutputType(typeof(ImapMessageInfo))]
 public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
     /// <summary>
@@ -133,6 +133,11 @@ public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
         if (conn != null && conn.Data != null) {
             var folder = conn.Folder?.FullName;
 
+            var del = Delete.IsPresent;
+            if (del && !ShouldProcess(folder ?? "INBOX", "Deleting IMAP messages")) {
+                del = false;
+            }
+
             await foreach (var message in MessageFetcher.Fetch(
                 conn.Data,
                 folder,
@@ -143,7 +148,7 @@ public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
                 Since,
                 Before,
                 All.IsPresent,
-                Delete.IsPresent,
+                del,
                 HasAttachment.IsPresent,
                 SearchQuery,
                 CancelToken)) {

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
@@ -9,7 +9,7 @@ namespace Mailozaurr.PowerShell;
 /// <summary>
 /// Moves a Microsoft Graph message to a different folder.
 /// </summary>
-[Cmdlet(VerbsCommon.Move, "GraphMessage")]
+[Cmdlet(VerbsCommon.Move, "GraphMessage", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Medium)]
 public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     /// <summary>
     /// UPN of the mailbox owner containing the message.
@@ -81,6 +81,9 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     /// </summary>
     /// <param name="cred">Credential used to access Graph.</param>
     private async Task ProcessGraphAsync(GraphCredential cred) {
+        if (!ShouldProcess(MessageId!, "Moving Graph message")) {
+            return;
+        }
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
         int attempts = 0;
         Exception? lastException = null;
@@ -114,6 +117,9 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     /// Executes the move operation using the <c>Invoke-MgGraphRequest</c> cmdlet.
     /// </summary>
     private void ProcessMgGraph() {
+        if (!ShouldProcess(MessageId!, "Moving Graph message")) {
+            return;
+        }
         var uri = $"https://graph.microsoft.com/v1.0/users/{UserPrincipalName}/messages/{MessageId}/move";
         var body = System.Text.Json.JsonSerializer.Serialize(new { destinationId = DestinationFolderId });
         var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPMessage.cs
@@ -19,7 +19,7 @@ namespace Mailozaurr.PowerShell;
 /// <seealso cref="CmdletConnectIMAP"/>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>
 /// </summary>
-[Cmdlet(VerbsCommon.Move, "IMAPMessage")]
+[Cmdlet(VerbsCommon.Move, "IMAPMessage", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Medium)]
 public sealed class CmdletMoveIMAPMessage : AsyncPSCmdlet {
     /// <summary>
     /// <para type="description">The <see cref="ImapConnectionInfo"/> object representing the active IMAP connection. This is the object returned by <c>Connect-IMAP</c>.</para>
@@ -53,6 +53,9 @@ public sealed class CmdletMoveIMAPMessage : AsyncPSCmdlet {
     protected override Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null && conn.Data != null) {
+            if (!ShouldProcess(Uid.ToString(), $"Moving IMAP message to {DestinationFolder}")) {
+                return Task.CompletedTask;
+            }
             var uid = new UniqueId(Uid);
             var source = conn.Data.GetCachedFolder(SourceFolder ?? conn.Folder?.FullName, FolderAccess.ReadWrite);
             var dest = conn.Data.GetCachedFolder(DestinationFolder!, FolderAccess.ReadWrite);

--- a/Tests/Get-IMAPMessage.WhatIf.Tests.ps1
+++ b/Tests/Get-IMAPMessage.WhatIf.Tests.ps1
@@ -1,0 +1,8 @@
+Describe 'Get-IMAPMessage -Delete with WhatIf' {
+    It 'Warns when deleting without connection' {
+        $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
+        Get-IMAPMessage -Client $info -Delete -WhatIf -WarningVariable warn
+        $warn | Should -Not -BeNullOrEmpty
+        $warn[0] | Should -Be 'Get-IMAPMessage - Is IMAP connected?'
+    }
+}

--- a/Tests/Move-GraphMessage.Tests.ps1
+++ b/Tests/Move-GraphMessage.Tests.ps1
@@ -1,0 +1,6 @@
+Describe 'Move-GraphMessage' {
+    It 'Skips execution when using WhatIf' {
+        Move-GraphMessage -UserPrincipalName 'u' -MessageId 'id' -DestinationFolderId 'dest' -MgGraphRequest -WhatIf -ErrorVariable err
+        $err | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Move-IMAPMessage.Tests.ps1
+++ b/Tests/Move-IMAPMessage.Tests.ps1
@@ -1,0 +1,8 @@
+Describe 'Move-IMAPMessage' {
+    It 'Warns when IMAP connection missing' {
+        $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
+        Move-IMAPMessage -Client $info -Uid 1 -DestinationFolder 'Archive' -WhatIf -WarningVariable warn
+        $warn | Should -Not -BeNullOrEmpty
+        $warn[0] | Should -Be 'Move-IMAPMessage - Is IMAP connected?'
+    }
+}


### PR DESCRIPTION
## Summary
- add support for ShouldProcess to Move-IMAPMessage, Move-GraphMessage and Get-IMAPMessage
- respect `-WhatIf` and `-Confirm` for these cmdlets
- test WhatIf handling for new cmdlets

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -File run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686a3e8b61b8832eb6efde13032162f4