### PR TITLE
Fix duplicate attachment paths

### DIFF
--- a/Examples/Example-SendEmail-DeduplicateAttachments.ps1
+++ b/Examples/Example-SendEmail-DeduplicateAttachments.ps1
@@ -1,0 +1,8 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$path = Join-Path $PSScriptRoot 'duplicate.txt'
+'data' | Set-Content -Path $path
+
+Send-EmailMessage -From 'example@example.com' -To 'recipient@example.com' -Subject 'Dedup attachments' -Body 'Demo' -Server 'smtp.example.com' -Port 25 -Attachment $path,$path -WhatIf
+
+Remove-Item $path

--- a/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
+++ b/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
@@ -150,5 +150,23 @@ namespace Mailozaurr.Tests {
             // Assert
             Assert.Equal(1, attachCount);
         }
-    }
-}
+
+        [Fact]
+        public void SendEmail_WithDuplicateAttachments_AddsOnce() {
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "data");
+            var smtp = new Smtp();
+            smtp.From = "a@b.com";
+            smtp.To = new object[] { "c@d.com" };
+            smtp.Subject = "test";
+            smtp.Attachments = new System.Collections.Generic.List<object> { tmp, tmp };
+            smtp.CreateMessage();
+
+            var attachCount = smtp.Message.BodyParts
+                .OfType<MimePart>()
+                .Count(p => p.IsAttachment);
+            File.Delete(tmp);
+
+            Assert.Equal(1, attachCount);
+        }
+    }}

--- a/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Reflection;
 using Xunit;
@@ -60,5 +61,29 @@ public class SendGridCreateMessageTests
         var json = prop?.GetValue(client) as string;
         Assert.NotNull(json);
         Assert.Contains("X-Test", json!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateMessage_DuplicateAttachments_IncludedOnce()
+    {
+        var tmp = Path.GetTempFileName();
+        File.WriteAllText(tmp, "data");
+        var client = new SendGridClient
+        {
+            From = "from@example.com",
+            To = new List<object> { "to@example.com" },
+            Subject = "subject",
+            Text = "text",
+            Credentials = new NetworkCredential("apikey", "test"),
+            Attachment = new object[] { tmp, tmp }
+        };
+        client.CreateMessage();
+        PropertyInfo? prop = typeof(SendGridClient).GetProperty("MessageJson", BindingFlags.NonPublic | BindingFlags.Instance);
+        var json = prop?.GetValue(client) as string;
+        File.Delete(tmp);
+        Assert.NotNull(json);
+        using var doc = System.Text.Json.JsonDocument.Parse(json!);
+        var count = doc.RootElement.GetProperty("Attachments").GetArrayLength();
+        Assert.Equal(1, count);
     }
 }

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -205,9 +205,14 @@ public class SendGridClient {
             return result;
         }
 
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var item in attachments) {
             var converted = ConvertToAttachment(item);
             if (converted != null) {
+                if (item is string path && !seen.Add(path)) {
+                    continue;
+                }
                 result.Add(converted);
             }
         }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -162,10 +162,13 @@ public partial class ClientSmtp : SmtpClient {
             bodyBuilder.TextBody = TextBody;
         }
         if (Attachments != null) {
+            var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var attachment in Attachments) {
                 switch (attachment) {
-                    case string path:
+                    case string path when seenPaths.Add(path):
                         bodyBuilder.Attachments.Add(path);
+                        break;
+                    case string:
                         break;
                     case MimeEntity entity:
                         bodyBuilder.Attachments.Add(entity);
@@ -174,10 +177,11 @@ public partial class ClientSmtp : SmtpClient {
             }
         }
         if (InlineAttachments != null) {
+            var seenInline = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var inline in InlineAttachments) {
                 MimeEntity? entity = null;
                 switch (inline) {
-                    case string path:
+                    case string path when seenInline.Add(path):
                     {
                         // Read the file into memory so it can be removed immediately
                         var bytes = File.ReadAllBytes(path);
@@ -193,6 +197,8 @@ public partial class ClientSmtp : SmtpClient {
                         entity = part;
                         break;
                     }
+                    case string:
+                        break;
                     case MimeEntity mime:
                         bodyBuilder.LinkedResources.Add(mime);
                         entity = mime;


### PR DESCRIPTION
## Summary
- prevent duplicate attachment paths in `ClientSmtp`
- skip duplicate attachment paths in `SendGridClient`
- test deduplication for SMTP and SendGrid
- add example showing deduplication

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File Mailozaurr.Tests.ps1` *(fails: Unable to find type `Mailozaurr.PowerShell.CmdletWaitIMAPMessage`)*

------
https://chatgpt.com/codex/tasks/task_e_686e24832ea4832e818b899d3d980685