### PR TITLE
Ensure SecureString is read-only before creating credential

### DIFF
--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -32,6 +32,7 @@ public static class Helpers {
         foreach (char c in password) {
             secStringPassword.AppendChar(c);
         }
+        secStringPassword.MakeReadOnly();
         return new NetworkCredential(userName, secStringPassword);
     }
 


### PR DESCRIPTION
## Summary
- protect `SecureString` in `ConvertFromPlainText` by calling `MakeReadOnly`

## Testing
- `dotnet build Sources/Mailozaurr.sln -f net8.0`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686d8f351dd4832eb9e531714f50e862