### PR TITLE
Improve error handling for IMAP/POP3 cmdlets

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletClearIMAPJunk.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletClearIMAPJunk.cs
@@ -103,7 +103,11 @@ public sealed class CmdletClearIMAPJunk : AsyncPSCmdlet {
                 SkipAttachmentExtension,
                 CancelToken);
         } else {
-            WriteWarning("Clear-IMAPJunk - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Clear-IMAPJunk - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPFolder.cs
@@ -71,7 +71,10 @@ public sealed class CmdletGetIMAPFolder : AsyncPSCmdlet {
                 WriteObject(conn);
             }
         } else {
-            WriteWarning("Get-IMAPFolder - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Get-IMAPFolder - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
-    }
-}
+    }}

--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
@@ -155,7 +155,10 @@ public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
                 WriteObject(new ImapMessageInfo(message));
             }
         } else {
-            WriteWarning("Get-IMAPMessage - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Get-IMAPMessage - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
-    }
-}
+    }}

--- a/Sources/Mailozaurr.PowerShell/CmdletGetPOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetPOP3Message.cs
@@ -123,7 +123,10 @@ public sealed class CmdletGetPOP3Message : AsyncPSCmdlet {
                 WriteObject(new Pop3MessageInfo(message));
             }
         } else {
-            WriteWarning("Get-POP3Message - Is POP3 connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Get-POP3Message - POP3 client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
-    }
-}
+    }}

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPFolder.cs
@@ -40,7 +40,11 @@ public sealed class CmdletMoveIMAPFolder : AsyncPSCmdlet {
             var dest = ParameterSetName == RootParameterSet ? null : DestinationFolder;
             await FolderOperations.MoveFolderAsync(conn.Data, Folder!, dest, CancelToken);
         } else {
-            WriteWarning("Move-IMAPFolder - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Move-IMAPFolder - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPMessage.cs
@@ -63,7 +63,11 @@ public sealed class CmdletMoveIMAPMessage : AsyncPSCmdlet {
             conn.Folders[dest.FullName] = (ImapFolder)dest;
             source.MoveTo(uid, dest);
         } else {
-            WriteWarning("Move-IMAPMessage - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Move-IMAPMessage - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
         return Task.CompletedTask;
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveIMAPFolder.cs
@@ -32,7 +32,11 @@ public sealed class CmdletRemoveIMAPFolder : AsyncPSCmdlet {
             }
             await FolderOperations.RemoveFolderAsync(conn.Data, Folder!, Recursive, CancelToken);
         } else {
-            WriteWarning("Remove-IMAPFolder - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Remove-IMAPFolder - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveIMAPMessage.cs
@@ -36,7 +36,11 @@ public sealed class CmdletRemoveIMAPMessage : AsyncPSCmdlet {
                 await MessageRemover.DeleteAsync(conn.Data, new UniqueId(u), folder, CancelToken);
             }
         } else {
-            WriteWarning("Remove-IMAPMessage - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Remove-IMAPMessage - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletRemovePOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemovePOP3Message.cs
@@ -33,7 +33,11 @@ public sealed class CmdletRemovePOP3Message : AsyncPSCmdlet {
                 }
             }
         } else {
-            WriteWarning("Remove-POP3Message - Is POP3 connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Remove-POP3Message - POP3 client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletRenameIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRenameIMAPFolder.cs
@@ -33,7 +33,11 @@ public sealed class CmdletRenameIMAPFolder : AsyncPSCmdlet {
             }
             await FolderOperations.RenameFolderAsync(conn.Data, Folder!, NewName!, CancelToken);
         } else {
-            WriteWarning("Rename-IMAPFolder - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Rename-IMAPFolder - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveIMAPMessage.cs
@@ -84,7 +84,11 @@ public sealed class CmdletSaveIMAPMessage : AsyncPSCmdlet {
                 }
             }
         } else {
-            WriteWarning("Save-IMAPMessage - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Save-IMAPMessage - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
         return Task.CompletedTask;
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveIMAPMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveIMAPMessageAttachment.cs
@@ -50,7 +50,11 @@ public sealed class CmdletSaveIMAPMessageAttachment : AsyncPSCmdlet {
             var message = mailFolder.GetMessage(uid);
             MimeKitUtils.SaveAttachments(message.Attachments, Path);
         } else {
-            WriteWarning("Save-IMAPMessageAttachment - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Save-IMAPMessageAttachment - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
         return Task.CompletedTask;
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletSavePOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSavePOP3Message.cs
@@ -75,8 +75,11 @@ public sealed class CmdletSavePOP3Message : AsyncPSCmdlet {
                 WriteWarning($"Save-POP3Message - Index is out of range. Use index less than {conn.Data.Count}.");
             }
         } else {
-            WriteWarning("Save-POP3Message - Is POP3 connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Save-POP3Message - POP3 client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
         return Task.CompletedTask;
-    }
-}
+    }}

--- a/Sources/Mailozaurr.PowerShell/CmdletSavePOP3MessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSavePOP3MessageAttachment.cs
@@ -43,7 +43,11 @@ public sealed class CmdletSavePOP3MessageAttachment : AsyncPSCmdlet {
                 WriteWarning($"Save-POP3MessageAttachment - Index is out of range. Use index less than {conn.Data.Count}.");
             }
         } else {
-            WriteWarning("Save-POP3MessageAttachment - Is POP3 connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Save-POP3MessageAttachment - POP3 client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
         return Task.CompletedTask;
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchIMAPMailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchIMAPMailbox.cs
@@ -100,7 +100,11 @@ public sealed class CmdletSearchIMAPMailbox : AsyncPSCmdlet {
                 WriteObject(msg);
             }
         } else {
-            WriteWarning("Search-IMAPMailbox - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Search-IMAPMailbox - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchPOP3Mailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchPOP3Mailbox.cs
@@ -89,7 +89,11 @@ public sealed class CmdletSearchPOP3Mailbox : AsyncPSCmdlet {
                 WriteObject(msg);
             }
         } else {
-            WriteWarning("Search-POP3Mailbox - Is POP3 connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Search-POP3Mailbox - POP3 client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletSetIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetIMAPFolder.cs
@@ -35,7 +35,11 @@ public sealed class CmdletSetIMAPFolder : AsyncPSCmdlet {
             DefaultSessions.ImapSession = conn;
             WriteObject(conn);
         } else {
-            WriteWarning("Set-IMAPFolder - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Set-IMAPFolder - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
         return Task.CompletedTask;
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletSetIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetIMAPMessage.cs
@@ -48,7 +48,11 @@ public sealed class CmdletSetIMAPMessage : AsyncPSCmdlet {
                 await MessageFlagSetter.SetFlagsAsync(conn.Data, uid, MessageFlags.Seen, false, Folder ?? conn.Folder?.FullName, CancelToken);
             }
         } else {
-            WriteWarning("Set-IMAPMessage - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Set-IMAPMessage - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletSetPOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetPOP3Message.cs
@@ -43,7 +43,11 @@ public sealed class CmdletSetPOP3Message : AsyncPSCmdlet {
                 return MessageFlagSetter.SetReadAsync(conn.Data, Index, false, CancelToken);
             }
         } else {
-            WriteWarning("Set-POP3Message - Is POP3 connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Set-POP3Message - POP3 client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
         }
         return Task.CompletedTask;
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletWaitIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWaitIMAPMessage.cs
@@ -70,7 +70,11 @@ public sealed class CmdletWaitIMAPMessage : AsyncPSCmdlet, System.IDisposable {
     protected override async Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn == null || conn.Data == null) {
-            WriteWarning("Wait-IMAPMessage - Is IMAP connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Wait-IMAPMessage - IMAP client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
             return;
         }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletWaitPOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWaitPOP3Message.cs
@@ -53,7 +53,11 @@ public sealed class CmdletWaitPOP3Message : AsyncPSCmdlet, IDisposable {
     protected override async Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.Pop3Session;
         if (conn == null || conn.Data == null) {
-            WriteWarning("Wait-POP3Message - Is POP3 connected?");
+            ThrowTerminatingError(new ErrorRecord(
+                new InvalidOperationException("Wait-POP3Message - POP3 client not provided or not connected."),
+                "ClientNotConnected",
+                ErrorCategory.InvalidOperation,
+                null));
             return;
         }
 

--- a/Tests/Clear-IMAPJunk.Tests.ps1
+++ b/Tests/Clear-IMAPJunk.Tests.ps1
@@ -1,29 +1,21 @@
 Describe 'Clear-IMAPJunk' {
-    It 'Warns when IMAP connection missing with -WhatIf and SkipFrom' {
+    It 'Throws when IMAP connection missing with -WhatIf and SkipFrom' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Clear-IMAPJunk -Client $info -WhatIf -SkipFrom 'a' -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Clear-IMAPJunk - Is IMAP connected?'
+        { Clear-IMAPJunk -Client $info -WhatIf -SkipFrom 'a' } | Should -Throw
     }
 
-    It 'Warns when IMAP connection missing with -Preview and SkipUid' {
+    It 'Throws when IMAP connection missing with -Preview and SkipUid' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Clear-IMAPJunk -Client $info -Preview -SkipUid 1 -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Clear-IMAPJunk - Is IMAP connected?'
+        { Clear-IMAPJunk -Client $info -Preview -SkipUid 1 } | Should -Throw
     }
 
-    It 'Warns when IMAP connection missing with -WhatIf and SkipHasAttachment' {
+    It 'Throws when IMAP connection missing with -WhatIf and SkipHasAttachment' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Clear-IMAPJunk -Client $info -WhatIf -SkipHasAttachment -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Clear-IMAPJunk - Is IMAP connected?'
+        { Clear-IMAPJunk -Client $info -WhatIf -SkipHasAttachment } | Should -Throw
     }
 
-    It 'Warns when IMAP connection missing with -Preview and SkipAttachmentExtension' {
+    It 'Throws when IMAP connection missing with -Preview and SkipAttachmentExtension' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Clear-IMAPJunk -Client $info -Preview -SkipAttachmentExtension 'zip' -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Clear-IMAPJunk - Is IMAP connected?'
+        { Clear-IMAPJunk -Client $info -Preview -SkipAttachmentExtension 'zip' } | Should -Throw
     }
 }

--- a/Tests/Get-IMAPFolderRoot.Tests.ps1
+++ b/Tests/Get-IMAPFolderRoot.Tests.ps1
@@ -1,8 +1,6 @@
 Describe 'Get-IMAPFolder -Root' {
-    It 'Warns when IMAP connection missing' {
+    It 'Throws when IMAP connection missing' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Get-IMAPFolder -Client $info -Root -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Get-IMAPFolder - Is IMAP connected?'
+        { Get-IMAPFolder -Client $info -Root } | Should -Throw
     }
 }

--- a/Tests/Get-IMAPMessage.Tests.ps1
+++ b/Tests/Get-IMAPMessage.Tests.ps1
@@ -1,14 +1,10 @@
 Describe 'Get-IMAPMessage' {
-    It 'Warns when IMAP connection missing' {
+    It 'Throws when IMAP connection missing' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Get-IMAPMessage -Client $info -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Get-IMAPMessage - Is IMAP connected?'
+        { Get-IMAPMessage -Client $info } | Should -Throw
     }
-    It 'Warns when deleting without connection' {
+    It 'Throws when deleting without connection' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Get-IMAPMessage -Client $info -Delete -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Get-IMAPMessage - Is IMAP connected?'
+        { Get-IMAPMessage -Client $info -Delete } | Should -Throw
     }
 }

--- a/Tests/Get-IMAPMessage.WhatIf.Tests.ps1
+++ b/Tests/Get-IMAPMessage.WhatIf.Tests.ps1
@@ -1,8 +1,6 @@
 Describe 'Get-IMAPMessage -Delete with WhatIf' {
-    It 'Warns when deleting without connection' {
+    It 'Throws when deleting without connection' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Get-IMAPMessage -Client $info -Delete -WhatIf -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Get-IMAPMessage - Is IMAP connected?'
+        { Get-IMAPMessage -Client $info -Delete -WhatIf } | Should -Throw
     }
 }

--- a/Tests/Get-POP3Message.Tests.ps1
+++ b/Tests/Get-POP3Message.Tests.ps1
@@ -1,8 +1,6 @@
 Describe 'Get-POP3Message' {
-    It 'Warns when POP connection missing' {
+    It 'Throws when POP connection missing' {
         $info = [Mailozaurr.PowerShell.PopConnectionInfo]::new()
-        Get-POP3Message -Client $info -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Get-POP3Message - Is POP3 connected?'
+        { Get-POP3Message -Client $info } | Should -Throw
     }
 }

--- a/Tests/Move-IMAPMessage.Tests.ps1
+++ b/Tests/Move-IMAPMessage.Tests.ps1
@@ -1,8 +1,6 @@
 Describe 'Move-IMAPMessage' {
-    It 'Warns when IMAP connection missing' {
+    It 'Throws when IMAP connection missing' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Move-IMAPMessage -Client $info -Uid 1 -DestinationFolder 'Archive' -WhatIf -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Move-IMAPMessage - Is IMAP connected?'
+        { Move-IMAPMessage -Client $info -Uid 1 -DestinationFolder 'Archive' -WhatIf } | Should -Throw
     }
 }

--- a/Tests/Remove-IMAPMessage.Tests.ps1
+++ b/Tests/Remove-IMAPMessage.Tests.ps1
@@ -1,8 +1,6 @@
 Describe 'Remove-IMAPMessage' {
-    It 'Warns when IMAP connection missing' {
+    It 'Throws when IMAP connection missing' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Remove-IMAPMessage -Client $info -Uid 1 -WhatIf -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Remove-IMAPMessage - Is IMAP connected?'
+        { Remove-IMAPMessage -Client $info -Uid 1 -WhatIf } | Should -Throw
     }
 }

--- a/Tests/Remove-POP3Message.Tests.ps1
+++ b/Tests/Remove-POP3Message.Tests.ps1
@@ -1,8 +1,6 @@
 Describe 'Remove-POP3Message' {
-    It 'Warns when POP3 connection missing' {
+    It 'Throws when POP3 connection missing' {
         $info = [Mailozaurr.PowerShell.PopConnectionInfo]::new()
-        Remove-POP3Message -Client $info -Index 0 -WhatIf -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Remove-POP3Message - Is POP3 connected?'
+        { Remove-POP3Message -Client $info -Index 0 -WhatIf } | Should -Throw
     }
 }

--- a/Tests/Search-IMAPMailbox.Tests.ps1
+++ b/Tests/Search-IMAPMailbox.Tests.ps1
@@ -1,8 +1,6 @@
 Describe 'Search-IMAPMailbox' {
-    It 'Warns when IMAP connection missing' {
+    It 'Throws when IMAP connection missing' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Search-IMAPMailbox -Client $info -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Search-IMAPMailbox - Is IMAP connected?'
+        { Search-IMAPMailbox -Client $info } | Should -Throw
     }
 }

--- a/Tests/Search-POP3Mailbox.Tests.ps1
+++ b/Tests/Search-POP3Mailbox.Tests.ps1
@@ -1,8 +1,6 @@
 Describe 'Search-POP3Mailbox' {
-    It 'Warns when POP3 connection missing' {
+    It 'Throws when POP3 connection missing' {
         $info = [Mailozaurr.PowerShell.PopConnectionInfo]::new()
-        Search-POP3Mailbox -Client $info -WarningVariable warn
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Search-POP3Mailbox - Is POP3 connected?'
+        { Search-POP3Mailbox -Client $info } | Should -Throw
     }
 }

--- a/Tests/Wait-IMAPMessage.Tests.ps1
+++ b/Tests/Wait-IMAPMessage.Tests.ps1
@@ -1,9 +1,7 @@
 Describe 'Wait-IMAPMessage' {
-    It 'Warns when IMAP connection missing' {
+    It 'Throws when IMAP connection missing' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
-        Wait-IMAPMessage -Client $info -WarningVariable warn -Action {} -ErrorAction SilentlyContinue
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Wait-IMAPMessage - Is IMAP connected?'
+        { Wait-IMAPMessage -Client $info -Action {} } | Should -Throw
     }
 
     It 'Invokes action and cancels on match' {

--- a/Tests/Wait-POP3Message.Tests.ps1
+++ b/Tests/Wait-POP3Message.Tests.ps1
@@ -1,9 +1,7 @@
 Describe 'Wait-POP3Message' {
-    It 'Warns when POP3 connection missing' {
+    It 'Throws when POP3 connection missing' {
         $info = [Mailozaurr.PowerShell.PopConnectionInfo]::new()
-        Wait-POP3Message -Client $info -WarningVariable warn -Action {} -ErrorAction SilentlyContinue
-        $warn | Should -Not -BeNullOrEmpty
-        $warn[0] | Should -Be 'Wait-POP3Message - Is POP3 connected?'
+        { Wait-POP3Message -Client $info -Action {} } | Should -Throw
     }
 
     It 'Invokes action and cancels on match' {


### PR DESCRIPTION
## Summary
- throw terminating errors when IMAP or POP3 clients are missing
- update tests for new error behavior

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `pwsh -NoProfile -Command ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686d8f67dbb4832ea1223c3eb2241eff