### PR TITLE
Add token overloads for SendEmailAsync

### DIFF
--- a/Sources/Mailozaurr.Examples/SendEmailMailgun.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailMailgun.cs
@@ -1,6 +1,7 @@
 using Mailozaurr;
 using System;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 
 /// <summary>
@@ -23,7 +24,8 @@ public static class SendEmailMailgun {
             mailgun.Text = "Hello from Mailozaurr via Mailgun!";
             mailgun.Html = "<p>Hello from Mailozaurr via Mailgun!</p>";
             mailgun.Credentials = new NetworkCredential("api", apiKey);
-            var result = await mailgun.SendEmailAsync();
+            using var cts = new CancellationTokenSource();
+            var result = await mailgun.SendEmailAsync(cts.Token);
             Console.WriteLine(result.Status ? "Mailgun: Email sent!" : $"Mailgun: Failed: {result.Error}");
         } catch (Exception ex) {
             Console.WriteLine($"Mailgun Example Error: {ex.Message}");

--- a/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
+++ b/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
@@ -61,6 +61,28 @@ namespace Mailozaurr.Tests {
         }
 
         [Fact]
+        public async Task SendEmail_SendGrid_WithToken_Succeeds() {
+            var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+            var client = new SendGridClient();
+            var field = typeof(SendGridClient).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            field.SetValue(client, new HttpClient(handler));
+
+            client.From = "sender@example.com";
+            client.To = new System.Collections.Generic.List<object> { "recipient@example.com" };
+            client.Subject = "Test Email (SendGrid)";
+            client.Html = "<b>Hello from Mailozaurr SendGrid!</b>";
+            client.Text = "Hello from Mailozaurr SendGrid!";
+            client.Credentials = new NetworkCredential("apikey", "SENDGRID_API_KEY");
+            client.CreateMessage();
+
+            using var cts = new CancellationTokenSource();
+            var result = await client.SendEmailAsync(cts.Token);
+
+            Assert.True(result.Status, $"SendGrid send failed: {result.Error}");
+            Assert.Single(handler.Requests);
+        }
+
+        [Fact]
         public async Task SendEmail_SendGrid_InvalidCredentialType_Fails() {
             var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
             var client = new SendGridClient();

--- a/Sources/Mailozaurr.Tests/SesClientSendEmailAsyncTests.cs
+++ b/Sources/Mailozaurr.Tests/SesClientSendEmailAsyncTests.cs
@@ -80,6 +80,20 @@ public class SesClientSendEmailAsyncTests
     }
 
     [Fact]
+    public async Task SendEmailAsync_WithToken_Succeeds()
+    {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+        using var client = CreateClient(handler);
+        client.WebhookUrl = null;
+
+        using var cts = new CancellationTokenSource();
+        var result = await client.SendEmailAsync(cts.Token);
+
+        Assert.True(result.Status);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
     public async Task SendEmailAsync_RetriesFailedRequest()
     {
         var handler = new RecordingHandler(

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -160,7 +160,12 @@ public class SesClient : IDisposable {
     /// <summary>
     /// Sends the email using Amazon SES.
     /// </summary>
-    public async Task<SmtpResult> SendEmailAsync(CancellationToken cancellationToken = default)
+    public Task<SmtpResult> SendEmailAsync() => SendEmailAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Sends the email using Amazon SES.
+    /// </summary>
+    public async Task<SmtpResult> SendEmailAsync(CancellationToken cancellationToken)
     {
         int attempts = 0;
         Exception? lastException = null;
@@ -175,7 +180,11 @@ public class SesClient : IDisposable {
             {
                 using HttpRequestMessage request = CreateRequest(body, DateTime.UtcNow);
                 HttpResponseMessage response = await _client.SendAsync(request, cancellationToken);
+#if NET5_0_OR_GREATER
+                string respContent = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
                 string respContent = await response.Content.ReadAsStringAsync();
+#endif
                 if (response.IsSuccessStatusCode)
                 {
                     SmtpResult ok = new(true, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString());

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -171,7 +171,13 @@ public class MailgunClient : IDisposable {
     /// Sends the email using the Mailgun REST API.
     /// </summary>
     /// <returns>The result of the send operation.</returns>
-    public async Task<SmtpResult> SendEmailAsync(CancellationToken cancellationToken = default) {
+    public Task<SmtpResult> SendEmailAsync() => SendEmailAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Sends the email using the Mailgun REST API.
+    /// </summary>
+    /// <returns>The result of the send operation.</returns>
+    public async Task<SmtpResult> SendEmailAsync(CancellationToken cancellationToken) {
         var url = $"https://api.mailgun.net/v3/{EmailDomain}/messages";
         var auth = Convert.ToBase64String(Encoding.ASCII.GetBytes($"api:{ApiKey}"));
 
@@ -190,7 +196,11 @@ public class MailgunClient : IDisposable {
                     await Helpers.PostWebhookAsync(WebhookUrl, okResult, cancellationToken);
                     return okResult;
                 }
+#if NET5_0_OR_GREATER
+                var error = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
                 var error = await response.Content.ReadAsStringAsync();
+#endif
                 throw new HttpRequestException(error);
             } catch (HttpRequestException ex) {
                 lastException = ex;

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -278,7 +278,13 @@ public class SendGridClient {
     /// Sends an email asynchronously using the SendGrid API.
     /// </summary>
     /// <returns>A Task that represents the asynchronous operation. The task result contains the result of the email sending operation.</returns>
-    public async Task<SmtpResult> SendEmailAsync(CancellationToken cancellationToken = default) {
+    public Task<SmtpResult> SendEmailAsync() => SendEmailAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Sends an email asynchronously using the SendGrid API.
+    /// </summary>
+    /// <returns>A Task that represents the asynchronous operation. The task result contains the result of the email sending operation.</returns>
+    public async Task<SmtpResult> SendEmailAsync(CancellationToken cancellationToken) {
         string apiKey;
         if (Credentials is NetworkCredential networkCredential) {
             apiKey = networkCredential.Password;
@@ -304,7 +310,11 @@ public class SendGridClient {
                 request.Headers.Add("Authorization", $"Bearer {apiKey}");
 
                 using var response = await _client.SendAsync(request, cancellationToken);
+#if NET5_0_OR_GREATER
+                lastContent = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
                 lastContent = await response.Content.ReadAsStringAsync();
+#endif
                 LogCollector.LogVerbose($"Send-EmailMessage - Sent email to {SentTo} using SendGrid");
 
                 if (response.IsSuccessStatusCode) {


### PR DESCRIPTION
## Summary
- add `SendEmailAsync` overloads that accept `CancellationToken`
- ensure SendGrid, Mailgun and SES clients pass the token to all awaits
- update example to show token usage
- test new overloads in SendGrid and SES clients

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686ec2b8058c832e9d19ea6d31059a95