### PR TITLE
Handle Graph 429 with retry-after

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
@@ -89,6 +89,24 @@ public class GraphBatchAndRetryTests {
         }
     }
 
+    private class RetryAfterHandler : HttpMessageHandler {
+        public int CallCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            CallCount++;
+            if (request.RequestUri!.AbsoluteUri.Contains("oauth2")) {
+                if (CallCount == 1) {
+                    var resp = new HttpResponseMessage((HttpStatusCode)429);
+                    resp.Headers.Add("Retry-After", "0");
+                    return Task.FromResult(resp);
+                }
+                var json = "{\"access_token\":\"token\",\"token_type\":\"Bearer\"}";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) });
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
     [Fact]
     public async Task ConnectO365GraphWithRetryAsync_RetriesUntilSuccess() {
         var handler = new RetryHandler();
@@ -110,6 +128,32 @@ public class GraphBatchAndRetryTests {
             string token = await MicrosoftGraphUtils.ConnectO365GraphWithRetryAsync(credential, "tenant", 2, 0, 1);
             Assert.Equal("Bearer token", token);
             Assert.Equal(3, handler.CallCount);
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+
+    [Fact]
+    public async Task ConnectO365GraphAsync_RetriesAfter429() {
+        var handler = new RetryAfterHandler();
+        var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)field.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
+        cache.Clear();
+        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
+        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+        oauthField?.SetValue(null, null);
+        string cachePath = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
+        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        try {
+            var credential = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            string token = await MicrosoftGraphUtils.ConnectO365GraphAsync(credential, "tenant", "https://graph.microsoft.com");
+            Assert.Equal("Bearer token", token);
+            Assert.Equal(2, handler.CallCount);
         } finally {
             handlerField.SetValue(client, original);
         }

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
@@ -38,6 +39,20 @@ namespace Mailozaurr {
         }
 
         internal static SemaphoreSlim ConcurrencySemaphore => _concurrencySemaphore;
+
+        private static TimeSpan GetRetryAfterDelay(HttpResponseMessage response) {
+            if (response.Headers.TryGetValues("Retry-After", out var values)) {
+                var value = System.Linq.Enumerable.FirstOrDefault(values);
+                if (int.TryParse(value, out var seconds)) {
+                    return TimeSpan.FromSeconds(seconds);
+                }
+                if (DateTimeOffset.TryParse(value, out var date)) {
+                    var diff = date - DateTimeOffset.UtcNow;
+                    return diff > TimeSpan.Zero ? diff : TimeSpan.Zero;
+                }
+            }
+            return TimeSpan.Zero;
+        }
 
         /// <summary>
         /// Gets or sets the timeout for HTTP operations in seconds.
@@ -122,8 +137,17 @@ namespace Mailozaurr {
             var content = new FormUrlEncodedContent(body);
             var url = $"https://login.microsoftonline.com/{tenantDomain}/oauth2/token";
             await ConcurrencySemaphore.WaitAsync();
+            HttpResponseMessage? response = null;
             try {
-                using var response = await HttpClient.PostAsync(url, content);
+                response = await HttpClient.PostAsync(url, content);
+                if ((int)response.StatusCode == 429) {
+                    var delay = GetRetryAfterDelay(response);
+                    response.Dispose();
+                    if (delay > TimeSpan.Zero) {
+                        await Task.Delay(delay);
+                    }
+                    response = await HttpClient.PostAsync(url, content);
+                }
                 var json = await response.Content.ReadAsStringAsync();
                 if (!response.IsSuccessStatusCode) {
                     throw new GraphApiException(
@@ -151,6 +175,7 @@ namespace Mailozaurr {
                 });
                 return $"{tokenType} {accessToken}";
             } finally {
+                response?.Dispose();
                 ConcurrencySemaphore.Release();
             }
         }
@@ -228,8 +253,17 @@ namespace Mailozaurr {
                 request.Content = new StringContent(body, Encoding.UTF8, "application/json");
             }
             await ConcurrencySemaphore.WaitAsync();
+            HttpResponseMessage? response = null;
             try {
-                using var response = await HttpClient.SendAsync(request);
+                response = await HttpClient.SendAsync(request);
+                if ((int)response.StatusCode == 429) {
+                    var delay = GetRetryAfterDelay(response);
+                    response.Dispose();
+                    if (delay > TimeSpan.Zero) {
+                        await Task.Delay(delay);
+                    }
+                    response = await HttpClient.SendAsync(request);
+                }
                 var responseContent = await response.Content.ReadAsStringAsync();
                 if (!response.IsSuccessStatusCode) {
                     throw new GraphApiException(
@@ -239,6 +273,7 @@ namespace Mailozaurr {
                 }
                 return JsonDocument.Parse(responseContent);
             } finally {
+                response?.Dispose();
                 ConcurrencySemaphore.Release();
             }
         }


### PR DESCRIPTION
## Summary
- delay and retry Microsoft Graph calls when a 429 status code is received
- test ConnectO365GraphAsync retry logic

## Testing
- `dotnet test Sources/Mailozaurr.sln --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686ec2b10448832ea96b5f5286fe8328