### PR TITLE
Add query language parsing to MailboxSearcher

### DIFF
--- a/Examples/Example-QueryLanguageSearch.ps1
+++ b/Examples/Example-QueryLanguageSearch.ps1
@@ -1,0 +1,13 @@
+# Demonstrates searching an IMAP mailbox using query language
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$imap = Connect-IMAP -Server 'imap.example.com' -Credential (Get-Credential)
+
+# search using query string for messages from boss with subject containing "report"
+$result = Search-IMAPMailbox -Client $imap -Query 'from:boss subject:"report"'
+
+$result | ForEach-Object {
+    Write-Host "Found message $($_.Message.Subject)"
+}
+
+Disconnect-IMAP -Client $imap

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchIMAPMailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchIMAPMailbox.cs
@@ -32,6 +32,12 @@ public sealed class CmdletSearchIMAPMailbox : AsyncPSCmdlet {
     public SearchQuery[]? SearchQuery { get; set; }
 
     /// <summary>
+    /// Query language string to filter messages.
+    /// </summary>
+    [Parameter]
+    public string? Query { get; set; }
+
+    /// <summary>
     /// Filters messages by subject.
     /// </summary>
     [Parameter]
@@ -95,7 +101,8 @@ public sealed class CmdletSearchIMAPMailbox : AsyncPSCmdlet {
                 HasAttachment.IsPresent,
                 SearchQuery,
                 Count,
-                CancelToken);
+                CancelToken,
+                Query);
             foreach (var msg in messages) {
                 WriteObject(msg);
             }

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchPOP3Mailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchPOP3Mailbox.cs
@@ -61,6 +61,12 @@ public sealed class CmdletSearchPOP3Mailbox : AsyncPSCmdlet {
     public SwitchParameter HasAttachment { get; set; }
 
     /// <summary>
+    /// Query language string to filter messages.
+    /// </summary>
+    [Parameter]
+    public string? Query { get; set; }
+
+    /// <summary>
     /// Maximum number of messages to return.
     /// </summary>
     [Parameter]
@@ -84,7 +90,8 @@ public sealed class CmdletSearchPOP3Mailbox : AsyncPSCmdlet {
                 Before,
                 HasAttachment.IsPresent,
                 Count,
-                CancelToken);
+                CancelToken,
+                Query);
             foreach (var msg in messages) {
                 WriteObject(msg);
             }

--- a/Sources/Mailozaurr.Tests/QueryLanguageParserTests.cs
+++ b/Sources/Mailozaurr.Tests/QueryLanguageParserTests.cs
@@ -1,0 +1,24 @@
+using System;
+using MailKit.Search;
+using Mailozaurr;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class QueryLanguageParserTests {
+    [Fact]
+    public void ParseQuery_ParsesBasicFields() {
+        var result = MailboxSearcher.ParseQuery("from:boss subject:\"report\"");
+        Assert.Equal("boss", result.FromContains);
+        Assert.Equal("report", result.Subject);
+    }
+
+    [Fact]
+    public void ParseQuery_ParsesDatesAndFlags() {
+        var result = MailboxSearcher.ParseQuery("since:2024-01-01 before:2024-02-01 has:attachment priority:high");
+        Assert.Equal(new DateTime(2024, 1, 1), result.Since);
+        Assert.Equal(new DateTime(2024, 2, 1), result.Before);
+        Assert.True(result.HasAttachment);
+        Assert.Equal(MessagePriority.High, result.Priority);
+    }
+}

--- a/Sources/Mailozaurr/Mailozaurr.csproj
+++ b/Sources/Mailozaurr/Mailozaurr.csproj
@@ -55,9 +55,14 @@
         <Using Include="System.Diagnostics" />
     </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
         <EmbeddedResource Include="Resources\disposable_email_blocklist.conf" />
         <EmbeddedResource Include="Resources\allowlist.conf" />
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Mailozaurr.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
 </Project>

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -29,20 +29,32 @@ public static class MailboxSearcher {
         bool hasAttachment = false,
         IEnumerable<SearchQuery>? additionalQueries = null,
         int maxResults = 0,
-        CancellationToken cancellationToken = default) {
+        CancellationToken cancellationToken = default,
+        string? queryString = null) {
         var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
-        SearchQuery query = SearchQuery.All;
-        if (!string.IsNullOrWhiteSpace(subject)) query = query.And(SearchQuery.SubjectContains(subject));
-        if (!string.IsNullOrWhiteSpace(fromContains)) query = query.And(SearchQuery.FromContains(fromContains));
-        if (!string.IsNullOrWhiteSpace(toContains)) query = query.And(SearchQuery.ToContains(toContains));
-        if (since.HasValue) query = query.And(SearchQuery.DeliveredAfter(since.Value));
-        if (before.HasValue) query = query.And(SearchQuery.DeliveredBefore(before.Value));
+        SearchQuery search = SearchQuery.All;
+        if (!string.IsNullOrWhiteSpace(subject)) search = search.And(SearchQuery.SubjectContains(subject));
+        if (!string.IsNullOrWhiteSpace(fromContains)) search = search.And(SearchQuery.FromContains(fromContains));
+        if (!string.IsNullOrWhiteSpace(toContains)) search = search.And(SearchQuery.ToContains(toContains));
+        if (since.HasValue) search = search.And(SearchQuery.DeliveredAfter(since.Value));
+        if (before.HasValue) search = search.And(SearchQuery.DeliveredBefore(before.Value));
         if (additionalQueries != null) {
             foreach (var q in additionalQueries) {
-                if (q != null) query = query.And(q);
+                if (q != null) search = search.And(q);
             }
         }
-        var uids = await mailFolder.SearchAsync(query, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(queryString)) {
+            var parsed = ParseQuery(queryString);
+            if (!string.IsNullOrWhiteSpace(parsed.Subject)) search = search.And(SearchQuery.SubjectContains(parsed.Subject));
+            if (!string.IsNullOrWhiteSpace(parsed.FromContains)) search = search.And(SearchQuery.FromContains(parsed.FromContains));
+            if (!string.IsNullOrWhiteSpace(parsed.ToContains)) search = search.And(SearchQuery.ToContains(parsed.ToContains));
+            if (parsed.Since.HasValue) search = search.And(SearchQuery.DeliveredAfter(parsed.Since.Value));
+            if (parsed.Before.HasValue) search = search.And(SearchQuery.DeliveredBefore(parsed.Before.Value));
+            foreach (var q in parsed.AdditionalQueries) search = search.And(q);
+            hasAttachment |= parsed.HasAttachment;
+            if (!priority.HasValue) priority = parsed.Priority;
+        }
+        var uids = await mailFolder.SearchAsync(search, cancellationToken).ConfigureAwait(false);
         var result = new List<ImapEmailMessage>(uids.Count);
         foreach (var uid in uids) {
             var message = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
@@ -67,7 +79,18 @@ public static class MailboxSearcher {
         DateTime? before = null,
         bool hasAttachment = false,
         int maxResults = 0,
-        CancellationToken cancellationToken = default) {
+        CancellationToken cancellationToken = default,
+        string? queryString = null) {
+        if (!string.IsNullOrWhiteSpace(queryString)) {
+            var parsed = ParseQuery(queryString);
+            if (string.IsNullOrWhiteSpace(subject)) subject = parsed.Subject;
+            if (string.IsNullOrWhiteSpace(fromContains)) fromContains = parsed.FromContains;
+            if (string.IsNullOrWhiteSpace(toContains)) toContains = parsed.ToContains;
+            if (!since.HasValue) since = parsed.Since;
+            if (!before.HasValue) before = parsed.Before;
+            if (!priority.HasValue) priority = parsed.Priority;
+            hasAttachment |= parsed.HasAttachment;
+        }
         var results = new List<Pop3EmailMessage>();
         for (int i = 0; i < client.Count; i++) {
             var message = await client.GetMessageAsync(i, cancellationToken).ConfigureAwait(false);
@@ -98,5 +121,89 @@ public static class MailboxSearcher {
             if (!string.IsNullOrWhiteSpace(addr.Name) && addr.Name.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
         }
         return false;
+    }
+
+    internal sealed class ParsedQuery {
+        public string? Subject { get; set; }
+        public string? FromContains { get; set; }
+        public string? ToContains { get; set; }
+        public MessagePriority? Priority { get; set; }
+        public DateTime? Since { get; set; }
+        public DateTime? Before { get; set; }
+        public bool HasAttachment { get; set; }
+        public List<SearchQuery> AdditionalQueries { get; } = new();
+    }
+
+    internal static ParsedQuery ParseQuery(string query) {
+        var result = new ParsedQuery();
+        if (string.IsNullOrWhiteSpace(query)) return result;
+        foreach (var token in SplitTokens(query)) {
+            var parts = token.Split(new[] { ':' }, 2);
+            if (parts.Length == 2) {
+                var key = parts[0].ToLowerInvariant();
+                var value = Unquote(parts[1]);
+                switch (key) {
+                    case "from":
+                        result.FromContains = value;
+                        break;
+                    case "to":
+                        result.ToContains = value;
+                        break;
+                    case "subject":
+                        result.Subject = value;
+                        break;
+                    case "since":
+                        if (DateTime.TryParse(value, out var sd)) result.Since = sd;
+                        break;
+                    case "before":
+                        if (DateTime.TryParse(value, out var bd)) result.Before = bd;
+                        break;
+                    case "priority":
+                        if (Enum.TryParse(value, true, out MessagePriority pr)) result.Priority = pr;
+                        break;
+                    case "has":
+                        if (value.Equals("attachment", StringComparison.OrdinalIgnoreCase) || value.Equals("attachments", StringComparison.OrdinalIgnoreCase)) result.HasAttachment = true;
+                        break;
+                    case "body":
+                        result.AdditionalQueries.Add(SearchQuery.BodyContains(value));
+                        break;
+                    default:
+                        result.AdditionalQueries.Add(SearchQuery.MessageContains(token));
+                        break;
+                }
+            } else {
+                var text = Unquote(token);
+                result.AdditionalQueries.Add(SearchQuery.MessageContains(text));
+            }
+        }
+        return result;
+    }
+
+    private static IEnumerable<string> SplitTokens(string input) {
+        var list = new List<string>();
+        var current = new System.Text.StringBuilder();
+        bool inQuotes = false;
+        foreach (var ch in input) {
+            if (ch == '"') {
+                inQuotes = !inQuotes;
+            } else if (char.IsWhiteSpace(ch) && !inQuotes) {
+                if (current.Length > 0) {
+                    list.Add(current.ToString());
+                    current.Clear();
+                }
+            } else {
+                current.Append(ch);
+            }
+        }
+        if (current.Length > 0) list.Add(current.ToString());
+        return list;
+    }
+
+    private static string Unquote(string value) {
+        if (value.Length > 1 &&
+            value.StartsWith("\"", StringComparison.Ordinal) &&
+            value.EndsWith("\"", StringComparison.Ordinal))
+            return value.Substring(1, value.Length - 2);
+        return value;
     }
 }


### PR DESCRIPTION
## Summary
- extend mailbox searcher to parse a simple query language
- expose Query parameter in PowerShell search cmdlets
- allow tests to access internal methods
- add example for query language search
- cover query parser with unit tests

## Testing
- `dotnet test Sources/Mailozaurr.sln -v minimal`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: 72 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_686ec2d6cbc8832ea0ae0c8301de13e3