### PR TITLE
Fix null inline attachments handling

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpInlineAttachmentTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpInlineAttachmentTests.cs
@@ -28,4 +28,21 @@ public class SmtpInlineAttachmentTests
         File.Delete(tmp);
         Assert.Equal(1, inlineCount);
     }
+
+    [Fact]
+    public void CreateMessage_NullInlineAttachments_DoesNotThrow()
+    {
+        var smtp = new Smtp
+        {
+            From = "a@b.com",
+            To = new object[] { "c@d.com" },
+            Subject = "test",
+            HtmlBody = "<b>body</b>",
+            InlineAttachments = null
+        };
+
+        var ex = Record.Exception(() => smtp.CreateMessage());
+
+        Assert.Null(ex);
+    }
 }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -99,6 +99,7 @@ public partial class ClientSmtp : SmtpClient {
     /// Builds the <see cref="MimeMessage"/> based on the configured properties.
     /// </summary>
     public void CreateMessage() {
+        InlineAttachments ??= new List<object>();
         var message = new MimeMessage();
         AddAddressesToMessage(message);
         SetMessagePriority(message);


### PR DESCRIPTION
## Summary
- avoid null ref when inline attachments are null
- add regression test for null inline attachments

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686d8f4b5928832e9d4ce10b7df6cae3