### PR TITLE
Fix disposed token check in poll loop

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -87,4 +87,44 @@ public class GraphMessageListenerTests {
         } finally {
             handlerField.SetValue(client, original);
         }
-    }}
+    }
+
+    [Fact]
+    public async Task Listener_PollLoopHandlesDisposedTokenSource() {
+        var responses = new[] {
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"access_token\":\"token\",\"token_type\":\"Bearer\"}") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") },
+        };
+        var handler = new QueueHandler(responses);
+        var clientField = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)clientField.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cache = (ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
+        cache.Clear();
+        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
+        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+        oauthField?.SetValue(null, null);
+        string cachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
+        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+
+        try {
+            var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            var listener = new GraphMessageListener(cred, "user", TimeSpan.FromMilliseconds(10));
+            var cancelField = typeof(GraphMessageListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            await listener.StartAsync();
+            var cts = (CancellationTokenSource)cancelField.GetValue(listener)!;
+            cts.Dispose();
+            cancelField.SetValue(listener, null);
+
+            await Task.Delay(50);
+            listener.Dispose();
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+}
+
+}

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -79,9 +79,14 @@ public class GraphMessageListener : IDisposable {
     }
 
     private async Task PollLoopAsync() {
-        while (!_cancel!.IsCancellationRequested) {
+        while (true) {
+            var cancel = _cancel;
+            if (cancel == null || cancel.IsCancellationRequested) {
+                break;
+            }
+
             try {
-                await Task.Delay(_interval, _cancel.Token).ConfigureAwait(false);
+                await Task.Delay(_interval, cancel.Token).ConfigureAwait(false);
                 var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(_credential, _userPrincipalName).ConfigureAwait(false);
                 foreach (var msg in messages) {
                     if (msg.TryGetValue("id", out var idObj) && idObj is string id && !_seenIds.Contains(id)) {
@@ -89,11 +94,15 @@ public class GraphMessageListener : IDisposable {
                         MessageArrived?.Invoke(this, msg);
                     }
                 }
-            } catch (OperationCanceledException) when (_cancel.IsCancellationRequested) {
+            } catch (OperationCanceledException) when (cancel.IsCancellationRequested) {
+                break;
+            } catch (ObjectDisposedException) {
                 break;
             } catch (Exception ex) {
                 PollError?.Invoke(this, ex);
-                await Task.Delay(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+                if (cancel != null) {
+                    await Task.Delay(TimeSpan.FromSeconds(5), cancel.Token).ConfigureAwait(false);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- handle disposed CancellationTokenSource in `GraphMessageListener`
- add regression test for disposed token handling

## Testing
- `dotnet build Sources/Mailozaurr.sln` *(fails: Unable to resolve packages)*
- `dotnet restore Sources/Mailozaurr.sln` *(fails: Unable to resolve packages)*
- `pwsh -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: 72 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687412b96094832ebdaa324c83ae2423