### PR TITLE
Fix Codecov failing the workflow

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -56,6 +56,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: '**/coverage.cobertura.xml'
+          fail_ci_if_error: false
 
   test-ubuntu:
     name: 'Ubuntu'
@@ -99,6 +100,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: '**/coverage.cobertura.xml'
+          fail_ci_if_error: false
 
   test-macos:
     name: 'macOS'
@@ -137,4 +139,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: '**/coverage.cobertura.xml'
+          fail_ci_if_error: false
 


### PR DESCRIPTION
## Summary
- make Codecov failures informational by adding `fail_ci_if_error: false`

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`


------
https://chatgpt.com/codex/tasks/task_e_686e0380faf8832eaf8be138dab4228f