### PR TITLE
Fix credential type check in SendGridClient

### DIFF
--- a/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
+++ b/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
@@ -61,6 +61,27 @@ namespace Mailozaurr.Tests {
         }
 
         [Fact]
+        public async Task SendEmail_SendGrid_InvalidCredentialType_Fails() {
+            var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+            var client = new SendGridClient();
+            var field = typeof(SendGridClient).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            field.SetValue(client, new HttpClient(handler));
+
+            client.From = "sender@example.com";
+            client.To = new System.Collections.Generic.List<object> { "recipient@example.com" };
+            client.Subject = "Test Email (SendGrid)";
+            client.Html = "<b>Hello from Mailozaurr SendGrid!</b>";
+            client.Text = "Hello from Mailozaurr SendGrid!";
+            client.Credentials = new CredentialCache();
+            client.CreateMessage();
+
+            var result = await client.SendEmailAsync();
+
+            Assert.False(result.Status);
+            Assert.Empty(handler.Requests);
+        }
+
+        [Fact]
         public async Task SendEmail_Graph_WithValidInput_Succeeds() {
             var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
             using var graph = new Graph();

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -275,15 +275,15 @@ public class SendGridClient {
     /// <returns>A Task that represents the asynchronous operation. The task result contains the result of the email sending operation.</returns>
     public async Task<SmtpResult> SendEmailAsync(CancellationToken cancellationToken = default) {
         string apiKey;
-        try {
-            var networkCredential = Credentials as NetworkCredential;
+        if (Credentials is NetworkCredential networkCredential) {
             apiKey = networkCredential.Password;
-        } catch (InvalidCastException ex) {
-            LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SendGrid: {ex.Message}");
+        } else {
+            const string message = "Credentials must be NetworkCredential";
+            LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SendGrid: {message}");
             if (ErrorAction == ActionPreference.Stop) {
-                throw;
+                throw new InvalidCastException(message);
             }
-            var credFail = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, "", ex.Message);
+            var credFail = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, string.Empty, message);
             await Helpers.PostWebhookAsync(WebhookUrl, credFail, cancellationToken);
             return credFail;
         }


### PR DESCRIPTION
## Summary
- validate NetworkCredential before casting in `SendGridClient.SendEmailAsync`
- add test covering invalid credential scenario

## Testing
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_686d8f2c7bd8832ea1e73135b91e29dd