### PR TITLE
Fix Pop3 listener disposal

### DIFF
--- a/Sources/Mailozaurr.Tests/Pop3PollListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/Pop3PollListenerTests.cs
@@ -1,0 +1,22 @@
+using MailKit.Net.Pop3;
+using System;
+using System.Reflection;
+using System.Threading;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class Pop3PollListenerTests {
+    [Fact]
+    public void Dispose_DisposesCancellationTokenSourceAndNullsField() {
+        var listener = new Pop3PollListener(new Pop3Client());
+        var field = typeof(Pop3PollListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var cts = new CancellationTokenSource();
+        field.SetValue(listener, cts);
+
+        listener.Dispose();
+
+        Assert.Null(field.GetValue(listener));
+        Assert.Throws<ObjectDisposedException>(() => _ = cts.Token.WaitHandle);
+    }
+}

--- a/Sources/Mailozaurr/Receive/Pop3PollListener.cs
+++ b/Sources/Mailozaurr/Receive/Pop3PollListener.cs
@@ -80,5 +80,7 @@ public class Pop3PollListener : IDisposable {
     /// <inheritdoc />
     public void Dispose() {
         Stop();
+        _cancel?.Dispose();
+        _cancel = null;
     }
 }


### PR DESCRIPTION
## Summary
- ensure `Pop3PollListener.Dispose` cleans up its token source
- add unit test for the disposal logic

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686e2455264c832eb95ab43e450a1531