### PR TITLE
Ensure ClientSmtp disconnects on dispose

### DIFF
--- a/Sources/Mailozaurr.Tests/ClientSmtpDisposeTests.cs
+++ b/Sources/Mailozaurr.Tests/ClientSmtpDisposeTests.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using MailKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ClientSmtpDisposeTests
+{
+    private class FakeClient : ClientSmtp
+    {
+        public bool DisconnectCalled;
+        private bool _connected;
+        public override bool IsConnected => _connected;
+        public void SetConnected(bool value) => _connected = value;
+        public override void Disconnect(bool quit, CancellationToken cancellationToken = default)
+        {
+            DisconnectCalled = true;
+        }
+    }
+
+    [Fact]
+    public void Dispose_DisconnectsWhenConnected()
+    {
+        var client = new FakeClient();
+        client.SetConnected(true);
+        client.Dispose();
+        Assert.True(client.DisconnectCalled);
+    }
+}

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.Disposal.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.Disposal.cs
@@ -1,0 +1,26 @@
+namespace Mailozaurr;
+
+public partial class ClientSmtp
+{
+    ~ClientSmtp()
+    {
+        Dispose(false);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (IsConnected)
+        {
+            try
+            {
+                Disconnect(true);
+            }
+            catch
+            {
+                // ignore errors while disposing
+            }
+        }
+        base.Dispose(disposing);
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure ClientSmtp always disconnects before disposing
- add unit test covering ClientSmtp disposal

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686ec2a465b8832e99ef79e326d62694