### PR TITLE
Add missing XML documentation

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -49,30 +49,51 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? DirectoryId { get; set; }
 
+    /// <summary>
+    /// Path to a PFX certificate used for authentication.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Certificate")]
     [ValidateNotNullOrEmpty]
     public string? CertificatePath { get; set; }
 
+    /// <summary>
+    /// Raw bytes of a PFX certificate used for authentication.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "CertificateBytes")]
     [ValidateNotNull]
     public byte[]? CertificateBytes { get; set; }
 
+    /// <summary>
+    /// Path to a PEM encoded certificate used for authentication.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "CertificatePem")]
     [ValidateNotNullOrEmpty]
     public string? CertificatePemPath { get; set; }
 
+    /// <summary>
+    /// Password used to decrypt the certificate file.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Certificate")]
     [Parameter(Mandatory = true, ParameterSetName = "CertificateBytes")]
     [ValidateNotNullOrEmpty]
     public string? CertificatePassword { get; set; }
 
+    /// <summary>
+    /// Use the device code flow for authentication.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "DeviceCode")]
     public SwitchParameter DeviceCode { get; set; }
 
+    /// <summary>
+    /// Access token to use for on-behalf-of authentication.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "OnBehalfOf")]
     [ValidateNotNullOrEmpty]
     public string? OnBehalfOfToken { get; set; }
 
+    /// <summary>
+    /// Microsoft Graph permission scopes to request.
+    /// </summary>
     [Parameter(ParameterSetName = "DeviceCode")]
     [Parameter(ParameterSetName = "OnBehalfOf")]
     public string[] Scopes { get; set; } = new[] { "https://graph.microsoft.com/.default" };

--- a/Sources/Mailozaurr.PowerShell/CmdletSetIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetIMAPMessage.cs
@@ -31,6 +31,9 @@ public sealed class CmdletSetIMAPMessage : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Unread { get; set; }
 
+    /// <summary>
+    /// Processes the cmdlet, updating message flags as requested.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         if (Read.IsPresent && Unread.IsPresent) {
             ThrowTerminatingError(new ErrorRecord(new PSArgumentException("Specify only -Read or -Unread."), "InvalidFlags", ErrorCategory.InvalidArgument, null));

--- a/Sources/Mailozaurr.PowerShell/CmdletSetPOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetPOP3Message.cs
@@ -26,6 +26,9 @@ public sealed class CmdletSetPOP3Message : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Unread { get; set; }
 
+    /// <summary>
+    /// Processes the cmdlet, updating POP3 message flags.
+    /// </summary>
     protected override Task ProcessRecordAsync() {
         if (Read.IsPresent && Unread.IsPresent) {
             ThrowTerminatingError(new ErrorRecord(new PSArgumentException("Specify only -Read or -Unread."), "InvalidFlags", ErrorCategory.InvalidArgument, null));

--- a/Sources/Mailozaurr.PowerShell/CmdletWaitGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWaitGraphMessage.cs
@@ -17,23 +17,41 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsLifecycle.Wait, "GraphMessage")]
 [OutputType(typeof(object))]
 public sealed class CmdletWaitGraphMessage : AsyncPSCmdlet, IDisposable {
+    /// <summary>
+    /// Graph connection information used when polling for messages.
+    /// </summary>
     [Parameter(ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// User principal name whose mailbox should be monitored.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Optional action executed for each received message.
+    /// </summary>
     [Parameter]
     public ScriptBlock? Action { get; set; }
 
+    /// <summary>
+    /// Script block that determines when to stop waiting for messages.
+    /// </summary>
     [Parameter]
     public ScriptBlock? Until { get; set; }
 
+    /// <summary>
+    /// Stops waiting when a message matches the <c>Until</c> condition.
+    /// </summary>
     [Parameter]
     public SwitchParameter StopOnMatch { get; set; }
 
+    /// <summary>
+    /// Optional timeout after which listening will stop automatically.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; }
 
@@ -42,6 +60,9 @@ public sealed class CmdletWaitGraphMessage : AsyncPSCmdlet, IDisposable {
     private CancellationTokenSource? _linkedSource;
 
     /// <inheritdoc />
+    /// <summary>
+    /// Starts listening for new Graph messages until stopped or timed out.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         var conn = Connection ?? DefaultSessions.GraphSession;
         if (conn == null || conn.Credential == null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletWaitIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWaitIMAPMessage.cs
@@ -36,17 +36,26 @@ public sealed class CmdletWaitIMAPMessage : AsyncPSCmdlet, System.IDisposable {
     public string? Folder { get; set; }
 
     /// <summary>
-    /// <para type="description">Optional script block invoked for each arriving message.</para>
+    /// Optional action executed for each received message.
     /// </summary>
     [Parameter]
     public ScriptBlock? Action { get; set; }
 
+    /// <summary>
+    /// Script block that determines when to stop waiting for messages.
+    /// </summary>
     [Parameter]
     public ScriptBlock? Until { get; set; }
 
+    /// <summary>
+    /// Stops listening when the <c>Until</c> condition is satisfied.
+    /// </summary>
     [Parameter]
     public SwitchParameter StopOnMatch { get; set; }
 
+    /// <summary>
+    /// Optional timeout after which the cmdlet stops waiting.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; }
 
@@ -55,6 +64,9 @@ public sealed class CmdletWaitIMAPMessage : AsyncPSCmdlet, System.IDisposable {
     private CancellationTokenSource? _linkedSource;
 
     /// <inheritdoc />
+    /// <summary>
+    /// Begins listening for new IMAP messages using the IDLE command.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn == null || conn.Data == null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletWaitPOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWaitPOP3Message.cs
@@ -11,19 +11,34 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsLifecycle.Wait, "POP3Message")]
 [OutputType(typeof(Pop3EmailMessage))]
 public sealed class CmdletWaitPOP3Message : AsyncPSCmdlet, IDisposable {
+    /// <summary>
+    /// Connection information for the POP3 session used for polling.
+    /// </summary>
     [Parameter(ValueFromPipeline = true)]
     [ValidateNotNull]
     public PopConnectionInfo? Client { get; set; }
 
+    /// <summary>
+    /// Optional action invoked for each message that arrives.
+    /// </summary>
     [Parameter]
     public ScriptBlock? Action { get; set; }
 
+    /// <summary>
+    /// Script block determining when to stop waiting for messages.
+    /// </summary>
     [Parameter]
     public ScriptBlock? Until { get; set; }
 
+    /// <summary>
+    /// Stops polling when the <c>Until</c> condition is satisfied.
+    /// </summary>
     [Parameter]
     public SwitchParameter StopOnMatch { get; set; }
 
+    /// <summary>
+    /// Optional timeout after which the cmdlet stops polling.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; }
 
@@ -32,6 +47,9 @@ public sealed class CmdletWaitPOP3Message : AsyncPSCmdlet, IDisposable {
     private CancellationTokenSource? _linkedSource;
 
     /// <inheritdoc />
+    /// <summary>
+    /// Begins polling the POP3 mailbox for new messages until stopped.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.Pop3Session;
         if (conn == null || conn.Data == null) {

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -56,7 +56,14 @@ public class SesClient : IDisposable {
     /// <summary>Collector used to store log entries.</summary>
     public LogCollector LogCollector { get; set; } = new();
 
+    /// <summary>
+    /// Gets the normalized sender email address.
+    /// </summary>
     public string SentFrom => Helpers.GetEmailAddress(From);
+
+    /// <summary>
+    /// Gets a comma separated list of recipient email addresses.
+    /// </summary>
     public string SentTo
     {
         get
@@ -70,14 +77,19 @@ public class SesClient : IDisposable {
         }
     }
 
-    public SesClient()
-    {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SesClient"/> class using a default <see cref="HttpClient"/>.
+    /// </summary>
+    public SesClient() {
         Stopwatch = Stopwatch.StartNew();
         _client = new HttpClient();
     }
 
-    public SesClient(HttpMessageHandler handler)
-    {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SesClient"/> class using the specified HTTP handler.
+    /// </summary>
+    /// <param name="handler">The HTTP handler to use for requests.</param>
+    public SesClient(HttpMessageHandler handler) {
         Stopwatch = Stopwatch.StartNew();
         _client = new HttpClient(handler);
     }
@@ -202,8 +214,10 @@ public class SesClient : IDisposable {
         return final;
     }
 
-    public void Dispose()
-    {
+    /// <summary>
+    /// Releases resources used by the <see cref="SesClient"/> instance.
+    /// </summary>
+    public void Dispose() {
         _client.Dispose();
     }
 }

--- a/Sources/Mailozaurr/Authentication/SaslMechanismNtlmIntegrated.cs
+++ b/Sources/Mailozaurr/Authentication/SaslMechanismNtlmIntegrated.cs
@@ -83,6 +83,9 @@ namespace Mailozaurr {
         }
 
 
+        /// <summary>
+        /// Resets the authentication state allowing the mechanism to be reused.
+        /// </summary>
         public override void Reset() {
             state = LoginState.Initial;
             base.Reset();

--- a/Sources/Mailozaurr/Connections/ImapConnector.cs
+++ b/Sources/Mailozaurr/Connections/ImapConnector.cs
@@ -9,7 +9,14 @@ namespace Mailozaurr;
 /// Provides helper methods for connecting to IMAP servers with retry logic.
 /// </summary>
 public static class ImapConnector {
+    /// <summary>
+    /// Factory used to create <see cref="ImapClient"/> instances.
+    /// </summary>
     public static Func<ImapClient> ClientFactory { get; set; } = () => new ImapClient();
+
+    /// <summary>
+    /// Delegate used to introduce a delay between connection retries.
+    /// </summary>
     public static Func<int, Task>? DelayAsync { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr/Connections/Pop3Connector.cs
+++ b/Sources/Mailozaurr/Connections/Pop3Connector.cs
@@ -9,7 +9,14 @@ namespace Mailozaurr;
 /// Provides helper methods for connecting to POP3 servers with retry logic.
 /// </summary>
 public static class Pop3Connector {
+    /// <summary>
+    /// Factory used to create <see cref="Pop3Client"/> instances.
+    /// </summary>
     public static Func<Pop3Client> ClientFactory { get; set; } = () => new Pop3Client();
+
+    /// <summary>
+    /// Delegate used to delay between connection retries.
+    /// </summary>
     public static Func<int, Task>? DelayAsync { get; set; }
     /// <summary>
     /// Connects and authenticates to a POP3 server with retry support.

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -142,6 +142,13 @@ public static class Helpers {
         }
     }
 
+    /// <summary>
+    /// Posts the provided <see cref="SmtpResult"/> to a webhook endpoint.
+    /// </summary>
+    /// <param name="url">Destination webhook URL.</param>
+    /// <param name="result">Result object describing the send operation.</param>
+    /// <param name="cancellationToken">Token used to cancel the request.</param>
+    /// <param name="client">Optional HTTP client to reuse.</param>
     public static async Task PostWebhookAsync(string? url, SmtpResult result, CancellationToken cancellationToken = default, HttpClient? client = null) {
         if (string.IsNullOrWhiteSpace(url)) {
             return;

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -9,8 +9,17 @@ namespace Mailozaurr;
 /// </summary>
 public class Graph : IDisposable {
     private readonly HttpClient _client;
+    /// <summary>
+    /// Serialized JSON representation of the current Graph message.
+    /// </summary>
     public string MessageJson = string.Empty;
+
+    /// <summary>
+    /// Container object used when building a Graph message.
+    /// </summary>
     public GraphMessageContainer MessageContainer;
+
+    /// <summary>Measures elapsed time spent during send operations.</summary>
     public readonly Stopwatch Stopwatch;
 
     /// <summary>
@@ -23,6 +32,9 @@ public class Graph : IDisposable {
     /// </summary>
     public List<GraphAttachment> ConvertedAttachments { get; set; } = new List<GraphAttachment>();
 
+    /// <summary>
+    /// Collection of attachment placeholders used for large file uploads.
+    /// </summary>
     public List<GraphAttachmentPlaceHolder> AttachmentsPlaceHolders { get; set; } = new List<GraphAttachmentPlaceHolder>();
 
     /// <summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentItemWrapper.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentItemWrapper.cs
@@ -5,6 +5,9 @@ namespace Mailozaurr;
 /// </summary>
 public class GraphAttachmentItemWrapper {
     [JsonPropertyName("AttachmentItem")]
+    /// <summary>
+    /// Gets the attachment item used when creating the upload session.
+    /// </summary>
     public GraphAttachmentItem AttachmentItem { get; set; }
 
     /// <summary>Initializes a new instance of the wrapper.</summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphErrors.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphErrors.cs
@@ -5,5 +5,8 @@
 /// </summary>
 public class GraphApiError {
     [JsonPropertyName("error")]
+    /// <summary>
+    /// Gets or sets the error details returned by the API.
+    /// </summary>
     public GraphApiErrorDetail Error { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphInboxRule.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphInboxRule.cs
@@ -60,6 +60,9 @@ public class GraphInboxRulePredicates
 {
     [JsonPropertyName("senderContains")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    /// <summary>
+    /// Gets or sets a list of strings that must appear in the sender address.
+    /// </summary>
     public List<string>? SenderContains { get; set; }
 
     [JsonPropertyName("recipientContains")]

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -12,13 +12,18 @@ using System.Threading;
 
 namespace Mailozaurr {
 
-
+    /// <summary>
+    /// Utility helpers for working with the Microsoft Graph API.
+    /// </summary>
     public static class MicrosoftGraphUtils {
         private static readonly HttpClient HttpClient;
         private static readonly ConcurrentDictionary<string, GraphAuthorization> TokenCache = new();
         private static SemaphoreSlim _concurrencySemaphore = new(5, 5);
         private static int _maxConcurrentRequests = 5;
 
+        /// <summary>
+        /// Gets or sets the maximum number of concurrent HTTP requests allowed.
+        /// </summary>
         public static int MaxConcurrentRequests {
             get => _maxConcurrentRequests;
             set {
@@ -35,7 +40,7 @@ namespace Mailozaurr {
         internal static SemaphoreSlim ConcurrencySemaphore => _concurrencySemaphore;
 
         /// <summary>
-        /// Timeout for HTTP operations in seconds.
+        /// Gets or sets the timeout for HTTP operations in seconds.
         /// </summary>
         public static int TimeoutSeconds {
             get => (int)HttpClient.Timeout.TotalSeconds;


### PR DESCRIPTION
## Summary
- add docs for POP3, IMAP and Graph wait cmdlets
- document POP3 and IMAP connector factories
- document SES client and NTLM SASL reset method
- fill out documentation for Graph helpers and utils

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./run-tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686b800094e4832e9330a6c192a4dc5c