### PR TITLE
Fix trimming for Graph credential parsing

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -71,6 +71,7 @@ namespace Mailozaurr {
         /// Converts a credential string (username@directory) and secret to a GraphCredential object.
         /// </summary>
         public static GraphCredential ConvertFromGraphCredential(string username, string password) {
+            username = username.Trim();
             var parts = username.Split('@');
             if (parts.Length != 2) {
                 throw new ArgumentException("Invalid credential format. Expected 'clientid@directoryid'.");

--- a/Tests/ConvertFromGraphCredential.Tests.ps1
+++ b/Tests/ConvertFromGraphCredential.Tests.ps1
@@ -6,6 +6,12 @@ Describe 'MicrosoftGraphUtils.ConvertFromGraphCredential' {
         $cred.ClientSecret | Should -Be 'secret'
     }
 
+    It 'Parses credential with whitespace' {
+        $cred = [Mailozaurr.MicrosoftGraphUtils]::ConvertFromGraphCredential('  client@tenant  ', 'secret')
+        $cred.ClientId | Should -Be 'client'
+        $cred.DirectoryId | Should -Be 'tenant'
+        $cred.ClientSecret | Should -Be 'secret'
+    }
     It 'Throws for invalid format' {
         { [Mailozaurr.MicrosoftGraphUtils]::ConvertFromGraphCredential('invalid', 'pwd') } | Should -Throw
     }


### PR DESCRIPTION
## Summary
- trim the username before splitting in `MicrosoftGraphUtils.ConvertFromGraphCredential`
- test parsing of credentials with leading/trailing whitespace

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `pwsh -NoLogo -NoProfile -File Mailozaurr.Tests.ps1` *(fails: Unable to find type [Mailozaurr.PowerShell.ImapConnectionInfo])*

------
https://chatgpt.com/codex/tasks/task_e_687412c4e5b4832eb364251aa2cfd0ae