### PR TITLE
Add missing XML documentation

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCertificateCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCertificateCredential.cs
@@ -18,22 +18,37 @@ using System.Threading.Tasks;
 [Cmdlet(VerbsData.ConvertTo, "GraphCertificateCredential")]
 [OutputType(typeof(PSCredential))]
 public class CmdletConvertToGraphCertificateCredential : PSCmdlet {
+    /// <summary>
+    /// Azure AD application (client) identifier.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? ClientId { get; set; }
 
+    /// <summary>
+    /// Azure AD tenant identifier.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? TenantId { get; set; }
 
+    /// <summary>
+    /// Path to the client certificate (PFX).
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? CertificatePath { get; set; }
 
+    /// <summary>
+    /// Password for the client certificate.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? CertificatePassword { get; set; }
 
+    /// <summary>
+    /// Optional scopes to request.
+    /// </summary>
     [Parameter]
     public string[]? Scopes { get; set; }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToMailgunCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToMailgunCredential.cs
@@ -14,6 +14,9 @@ using System.Security;
 [Cmdlet(VerbsData.ConvertTo, "MailgunCredential")]
 [OutputType(typeof(PSCredential))]
 public class CmdletConvertToMailgunCredential : PSCmdlet {
+    /// <summary>
+    /// Mailgun API key used for authentication.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? ApiKey { get; set; }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
@@ -17,13 +17,22 @@ namespace Mailozaurr.PowerShell;
 public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "Graph")]
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
+    /// <summary>
+    /// User principal name whose mailbox is queried.
+    /// </summary>
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Graph connection information.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph", ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Message properties to select.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph")]
     [Parameter(ParameterSetName = "MgGraphRequest")]
     public string[]? Property { get; set; }
@@ -36,49 +45,94 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     [Alias("ODataFilter")]
     public string? Filter { get; set; }
 
+    /// <summary>
+    /// Limits the number of returned messages.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph")]
     [Parameter(ParameterSetName = "MgGraphRequest")]
     public int? Limit { get; set; }
 
+    /// <summary>
+    /// Filters messages by subject text.
+    /// </summary>
     [Parameter]
     public string? Subject { get; set; }
 
+    /// <summary>
+    /// Filters messages where the sender contains this value.
+    /// </summary>
     [Parameter]
     public string? FromContains { get; set; }
 
+    /// <summary>
+    /// Filters messages where the recipient contains this value.
+    /// </summary>
     [Parameter]
     public string? ToContains { get; set; }
 
+    /// <summary>
+    /// Filters messages by importance.
+    /// </summary>
     [Parameter]
     public MessagePriority? Priority { get; set; }
 
+    /// <summary>
+    /// Retrieves messages received since this date.
+    /// </summary>
     [Parameter]
     public DateTime? Since { get; set; }
 
+    /// <summary>
+    /// Retrieves messages received before this date.
+    /// </summary>
     [Parameter]
     public DateTime? Before { get; set; }
 
+    /// <summary>
+    /// Filters messages that have attachments.
+    /// </summary>
     [Parameter]
     public SwitchParameter HasAttachment { get; set; }
 
+    /// <summary>
+    /// When present, retrieves all messages ignoring limit.
+    /// </summary>
     [Parameter]
     public SwitchParameter All { get; set; }
 
+    /// <summary>
+    /// Deletes messages after retrieval when set.
+    /// </summary>
     [Parameter]
     public SwitchParameter Delete { get; set; }
 
+    /// <summary>
+    /// When specified, uses Invoke-MgGraphRequest for the operation.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Maximum number of concurrent Graph requests.
+    /// </summary>
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessageAttachment.cs
@@ -36,23 +36,41 @@ public class CmdletGetEmailGraphMessageAttachment : AsyncPSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? MessageId { get; set; }
     /// <summary>
+    /// <summary>
+    /// Graph connection information.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph", ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
 
+    /// <summary>
+    /// Executes the request via Invoke-MgGraphRequest when set.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Maximum number of concurrent Graph requests.
+    /// </summary>
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletGetGraphInboxRule.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetGraphInboxRule.cs
@@ -13,27 +13,48 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.Get, "GraphInboxRule")]
 [OutputType(typeof(GraphInboxRule))]
 public sealed class CmdletGetGraphInboxRule : AsyncPSCmdlet {
+    /// <summary>
+    /// User principal name whose inbox rules are retrieved.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Graph")]
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Connection information for Microsoft Graph.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph", ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Optional OData filter string.
+    /// </summary>
     [Parameter]
     public string? Filter { get; set; }
 
+    /// <summary>
+    /// Indicates the use of Invoke-MgGraphRequest for this operation.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletGetGraphMailboxPermission.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetGraphMailboxPermission.cs
@@ -25,12 +25,21 @@ public class CmdletGetGraphMailboxPermission : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Number of retries on transient failures.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retry attempts in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleBuilder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleBuilder.cs
@@ -11,42 +11,81 @@ namespace Mailozaurr.PowerShell;
 [OutputType(typeof(GraphInboxRuleBuilder))]
 public sealed class CmdletNewGraphInboxRuleBuilder : PSCmdlet
 {
+    /// <summary>
+    /// Display name for the inbox rule.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string DisplayName { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Rule processing order.
+    /// </summary>
     [Parameter]
     public int Sequence { get; set; }
 
+    /// <summary>
+    /// Enables the rule when set.
+    /// </summary>
     [Parameter]
     public SwitchParameter Enabled { get; set; }
 
+    /// <summary>
+    /// Destination folder to move messages to.
+    /// </summary>
     [Parameter]
     public string? MoveToFolder { get; set; }
 
+    /// <summary>
+    /// Destination folder to copy messages to.
+    /// </summary>
     [Parameter]
     public string? CopyToFolder { get; set; }
 
+    /// <summary>
+    /// Deletes messages that match the rule.
+    /// </summary>
     [Parameter]
     public SwitchParameter Delete { get; set; }
 
+    /// <summary>
+    /// Addresses to forward matching messages to.
+    /// </summary>
     [Parameter]
     public string[]? ForwardTo { get; set; }
 
+    /// <summary>
+    /// Stops processing further rules when this rule matches.
+    /// </summary>
     [Parameter]
     public SwitchParameter StopProcessing { get; set; }
 
+    /// <summary>
+    /// Sender address patterns to match.
+    /// </summary>
     [Parameter]
     public string[]? SenderContains { get; set; }
 
+    /// <summary>
+    /// Recipient address patterns to match.
+    /// </summary>
     [Parameter]
     public string[]? RecipientContains { get; set; }
 
+    /// <summary>
+    /// Subject text patterns to match.
+    /// </summary>
     [Parameter]
     public string[]? SubjectContains { get; set; }
 
+    /// <summary>
+    /// Body text patterns to match.
+    /// </summary>
     [Parameter]
     public string[]? BodyContains { get; set; }
 
+    /// <summary>
+    /// Message importance to match.
+    /// </summary>
     [Parameter]
     public string? Importance { get; set; }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleObject.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleObject.cs
@@ -12,45 +12,87 @@ namespace Mailozaurr.PowerShell;
 [OutputType(typeof(GraphInboxRule))]
 public sealed class CmdletNewGraphInboxRuleObject : PSCmdlet
 {
+    /// <summary>
+    /// Display name for the inbox rule.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Params")]
     public string DisplayName { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Builder object used to create the rule.
+    /// </summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = "Builder")]
     public GraphInboxRuleBuilder? Builder { get; set; }
 
+    /// <summary>
+    /// Rule processing sequence number.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public int Sequence { get; set; }
 
+    /// <summary>
+    /// Enables the rule when set.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public SwitchParameter Enabled { get; set; }
 
+    /// <summary>
+    /// Folder to move matching messages to.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string? MoveToFolder { get; set; }
 
+    /// <summary>
+    /// Folder to copy matching messages to.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string? CopyToFolder { get; set; }
 
+    /// <summary>
+    /// Deletes matching messages.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public SwitchParameter Delete { get; set; }
 
+    /// <summary>
+    /// Addresses to forward matching messages to.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string[]? ForwardTo { get; set; }
 
+    /// <summary>
+    /// Stops processing additional rules when this rule matches.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public SwitchParameter StopProcessing { get; set; }
 
+    /// <summary>
+    /// Sender address patterns to match.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string[]? SenderContains { get; set; }
 
+    /// <summary>
+    /// Recipient address patterns to match.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string[]? RecipientContains { get; set; }
 
+    /// <summary>
+    /// Subject text patterns to match.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string[]? SubjectContains { get; set; }
 
+    /// <summary>
+    /// Body text patterns to match.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string[]? BodyContains { get; set; }
 
+    /// <summary>
+    /// Importance level to match.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string? Importance { get; set; }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphMailboxPermissionObject.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphMailboxPermissionObject.cs
@@ -9,18 +9,33 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.New, "GraphMailboxPermissionObject")]
 [OutputType(typeof(GraphMailboxPermission))]
 public sealed class CmdletNewGraphMailboxPermissionObject : PSCmdlet {
+    /// <summary>
+    /// User principal name of the grantee.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Params")]
     public string GrantedToUser { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Roles assigned to the grantee.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public GraphMailboxRole[]? Roles { get; set; }
 
+    /// <summary>
+    /// Mailbox owner user principal name.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Permission identifier.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string? Id { get; set; }
 
+    /// <summary>
+    /// Permission builder object used to create the permission.
+    /// </summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = "Builder")]
     public GraphMailboxPermissionBuilder? Builder { get; set; }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphFolder.cs
@@ -37,6 +37,9 @@ public class CmdletRemoveGraphFolder : AsyncPSCmdlet {
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Maximum number of concurrent Microsoft Graph requests allowed.
+    /// </summary>
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMessage.cs
@@ -29,15 +29,27 @@ public class CmdletRemoveGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Maximum number of concurrent Graph requests.
+    /// </summary>
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchGraphMailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchGraphMailbox.cs
@@ -11,26 +11,44 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.Search, "GraphMailbox")]
 [OutputType(typeof(GraphMessageInfo))]
 public class CmdletSearchGraphMailbox : AsyncPSCmdlet {
+    /// <summary>
+    /// User principal names to search across.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string[]? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Query string used to filter messages.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? Query { get; set; }
 
+    /// <summary>
+    /// Graph connection information.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph", ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Message index to start from.
+    /// </summary>
     [Parameter]
     public int From { get; set; }
 
+    /// <summary>
+    /// Number of messages to retrieve.
+    /// </summary>
     [Parameter]
     [Alias("Count")]
     [ValidateRange(1, int.MaxValue)]
     public int Size { get; set; } = 25;
 
+    /// <summary>
+    /// Maximum number of parallel Graph requests.
+    /// </summary>
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchIMAPMailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchIMAPMailbox.cs
@@ -12,37 +12,70 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.Search, "IMAPMailbox")]
 [OutputType(typeof(ImapEmailMessage))]
 public sealed class CmdletSearchIMAPMailbox : AsyncPSCmdlet {
+    /// <summary>
+    /// Active IMAP connection.
+    /// </summary>
     [Parameter(ValueFromPipeline = true)]
     [ValidateNotNull]
     public ImapConnectionInfo? Client { get; set; }
 
+    /// <summary>
+    /// Folder to search. Defaults to inbox.
+    /// </summary>
     [Parameter]
     public string? Folder { get; set; }
 
+    /// <summary>
+    /// Additional MailKit search queries.
+    /// </summary>
     [Parameter]
     public SearchQuery[]? SearchQuery { get; set; }
 
+    /// <summary>
+    /// Filters messages by subject.
+    /// </summary>
     [Parameter]
     public string? Subject { get; set; }
 
+    /// <summary>
+    /// Filters messages by sender content.
+    /// </summary>
     [Parameter]
     public string? FromContains { get; set; }
 
+    /// <summary>
+    /// Filters messages by recipient content.
+    /// </summary>
     [Parameter]
     public string? ToContains { get; set; }
 
+    /// <summary>
+    /// Filters messages by priority.
+    /// </summary>
     [Parameter]
     public MessagePriority? Priority { get; set; }
 
+    /// <summary>
+    /// Only messages received since this date are returned.
+    /// </summary>
     [Parameter]
     public DateTime? Since { get; set; }
 
+    /// <summary>
+    /// Only messages received before this date are returned.
+    /// </summary>
     [Parameter]
     public DateTime? Before { get; set; }
 
+    /// <summary>
+    /// Filters messages that contain attachments.
+    /// </summary>
     [Parameter]
     public SwitchParameter HasAttachment { get; set; }
 
+    /// <summary>
+    /// Maximum number of messages to return.
+    /// </summary>
     [Parameter]
     [ValidateRange(1, int.MaxValue)]
     public int Count { get; set; }

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchPOP3Mailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchPOP3Mailbox.cs
@@ -11,31 +11,58 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.Search, "POP3Mailbox")]
 [OutputType(typeof(Pop3EmailMessage))]
 public sealed class CmdletSearchPOP3Mailbox : AsyncPSCmdlet {
+    /// <summary>
+    /// Active POP3 connection.
+    /// </summary>
     [Parameter(ValueFromPipeline = true)]
     [ValidateNotNull]
     public PopConnectionInfo? Client { get; set; }
 
+    /// <summary>
+    /// Filters messages by subject.
+    /// </summary>
     [Parameter]
     public string? Subject { get; set; }
 
+    /// <summary>
+    /// Filters messages where the sender contains this string.
+    /// </summary>
     [Parameter]
     public string? FromContains { get; set; }
 
+    /// <summary>
+    /// Filters messages where the recipient contains this string.
+    /// </summary>
     [Parameter]
     public string? ToContains { get; set; }
 
+    /// <summary>
+    /// Filters messages by priority.
+    /// </summary>
     [Parameter]
     public MessagePriority? Priority { get; set; }
 
+    /// <summary>
+    /// Only return messages sent since this date.
+    /// </summary>
     [Parameter]
     public DateTime? Since { get; set; }
 
+    /// <summary>
+    /// Only return messages sent before this date.
+    /// </summary>
     [Parameter]
     public DateTime? Before { get; set; }
 
+    /// <summary>
+    /// Filters messages that have attachments.
+    /// </summary>
     [Parameter]
     public SwitchParameter HasAttachment { get; set; }
 
+    /// <summary>
+    /// Maximum number of messages to return.
+    /// </summary>
     [Parameter]
     [ValidateRange(1, int.MaxValue)]
     public int Count { get; set; }

--- a/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetGraphMessage.cs
@@ -45,15 +45,27 @@ public class CmdletSetGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Maximum number of concurrent Graph requests.
+    /// </summary>
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 


### PR DESCRIPTION
## Summary
- add XML docs for Graph mailbox searches and mailbox rule cmdlets
- document Graph certificate credential cmdlet
- document Graph message retrieval and removal cmdlets
- document Graph folder removal and POP3/IMAP searches

## Testing
- `dotnet build Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_686b924802e8832ea9c0cdc5a2c485a3