### PR TITLE
Improve XML comments

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletAddGraphMailboxPermission.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletAddGraphMailboxPermission.cs
@@ -73,6 +73,9 @@ public class CmdletAddGraphMailboxPermission : AsyncPSCmdlet {
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Executes the cmdlet logic asynchronously.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         if (ParameterSetName == "MgGraphRequest") {
             ProcessMgGraph();

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
@@ -15,11 +15,11 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.Get, "EmailGraphMessage")]
 [OutputType(typeof(GraphMessageInfo))]
 public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
-    [Parameter(Mandatory = true, ParameterSetName = "Graph")]
-    [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     /// <summary>
     /// User principal name whose mailbox is queried.
     /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "Graph")]
+    [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRule.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRule.cs
@@ -88,6 +88,9 @@ public sealed class CmdletNewGraphInboxRule : AsyncPSCmdlet {
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Executes the cmdlet logic asynchronously.
+    /// </summary>
     protected override Task ProcessRecordAsync() {
         if (ParameterSetName == "MgGraphRequest") {
             ProcessMgGraph();

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphInboxRule.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphInboxRule.cs
@@ -35,6 +35,9 @@ public sealed class CmdletRemoveGraphInboxRule : AsyncPSCmdlet {
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Executes the cmdlet logic asynchronously.
+    /// </summary>
     protected override Task ProcessRecordAsync() {
         switch (ParameterSetName) {
             case "Graph":

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchGraphMailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchGraphMailbox.cs
@@ -52,6 +52,9 @@ public class CmdletSearchGraphMailbox : AsyncPSCmdlet {
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 
+    /// <summary>
+    /// Executes the cmdlet logic asynchronously.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         var conn = Connection ?? DefaultSessions.GraphSession;
         if (conn == null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletSendGmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendGmailMessage.cs
@@ -36,6 +36,9 @@ public sealed class CmdletSendGmailMessage : AsyncPSCmdlet {
     [Parameter]
     public object[]? Attachment { get; set; }
 
+    /// <summary>
+    /// Executes the cmdlet logic asynchronously.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         var net = Credential!.GetNetworkCredential();
         var oauth = new OAuthCredential {

--- a/Sources/Mailozaurr.PowerShell/CmdletSetGraphInboxRule.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetGraphInboxRule.cs
@@ -35,18 +35,33 @@ public sealed class CmdletSetGraphInboxRule : AsyncPSCmdlet
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// When set, uses <c>Invoke-MgGraphRequest</c> for the update instead of the SDK.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Timeout in seconds for Graph operations.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Number of retry attempts when a request fails.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retry attempts in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Executes the cmdlet logic asynchronously.
+    /// </summary>
     protected override Task ProcessRecordAsync()
     {
         if (ParameterSetName == "MgGraphRequest")

--- a/Sources/Mailozaurr.PowerShell/CmdletSetIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetIMAPFolder.cs
@@ -23,6 +23,9 @@ public sealed class CmdletSetIMAPFolder : AsyncPSCmdlet {
     [Parameter]
     public FolderAccess FolderAccess { get; set; } = FolderAccess.ReadOnly;
 
+    /// <summary>
+    /// Executes the cmdlet logic asynchronously.
+    /// </summary>
     protected override Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null && conn.Data != null) {

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentItemWrapper.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentItemWrapper.cs
@@ -4,10 +4,10 @@ namespace Mailozaurr;
 /// Wrapper used when creating an upload session.
 /// </summary>
 public class GraphAttachmentItemWrapper {
-    [JsonPropertyName("AttachmentItem")]
     /// <summary>
     /// Gets the attachment item used when creating the upload session.
     /// </summary>
+    [JsonPropertyName("AttachmentItem")]
     public GraphAttachmentItem AttachmentItem { get; set; }
 
     /// <summary>Initializes a new instance of the wrapper.</summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphErrors.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphErrors.cs
@@ -4,9 +4,9 @@
 /// Container for an error returned by the Graph API.
 /// </summary>
 public class GraphApiError {
-    [JsonPropertyName("error")]
     /// <summary>
     /// Gets or sets the error details returned by the API.
     /// </summary>
+    [JsonPropertyName("error")]
     public GraphApiErrorDetail Error { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphInboxRule.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphInboxRule.cs
@@ -58,25 +58,37 @@ public class GraphInboxRule
 /// </summary>
 public class GraphInboxRulePredicates
 {
-    [JsonPropertyName("senderContains")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     /// <summary>
     /// Gets or sets a list of strings that must appear in the sender address.
     /// </summary>
+    [JsonPropertyName("senderContains")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string>? SenderContains { get; set; }
 
+    /// <summary>
+    /// Gets or sets a list of strings that must appear in the recipient address.
+    /// </summary>
     [JsonPropertyName("recipientContains")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string>? RecipientContains { get; set; }
 
+    /// <summary>
+    /// Gets or sets a list of strings that must appear in the subject line.
+    /// </summary>
     [JsonPropertyName("subjectContains")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string>? SubjectContains { get; set; }
 
+    /// <summary>
+    /// Gets or sets a list of strings that must appear in the message body.
+    /// </summary>
     [JsonPropertyName("bodyContains")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string>? BodyContains { get; set; }
 
+    /// <summary>
+    /// Gets or sets the required importance value.
+    /// </summary>
     [JsonPropertyName("importance")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Importance { get; set; }
@@ -87,22 +99,37 @@ public class GraphInboxRulePredicates
 /// </summary>
 public class GraphInboxRuleActions
 {
+    /// <summary>
+    /// Folder path the message should be moved to.
+    /// </summary>
     [JsonPropertyName("moveToFolder")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? MoveToFolder { get; set; }
 
+    /// <summary>
+    /// Folder path the message should be copied to.
+    /// </summary>
     [JsonPropertyName("copyToFolder")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? CopyToFolder { get; set; }
 
+    /// <summary>
+    /// Indicates whether the message should be deleted.
+    /// </summary>
     [JsonPropertyName("delete")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Delete { get; set; }
 
+    /// <summary>
+    /// Addresses the message should be forwarded to.
+    /// </summary>
     [JsonPropertyName("forwardTo")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<GraphEmailAddress>? ForwardTo { get; set; }
 
+    /// <summary>
+    /// Stops further rule processing when set.
+    /// </summary>
     [JsonPropertyName("stopProcessingRules")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? StopProcessingRules { get; set; }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMessage.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMessage.cs
@@ -82,6 +82,10 @@ public class GraphMessage {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<GraphAttachment>? Attachments { get; set; }
 
+    /// <summary>
+    /// Collection of MIME headers associated with the message.
+    /// </summary>
     [JsonPropertyName("internetMessageHeaders")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<GraphInternetMessageHeader>? InternetMessageHeaders { get; set; }}
+    public List<GraphInternetMessageHeader>? InternetMessageHeaders { get; set; }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphUploadSessionResult.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphUploadSessionResult.cs
@@ -6,6 +6,10 @@ namespace Mailozaurr;
 /// Result returned when creating an upload session for large attachments.
 /// </summary>
 public class GraphUploadSessionResult {
+    /// <summary>
+    /// Gets or sets the URL that should be used to upload the attachment bytes.
+    /// </summary>
     [JsonPropertyName("uploadUrl")]
     public string UploadUrl { get; set; }
 }
+

--- a/Sources/Mailozaurr/SendGrid/SendGridMessage.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridMessage.cs
@@ -31,11 +31,11 @@ public class SendGridMessage {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public SendGridEmailAddress? ReplyTo { get; set; }
 
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     /// <summary>Attachments to include with the message.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<SendGridAttachment>? Attachments { get; set; }
 
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     /// <summary>Custom headers to include with the message.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, string>? Headers { get; set; }
 }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.Disposal.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.Disposal.cs
@@ -2,11 +2,18 @@ namespace Mailozaurr;
 
 public partial class ClientSmtp
 {
+    /// <summary>
+    /// Finalizer to ensure the client is properly disposed.
+    /// </summary>
     ~ClientSmtp()
     {
         Dispose(false);
     }
 
+    /// <summary>
+    /// Releases the unmanaged resources used by the client and optionally disposes of the managed resources.
+    /// </summary>
+    /// <param name="disposing">If set to <c>true</c> the method has been invoked directly or indirectly by a user's code.</param>
     protected override void Dispose(bool disposing)
     {
         if (IsConnected)


### PR DESCRIPTION
## Summary
- add XML docs to missing public members across cmdlets and Graph models
- document ClientSmtp disposal logic
- improve SendGrid message property docs

## Testing
- `pwsh -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: 72 tests failed)*
- `dotnet build Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687351a19984832eac2498076ad0a84b