### PR TITLE
Add async connect/authenticate wrappers

### DIFF
--- a/Sources/Mailozaurr.Examples/Program.cs
+++ b/Sources/Mailozaurr.Examples/Program.cs
@@ -10,6 +10,7 @@ class Program {
         await SendEmailGraphClientSecret.RunAsync();
         // await SendEmailGraphCertificate.RunAsync();
         await SendEmailMailgun.RunAsync();
+        // await SendEmailSmtpAsync.RunAsync();
         // await FetchImapMessages.RunAsync();
         // await FetchPopMessages.RunAsync();
     }
@@ -27,3 +28,4 @@ class Program {
 //   - AcquireGoogleTokenInteractive.cs
 //   - AcquireO365TokenInteractive.cs
 //   - SendEmailMailgun.cs
+//   - SendEmailSmtpAsync.cs

--- a/Sources/Mailozaurr.Examples/SendEmailSmtpAsync.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailSmtpAsync.cs
@@ -1,0 +1,28 @@
+using MailKit.Security;
+using Mailozaurr;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Example demonstrating asynchronous SMTP usage.
+/// </summary>
+public static class SendEmailSmtpAsync {
+    /// <summary>Runs the example.</summary>
+    public static async Task RunAsync() {
+        var smtp = new Smtp();
+        smtp.From = "sender@example.com";
+        smtp.To = new[] { "recipient@example.com" };
+        smtp.Subject = "Async SMTP";
+        smtp.TextBody = "Hello from async SMTP";
+        var connectResult = await smtp.ConnectAsync("smtp.example.com", 25);
+        if (!connectResult.Status)
+            throw new Exception($"SMTP Connect failed: {connectResult.Error}");
+        var authResult = await smtp.AuthenticateAsync(new NetworkCredential("user", "pass"));
+        if (!authResult.Status)
+            throw new Exception($"SMTP Auth failed: {authResult.Error}");
+        var sendResult = await smtp.SendAsync();
+        Console.WriteLine(sendResult.Status ? "SMTP async: Email sent!" : $"SMTP async: Failed: {sendResult.Error}");
+        smtp.Disconnect();
+    }
+}

--- a/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using System.Net;
+using System.Threading.Tasks;
+using MailKit.Security;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpAsyncWrappersTests
+{
+    private class FakeClient : ClientSmtp
+    {
+        public bool ConnectCalled;
+        public override Task ConnectAsync(string host, int port, SecureSocketOptions options, System.Threading.CancellationToken cancellationToken = default)
+        {
+            ConnectCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ConnectAsync_InvokesClientConnectAsync()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeClient();
+        var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(smtp, fake);
+
+        var result = await smtp.ConnectAsync("host", 25);
+
+        Assert.True(fake.ConnectCalled);
+        Assert.True(result.Status);
+    }
+
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -265,6 +265,41 @@ public class Smtp {
     }
 
     /// <summary>
+    /// Asynchronously connect to the SMTP server using the provided server and port.
+    /// </summary>
+    /// <param name="server"></param>
+    /// <param name="port"></param>
+    /// <param name="secureSocketOptions">Options controlling SSL/TLS usage. If left
+    /// as <see cref="SecureSocketOptions.Auto"/> and <paramref name="useSsl"/> is
+    /// <c>true</c>, <see cref="SecureSocketOptions.StartTls"/> will be used.</param>
+    /// <param name="useSsl">Compatibility switch. Overrides
+    /// <paramref name="secureSocketOptions"/> only when set to <c>true</c> and the
+    /// option is left as <see cref="SecureSocketOptions.Auto"/>.</param>
+    /// <returns></returns>
+    public async Task<SmtpResult> ConnectAsync(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false) {
+        Server = server;
+        Port = port;
+        try {
+            if (useSsl && secureSocketOptions == SecureSocketOptions.Auto) {
+                // Maintain backwards compatibility with Send-MailMessage by
+                // defaulting to StartTls when the UseSsl flag is supplied and
+                // no explicit option was provided.
+                secureSocketOptions = SecureSocketOptions.StartTls;
+            }
+            await Client.ConnectAsync(server, port, secureSocketOptions);
+            LoggingMessages.Logger.WriteVerbose($"Connected to {server} on {port} port using SSL: {secureSocketOptions}");
+            return new SmtpResult(true, EmailAction.Connect, SentTo, SentFrom, server, port, Stopwatch.Elapsed, "");
+        } catch (Exception ex) {
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during connect: {ex.Message}");
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Possible issue: Port? ({port} was used), Using SSL? ({secureSocketOptions}, was used). You can also try 'SkipCertificateValidation' or 'SkipCertificateRevocation'.");
+            if (ErrorAction == ActionPreference.Stop) {
+                throw;
+            }
+            return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, server, port, Stopwatch.Elapsed, "", ex.Message);
+        }
+    }
+
+    /// <summary>
     /// Authenticate using the provided credentials.
     /// </summary>
     /// <param name="Credentials"></param>
@@ -284,6 +319,36 @@ public class Smtp {
             } else {
                 Client.Authenticate(Credentials);
                 //  Settings.Logger.WriteVerbose($"Send-EmailMessage - Authenticated using ICredentials");
+            }
+            return new SmtpResult(true, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
+        } catch (Exception ex) {
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during authentication (oAuth): {ex.Message}");
+            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Possible issue: OAuth? ({isOAuth} was used), ICredentials? ({Credentials}, was used).");
+            if (ErrorAction == ActionPreference.Stop) {
+                throw;
+            }
+            return new SmtpResult(false, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously authenticate using the provided credentials.
+    /// </summary>
+    /// <param name="Credentials"></param>
+    /// <param name="isOAuth"></param>
+    /// <returns></returns>
+    public async Task<SmtpResult> AuthenticateAsync(ICredentials Credentials, bool isOAuth = false) {
+        try {
+            if (isOAuth) {
+                var networkCredential = Credentials as NetworkCredential;
+                if (networkCredential != null) {
+                    var (userName, token) = Helpers.ConvertFromOAuth2Credential(networkCredential);
+                    var oauth2 = new SaslMechanismOAuth2(userName, token);
+                    await Client.AuthenticateAsync(oauth2);
+                }
+                LoggingMessages.Logger.WriteVerbose($"Send-EmailMessage - Authenticated using oAuth");
+            } else {
+                await Client.AuthenticateAsync(Credentials);
             }
             return new SmtpResult(true, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
         } catch (Exception ex) {


### PR DESCRIPTION
## Summary
- add `ConnectAsync` and `AuthenticateAsync` wrappers in `Smtp`
- document async SMTP usage via new example
- expose new example option in Program
- test async connect wrapper

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686ec2880b54832e9a174299a6728e4f