### PR TITLE
Add remote image embedding

### DIFF
--- a/Sources/Mailozaurr.Examples/SendEmailRemoteImages.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailRemoteImages.cs
@@ -1,0 +1,19 @@
+using Mailozaurr;
+
+/// <summary>
+/// Example showing how to embed remote images automatically.
+/// </summary>
+public static class SendEmailRemoteImages
+{
+    public static void Run()
+    {
+        var smtp = new Smtp { AutoEmbedRemoteImages = true };
+        smtp.From = "sender@example.com";
+        smtp.To = new[] { "recipient@example.com" };
+        smtp.Subject = "Remote Images";
+        smtp.HtmlBody = "<img src=\"https://example.com/logo.png\">";
+        smtp.Connect("smtp.example.com", 25);
+        smtp.Send();
+        smtp.Disconnect();
+    }
+}

--- a/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
@@ -1,5 +1,9 @@
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
 using MimeKit;
 using Xunit;
 
@@ -40,5 +44,33 @@ public class HtmlAutoEmbedImageTests {
         var attachment = Assert.Single(graph.MessageContainer.Message.Attachments);
         Assert.True(attachment.IsInline);
         Assert.Contains("cid:" + attachment.ContentId, graph.HTML);
+    }
+
+    [Fact]
+    public void Smtp_CreateMessage_EmbedsRemoteImages() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new ByteArrayContent(new byte[] { 1, 2, 3 }) {
+                Headers = { ContentType = new MediaTypeHeaderValue("image/png") }
+            }
+        });
+        var field = typeof(HtmlUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = new HttpClient(handler);
+        var original = (HttpClient)field.GetValue(null)!;
+        field.SetValue(null, client);
+        try {
+            var smtp = new Smtp { AutoEmbedRemoteImages = true };
+            smtp.From = "a@b.com";
+            smtp.To = new object[] { "c@d.com" };
+            smtp.Subject = "test";
+            smtp.HtmlBody = "<img src=\"https://example.com/img.png\">";
+            smtp.CreateMessage();
+            var body = (MultipartRelated)smtp.Message.Body!;
+            var inline = body.OfType<MimePart>().FirstOrDefault(p => p.ContentDisposition?.Disposition == ContentDisposition.Inline);
+            Assert.NotNull(inline);
+            Assert.Contains("cid:img.png", smtp.HtmlBody);
+            Assert.Single(handler.Requests);
+        } finally {
+            field.SetValue(null, original);
+        }
     }
 }

--- a/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
@@ -53,10 +53,10 @@ public class HtmlAutoEmbedImageTests {
                 Headers = { ContentType = new MediaTypeHeaderValue("image/png") }
             }
         });
-        var field = typeof(HtmlUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var property = typeof(HtmlUtils).GetProperty("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
         var client = new HttpClient(handler);
-        var original = (HttpClient)field.GetValue(null)!;
-        field.SetValue(null, client);
+        var original = (HttpClient)property.GetValue(null)!;
+        property.SetValue(null, client);
         try {
             var smtp = new Smtp { AutoEmbedRemoteImages = true };
             smtp.From = "a@b.com";
@@ -70,7 +70,7 @@ public class HtmlAutoEmbedImageTests {
             Assert.Contains("cid:img.png", smtp.HtmlBody);
             Assert.Single(handler.Requests);
         } finally {
-            field.SetValue(null, original);
+            property.SetValue(null, original);
         }
     }
 }

--- a/Sources/Mailozaurr/Helpers/HtmlUtils.cs
+++ b/Sources/Mailozaurr/Helpers/HtmlUtils.cs
@@ -8,7 +8,7 @@ namespace Mailozaurr;
 /// Helper utilities for working with HTML content.
 /// </summary>
 public static class HtmlUtils {
-    internal static readonly HttpClient HttpClient;
+    internal static HttpClient HttpClient { get; set; }
 
     static HtmlUtils() {
         HttpClient = new HttpClient();
@@ -59,7 +59,7 @@ public static class HtmlUtils {
             try {
                 using var response = await HttpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode) continue;
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
                 var data = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 #else
                 var data = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);

--- a/Sources/Mailozaurr/Helpers/HtmlUtils.cs
+++ b/Sources/Mailozaurr/Helpers/HtmlUtils.cs
@@ -1,3 +1,5 @@
+using System.Net.Http;
+using System.Threading;
 using System.Text.RegularExpressions;
 
 namespace Mailozaurr;
@@ -6,6 +8,17 @@ namespace Mailozaurr;
 /// Helper utilities for working with HTML content.
 /// </summary>
 public static class HtmlUtils {
+    internal static readonly HttpClient HttpClient;
+
+    static HtmlUtils() {
+        HttpClient = new HttpClient();
+    }
+
+    public class RemoteImage {
+        public string ContentId { get; set; } = string.Empty;
+        public byte[] Data { get; set; } = Array.Empty<byte>();
+        public string MediaType { get; set; } = string.Empty;
+    }
     /// <summary>
     /// Replaces local image <c>src</c> references with <c>cid:</c> links and returns the
     /// updated HTML and a collection of the embedded file paths.
@@ -32,5 +45,35 @@ public static class HtmlUtils {
             }
         }
         return (html, paths);
+    }
+
+    public static async Task<(string Html, List<RemoteImage> Images)> DownloadRemoteImagesAsync(string html, CancellationToken cancellationToken = default) {
+        var images = new List<RemoteImage>();
+        if (string.IsNullOrWhiteSpace(html)) return (html, images);
+
+        string pattern = "<img[^>]+src=['\"]([^'\"]+)['\"]";
+        foreach (Match match in Regex.Matches(html, pattern, RegexOptions.IgnoreCase)) {
+            var url = match.Groups[1].Value;
+            if (string.IsNullOrWhiteSpace(url)) continue;
+            if (!url.StartsWith("http", StringComparison.OrdinalIgnoreCase)) continue;
+            try {
+                using var response = await HttpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode) continue;
+#if NETFRAMEWORK
+                var data = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+#else
+                var data = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+#endif
+                var mediaType = response.Content.Headers.ContentType?.MediaType ?? MimeTypes.GetMimeType(Path.GetFileName(url));
+                var fileName = Path.GetFileName(new Uri(url).AbsolutePath);
+                if (string.IsNullOrEmpty(fileName)) fileName = Guid.NewGuid().ToString("N");
+                html = html.Replace(url, $"cid:{fileName}");
+                images.Add(new RemoteImage { ContentId = fileName, Data = data, MediaType = mediaType });
+            } catch (Exception ex) {
+                LoggingMessages.Logger.WriteWarning($"Failed to download image '{url}': {ex.Message}");
+            }
+        }
+
+        return (html, images);
     }
 }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -34,6 +34,8 @@ public partial class ClientSmtp : SmtpClient {
     public DeliveryNotification[]? DeliveryNotificationOption { get; set; }
     /// <summary>Custom headers to add to the message.</summary>
     public IDictionary<string, string>? Headers { get; set; }
+    /// <summary>Download remote images referenced in HtmlBody and embed them.</summary>
+    public bool AutoEmbedRemoteImages { get; set; } = false;
     /// <summary>Comma separated list of all recipients.</summary>
     public string SentTo {
         get {
@@ -220,6 +222,21 @@ public partial class ClientSmtp : SmtpClient {
                 if (entity is MimePart inlinePart && string.IsNullOrWhiteSpace(inlinePart.ContentId)) {
                     inlinePart.ContentId = MimeUtils.GenerateMessageId();
                 }
+            }
+        }
+        if (AutoEmbedRemoteImages && !string.IsNullOrWhiteSpace(bodyBuilder.HtmlBody)) {
+            var (html, images) = HtmlUtils.DownloadRemoteImagesAsync(bodyBuilder.HtmlBody).GetAwaiter().GetResult();
+            bodyBuilder.HtmlBody = html;
+            HtmlBody = html;
+            foreach (var img in images) {
+                using var ms = new MemoryStream(img.Data);
+                var part = new MimePart(img.MediaType) {
+                    Content = new MimeContent(ms),
+                    FileName = img.ContentId,
+                    ContentId = img.ContentId,
+                    ContentDisposition = new ContentDisposition(ContentDisposition.Inline)
+                };
+                bodyBuilder.LinkedResources.Add(part);
             }
         }
         message.Body = bodyBuilder.ToMessageBody();

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -130,6 +130,15 @@ public class Smtp {
     public bool AutoEmbedImages { get; set; } = false;
 
     /// <summary>
+    /// When set to <see langword="true"/>, downloads remote images referenced in
+    /// <see cref="HtmlBody"/> and embeds them as inline attachments.
+    /// </summary>
+    public bool AutoEmbedRemoteImages {
+        get => Client.AutoEmbedRemoteImages;
+        set => Client.AutoEmbedRemoteImages = value;
+    }
+
+    /// <summary>
     /// Forces retries even when the encountered error is not considered
     /// transient. By default retries occur only for transient failures.
     /// </summary>


### PR DESCRIPTION
## Summary
- extend HtmlUtils with remote image download support
- embed downloaded images in ClientSmtp
- expose AutoEmbedRemoteImages in Smtp
- test downloading remote images
- add remote image example

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -f net472`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6874130b60b0832e8a231eb09dc9b95c