### PR TITLE
Update workflow to auto-commit PSD1

### DIFF
--- a/.github/workflows/powershell-tests-all.yml
+++ b/.github/workflows/powershell-tests-all.yml
@@ -28,6 +28,18 @@ jobs:
         run: ./Build/Manage-Mailozaurr.ps1
         shell: pwsh
 
+      - name: Commit refreshed PSD1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Mailozaurr.psd1
+          git commit -m "chore: regenerate psd1" || echo "No changes to commit"
+          git push origin HEAD:$Env:HEAD_BRANCH
+        shell: pwsh
+
       - name: Upload refreshed manifest
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- auto commit the regenerated PSD1 file in `powershell-tests-all.yml`

## Testing
- `dotnet build Sources/Mailozaurr.sln --configuration Debug --no-restore`
- `dotnet test Sources/Mailozaurr.sln --configuration Debug --no-build --verbosity normal`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_687360fb6468832e99590997c1f90cd8