### PR TITLE
Add header support

### DIFF
--- a/Examples/Example-SendEmail-Graph-Headers.ps1
+++ b/Examples/Example-SendEmail-Graph-Headers.ps1
@@ -1,0 +1,5 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$Credential = ConvertTo-GraphCredential -ClientID 'client-id' -ClientSecret 'secret' -DirectoryID 'tenant-id'
+
+Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' -Subject 'Graph Header Test' -Body 'Hello from Graph' -Graph -Credential $Credential -Headers @{ 'X-Tracking-ID' = 'abc123'; 'X-Source' = 'Mailozaurr' }

--- a/Examples/Example-SendEmail-Headers.ps1
+++ b/Examples/Example-SendEmail-Headers.ps1
@@ -1,0 +1,3 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' -Subject 'Header Test' -Body 'Hello' -Server 'smtp.example.com' -Headers @{ 'X-Tracking-ID' = 'abc123'; 'X-Custom' = 'Mailozaurr' }

--- a/Examples/Example-SendEmail-Mailgun-Headers.ps1
+++ b/Examples/Example-SendEmail-Mailgun-Headers.ps1
@@ -1,0 +1,6 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$ApiKey = 'mailgun-api-key'
+$Credential = ConvertTo-MailgunCredential -ApiKey $ApiKey
+
+Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' -Subject 'Mailgun Header Test' -Body 'Hello from Mailgun' -EmailProvider Mailgun -Credential $Credential -Headers @{ 'X-Tracking-ID' = 'abc123'; 'X-Source' = 'Mailozaurr' }

--- a/Examples/Example-SendEmail-SendGrid-Headers.ps1
+++ b/Examples/Example-SendEmail-SendGrid-Headers.ps1
@@ -1,0 +1,6 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$ApiKey = 'sendgrid-api-key'
+$Credential = ConvertTo-SendGridCredential -ApiKey $ApiKey
+
+Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' -Subject 'SendGrid Header Test' -Body 'Hello from SendGrid' -SendGrid -Credential $Credential -Headers @{ 'X-Tracking-ID' = 'abc123'; 'X-Source' = 'Mailozaurr' }

--- a/Examples/Example-SendEmail-Ses-Headers.ps1
+++ b/Examples/Example-SendEmail-Ses-Headers.ps1
@@ -1,0 +1,5 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$Credential = Get-Credential -UserName 'AKIA...' -Message 'Enter AWS Secret Key'
+
+Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' -Subject 'SES Header Test' -Body 'Hello from SES' -Ses -Region 'us-east-1' -Credential $Credential -Headers @{ 'X-Tracking-ID' = 'abc123'; 'X-Source' = 'Mailozaurr' }

--- a/Sources/Mailozaurr.Examples/SendEmailHeadersGraph.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailHeadersGraph.cs
@@ -1,0 +1,29 @@
+using Mailozaurr;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+public static class SendEmailHeadersGraph
+{
+    public static async Task RunAsync()
+    {
+        using var graph = new Graph();
+        graph.From = "sender@example.com";
+        graph.To = new[] { "recipient@example.com" };
+        graph.Subject = "Graph Headers";
+        graph.HTML = "<p>Hello</p>";
+        graph.Headers = new Dictionary<string, string>
+        {
+            ["X-Tracking-ID"] = "abc123",
+            ["X-Source"] = "Mailozaurr"
+        };
+        var cred = new NetworkCredential("clientid@tenant", "secret");
+        graph.Authenticate(cred);
+        var connect = await graph.ConnectO365GraphAsync();
+        if (connect.Status)
+        {
+            await graph.SendMessageAsync();
+        }
+    }
+}

--- a/Sources/Mailozaurr.Examples/SendEmailHeadersSendGrid.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailHeadersSendGrid.cs
@@ -1,0 +1,24 @@
+using Mailozaurr;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+public static class SendEmailHeadersSendGrid
+{
+    public static async Task RunAsync()
+    {
+        var sendGrid = new SendGridClient();
+        sendGrid.From = "sender@example.com";
+        sendGrid.To = new List<object> { "recipient@example.com" };
+        sendGrid.Subject = "SendGrid Headers";
+        sendGrid.Html = "<p>Hello</p>";
+        sendGrid.Headers = new Dictionary<string, string>
+        {
+            ["X-Tracking-ID"] = "abc123",
+            ["X-Source"] = "Mailozaurr"
+        };
+        sendGrid.Credentials = new NetworkCredential("apikey", "sg-key");
+        await sendGrid.SendEmailAsync();
+    }
+}

--- a/Sources/Mailozaurr.Examples/SendEmailHeadersSmtp.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailHeadersSmtp.cs
@@ -1,0 +1,23 @@
+using Mailozaurr;
+using System;
+using System.Collections.Generic;
+
+public static class SendEmailHeadersSmtp
+{
+    public static void Run()
+    {
+        var smtp = new Smtp();
+        smtp.From = "sender@example.com";
+        smtp.To = new[] { "recipient@example.com" };
+        smtp.Subject = "SMTP Headers";
+        smtp.TextBody = "Hello";
+        smtp.Headers = new Dictionary<string, string>
+        {
+            ["X-Tracking-ID"] = "abc123",
+            ["X-Source"] = "Mailozaurr"
+        };
+        smtp.Connect("smtp.example.com", 25);
+        smtp.Send();
+        smtp.Disconnect();
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -296,6 +296,16 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     [Alias("InlineAttachments")]
     public object[]? InlineAttachment { get; set; }
 
+    [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
+    [Parameter(Mandatory = false, ParameterSetName = "SecureString")]
+    [Parameter(Mandatory = false, ParameterSetName = "oAuth")]
+    [Parameter(Mandatory = false, ParameterSetName = "Graph")]
+    [Parameter(Mandatory = false, ParameterSetName = "MgGraphRequest")]
+    [Parameter(Mandatory = false, ParameterSetName = "Compatibility")]
+    [Parameter(Mandatory = false, ParameterSetName = "SendGrid")]
+    [Parameter(Mandatory = false, ParameterSetName = "EmailProviders")]
+    public Hashtable? Headers { get; set; }
+
     /// <summary>
     /// <para>Specifies the maximum time (in milliseconds) to wait for the SMTP operation to complete. Default is 12000.</para>
     /// </summary>
@@ -640,6 +650,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
         if (Attachment != null) {
             sendGrid.Attachment = Attachment.Select(a => a?.ToString() ?? string.Empty).ToArray();
         }
+        if (Headers != null) sendGrid.Headers = Headers.Cast<DictionaryEntry>().ToDictionary(d => (string)d.Key, d => (string)d.Value);
         sendGrid.SeparateTo = SeparateTo;
         sendGrid.ErrorAction = errorAction;
         sendGrid.RetryCount = RetryCount;
@@ -678,6 +689,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
         if (InlineAttachment != null) {
             mailgun.InlineAttachment = InlineAttachment.Select(a => a?.ToString() ?? string.Empty).ToArray();
         }
+        if (Headers != null) mailgun.Headers = Headers.Cast<DictionaryEntry>().ToDictionary(d => (string)d.Key, d => (string)d.Value);
         mailgun.ErrorAction = errorAction;
         mailgun.RetryCount = RetryCount;
         mailgun.RetryDelayMilliseconds = RetryDelayMilliseconds;
@@ -714,6 +726,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
         if (InlineAttachment != null) {
             ses.InlineAttachment = InlineAttachment.Select(a => a?.ToString() ?? string.Empty).ToArray();
         }
+        if (Headers != null) ses.Headers = Headers.Cast<DictionaryEntry>().ToDictionary(d => (string)d.Key, d => (string)d.Value);
         ses.ErrorAction = errorAction;
         ses.RetryCount = RetryCount;
         ses.RetryDelayMilliseconds = RetryDelayMilliseconds;
@@ -753,6 +766,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
         graph.HTML = string.Join("", HTML);
         graph.ContentType = "HTML";
         graph.Attachments = Attachment;
+        if (Headers != null) graph.Headers = Headers.Cast<DictionaryEntry>().ToDictionary(d => (string)d.Key, d => (string)d.Value);
         graph.CreateAttachments();
         long graphSize = GetTotalAttachmentSize(graph.ConvertedAttachments);
         if (graphSize > GraphAttachmentLimitBytes) {
@@ -817,6 +831,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
         graph.HTML = string.Join("", HTML);
         graph.ContentType = "HTML";
         graph.Attachments = Attachment;
+        if (Headers != null) graph.Headers = Headers.Cast<DictionaryEntry>().ToDictionary(d => (string)d.Key, d => (string)d.Value);
         graph.CreateAttachments();
         long size = GetTotalAttachmentSize(graph.ConvertedAttachments);
         if (size > GraphAttachmentLimitBytes) {
@@ -869,6 +884,7 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
 
         smtpClient.Attachments = Attachment?.ToList();
         smtpClient.InlineAttachments = InlineAttachment?.ToList();
+        if (Headers != null) smtpClient.Headers = Headers.Cast<DictionaryEntry>().ToDictionary(d => (string)d.Key, d => (string)d.Value);
         smtpClient.Timeout = Timeout;
 
         smtpClient.ErrorAction = errorAction;

--- a/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
@@ -26,6 +26,22 @@ public class GraphCreateMessageTests
     }
 
     [Fact]
+    public void CreateMessage_WithHeaders_IncludesHeaders()
+    {
+        using var graph = new Graph
+        {
+            From = "from@example.com",
+            To = new object[] { "to@example.com" },
+            Subject = "subject",
+            HTML = "body",
+            ContentType = "HTML",
+            Headers = new System.Collections.Generic.Dictionary<string, string> { ["X-Test"] = "123" }
+        };
+        graph.CreateMessage();
+        Assert.Contains("X-Test", graph.MessageJson, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void CreateAttachments_WithMissingFile_ThrowsFileNotFoundException()
     {
         using var graph = new Graph

--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Net.Http;
 using System.Reflection;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -14,5 +17,23 @@ public class MailgunClientTests
         var ex = Assert.Throws<TargetInvocationException>(() => prop!.GetValue(client));
         Assert.IsType<ArgumentException>(ex.InnerException);
         Assert.Contains("invalid", ex.InnerException!.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateContentAsync_WithHeaders_IncludesHeaders()
+    {
+        using var client = new MailgunClient
+        {
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            Headers = new Dictionary<string, string> { ["X-Test"] = "123" }
+        };
+        MethodInfo? method = typeof(MailgunClient).GetMethod("CreateContentAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        var task = (Task<MultipartFormDataContent>)method!.Invoke(client, new object[] { default(System.Threading.CancellationToken) })!;
+        using var content = await task;
+        string body = await content.ReadAsStringAsync();
+        Assert.Contains("h:X-Test", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("123", body, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
@@ -42,4 +42,23 @@ public class SendGridCreateMessageTests
         };
         Assert.Throws<ArgumentException>(() => client.CreateMessage());
     }
+
+    [Fact]
+    public void CreateMessage_WithHeaders_IncludesHeaders()
+    {
+        var client = new SendGridClient
+        {
+            From = "from@example.com",
+            To = new List<object> { "to@example.com" },
+            Subject = "subject",
+            Text = "text",
+            Credentials = new NetworkCredential("apikey", "test"),
+            Headers = new Dictionary<string, string> { ["X-Test"] = "123" }
+        };
+        client.CreateMessage();
+        PropertyInfo? prop = typeof(SendGridClient).GetProperty("MessageJson", BindingFlags.NonPublic | BindingFlags.Instance);
+        var json = prop?.GetValue(client) as string;
+        Assert.NotNull(json);
+        Assert.Contains("X-Test", json!, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/Sources/Mailozaurr.Tests/SesClientTests.cs
+++ b/Sources/Mailozaurr.Tests/SesClientTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Collections.Generic;
 using MimeKit;
 using Xunit;
 
@@ -21,5 +22,21 @@ public class SesClientTests
         Assert.NotNull(msg);
         Assert.Equal("subject", msg!.Subject);
         Assert.Contains("to@example.com", msg.To.ToString());
+    }
+
+    [Fact]
+    public void BuildMessage_WithHeaders_AddsHeaders()
+    {
+        using var client = new SesClient
+        {
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            Subject = "subject",
+            Headers = new Dictionary<string, string> { ["X-Test"] = "123" }
+        };
+        MethodInfo? method = typeof(SesClient).GetMethod("BuildMessage", BindingFlags.NonPublic | BindingFlags.Instance);
+        var message = method!.Invoke(client, null) as MimeMessage;
+        Assert.NotNull(message);
+        Assert.Equal("123", message!.Headers["X-Test"]);
     }
 }

--- a/Sources/Mailozaurr.Tests/SmtpHeadersTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpHeadersTests.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Xunit;
+using MimeKit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpHeadersTests
+{
+    [Fact]
+    public void CreateMessage_WithHeaders_AddsHeaders()
+    {
+        var smtp = new Smtp();
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "c@d.com" };
+        smtp.Subject = "test";
+        smtp.TextBody = "body";
+        smtp.Headers = new Dictionary<string, string> { ["X-Test"] = "123" };
+        smtp.CreateMessage();
+        Assert.Equal("123", smtp.Message.Headers["X-Test"]);
+    }
+}

--- a/Sources/Mailozaurr.Tests/SmtpHeadersTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpHeadersTests.cs
@@ -18,4 +18,26 @@ public class SmtpHeadersTests
         smtp.CreateMessage();
         Assert.Equal("123", smtp.Message.Headers["X-Test"]);
     }
+
+    [Fact]
+    public void CreateMessage_WithMultipleHeaders_AddsAllHeaders()
+    {
+        var smtp = new Smtp
+        {
+            From = "a@b.com",
+            To = new object[] { "c@d.com" },
+            Subject = "test",
+            TextBody = "body",
+            Headers = new Dictionary<string, string>
+            {
+                ["X-One"] = "1",
+                ["X-Two"] = "2"
+            }
+        };
+
+        smtp.CreateMessage();
+
+        Assert.Equal("1", smtp.Message.Headers["X-One"]);
+        Assert.Equal("2", smtp.Message.Headers["X-Two"]);
+    }
 }

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -39,6 +39,8 @@ public class SesClient : IDisposable {
     /// <summary>Paths to inline attachments to include.</summary>
     public string[]? InlineAttachment { get; set; }
 
+    public Dictionary<string, string>? Headers { get; set; }
+
     /// <summary>Number of retry attempts on failure.</summary>
     public int RetryCount { get; set; } = 0;
     /// <summary>Base delay in milliseconds between retries.</summary>
@@ -107,6 +109,7 @@ public class SesClient : IDisposable {
         smtp.HtmlBody = Html;
         if (Attachment != null) smtp.Attachments = Attachment.ToList<object>();
         if (InlineAttachment != null) smtp.InlineAttachments = InlineAttachment.ToList<object>();
+        if (Headers != null) smtp.Headers = Headers;
         smtp.CreateMessage();
         return smtp.Message;
     }

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -51,6 +51,8 @@ public class MailgunClient : IDisposable {
     /// <summary>File paths to include as inline attachments.</summary>
     public string[]? InlineAttachment { get; set; }
 
+    public Dictionary<string, string>? Headers { get; set; }
+
     /// <summary>Collector used to store log entries.</summary>
     public LogCollector LogCollector { get; set; } = new();
     /// <summary>Number of retry attempts on failure.</summary>
@@ -155,6 +157,11 @@ public class MailgunClient : IDisposable {
                 var fileContent = new ByteArrayContent(bytes);
                 fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
                 content.Add(fileContent, "inline", Path.GetFileName(path));
+            }
+        }
+        if (Headers != null) {
+            foreach (var kvp in Headers) {
+                content.Add(new StringContent(kvp.Value), $"h:{kvp.Key}");
             }
         }
         return content;

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -154,6 +154,8 @@ public class Graph : IDisposable {
 
     public string? WebhookUrl { get; set; }
 
+    public Dictionary<string, string>? Headers { get; set; }
+
     /// <summary>
     /// Size in bytes of the chunks used when uploading attachments. Defaults to
     /// 9MB.
@@ -294,6 +296,9 @@ public class Graph : IDisposable {
         };
         if (ConvertedAttachments.Count > 0 && IsLargerAttachment == false) {
             MessageContainer.Message.Attachments = ConvertedAttachments;
+        }
+        if (Headers != null && Headers.Count > 0) {
+            MessageContainer.Message.InternetMessageHeaders = Headers.Select(kvp => new GraphInternetMessageHeader { Name = kvp.Key, Value = kvp.Value }).ToList();
         }
 
         var options = new JsonSerializerOptions() {

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphInternetMessageHeader.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphInternetMessageHeader.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+namespace Mailozaurr;
+
+public class GraphInternetMessageHeader
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("value")]
+    public string Value { get; set; }
+}
+

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMessage.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMessage.cs
@@ -81,4 +81,7 @@ public class GraphMessage {
     [JsonPropertyName("attachments")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<GraphAttachment>? Attachments { get; set; }
-}
+
+    [JsonPropertyName("internetMessageHeaders")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<GraphInternetMessageHeader>? InternetMessageHeaders { get; set; }}

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -51,6 +51,8 @@ public class SendGridClient {
     /// </summary>
     public object[]? Attachment { get; set; }
 
+    public Dictionary<string, string>? Headers { get; set; }
+
     /// <summary>
     /// Gets or sets the subject of the email.
     /// </summary>
@@ -255,7 +257,8 @@ public class SendGridClient {
             Subject = Subject,
             Content = content,
             ReplyTo = ConvertToEmailObject(ReplyTo),
-            Attachments = attachments
+            Attachments = attachments,
+            Headers = Headers
         };
 
         var options = new JsonSerializerOptions() {

--- a/Sources/Mailozaurr/SendGrid/SendGridMessage.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridMessage.cs
@@ -33,4 +33,7 @@ public class SendGridMessage {
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<SendGridAttachment>? Attachments { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, string>? Headers { get; set; }
 }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -32,6 +32,8 @@ public partial class ClientSmtp : SmtpClient {
     public MessagePriority Priority { get; set; }
     /// <summary>Delivery notification options.</summary>
     public DeliveryNotification[]? DeliveryNotificationOption { get; set; }
+    /// <summary>Custom headers to add to the message.</summary>
+    public IDictionary<string, string>? Headers { get; set; }
     /// <summary>Comma separated list of all recipients.</summary>
     public string SentTo {
         get {
@@ -102,6 +104,7 @@ public partial class ClientSmtp : SmtpClient {
         SetMessagePriority(message);
         BuildMessageBody(message);
         message.Subject = Subject;
+        AddHeaders(message);
         Message = message;
     }
 
@@ -200,6 +203,13 @@ public partial class ClientSmtp : SmtpClient {
             }
         }
         message.Body = bodyBuilder.ToMessageBody();
+    }
+
+    private void AddHeaders(MimeMessage message) {
+        if (Headers == null) return;
+        foreach (var kvp in Headers) {
+            message.Headers.Add(kvp.Key, kvp.Value);
+        }
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -43,6 +43,11 @@ public class Smtp {
         set => Client.InlineAttachments = value;
     }
 
+    public IDictionary<string, string>? Headers {
+        get => Client.Headers;
+        set => Client.Headers = value;
+    }
+
     public object From {
         get => Client.From;
         set => Client.From = value;

--- a/Tests/Send-EmailMessage.Headers.Tests.ps1
+++ b/Tests/Send-EmailMessage.Headers.Tests.ps1
@@ -1,0 +1,6 @@
+Describe 'Send-EmailMessage - Headers' {
+    It 'Accepts custom headers parameter' {
+        $result = Send-EmailMessage -From 'a@b.com' -To 'c@d.com' -Subject 't' -Body 'b' -Server 'smtp.example.com' -Headers @{ 'X-Test'='123' } -WhatIf
+        $result.Error | Should -Be 'Email not sent (WhatIf)'
+    }
+}


### PR DESCRIPTION
## Summary
- allow custom headers on ClientSmtp
- expose Headers property on Smtp wrapper
- handle headers in Graph, SES, Mailgun and SendGrid clients
- add PowerShell support via `-Headers` parameter
- add example and tests
- add more examples demonstrating headers in C# and PowerShell

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Release`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Debug`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`
- `pwsh -NoProfile -Command ./Mailozaurr.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_686d78cdbf7c832ea9d12c68366c04a9