### PR TITLE
Verify attachment paths before adding

### DIFF
--- a/Examples/Example-SendEmail-VerifyAttachment.ps1
+++ b/Examples/Example-SendEmail-VerifyAttachment.ps1
@@ -1,0 +1,7 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$missing = "$PSScriptRoot\missing-file.txt"
+
+Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' \
+    -Server 'smtp.example.com' -Port 25 -Subject 'Verify attachments demo' \
+    -Body 'demo body' -Attachment $missing -WhatIf -Verbose

--- a/Sources/Mailozaurr.Examples/SendEmailVerifyAttachments.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailVerifyAttachments.cs
@@ -1,0 +1,21 @@
+using Mailozaurr;
+using System.Collections.Generic;
+
+public static class SendEmailVerifyAttachments
+{
+    public static void Run()
+    {
+        var smtp = new Smtp
+        {
+            From = "sender@example.com",
+            To = new[] { "recipient@example.com" },
+            Subject = "Verify attachments demo",
+            TextBody = "body",
+            Attachments = new List<object> { "missing-file.txt" }
+        };
+
+        smtp.Connect("smtp.example.com", 25);
+        smtp.Send();
+        smtp.Disconnect();
+    }
+}

--- a/Sources/Mailozaurr.Tests/SmtpAttachmentTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAttachmentTests.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.IO;
+using MimeKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpAttachmentTests
+{
+    [Fact]
+    public void CreateMessage_MissingAttachment_SkipsAttachment()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        if (File.Exists(path)) File.Delete(path);
+        var smtp = new Smtp
+        {
+            From = "a@b.com",
+            To = new object[] { "c@d.com" },
+            Subject = "test",
+            TextBody = "body",
+            Attachments = new List<object> { path }
+        };
+
+        smtp.CreateMessage();
+
+        Assert.IsNotType<Multipart>(smtp.Message.Body);
+    }
+}

--- a/Sources/Mailozaurr.Tests/SmtpInlineAttachmentTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpInlineAttachmentTests.cs
@@ -45,4 +45,23 @@ public class SmtpInlineAttachmentTests
 
         Assert.Null(ex);
     }
+
+    [Fact]
+    public void CreateMessage_MissingInlineAttachment_SkipsResource()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        if (File.Exists(path)) File.Delete(path);
+        var smtp = new Smtp
+        {
+            From = "a@b.com",
+            To = new object[] { "c@d.com" },
+            Subject = "test",
+            HtmlBody = "<img src=\"cid:test\">",
+            InlineAttachments = new List<object> { path }
+        };
+
+        smtp.CreateMessage();
+
+        Assert.IsType<TextPart>(smtp.Message.Body);
+    }
 }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -166,7 +166,12 @@ public partial class ClientSmtp : SmtpClient {
             foreach (var attachment in Attachments) {
                 switch (attachment) {
                     case string path when seenPaths.Add(path):
-                        bodyBuilder.Attachments.Add(path);
+                        if (File.Exists(path)) {
+                            bodyBuilder.Attachments.Add(path);
+                        } else {
+                            LoggingMessages.Logger.WriteWarning(
+                                $"Send-EmailMessage - File not found: {path}. Skipping attachment.");
+                        }
                         break;
                     case string:
                         break;
@@ -183,18 +188,23 @@ public partial class ClientSmtp : SmtpClient {
                 switch (inline) {
                     case string path when seenInline.Add(path):
                     {
-                        // Read the file into memory so it can be removed immediately
-                        var bytes = File.ReadAllBytes(path);
-                        using var ms = new MemoryStream(bytes);
-                        var part = new MimePart(MimeTypes.GetMimeType(path))
-                        {
-                            Content = new MimeContent(ms),
-                            FileName = Path.GetFileName(path),
-                            ContentId = Path.GetFileName(path),
-                            ContentDisposition = new ContentDisposition(ContentDisposition.Inline)
-                        };
-                        bodyBuilder.LinkedResources.Add(part);
-                        entity = part;
+                        if (File.Exists(path)) {
+                            // Read the file into memory so it can be removed immediately
+                            var bytes = File.ReadAllBytes(path);
+                            using var ms = new MemoryStream(bytes);
+                            var part = new MimePart(MimeTypes.GetMimeType(path))
+                            {
+                                Content = new MimeContent(ms),
+                                FileName = Path.GetFileName(path),
+                                ContentId = Path.GetFileName(path),
+                                ContentDisposition = new ContentDisposition(ContentDisposition.Inline)
+                            };
+                            bodyBuilder.LinkedResources.Add(part);
+                            entity = part;
+                        } else {
+                            LoggingMessages.Logger.WriteWarning(
+                                $"Send-EmailMessage - File not found: {path}. Skipping inline attachment.");
+                        }
                         break;
                     }
                     case string:


### PR DESCRIPTION
## Summary
- add missing path handling for SMTP attachments
- add examples for skipped attachment paths
- test skipped attachments and inline attachments

## Testing
- `dotnet test Sources/Mailozaurr.sln --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686ec2606d6c832eae86e408949c29f8