### PR TITLE
Add missing XML documentation

### DIFF
--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -39,6 +39,7 @@ public class SesClient : IDisposable {
     /// <summary>Paths to inline attachments to include.</summary>
     public string[]? InlineAttachment { get; set; }
 
+    /// <summary>Custom headers to include with the message.</summary>
     public Dictionary<string, string>? Headers { get; set; }
 
     /// <summary>Number of retry attempts on failure.</summary>

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -131,10 +131,12 @@ public sealed class GmailApiClient {
     }
 
     private sealed class AttachmentResponse {
+        /// <summary>Base64 encoded attachment data.</summary>
         public string? Data { get; set; }
     }
 
     private sealed class GmailListResponse {
+        /// <summary>Messages returned by the API.</summary>
         public List<GmailMessage>? Messages { get; set; }
     }
 }

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -51,6 +51,7 @@ public class MailgunClient : IDisposable {
     /// <summary>File paths to include as inline attachments.</summary>
     public string[]? InlineAttachment { get; set; }
 
+    /// <summary>Custom headers to include with the message.</summary>
     public Dictionary<string, string>? Headers { get; set; }
 
     /// <summary>Collector used to store log entries.</summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -152,8 +152,10 @@ public class Graph : IDisposable {
     /// </summary>
     public bool RetryAlways { get; set; } = false;
 
+    /// <summary>Webhook invoked after sending.</summary>
     public string? WebhookUrl { get; set; }
 
+    /// <summary>Custom headers to include with the message.</summary>
     public Dictionary<string, string>? Headers { get; set; }
 
     /// <summary>
@@ -202,6 +204,7 @@ public class Graph : IDisposable {
     /// </summary>
     public bool RequestDeliveryReceipt { get; set; }
 
+    /// <summary>Collector used to store log entries.</summary>
     public LogCollector LogCollector { get; set; } = new();
 
     /// <summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphInternetMessageHeader.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphInternetMessageHeader.cs
@@ -1,11 +1,15 @@
 using System.Text.Json.Serialization;
 namespace Mailozaurr;
 
-public class GraphInternetMessageHeader
-{
+/// <summary>
+/// Represents a single internet message header returned by Microsoft Graph.
+/// </summary>
+public class GraphInternetMessageHeader {
+    /// <summary>Header name.</summary>
     [JsonPropertyName("name")]
     public string Name { get; set; }
 
+    /// <summary>Header value.</summary>
     [JsonPropertyName("value")]
     public string Value { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -631,6 +631,16 @@ namespace Mailozaurr {
             }
         }
 
+        /// <summary>
+        /// Filters a collection of messages using provided skip criteria.
+        /// </summary>
+        /// <param name="messages">Messages to filter.</param>
+        /// <param name="skipIds">IDs of messages to exclude.</param>
+        /// <param name="skipFrom">Sender addresses to exclude.</param>
+        /// <param name="skipTo">Recipient addresses to exclude.</param>
+        /// <param name="skipSubjectContains">Subject substrings to exclude.</param>
+        /// <param name="skipHasAttachment">Exclude messages that have attachments.</param>
+        /// <returns>List of messages that are not considered junk.</returns>
         public static List<Dictionary<string, object>> FilterJunkMessages(
             IEnumerable<Dictionary<string, object>> messages,
             IEnumerable<string>? skipIds = null,

--- a/Sources/Mailozaurr/Receive/MessageFlagSetter.cs
+++ b/Sources/Mailozaurr/Receive/MessageFlagSetter.cs
@@ -17,13 +17,25 @@ public static class MessageFlagSetter {
     /// Abstraction for flag operations on a folder.
     /// </summary>
     public interface IImapFolder {
+        /// <summary>Adds flags to the specified message.</summary>
+        /// <param name="uid">Message unique identifier.</param>
+        /// <param name="flags">Flags to add.</param>
+        /// <param name="silent">Whether to perform the operation silently.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         Task AddFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default);
+        /// <summary>Removes flags from the specified message.</summary>
+        /// <param name="uid">Message unique identifier.</param>
+        /// <param name="flags">Flags to remove.</param>
+        /// <param name="silent">Whether to perform the operation silently.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         Task RemoveFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default);
     }
 
     private class FolderWrapper(IMailFolder folder) : IImapFolder {
+        /// <inheritdoc />
         public Task AddFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) =>
             folder.AddFlagsAsync(uid, flags, silent, cancellationToken);
+        /// <inheritdoc />
         public Task RemoveFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) =>
             folder.RemoveFlagsAsync(uid, flags, silent, cancellationToken);
     }
@@ -54,6 +66,13 @@ public static class MessageFlagSetter {
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Tries to get the local read flag for a POP3 message.
+    /// </summary>
+    /// <param name="client">POP3 client.</param>
+    /// <param name="index">Message index.</param>
+    /// <param name="read">Returns the current read state.</param>
+    /// <returns><c>true</c> when a state was found.</returns>
     public static bool TryGetPop3Read(Pop3Client client, int index, out bool read) {
         var state = Pop3Flags.GetOrCreateValue(client);
         return state.TryGetValue(index, out read);

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -51,6 +51,7 @@ public class SendGridClient {
     /// </summary>
     public object[]? Attachment { get; set; }
 
+    /// <summary>Custom headers to include with the message.</summary>
     public Dictionary<string, string>? Headers { get; set; }
 
     /// <summary>
@@ -110,6 +111,7 @@ public class SendGridClient {
     /// </summary>
     public bool RetryAlways { get; set; } = false;
 
+    /// <summary>Webhook invoked after sending.</summary>
     public string? WebhookUrl { get; set; }
 
     /// <summary>

--- a/Sources/Mailozaurr/SendGrid/SendGridMessage.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridMessage.cs
@@ -32,8 +32,10 @@ public class SendGridMessage {
     public SendGridEmailAddress? ReplyTo { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    /// <summary>Attachments to include with the message.</summary>
     public List<SendGridAttachment>? Attachments { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    /// <summary>Custom headers to include with the message.</summary>
     public Dictionary<string, string>? Headers { get; set; }
 }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -60,8 +60,11 @@ public partial class ClientSmtp : SmtpClient {
         }
     }
 
+    /// <summary>Initializes a new instance of the <see cref="ClientSmtp"/> class.</summary>
     public ClientSmtp() { }
 
+    /// <summary>Initializes a new instance of the <see cref="ClientSmtp"/> class using the specified logger.</summary>
+    /// <param name="protocolLogger">The protocol logger.</param>
     public ClientSmtp(ProtocolLogger protocolLogger) : base(protocolLogger) { }
 
     /// <summary>

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -14,75 +14,91 @@ namespace Mailozaurr;
 /// High level wrapper around <see cref="ClientSmtp"/> that exposes convenient methods and retry logic.
 /// </summary>
 public class Smtp {
+    /// <summary>Configuration used for protocol logging.</summary>
     public LoggingConfigurator? Logging;
 
+    /// <summary>Underlying SMTP client used to send messages.</summary>
     public ClientSmtp Client { get; }
 
+    /// <summary>Subject of the message.</summary>
     public string Subject {
         get => Client.Subject;
         set => Client.Subject = value;
     }
 
+    /// <summary>HTML body of the message.</summary>
     public string HtmlBody {
         get => Client.HtmlBody;
         set => Client.HtmlBody = value;
     }
 
+    /// <summary>Plain text body of the message.</summary>
     public string TextBody {
         get => Client.TextBody;
         set => Client.TextBody = value;
     }
 
+    /// <summary>Attachments to include with the message.</summary>
     public List<object>? Attachments {
         get => Client.Attachments;
         set => Client.Attachments = value;
     }
 
+    /// <summary>Inline attachments to embed in the message.</summary>
     public List<object>? InlineAttachments {
         get => Client.InlineAttachments;
         set => Client.InlineAttachments = value;
     }
 
+    /// <summary>Custom headers to add to the message.</summary>
     public IDictionary<string, string>? Headers {
         get => Client.Headers;
         set => Client.Headers = value;
     }
 
+    /// <summary>The sender address.</summary>
     public object From {
         get => Client.From;
         set => Client.From = value;
     }
 
+    /// <summary>Primary recipients.</summary>
     public IEnumerable<object>? To {
         get => Client.To;
         set => Client.To = value;
     }
 
+    /// <summary>Carbon copy recipients.</summary>
     public IEnumerable<object>? Cc {
         get => Client.Cc;
         set => Client.Cc = value;
     }
 
+    /// <summary>Blind carbon copy recipients.</summary>
     public IEnumerable<object>? Bcc {
         get => Client.Bcc;
         set => Client.Bcc = value;
     }
 
+    /// <summary>Reply-to address.</summary>
     public object? ReplyTo {
         get => Client.ReplyTo;
         set => Client.ReplyTo = value;
     }
 
+    /// <summary>The underlying MIME message.</summary>
     public MimeMessage Message {
         get => Client.Message;
         set => Client.Message = value;
     }
 
+    /// <summary>Priority of the message.</summary>
     public MessagePriority Priority {
         get => Client.Priority;
         set => Client.Priority = value;
     }
 
+    /// <summary>Delivery notification options.</summary>
     public DeliveryNotification[]? DeliveryNotificationOption {
         get => Client.DeliveryNotificationOption;
         set {
@@ -92,15 +108,19 @@ public class Smtp {
         }
     }
 
+    /// <summary>Timeout for SMTP operations in milliseconds.</summary>
     public int Timeout {
         get => Client.Timeout;
         set => Client.Timeout = value;
     }
 
+    /// <summary>Number of retry attempts on failure.</summary>
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>Base delay in milliseconds between retries.</summary>
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>Exponential backoff multiplier for retries.</summary>
     public double RetryDelayBackoff { get; set; } = 1.0;
 
     /// <summary>
@@ -115,14 +135,17 @@ public class Smtp {
     /// </summary>
     public bool RetryAlways { get; set; } = false;
 
+    /// <summary>Webhook invoked after sending.</summary>
     public string? WebhookUrl { get; set; }
 
+    /// <summary>Validate the server certificate against revocation lists.</summary>
     public bool CheckCertificateRevocation {
         get => Client.CheckCertificateRevocation;
         set => Client.CheckCertificateRevocation = value;
     }
 
     private bool _skipCertificateValidation;
+    /// <summary>Skip server certificate validation.</summary>
     public bool SkipCertificateValidation {
         get => _skipCertificateValidation;
         set {
@@ -135,6 +158,7 @@ public class Smtp {
         }
     }
 
+    /// <summary>Domain name to use in the SMTP HELO.</summary>
     public string LocalDomain {
         get => Client.LocalDomain;
         set {
@@ -142,6 +166,7 @@ public class Smtp {
         }
     }
 
+    /// <summary>Delivery status notification type to request.</summary>
     public DeliveryStatusNotificationType? DeliveryStatusNotificationType {
         get => Client.DeliveryStatusNotificationType;
         set {
@@ -151,20 +176,27 @@ public class Smtp {
         }
     }
 
+    /// <summary>Custom certificate validation callback.</summary>
     public RemoteCertificateValidationCallback ServerCertificateValidationCallback {
         get => Client.ServerCertificateValidationCallback;
         set => Client.ServerCertificateValidationCallback = value;
     }
 
+    /// <summary>Port used to connect to the SMTP server.</summary>
     public int Port { get; private set; } = 25;
 
+    /// <summary>SMTP server host name.</summary>
     public string Server { get; private set; } = String.Empty;
 
+    /// <summary>Action to take when an error occurs.</summary>
     public ActionPreference? ErrorAction { get; set; }
 
+    /// <summary>Comma separated list of all recipients.</summary>
     public string SentTo => Client.SentTo;
+    /// <summary>Normalized address the message is sent from.</summary>
     public string SentFrom => Helpers.GetEmailAddress(From);
 
+    /// <summary>Stopwatch measuring the time of operations.</summary>
     public readonly Stopwatch Stopwatch;
 
     /// <summary>
@@ -731,6 +763,11 @@ public class Smtp {
         return new SmtpResult(true, EmailAction.SMimeSignAndEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
     }
 
+    /// <summary>
+    /// Encrypts the current message using the specified OpenPGP public key.
+    /// </summary>
+    /// <param name="publicKeyPath">Path to the recipient public key.</param>
+    /// <returns>The result of the encryption operation.</returns>
     public SmtpResult PgpEncrypt(string publicKeyPath) {
         if (!File.Exists(publicKeyPath)) {
             string messageText = $"Public key file not found: {publicKeyPath}";
@@ -756,6 +793,14 @@ public class Smtp {
         }
     }
 
+    /// <summary>
+    /// Signs the current message using OpenPGP keys.
+    /// </summary>
+    /// <param name="publicKeyPath">Path to the public key.</param>
+    /// <param name="privateKeyPath">Path to the private key.</param>
+    /// <param name="password">Password protecting the private key.</param>
+    /// <param name="isSecureString">Whether the password is protected.</param>
+    /// <returns>The result of the signing operation.</returns>
     public SmtpResult PgpSign(string publicKeyPath, string privateKeyPath, string password, bool isSecureString) {
         password = ConvertSecureStringToPlainString(password, isSecureString);
         try {
@@ -803,6 +848,14 @@ public class Smtp {
         }
     }
 
+    /// <summary>
+    /// Signs and encrypts the current message using OpenPGP keys.
+    /// </summary>
+    /// <param name="publicKeyPath">Path to the public key.</param>
+    /// <param name="privateKeyPath">Path to the private key.</param>
+    /// <param name="password">Password protecting the private key.</param>
+    /// <param name="isSecureString">Whether the password is protected.</param>
+    /// <returns>The result of the sign and encrypt operation.</returns>
     public SmtpResult PgpSignAndEncrypt(string publicKeyPath, string privateKeyPath, string password, bool isSecureString) {
         password = ConvertSecureStringToPlainString(password, isSecureString);
         try {


### PR DESCRIPTION
## Summary
- add XML comments to public members across the main libraries
- include documentation for SMTP helpers and other utilities

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: 72 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_686ec2921974832eb4f2508999a0e898