### PR TITLE
Fix GraphMessageListener disposal

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
@@ -99,6 +99,9 @@ public class GraphBatchAndRetryTests {
         var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
         cache.Clear();
+        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
+        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+        oauthField?.SetValue(null, null);
         string cachePath = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
         if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
         try {

--- a/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Mailozaurr.Tests;
 
+[Collection("GraphCollection")]
 public class GraphBatchAndRetryTests {
     private class BatchHandler : HttpMessageHandler {
         public HttpRequestMessage? BatchRequest;

--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Mailozaurr.Tests;
 
+[Collection("GraphCollection")]
 public class GraphMessageListenerTests {
     private class QueueHandler : HttpMessageHandler {
         private readonly Queue<HttpResponseMessage> _responses;

--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class GraphMessageListenerTests {
+    private class QueueHandler : HttpMessageHandler {
+        private readonly Queue<HttpResponseMessage> _responses;
+
+        public QueueHandler(IEnumerable<HttpResponseMessage> responses) {
+            _responses = new Queue<HttpResponseMessage>(responses);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            if (_responses.Count > 0) {
+                return Task.FromResult(_responses.Dequeue());
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("{\"value\":[]}")
+            });
+        }
+    }
+
+    private static FieldInfo GetHandlerField() =>
+        typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.NonPublic | BindingFlags.Instance) ??
+        typeof(HttpMessageInvoker).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance) ??
+        throw new InvalidOperationException("HttpClient handler field not found");
+
+    [Fact]
+    public async Task Listener_StartStopMultipleTimes_DoesNotLeakResources() {
+        var responses = new[] {
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"access_token\":\"token\",\"token_type\":\"Bearer\"}") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") }
+        };
+        var handler = new QueueHandler(responses);
+        var clientField = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)clientField.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cache = (ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
+        cache.Clear();
+        string cachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
+        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        try {
+            var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            var listener = new GraphMessageListener(cred, "user", TimeSpan.FromMilliseconds(10));
+            var cancelField = typeof(GraphMessageListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+            await listener.StartAsync();
+            var first = cancelField.GetValue(listener);
+            await Task.Delay(20);
+            listener.Dispose();
+            Assert.Null(cancelField.GetValue(listener));
+
+            await listener.StartAsync();
+            var second = cancelField.GetValue(listener);
+            await Task.Delay(20);
+            listener.Dispose();
+            Assert.Null(cancelField.GetValue(listener));
+
+            Assert.NotNull(first);
+            Assert.NotNull(second);
+            Assert.NotSame(first, second);
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -38,7 +38,7 @@ public class GraphMessageListenerTests {
         var responses = new[] {
             new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"access_token\":\"token\",\"token_type\":\"Bearer\"}") },
             new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") },
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"access_token\":\"token\",\"token_type\":\"Bearer\"}") },
             new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") }
         };
         var handler = new QueueHandler(responses);
@@ -56,24 +56,31 @@ public class GraphMessageListenerTests {
             var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
             var listener = new GraphMessageListener(cred, "user", TimeSpan.FromMilliseconds(10));
             var cancelField = typeof(GraphMessageListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var pollField = typeof(GraphMessageListener).GetField("_pollTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
 
             await listener.StartAsync();
             var first = cancelField.GetValue(listener);
+            var firstPoll = pollField.GetValue(listener);
             await Task.Delay(20);
             listener.Dispose();
             Assert.Null(cancelField.GetValue(listener));
+            Assert.Null(pollField.GetValue(listener));
 
             await listener.StartAsync();
             var second = cancelField.GetValue(listener);
+            var secondPoll = pollField.GetValue(listener);
             await Task.Delay(20);
             listener.Dispose();
             Assert.Null(cancelField.GetValue(listener));
+            Assert.Null(pollField.GetValue(listener));
 
             Assert.NotNull(first);
             Assert.NotNull(second);
             Assert.NotSame(first, second);
+            Assert.NotNull(firstPoll);
+            Assert.NotNull(secondPoll);
+            Assert.NotSame(firstPoll, secondPoll);
         } finally {
             handlerField.SetValue(client, original);
         }
-    }
-}
+    }}

--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -50,11 +50,14 @@ public class GraphMessageListenerTests {
         var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var cache = (ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
         cache.Clear();
+        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
+        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+        oauthField?.SetValue(null, null);
         string cachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
         if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
         try {
             var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
-            var listener = new GraphMessageListener(cred, "user", TimeSpan.FromMilliseconds(10));
+            var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
             var cancelField = typeof(GraphMessageListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
             var pollField = typeof(GraphMessageListener).GetField("_pollTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
 

--- a/Sources/Mailozaurr.Tests/GraphTestCollection.cs
+++ b/Sources/Mailozaurr.Tests/GraphTestCollection.cs
@@ -1,0 +1,11 @@
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+/// <summary>
+/// Collection used for tests that mutate shared static state.
+/// Parallelization is disabled to avoid interference.
+/// </summary>
+[CollectionDefinition("GraphCollection", DisableParallelization = true)]
+public class GraphTestCollection { }
+

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -85,5 +85,7 @@ public class GraphMessageListener : IDisposable {
     /// <inheritdoc />
     public void Dispose() {
         Stop();
+        _cancel?.Dispose();
+        _cancel = null;
     }
 }

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -99,5 +99,9 @@ public class GraphMessageListener : IDisposable {
     }
 
     /// <inheritdoc />
-    public void Dispose() => Stop();
+    public void Dispose() {
+        Stop();
+        _cancel?.Dispose();
+        _cancel = null;
+    }
 }

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -13,6 +13,7 @@ public class GraphMessageListener : IDisposable {
     private readonly string _userPrincipalName;
     private readonly HashSet<string> _seenIds = new();
     private CancellationTokenSource? _cancel;
+    private Task? _pollTask;
     private readonly TimeSpan _interval;
 
     /// <summary>
@@ -54,13 +55,28 @@ public class GraphMessageListener : IDisposable {
             }
         }
 
-        _ = PollLoopAsync();
+        _pollTask = PollLoopAsync();
     }
 
     /// <summary>
     /// Stops listening for new messages.
     /// </summary>
-    public void Stop() => _cancel?.Cancel();
+    public void Stop() {
+        if (_cancel == null) {
+            return;
+        }
+
+        _cancel.Cancel();
+        try {
+            _pollTask?.GetAwaiter().GetResult();
+        } catch (OperationCanceledException) {
+            // ignored
+        }
+
+        _cancel.Dispose();
+        _cancel = null;
+        _pollTask = null;
+    }
 
     private async Task PollLoopAsync() {
         while (!_cancel!.IsCancellationRequested) {
@@ -83,9 +99,5 @@ public class GraphMessageListener : IDisposable {
     }
 
     /// <inheritdoc />
-    public void Dispose() {
-        Stop();
-        _cancel?.Dispose();
-        _cancel = null;
-    }
+    public void Dispose() => Stop();
 }


### PR DESCRIPTION
## Summary
- dispose cancellation source in GraphMessageListener
- reset field when disposing
- add test verifying listener can start/stop repeatedly

## Testing
- `dotnet build Sources/Mailozaurr.sln --no-restore --verbosity minimal`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --no-build --verbosity normal` *(fails: The argument path is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686e2450596c832e8dcb37da517ad53d