### PR TITLE
Fix CredentialToApiKey casting

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -68,6 +68,31 @@ public class HelpersTests
     }
 
     [Fact]
+    public void CredentialToApiKey_ReturnsPassword_WhenNetworkCredential()
+    {
+        var cred = new NetworkCredential("apikey", "theKey");
+
+        string result = Mailozaurr.Helpers.CredentialToApiKey(cred);
+
+        Assert.Equal("theKey", result);
+    }
+
+    private class DummyCredentials : ICredentials
+    {
+        public NetworkCredential GetCredential(Uri uri, string authType) => new NetworkCredential();
+    }
+
+    [Fact]
+    public void CredentialToApiKey_ReturnsEmptyString_WhenNotNetworkCredential()
+    {
+        ICredentials creds = new DummyCredentials();
+
+        string result = Mailozaurr.Helpers.CredentialToApiKey(creds);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
     public void GetEmailAndName_ReturnsTuple_WhenDictionaryProvided()
     {
         var input = new Dictionary<string, object> { { "Email", "a@b.com" }, { "Name", "Alice" } };

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -39,14 +39,10 @@ public static class Helpers {
     /// <param name="credentials">Credential containing the key.</param>
     /// <returns>The API key.</returns>
     public static string CredentialToApiKey(ICredentials credentials) {
-        string apiKey;
-        try {
-            var networkCredential = credentials as NetworkCredential;
-            apiKey = networkCredential.Password;
-        } catch (InvalidCastException) {
-            apiKey = string.Empty;
+        if (credentials is NetworkCredential networkCredential) {
+            return networkCredential.Password;
         }
-        return apiKey;
+        return string.Empty;
     }
 
     /// <summary>Retrieves the email address string from various types of objects.</summary>


### PR DESCRIPTION
## Summary
- handle non-NetworkCredential objects in `CredentialToApiKey`
- add unit tests for `CredentialToApiKey`

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686d8f3c0984832ebec2396d236f6600