### PR TITLE
Handle mailbox parse errors

### DIFF
--- a/Sources/Mailozaurr.Tests/ClientSmtpTests.cs
+++ b/Sources/Mailozaurr.Tests/ClientSmtpTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Reflection;
+using System.Collections.Generic;
+using System.Linq;
 using MimeKit;
 using Xunit;
 
@@ -19,5 +21,25 @@ public class ClientSmtpTests
         using var enumerator = enumerable.GetEnumerator();
         var ex = Assert.Throws<ArgumentException>(() => enumerator.MoveNext());
         Assert.Contains("42", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConvertStringToMailboxAddresses_InvalidInput_LogsWarning()
+    {
+        var client = new ClientSmtp();
+        MethodInfo? method = typeof(ClientSmtp).GetMethod(
+            "ConvertStringToMailboxAddresses",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        var messages = new List<string>();
+        void Handler(object? _, LogEventArgs e) => messages.Add(e.Message);
+        LoggingMessages.Logger.OnWarningMessage += Handler;
+
+        var enumerable = (IEnumerable<MailboxAddress>)method!.Invoke(client, new object[] { "invalid@" })!;
+        var result = enumerable.ToList();
+
+        LoggingMessages.Logger.OnWarningMessage -= Handler;
+        Assert.Empty(result);
+        Assert.Contains(messages, static m => m.Contains("invalid@"));
     }
 }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -269,7 +269,14 @@ public partial class ClientSmtp : SmtpClient {
     }
 
     private IEnumerable<MailboxAddress> ConvertStringToMailboxAddresses(string value) {
-        var mailbox = MailboxAddress.Parse(value);
+        MailboxAddress mailbox;
+        try {
+            mailbox = MailboxAddress.Parse(value);
+        } catch (Exception ex) {
+            LoggingMessages.Logger.WriteWarning($"Failed to parse address '{value}': {ex.Message}");
+            yield break;
+        }
+
         if (value.Contains('<') || value.Contains('>')) {
             yield return mailbox;
         } else {
@@ -290,5 +297,4 @@ public partial class ClientSmtp : SmtpClient {
             }
         }
     }
-
 }


### PR DESCRIPTION
## Summary
- catch mailbox parsing errors in ClientSmtp.ConvertStringToMailboxAddresses
- log warning when mailbox parse fails
- test warning logging on invalid address

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln --filter "FullyQualifiedName~ClientSmtpTests.ConvertStringToMailboxAddresses_InvalidInput_LogsWarning"`

------
https://chatgpt.com/codex/tasks/task_e_686ec26e5edc832ebb685f48e7b24c30