### PR TITLE
Fix flaky warning test

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -171,14 +171,13 @@ public class HelpersTests
     {
         var client = new HttpClient(new ThrowHandler());
         var result = new SmtpResult(true, EmailAction.Send, string.Empty, string.Empty, string.Empty, 0, TimeSpan.Zero);
-        string? message = null;
-        void Handler(object? _, LogEventArgs e) => message = e.Message;
+        var messages = new List<string>();
+        void Handler(object? _, LogEventArgs e) => messages.Add(e.Message);
         Mailozaurr.LoggingMessages.Logger.OnWarningMessage += Handler;
 
         await Mailozaurr.Helpers.PostWebhookAsync("http://localhost", result, default, client);
 
         Mailozaurr.LoggingMessages.Logger.OnWarningMessage -= Handler;
-        Assert.NotNull(message);
-        Assert.Contains("Failed to post webhook", message);
+        Assert.Contains(messages, static m => m.Contains("Failed to post webhook"));
     }
 }


### PR DESCRIPTION
## Summary
- ensure `PostWebhookAsync_HttpRequestException_LogsWarning` checks all logged messages

## Testing
- `dotnet test Mailozaurr.sln -f net8.0 --no-build --verbosity minimal`
- `dotnet build Mailozaurr.sln -c Release -f net472 --no-restore` *(fails: .NETFramework reference assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b7c059608832e9dce044b46073d7d