### PR TITLE
Add GraphEvent builder cmdlet

### DIFF
--- a/Examples/Example-GetGraphEvent.ps1
+++ b/Examples/Example-GetGraphEvent.ps1
@@ -1,0 +1,3 @@
+# Retrieve upcoming events for a user
+$cred = Connect-EmailGraph -ClientId 'client' -TenantId 'tenant' -ClientSecret 'secret'
+Get-GraphEvent -UserPrincipalName 'user@example.com' -Connection $cred -Limit 5

--- a/Examples/Example-NewGraphEvent.ps1
+++ b/Examples/Example-NewGraphEvent.ps1
@@ -1,0 +1,4 @@
+# Create a simple event
+$cred = Connect-EmailGraph -ClientId 'client' -TenantId 'tenant' -ClientSecret 'secret'
+$builder = New-GraphEventBuilder -Subject 'Demo Meeting' -Start (Get-Date).AddHours(1) -End (Get-Date).AddHours(2) -Attendees 'user@example.com'
+New-GraphEvent -UserPrincipalName 'user@example.com' -EventBuilder $builder -Connection $cred

--- a/Sources/Mailozaurr.PowerShell/CmdletGetGraphEvent.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetGraphEvent.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Threading.Tasks;
+using Mailozaurr;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// Retrieves calendar events using Microsoft Graph.
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "GraphEvent")]
+[OutputType(typeof(Dictionary<string, object>))]
+public sealed class CmdletGetGraphEvent : AsyncPSCmdlet {
+    [Parameter(Mandatory = true)]
+    public string? UserPrincipalName { get; set; }
+
+    [Parameter(ValueFromPipeline = true)]
+    [ValidateNotNull]
+    public GraphConnectionInfo? Connection { get; set; }
+
+    [Parameter]
+    public string[]? Property { get; set; }
+
+    [Parameter]
+    public string? Filter { get; set; }
+
+    [Parameter]
+    public int? Limit { get; set; }
+
+    [Parameter]
+    public int TimeoutSeconds { get; set; } = 100;
+
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    protected override Task ProcessRecordAsync() {
+        var conn = Connection ?? DefaultSessions.GraphSession;
+        if (conn == null) {
+            WriteWarning("Get-GraphEvent - Connection not provided and no default session available.");
+            return Task.CompletedTask;
+        }
+        return ProcessGraphAsync(conn.Credential);
+    }
+
+    private async Task ProcessGraphAsync(GraphCredential cred) {
+        MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        int attempts = 0;
+        Exception? last = null;
+        do {
+            try {
+                var events = await MicrosoftGraphUtils.GetEventsAsync(cred, UserPrincipalName!, Property, Filter, Limit);
+                foreach (var ev in events) WriteObject(ev);
+                return;
+            } catch (Exception ex) {
+                last = ex;
+                WriteWarning($"Get-GraphEvent - {ex.Message}");
+                if (!Helpers.IsTransient(ex) || attempts >= RetryCount) {
+                    if (ex is GraphApiException gex) WriteError(new ErrorRecord(gex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+                    else WriteError(new ErrorRecord(ex, "GraphError", ErrorCategory.InvalidOperation, null));
+                    return;
+                }
+                if (RetryDelayMilliseconds > 0) await Task.Delay(RetryDelayMilliseconds);
+            }
+            attempts++;
+        } while (attempts <= RetryCount);
+        if (last != null) WriteError(new ErrorRecord(last, "GraphError", ErrorCategory.InvalidOperation, null));
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphEvent.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphEvent.cs
@@ -1,0 +1,71 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+using Mailozaurr;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// Creates a new calendar event via Microsoft Graph.
+/// </summary>
+[Cmdlet(VerbsCommon.New, "GraphEvent")]
+[OutputType(typeof(GraphEvent))]
+public sealed class CmdletNewGraphEvent : AsyncPSCmdlet
+{
+    [Parameter(Mandatory = true)]
+    public string? UserPrincipalName { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "Event")]
+    [ValidateNotNull]
+    public GraphEvent? Event { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "Builder")]
+    [ValidateNotNull]
+    public GraphEventBuilder? EventBuilder { get; set; }
+
+    [Parameter(ValueFromPipeline = true)]
+    [ValidateNotNull]
+    public GraphConnectionInfo? Connection { get; set; }
+
+    [Parameter]
+    public int TimeoutSeconds { get; set; } = 100;
+
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    protected override Task ProcessRecordAsync() {
+        var conn = Connection ?? DefaultSessions.GraphSession;
+        if (conn == null) {
+            WriteWarning("New-GraphEvent - Connection not provided and no default session available.");
+            return Task.CompletedTask;
+        }
+        return ProcessGraphAsync(conn.Credential);
+    }
+
+    private async Task ProcessGraphAsync(GraphCredential cred) {
+        MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        int attempts = 0;
+        Exception? last = null;
+        GraphEvent toCreate = ParameterSetName == "Builder" ? EventBuilder! : Event!;
+        do {
+            try {
+                var result = await MicrosoftGraphUtils.NewEventAsync(cred, UserPrincipalName!, toCreate);
+                WriteObject(result);
+                return;
+            } catch (Exception ex) {
+                last = ex;
+                WriteWarning($"New-GraphEvent - {ex.Message}");
+                if (!Helpers.IsTransient(ex) || attempts >= RetryCount) {
+                    if (ex is GraphApiException gex) WriteError(new ErrorRecord(gex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+                    else WriteError(new ErrorRecord(ex, "GraphError", ErrorCategory.InvalidOperation, null));
+                    return;
+                }
+                if (RetryDelayMilliseconds > 0) await Task.Delay(RetryDelayMilliseconds);
+            }
+            attempts++;
+        } while (attempts <= RetryCount);
+        if (last != null) WriteError(new ErrorRecord(last, "GraphError", ErrorCategory.InvalidOperation, null));
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphEventBuilder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphEventBuilder.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Management.Automation;
+using Mailozaurr;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// Creates a <see cref="GraphEventBuilder"/> instance.
+/// </summary>
+[Cmdlet(VerbsCommon.New, "GraphEventBuilder")]
+[OutputType(typeof(GraphEventBuilder))]
+public sealed class CmdletNewGraphEventBuilder : PSCmdlet
+{
+    [Parameter]
+    public string? Subject { get; set; }
+
+    [Parameter]
+    public DateTime? Start { get; set; }
+
+    [Parameter]
+    public string StartTimeZone { get; set; } = "UTC";
+
+    [Parameter]
+    public DateTime? End { get; set; }
+
+    [Parameter]
+    public string EndTimeZone { get; set; } = "UTC";
+
+    [Parameter]
+    public string? Body { get; set; }
+
+    [Parameter]
+    public string BodyType { get; set; } = "HTML";
+
+    [Parameter]
+    public string[]? Attendees { get; set; }
+
+    protected override void ProcessRecord()
+    {
+        var builder = new GraphEventBuilder();
+        if (!string.IsNullOrEmpty(Subject))
+            builder.Subject(Subject);
+        if (Start.HasValue)
+            builder.Start(Start.Value, StartTimeZone);
+        if (End.HasValue)
+            builder.End(End.Value, EndTimeZone);
+        if (!string.IsNullOrEmpty(Body))
+            builder.Body(Body, BodyType);
+        if (Attendees != null)
+        {
+            foreach (var addr in Attendees)
+            {
+                builder.Attendee(addr, addr);
+            }
+        }
+        WriteObject(builder);
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphEvent.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphEvent.cs
@@ -1,0 +1,65 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+using Mailozaurr;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// Removes a calendar event via Microsoft Graph.
+/// </summary>
+[Cmdlet(VerbsCommon.Remove, "GraphEvent", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+public sealed class CmdletRemoveGraphEvent : AsyncPSCmdlet {
+    [Parameter(Mandatory = true)]
+    public string? UserPrincipalName { get; set; }
+
+    [Parameter(Mandatory = true)]
+    public string? EventId { get; set; }
+
+    [Parameter(ValueFromPipeline = true)]
+    [ValidateNotNull]
+    public GraphConnectionInfo? Connection { get; set; }
+
+    [Parameter]
+    public int TimeoutSeconds { get; set; } = 100;
+
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    protected override Task ProcessRecordAsync() {
+        var conn = Connection ?? DefaultSessions.GraphSession;
+        if (conn == null) {
+            WriteWarning("Remove-GraphEvent - Connection not provided and no default session available.");
+            return Task.CompletedTask;
+        }
+        return ProcessGraphAsync(conn.Credential);
+    }
+
+    private async Task ProcessGraphAsync(GraphCredential cred) {
+        if (!ShouldProcess(EventId!, "Removing event")) {
+            return;
+        }
+        MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        int attempts = 0;
+        Exception? last = null;
+        do {
+            try {
+                await MicrosoftGraphUtils.RemoveEventAsync(cred, UserPrincipalName!, EventId!);
+                return;
+            } catch (Exception ex) {
+                last = ex;
+                WriteWarning($"Remove-GraphEvent - {ex.Message}");
+                if (!Helpers.IsTransient(ex) || attempts >= RetryCount) {
+                    if (ex is GraphApiException gex) WriteError(new ErrorRecord(gex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+                    else WriteError(new ErrorRecord(ex, "GraphError", ErrorCategory.InvalidOperation, null));
+                    return;
+                }
+                if (RetryDelayMilliseconds > 0) await Task.Delay(RetryDelayMilliseconds);
+            }
+            attempts++;
+        } while (attempts <= RetryCount);
+        if (last != null) WriteError(new ErrorRecord(last, "GraphError", ErrorCategory.InvalidOperation, null));
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletSetGraphEvent.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetGraphEvent.cs
@@ -1,0 +1,71 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+using Mailozaurr;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// Updates an existing calendar event via Microsoft Graph.
+/// </summary>
+[Cmdlet(VerbsCommon.Set, "GraphEvent", SupportsShouldProcess = true)]
+[OutputType(typeof(GraphEvent))]
+public sealed class CmdletSetGraphEvent : AsyncPSCmdlet {
+    [Parameter(Mandatory = true)]
+    public string? UserPrincipalName { get; set; }
+
+    [Parameter(Mandatory = true)]
+    public string? EventId { get; set; }
+
+    [Parameter(Mandatory = true)]
+    [ValidateNotNull]
+    public GraphEvent? Event { get; set; }
+
+    [Parameter(ValueFromPipeline = true)]
+    [ValidateNotNull]
+    public GraphConnectionInfo? Connection { get; set; }
+
+    [Parameter]
+    public int TimeoutSeconds { get; set; } = 100;
+
+    [Parameter]
+    public int RetryCount { get; set; } = 0;
+
+    [Parameter]
+    public int RetryDelayMilliseconds { get; set; } = 0;
+
+    protected override Task ProcessRecordAsync() {
+        var conn = Connection ?? DefaultSessions.GraphSession;
+        if (conn == null) {
+            WriteWarning("Set-GraphEvent - Connection not provided and no default session available.");
+            return Task.CompletedTask;
+        }
+        return ProcessGraphAsync(conn.Credential);
+    }
+
+    private async Task ProcessGraphAsync(GraphCredential cred) {
+        if (!ShouldProcess(EventId!, "Updating event")) {
+            return;
+        }
+        MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        int attempts = 0;
+        Exception? last = null;
+        do {
+            try {
+                var result = await MicrosoftGraphUtils.UpdateEventAsync(cred, UserPrincipalName!, EventId!, Event!);
+                WriteObject(result);
+                return;
+            } catch (Exception ex) {
+                last = ex;
+                WriteWarning($"Set-GraphEvent - {ex.Message}");
+                if (!Helpers.IsTransient(ex) || attempts >= RetryCount) {
+                    if (ex is GraphApiException gex) WriteError(new ErrorRecord(gex, "GraphApiError", ErrorCategory.InvalidOperation, null));
+                    else WriteError(new ErrorRecord(ex, "GraphError", ErrorCategory.InvalidOperation, null));
+                    return;
+                }
+                if (RetryDelayMilliseconds > 0) await Task.Delay(RetryDelayMilliseconds);
+            }
+            attempts++;
+        } while (attempts <= RetryCount);
+        if (last != null) WriteError(new ErrorRecord(last, "GraphError", ErrorCategory.InvalidOperation, null));
+    }
+}

--- a/Sources/Mailozaurr.Tests/GraphEventBuilderTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphEventBuilderTests.cs
@@ -1,0 +1,21 @@
+using System;
+using Xunit;
+using Mailozaurr;
+
+namespace Mailozaurr.Tests;
+
+public class GraphEventBuilderTests {
+    [Fact]
+    public void Builder_CreatesEvent() {
+        GraphEvent ev = new GraphEventBuilder()
+            .Subject("Test")
+            .Start(new DateTime(2024,1,1,12,0,0,DateTimeKind.Utc))
+            .End(new DateTime(2024,1,1,13,0,0,DateTimeKind.Utc))
+            .Attendee("user@example.com", "User");
+        Assert.Equal("Test", ev.Subject);
+        Assert.NotNull(ev.Start);
+        Assert.NotNull(ev.End);
+        Assert.NotNull(ev.Attendees);
+        Assert.Contains(ev.Attendees!, a => a.EmailAddress.Email.Address == "user@example.com");
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphEvent.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphEvent.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents a calendar event used with Microsoft Graph.
+/// </summary>
+public class GraphEvent {
+    /// <summary>Event identifier.</summary>
+    [JsonPropertyName("id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Id { get; set; }
+
+    /// <summary>Subject of the event.</summary>
+    [JsonPropertyName("subject")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Subject { get; set; }
+
+    /// <summary>Event start time.</summary>
+    [JsonPropertyName("start")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public GraphEventTime? Start { get; set; }
+
+    /// <summary>Event end time.</summary>
+    [JsonPropertyName("end")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public GraphEventTime? End { get; set; }
+
+    /// <summary>Body of the event.</summary>
+    [JsonPropertyName("body")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public GraphContent? Body { get; set; }
+
+    /// <summary>Attendees of the event.</summary>
+    [JsonPropertyName("attendees")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<GraphEventAttendee>? Attendees { get; set; }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphEventAttendee.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphEventAttendee.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents an attendee for a calendar event.
+/// </summary>
+public class GraphEventAttendee {
+    /// <summary>Email address of the attendee.</summary>
+    [JsonPropertyName("emailAddress")]
+    public GraphEmailAddress EmailAddress { get; set; } = new();
+
+    /// <summary>Attendee type such as required or optional.</summary>
+    [JsonPropertyName("type")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Type { get; set; }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphEventBuilder.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphEventBuilder.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Fluent builder for <see cref="GraphEvent"/> objects.
+/// </summary>
+public sealed class GraphEventBuilder {
+    private readonly GraphEvent _event = new();
+
+    /// <summary>Sets the subject.</summary>
+    public GraphEventBuilder Subject(string subject) {
+        _event.Subject = subject;
+        return this;
+    }
+
+    /// <summary>Sets the start time.</summary>
+    public GraphEventBuilder Start(DateTime dateTime, string timeZone = "UTC") {
+        _event.Start = new GraphEventTime { DateTime = dateTime.ToString("o"), TimeZone = timeZone };
+        return this;
+    }
+
+    /// <summary>Sets the end time.</summary>
+    public GraphEventBuilder End(DateTime dateTime, string timeZone = "UTC") {
+        _event.End = new GraphEventTime { DateTime = dateTime.ToString("o"), TimeZone = timeZone };
+        return this;
+    }
+
+    /// <summary>Sets the body content.</summary>
+    public GraphEventBuilder Body(string content, string type = "HTML") {
+        _event.Body = new GraphContent { Content = content, Type = type };
+        return this;
+    }
+
+    /// <summary>Adds an attendee.</summary>
+    public GraphEventBuilder Attendee(string address, string name, string type = "required") {
+        _event.Attendees ??= new List<GraphEventAttendee>();
+        _event.Attendees.Add(new GraphEventAttendee {
+            EmailAddress = new GraphEmailAddress { Email = new GraphEmail { Address = address } },
+            Type = type
+        });
+        return this;
+    }
+
+    /// <summary>Gets the constructed <see cref="GraphEvent"/> instance.</summary>
+    internal GraphEvent Build() => _event;
+
+    /// <summary>
+    /// Allows <see cref="GraphEventBuilder"/> to be used wherever
+    /// <see cref="GraphEvent"/> is expected.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    public static implicit operator GraphEvent(GraphEventBuilder builder) => builder._event;
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphEventTime.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphEventTime.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents date/time with timezone for Graph calendar events.
+/// </summary>
+public class GraphEventTime {
+    /// <summary>Date/time value in ISO 8601 format.</summary>
+    [JsonPropertyName("dateTime")]
+    public string DateTime { get; set; } = string.Empty;
+
+    /// <summary>Time zone identifier.</summary>
+    [JsonPropertyName("timeZone")]
+    public string TimeZone { get; set; } = "UTC";
+}

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Linq;
 using System.IO;
+using System.Text.Json.Serialization;
 using System.Collections.Concurrent;
 using System.Threading;
 
@@ -1067,6 +1068,81 @@ namespace Mailozaurr {
             var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
             headers["Authorization"] = token;
             var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/mailFolders/inbox/messageRules/{ruleId}");
+            await InvokeGraphApiAsync("DELETE", uri, headers);
+        }
+
+        /// <summary>
+        /// Retrieves calendar events for the specified user.
+        /// </summary>
+        public static async Task<List<Dictionary<string, object>>> GetEventsAsync(
+            GraphCredential credential,
+            string userPrincipalName,
+            IEnumerable<string>? properties = null,
+            string? filter = null,
+            int? limit = null) {
+            var headers = new Dictionary<string, string>();
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            headers["Authorization"] = token;
+            var qp = new Dictionary<string, object>();
+            if (!string.IsNullOrWhiteSpace(filter)) qp["$filter"] = filter;
+            if (properties != null && properties.Any()) qp["$select"] = string.Join(",", properties);
+            var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/events", qp);
+            var doc = await InvokeGraphApiAsync("GET", uri, headers);
+            var events = new List<Dictionary<string, object>>();
+            if (doc.RootElement.TryGetProperty("value", out var val) && val.ValueKind == JsonValueKind.Array) {
+                foreach (var item in val.EnumerateArray()) {
+                    if (limit.HasValue && events.Count >= limit.Value) break;
+                    var dict = ConvertJsonElementToNativeObject(item) as Dictionary<string, object>;
+                    if (dict != null) events.Add(dict);
+                }
+            }
+            return events;
+        }
+
+        /// <summary>
+        /// Creates a new calendar event.
+        /// </summary>
+        public static async Task<GraphEvent> NewEventAsync(
+            GraphCredential credential,
+            string userPrincipalName,
+            GraphEvent ev) {
+            var headers = new Dictionary<string, string>();
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            headers["Authorization"] = token;
+            var body = JsonSerializer.Serialize(ev, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+            var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/events");
+            var doc = await InvokeGraphApiAsync("POST", uri, headers, body);
+            return JsonSerializer.Deserialize<GraphEvent>(doc.RootElement.GetRawText())!;
+        }
+
+        /// <summary>
+        /// Updates an existing calendar event.
+        /// </summary>
+        public static async Task<GraphEvent> UpdateEventAsync(
+            GraphCredential credential,
+            string userPrincipalName,
+            string eventId,
+            GraphEvent ev) {
+            var headers = new Dictionary<string, string>();
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            headers["Authorization"] = token;
+            var body = JsonSerializer.Serialize(ev, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+            var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/events/{eventId}");
+            var doc = await InvokeGraphApiAsync("PATCH", uri, headers, body);
+            return JsonSerializer.Deserialize<GraphEvent>(doc.RootElement.GetRawText())!;
+        }
+
+        /// <summary>
+        /// Removes the specified calendar event.
+        /// </summary>
+        public static async Task RemoveEventAsync(
+            GraphCredential credential,
+            string userPrincipalName,
+            string eventId) {
+            var headers = new Dictionary<string, string>();
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            headers["Authorization"] = token;
+            var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/events/{eventId}");
             await InvokeGraphApiAsync("DELETE", uri, headers);
         }
     }

--- a/Tests/Get-GraphEvent.Tests.ps1
+++ b/Tests/Get-GraphEvent.Tests.ps1
@@ -1,0 +1,8 @@
+Describe 'Get-GraphEvent' {
+    It 'Warns when Graph connection missing' {
+        $info = [Mailozaurr.PowerShell.GraphConnectionInfo]::new()
+        Get-GraphEvent -UserPrincipalName 'u' -WarningVariable warn
+        $warn | Should -Not -BeNullOrEmpty
+        $warn[0] | Should -Be 'Get-GraphEvent - Connection not provided and no default session available.'
+    }
+}

--- a/Tests/New-GraphEvent.Tests.ps1
+++ b/Tests/New-GraphEvent.Tests.ps1
@@ -1,0 +1,16 @@
+Describe 'New-GraphEvent' {
+    It 'Warns when Graph connection missing' {
+        $info = [Mailozaurr.PowerShell.GraphConnectionInfo]::new()
+        $ev = [Mailozaurr.GraphEvent]::new()
+        New-GraphEvent -UserPrincipalName 'u' -Event $ev -WarningVariable warn
+        $warn | Should -Not -BeNullOrEmpty
+        $warn[0] | Should -Be 'New-GraphEvent - Connection not provided and no default session available.'
+    }
+
+    It 'Warns when connection missing with builder' {
+        $b = New-GraphEventBuilder -Subject 't' -Start (Get-Date) -End (Get-Date)
+        New-GraphEvent -UserPrincipalName 'u' -EventBuilder $b -WarningVariable warn
+        $warn | Should -Not -BeNullOrEmpty
+        $warn[0] | Should -Be 'New-GraphEvent - Connection not provided and no default session available.'
+    }
+}

--- a/Tests/Remove-GraphEvent.Tests.ps1
+++ b/Tests/Remove-GraphEvent.Tests.ps1
@@ -1,0 +1,8 @@
+Describe 'Remove-GraphEvent' {
+    It 'Warns when Graph connection missing' {
+        $info = [Mailozaurr.PowerShell.GraphConnectionInfo]::new()
+        Remove-GraphEvent -UserPrincipalName 'u' -EventId 'id' -WarningVariable warn
+        $warn | Should -Not -BeNullOrEmpty
+        $warn[0] | Should -Be 'Remove-GraphEvent - Connection not provided and no default session available.'
+    }
+}

--- a/Tests/Set-GraphEvent.Tests.ps1
+++ b/Tests/Set-GraphEvent.Tests.ps1
@@ -1,0 +1,9 @@
+Describe 'Set-GraphEvent' {
+    It 'Warns when Graph connection missing' {
+        $info = [Mailozaurr.PowerShell.GraphConnectionInfo]::new()
+        $ev = [Mailozaurr.GraphEvent]::new()
+        Set-GraphEvent -UserPrincipalName 'u' -EventId 'id' -Event $ev -WarningVariable warn
+        $warn | Should -Not -BeNullOrEmpty
+        $warn[0] | Should -Be 'Set-GraphEvent - Connection not provided and no default session available.'
+    }
+}


### PR DESCRIPTION
## Summary
- add `CmdletNewGraphEventBuilder` for building Graph events
- let `New-GraphEvent` accept `-EventBuilder`
- update example to use builder cmdlet
- test builder parameter in `New-GraphEvent`
- hide `Build()` usage by adding implicit conversion from `GraphEventBuilder`

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `dotnet test Sources/Mailozaurr.sln -c Debug --no-build`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: 77 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687413394214832e937f06af036daa68