### PR TITLE
Fix ConfigureAwait on webhook PostAsync

### DIFF
--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -160,7 +160,7 @@ public static class Helpers {
             }
             var json = JsonSerializer.Serialize(result);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
-            using var response = await client.PostAsync(url, content, cancellationToken);
+            using var response = await client.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
         } catch (HttpRequestException ex) {
             LoggingMessages.Logger.WriteWarning($"Failed to post webhook: {ex.Message}");
         } finally {


### PR DESCRIPTION
## Summary
- configure PostWebhookAsync's HTTP call to use `.ConfigureAwait(false)`

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --no-build --verbosity minimal`
- `pwsh ./Mailozaurr.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686e246fb8a8832e86f3ca93d0087351