### PR TITLE
Handle missing certificate in Smtp.Sign

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpSignTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSignTests.cs
@@ -1,0 +1,23 @@
+using System;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpSignTests
+{
+    [Fact]
+    public void Sign_MissingCertificate_ReturnsFailedResult()
+    {
+        var smtp = new Smtp();
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "c@d.com" };
+        smtp.Subject = "test";
+        smtp.TextBody = "body";
+        smtp.CreateMessage();
+
+        var result = smtp.Sign("0000000000000000000000000000000000000000");
+
+        Assert.False(result.Status);
+        Assert.Equal("Certificate not found in the store.", result.Error);
+    }
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -598,9 +598,17 @@ public class Smtp {
         if (certificates.Count > 0) {
             // Use the certificate directly from the store to sign the email
             return Sign(certificates[0]);
-        } else {
-            throw new Exception("Certificate not found in the store.");
         }
+
+        var messageText = "Certificate not found in the store.";
+        LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - {messageText}");
+        LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Possible issue: Thumbprint '{certificateThumbprint}' is invalid or the certificate is missing.");
+
+        if (ErrorAction == ActionPreference.Stop) {
+            throw new Exception(messageText);
+        }
+
+        return new SmtpResult(false, EmailAction.SMimeSignature, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- avoid throwing when S/MIME certificate is not found
- add unit test covering missing certificate

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0 --no-build --verbosity normal`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686d8f24ca58832e81ea8c4aa6a65573