### PR TITLE
Fix ephemeral pgp dir cleanup

### DIFF
--- a/Sources/Mailozaurr.Tests/EphemeralOpenPgpContextTests.cs
+++ b/Sources/Mailozaurr.Tests/EphemeralOpenPgpContextTests.cs
@@ -32,4 +32,19 @@ public class EphemeralOpenPgpContextTests
             Assert.False(Directory.Exists(dir));
         }
     }
+
+    [Fact]
+    public void Dispose_DoesNotThrow_WhenDirectoryAlreadyDeleted()
+    {
+        var field = typeof(EphemeralOpenPgpContext).GetField("_tempDirectory", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var ctx = new EphemeralOpenPgpContext();
+        var dir = (string)field.GetValue(ctx)!;
+
+        Assert.True(Directory.Exists(dir));
+        Directory.Delete(dir, true);
+        Assert.False(Directory.Exists(dir));
+
+        var ex = Record.Exception(() => ctx.Dispose());
+        Assert.Null(ex);
+    }
 }

--- a/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
+++ b/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
@@ -57,6 +57,9 @@ public class EphemeralOpenPgpContext : GnuPGContext, IDisposable {
     /// </summary>
     public new void Dispose() {
         base.Dispose();
+        if (!Directory.Exists(_tempDirectory))
+            return;
+
         try {
             Directory.Delete(_tempDirectory, true);
         } catch (IOException ex) {


### PR DESCRIPTION
## Summary
- avoid deleting ephemeral temp directory if it no longer exists
- add tests for directory cleanup behaviour

## Testing
- `dotnet test Sources/Mailozaurr.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686d8f46c5d0832e811205ea615a6f5b