### PR TITLE
Ensure temp directory uses secure permissions

### DIFF
--- a/Sources/Mailozaurr.Tests/EphemeralOpenPgpContextTests.cs
+++ b/Sources/Mailozaurr.Tests/EphemeralOpenPgpContextTests.cs
@@ -3,6 +3,11 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
+#if !UNIX
+using System.Security.AccessControl;
+using System.Security.Principal;
+#endif
 using System.Threading.Tasks;
 using Xunit;
 
@@ -47,4 +52,41 @@ public class EphemeralOpenPgpContextTests
         var ex = Record.Exception(() => ctx.Dispose());
         Assert.Null(ex);
     }
+
+#if NET8_0_OR_GREATER
+    [Fact]
+    public void CreateTempDirectory_HasRestrictivePermissions()
+    {
+        var field = typeof(EphemeralOpenPgpContext).GetField("_tempDirectory", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        using var ctx = new EphemeralOpenPgpContext();
+        var dir = (string)field.GetValue(ctx)!;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+#if !UNIX
+            var security = new DirectoryInfo(dir).GetAccessControl();
+            var rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
+            var current = WindowsIdentity.GetCurrent().User;
+            bool hasUserRule = false;
+            foreach (FileSystemAccessRule rule in rules)
+            {
+                if (rule.IdentityReference.Equals(current) && rule.AccessControlType == AccessControlType.Allow && rule.FileSystemRights.HasFlag(FileSystemRights.FullControl))
+                {
+                    hasUserRule = true;
+                }
+                else if (rule.AccessControlType == AccessControlType.Allow)
+                {
+                    Assert.False(true, "Unexpected access rule found");
+                }
+            }
+            Assert.True(hasUserRule);
+#endif
+        }
+        else
+        {
+            var mode = new DirectoryInfo(dir).UnixFileMode;
+            Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute, mode);
+        }
+    }
+#endif
 }

--- a/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
+++ b/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
@@ -1,5 +1,10 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
+#if !UNIX
+using System.Security.AccessControl;
+using System.Security.Principal;
+#endif
 using Org.BouncyCastle.Bcpg.OpenPgp;
 using MimeKit.Cryptography;
 
@@ -36,11 +41,43 @@ public class EphemeralOpenPgpContext : GnuPGContext, IDisposable {
                 fs.Close();
                 File.Delete(path);
                 Directory.CreateDirectory(path);
+                SetRestrictivePermissions(path);
                 return path;
             } catch (IOException) {
                 // Collision occurred, retry with a new path
             }
         }
+    }
+
+#if UNIX
+    [DllImport("libc", SetLastError = true)]
+    private static extern int chmod(string path, int mode);
+#endif
+
+    private static void SetRestrictivePermissions(string directory) {
+#if UNIX
+        try {
+            _ = chmod(directory, Convert.ToInt32("700", 8));
+        } catch (Exception ex) {
+            LoggingMessages.Logger.WriteWarning($"Failed to set permissions on temporary directory: {ex.Message}");
+        }
+#else
+        try {
+            var info = new DirectoryInfo(directory);
+            var current = WindowsIdentity.GetCurrent().User!;
+            var security = new DirectorySecurity();
+            security.SetOwner(current);
+            security.SetAccessRule(new FileSystemAccessRule(
+                current,
+                FileSystemRights.FullControl,
+                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                PropagationFlags.None,
+                AccessControlType.Allow));
+            info.SetAccessControl(security);
+        } catch (Exception ex) {
+            LoggingMessages.Logger.WriteWarning($"Failed to set permissions on temporary directory: {ex.Message}");
+        }
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- secure temp directory permissions in `EphemeralOpenPgpContext`
- verify permissions in new unit test

## Testing
- `dotnet restore` *(fails: unable to resolve packages)*
- `dotnet test Sources/Mailozaurr.sln --no-build --no-restore` *(fails: invalid arguments because build failed)*
- `pwsh -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: 72 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687412cffe50832e865f2907147bd7a4