### PR TITLE
Implement SMTP connection test info

### DIFF
--- a/Examples/Example-SendEmail-ConnectionPool-Advanced.ps1
+++ b/Examples/Example-SendEmail-ConnectionPool-Advanced.ps1
@@ -1,0 +1,24 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$Credential = Get-Credential
+
+$common = @{
+    From = 'sender@example.com'
+    Server = 'smtp.example.com'
+    Credential = $Credential
+    UseConnectionPool = $true
+    ConnectionPoolSize = 2
+    WhatIf = $true
+}
+
+# Send a plain text message
+Send-EmailMessage @common -To 'user1@example.com' -Subject 'First' -Body 'First message'
+
+# Send a high priority message with an attachment
+Send-EmailMessage @common -To 'user2@example.com' -Subject 'Second' -Body 'Second message' -Priority High -Attachment "$PSScriptRoot\..\README.MD"
+
+# Send HTML content
+Send-EmailMessage @common -To 'user3@example.com' -Subject 'Third' -HTML '<b>Third message</b>'
+
+# When done with the pool
+Clear-SmtpConnectionPool

--- a/Examples/Example-SendEmail-ConnectionPool.ps1
+++ b/Examples/Example-SendEmail-ConnectionPool.ps1
@@ -1,0 +1,12 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+# Obtain credentials for SMTP authentication
+$Credential = Get-Credential
+
+$common = @{From='sender@example.com'; To='recipient@example.com'; Subject='Test'; Server='smtp.example.com'; Credential=$Credential; WhatIf=$true}
+
+# First send creates and pools the connection
+Send-EmailMessage @common -UseConnectionPool -ConnectionPoolSize 3
+
+# Second send reuses the connection from the pool
+Send-EmailMessage @common -UseConnectionPool

--- a/Examples/Example-TestSmtpConnection.ps1
+++ b/Examples/Example-TestSmtpConnection.ps1
@@ -1,0 +1,14 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+# Examine server capabilities and check if connections stay open
+$info = Test-SmtpConnection -Server 'smtp.example.com' -Port 587
+
+if ($info.Persistent) {
+    Write-Host "Server keeps the connection open. Enabling pooling."
+    $poolSettings = @{ UseConnectionPool = $true; ConnectionPoolSize = 2 }
+} else {
+    Write-Warning "Server closes the connection after each command. Pooling disabled."
+    $poolSettings = @{}
+}
+
+Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' -Server 'smtp.example.com' @poolSettings -WhatIf

--- a/README.MD
+++ b/README.MD
@@ -288,6 +288,7 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - [Example-SendEmail-Attachments.ps1](Examples/Example-SendEmail-Attachments.ps1) - demonstrate file and in-memory attachments.
 - [Example-SendEmail-ConnectionPool.ps1](Examples/Example-SendEmail-ConnectionPool.ps1) - basic connection pool usage.
 - [Example-SendEmail-ConnectionPool-Advanced.ps1](Examples/Example-SendEmail-ConnectionPool-Advanced.ps1) - reuse the connection while sending multiple different messages.
+- [Example-TestSmtpConnection.ps1](Examples/Example-TestSmtpConnection.ps1) - verify if the server keeps connections alive before enabling pooling.
 - [Example-WaitImapMessage.ps1](Examples/Example-WaitImapMessage.ps1) - wait for new mail from PowerShell.
 - [Example-DeleteImapMessages.ps1](Examples/Example-DeleteImapMessages.ps1) - delete messages from an IMAP mailbox.
 - [Example-DeletePop3Messages.ps1](Examples/Example-DeletePop3Messages.ps1) - delete messages from a POP3 mailbox.
@@ -344,7 +345,7 @@ Keep in mind PSSharedGoods is only required for development. When you use this m
 
 ### SMTP connection pooling
 
-You can reuse SMTP connections by enabling the connection pool with the `-UseConnectionPool` switch of `Send-EmailMessage`. The `-ConnectionPoolSize` parameter controls how many connections are kept alive. Use `Test-SmtpConnection` to check whether your SMTP server keeps connections alive. If needed, call `Clear-SmtpConnectionPool` to discard existing pooled clients.
+You can reuse SMTP connections by enabling the connection pool with the `-UseConnectionPool` switch of `Send-EmailMessage`. The `-ConnectionPoolSize` parameter controls how many connections are kept alive. Use `Test-SmtpConnection` to examine the banner and capabilities and to check whether the connection remains open after a `NOOP` command. If the returned object has `Persistent` set to `True`, you can safely enable pooling. Call `Clear-SmtpConnectionPool` whenever you need to discard existing pooled clients.
 
 ### Limiting access to mailboxes (Microsoft Graph API)
 

--- a/README.MD
+++ b/README.MD
@@ -94,6 +94,7 @@ This will make sure the project has required libraries.
   - [x] Office 365 Graph API
   - [x] PGP/MIME encryption and signature verification
   - Optional retry logic for `Send-EmailMessage` via `-RetryCount`, `-RetryDelayMilliseconds`, `-RetryDelayBackoff` and `-RetryAlways`.  Retries are only attempted for transient errors by default, but `-RetryAlways` forces retries on all errors.
+  - Optional SMTP connection pooling via `-UseConnectionPool` and `-ConnectionPoolSize` for faster repeated sends. Use `Clear-SmtpConnectionPool` to reset the pool and `Test-SmtpConnection` to check if your server keeps connections open.
 - POP3
   - [x] Connect to POP3
   - [x] Get POP3 Emails
@@ -285,6 +286,8 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - Use `Connect-EmailGraph` and `Disconnect-EmailGraph` to authenticate and release application credentials for Microsoft Graph. The connection cmdlet supports both client secret and certificate authentication modes.
 - `Connect-EmailGraph`, `Connect-IMAP` and `Connect-POP3` store the last successful connection in module variables. Subsequent cmdlets use these defaults when `-Connection` or `-Client` is omitted.
 - [Example-SendEmail-Attachments.ps1](Examples/Example-SendEmail-Attachments.ps1) - demonstrate file and in-memory attachments.
+- [Example-SendEmail-ConnectionPool.ps1](Examples/Example-SendEmail-ConnectionPool.ps1) - basic connection pool usage.
+- [Example-SendEmail-ConnectionPool-Advanced.ps1](Examples/Example-SendEmail-ConnectionPool-Advanced.ps1) - reuse the connection while sending multiple different messages.
 - [Example-WaitImapMessage.ps1](Examples/Example-WaitImapMessage.ps1) - wait for new mail from PowerShell.
 - [Example-DeleteImapMessages.ps1](Examples/Example-DeleteImapMessages.ps1) - delete messages from an IMAP mailbox.
 - [Example-DeletePop3Messages.ps1](Examples/Example-DeletePop3Messages.ps1) - delete messages from a POP3 mailbox.
@@ -338,6 +341,10 @@ Get-EmailGraphMessage -UserPrincipalName 'user@example.com' -Filter "receivedDat
 See the [Microsoft Graph query parameters documentation](https://learn.microsoft.com/en-us/graph/query-parameters#filter-parameter) for details.
 
 Keep in mind PSSharedGoods is only required for development. When you use this module from PowerShellGallery it's not installed as everything is merged.
+
+### SMTP connection pooling
+
+You can reuse SMTP connections by enabling the connection pool with the `-UseConnectionPool` switch of `Send-EmailMessage`. The `-ConnectionPoolSize` parameter controls how many connections are kept alive. Use `Test-SmtpConnection` to check whether your SMTP server keeps connections alive. If needed, call `Clear-SmtpConnectionPool` to discard existing pooled clients.
 
 ### Limiting access to mailboxes (Microsoft Graph API)
 

--- a/Sources/Mailozaurr.PowerShell/CmdletClearSmtpConnectionPool.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletClearSmtpConnectionPool.cs
@@ -1,0 +1,24 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// <para type="synopsis">Clears all cached SMTP connections used for connection pooling.</para>
+/// <para type="description">The <c>Clear-SmtpConnectionPool</c> cmdlet removes any
+/// pooled SMTP connections maintained by the <see cref="Smtp"/> class. Use this
+/// when you want to force new connections, for example after changing credentials
+/// or server settings.</para>
+/// <example>
+///   <summary>Reset the SMTP connection pool</summary>
+///   <code>Clear-SmtpConnectionPool</code>
+/// </example>
+/// </summary>
+[Cmdlet(VerbsCommon.Clear, "SmtpConnectionPool")]
+public sealed class CmdletClearSmtpConnectionPool : AsyncPSCmdlet {
+    /// <summary>Clears all connections from the pool.</summary>
+    protected override Task ProcessRecordAsync() {
+        Smtp.ClearConnectionPool();
+        return Task.CompletedTask;
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -353,6 +353,20 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     public string? GmailAccount { get; set; }
 
     /// <summary>
+    /// <para>Enables reuse of SMTP connections via a connection pool.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public SwitchParameter UseConnectionPool { get; set; }
+
+    /// <summary>
+    /// <para>Maximum number of connections to keep in the pool.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    [ValidateRange(1, int.MaxValue)]
+    public int ConnectionPoolSize { get; set; } = 2;
+
+
+    /// <summary>
     /// <para>Specifies chunk size in bytes used for Graph attachment uploads. Default is 9MB.</para>
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "Graph")]
@@ -616,6 +630,9 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
                 errorAction = actionPreference;
             }
         }
+
+        Smtp.MaxPoolSize = ConnectionPoolSize;
+        Smtp.PoolingEnabled = UseConnectionPool.IsPresent;
     }
     /// <summary>
     /// Process the record.

--- a/Sources/Mailozaurr.PowerShell/CmdletTestSmtpConnection.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletTestSmtpConnection.cs
@@ -1,0 +1,35 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+using MailKit.Security;
+using MailKit.Net.Smtp;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// <para type="synopsis">Tests SMTP connectivity and reports server capabilities.</para>
+/// <para type="description">The <c>Test-SmtpConnection</c> cmdlet connects to an
+/// SMTP server and returns information about supported features. It also checks
+/// if the connection remains open after a NOOP command which indicates support
+/// for persistent connections.</para>
+/// <example>
+///   <summary>Check capabilities of an SMTP server</summary>
+///   <code>Test-SmtpConnection -Server "smtp.example.com" -Port 25</code>
+/// </example>
+/// </summary>
+[Cmdlet(VerbsDiagnostic.Test, "SmtpConnection")]
+public sealed class CmdletTestSmtpConnection : AsyncPSCmdlet {
+    [Parameter(Mandatory = true)]
+    public string? Server { get; set; }
+
+    [Parameter]
+    public int Port { get; set; } = 587;
+
+    [Parameter]
+    public SwitchParameter UseSsl { get; set; }
+
+    protected override Task ProcessRecordAsync() {
+        var info = Smtp.TestConnection(Server!, Port, SecureSocketOptions.Auto, UseSsl.IsPresent);
+        WriteObject(info);
+        return Task.CompletedTask;
+    }
+}

--- a/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
@@ -1,0 +1,44 @@
+using System.Threading;
+using MailKit.Security;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpConnectionPoolTests
+{
+    private class FakeClient : ClientSmtp
+    {
+        public int ConnectCalls;
+        private bool _connected;
+        public override bool IsConnected => _connected;
+        public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
+        {
+            ConnectCalls++;
+            _connected = true;
+        }
+    }
+
+    [Fact]
+    public void Disconnect_ReturnsClientToPool()
+    {
+        Smtp.PoolingEnabled = true;
+        Smtp.ClearConnectionPool();
+        var fake = new FakeClient();
+        Smtp.ClientFactory = _ => fake;
+
+        var smtp1 = new Smtp();
+        smtp1.Connect("h", 25);
+        smtp1.Disconnect();
+
+        var smtp2 = new Smtp();
+        Smtp.ClientFactory = _ => new FakeClient();
+        smtp2.Connect("h", 25);
+
+        Assert.Same(fake, smtp2.Client);
+        Assert.Equal(1, fake.ConnectCalls);
+
+        Smtp.ClientFactory = logger => new ClientSmtp();
+        Smtp.ClearConnectionPool();
+        Smtp.PoolingEnabled = false;
+    }
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using Org.BouncyCastle.Bcpg.OpenPgp;
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using System.Threading;
 
@@ -14,11 +15,19 @@ namespace Mailozaurr;
 /// High level wrapper around <see cref="ClientSmtp"/> that exposes convenient methods and retry logic.
 /// </summary>
 public class Smtp {
+    private static readonly ConcurrentDictionary<string, ConcurrentBag<ClientSmtp>> _connectionPool = new();
+    /// <summary>Maximum number of pooled connections per server/port.</summary>
+    public static int MaxPoolSize { get; set; } = 2;
+    /// <summary>Enables or disables connection pooling.</summary>
+    public static bool PoolingEnabled { get; set; } = false;
+
+    /// <summary>Factory used to create <see cref="ClientSmtp"/> instances.</summary>
+    internal static Func<ProtocolLogger?, ClientSmtp> ClientFactory { get; set; } = logger => logger == null ? new ClientSmtp() : new ClientSmtp(logger);
     /// <summary>Configuration used for protocol logging.</summary>
     public LoggingConfigurator? Logging;
 
     /// <summary>Underlying SMTP client used to send messages.</summary>
-    public ClientSmtp Client { get; }
+    public ClientSmtp Client { get; private set; }
 
     /// <summary>Subject of the message.</summary>
     public string Subject {
@@ -206,7 +215,7 @@ public class Smtp {
     public Smtp(LoggingConfigurator? logging = null) {
         Stopwatch = Stopwatch.StartNew();
         Logging = logging;
-        Client = logging?.ProtocolLogger == null ? new ClientSmtp() : new ClientSmtp(logging.ProtocolLogger);
+        Client = ClientFactory(logging?.ProtocolLogger);
     }
 
     /// <summary>
@@ -228,8 +237,118 @@ public class Smtp {
         LoggingMessages.Logger.WriteVerbose($"Send-EmailMessage - Logging configuration: Path: {logPath}, Console: {logConsole}, Object: {logObject}, Timestamps: {logTimestamps}, Secrets: {logSecrets}, TimestampsFormat: {logTimestampsFormat}, ServerPrefix: {logServerPrefix}, ClientPrefix: {logClientPrefix}, Overwrite: {logOverwrite}");
         Logging = new LoggingConfigurator();
         Logging.ConfigureLogging(logPath, logConsole, logObject, logTimestamps, logSecrets, logTimestampsFormat, logServerPrefix, logClientPrefix, logOverwrite);
-        Client = Logging.ProtocolLogger == null ? new ClientSmtp() : new ClientSmtp(Logging.ProtocolLogger);
+        Client = ClientFactory(Logging.ProtocolLogger);
         Stopwatch = Stopwatch.StartNew();
+    }
+
+    private ClientSmtp? TryRentClient(string server, int port)
+    {
+        if (!PoolingEnabled)
+        {
+            return null;
+        }
+
+        var key = $"{server}:{port}";
+        if (_connectionPool.TryGetValue(key, out var bag))
+        {
+            while (bag.TryTake(out var pooled))
+            {
+                if (pooled.IsConnected)
+                {
+                    return pooled;
+                }
+                pooled.Dispose();
+            }
+        }
+        return null;
+    }
+
+    private static void ReturnClient(string server, int port, ClientSmtp client)
+    {
+        if (!PoolingEnabled)
+        {
+            client.Dispose();
+            return;
+        }
+
+        var key = $"{server}:{port}";
+        var bag = _connectionPool.GetOrAdd(key, _ => new ConcurrentBag<ClientSmtp>());
+        if (bag.Count >= MaxPoolSize)
+        {
+            client.Dispose();
+        }
+        else
+        {
+            bag.Add(client);
+        }
+    }
+
+    public static void ClearConnectionPool()
+    {
+        foreach (var bag in _connectionPool.Values)
+        {
+            while (bag.TryTake(out var client))
+            {
+                client.Dispose();
+            }
+        }
+        _connectionPool.Clear();
+    }
+
+    /// <summary>
+    /// Connects to the specified SMTP server and returns detailed information about the connection.
+    /// </summary>
+    /// <param name="server">SMTP server name.</param>
+    /// <param name="port">Port number.</param>
+    /// <param name="secureSocketOptions">Controls SSL/TLS usage.</param>
+    /// <param name="useSsl">Compatibility flag overriding <paramref name="secureSocketOptions"/> when set.</param>
+    public static SmtpConnectionInfo TestConnection(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false)
+    {
+        var logging = new LoggingConfigurator();
+        logging.ConfigureLogging(null!, false, true, false, false);
+
+        var smtp = new Smtp(logging);
+        _ = smtp.Connect(server, port, secureSocketOptions, useSsl);
+
+        string? banner = null;
+        string? software = null;
+
+        if (logging.LogStream != null)
+        {
+            logging.LogStream.Position = 0;
+            using var reader = new StreamReader(logging.LogStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+            var line = reader.ReadLine();
+            if (!string.IsNullOrWhiteSpace(line))
+            {
+                var trimmed = line.Trim();
+                if (trimmed.StartsWith("<--", StringComparison.Ordinal))
+                {
+                    trimmed = trimmed.Substring(3).Trim();
+                }
+                banner = trimmed;
+                var parts = trimmed.Split(new[] { ' ' }, 3, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length >= 3)
+                {
+                    software = parts[2];
+                }
+            }
+        }
+
+        var persistent = false;
+        try
+        {
+            smtp.Client.NoOp();
+            persistent = smtp.Client.IsConnected;
+        }
+        catch
+        {
+            persistent = false;
+        }
+
+        var info = new SmtpConnectionInfo(server, port, banner, software, smtp.Client.Capabilities, persistent);
+        smtp.Disconnect();
+        smtp.Dispose();
+        return info;
     }
 
     /// <summary>
@@ -274,16 +393,39 @@ public class Smtp {
     /// option is left as <see cref="SecureSocketOptions.Auto"/>.</param>
     /// <returns></returns>
     public SmtpResult Connect(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false) {
+        var oldServer = Server;
+        var oldPort = Port;
         Server = server;
         Port = port;
-        try {
-            if (useSsl && secureSocketOptions == SecureSocketOptions.Auto) {
-                // Maintain backwards compatibility with Send-MailMessage by
-                // defaulting to StartTls when the UseSsl flag is supplied and
-                // no explicit option was provided.
-                secureSocketOptions = SecureSocketOptions.StartTls;
+        if (Client.IsConnected)
+        {
+            if (PoolingEnabled)
+            {
+                ReturnClient(oldServer, oldPort, Client);
             }
-            Client.Connect(server, port, secureSocketOptions);
+            else
+            {
+                Client.Disconnect(true);
+            }
+            Client = ClientFactory(Logging?.ProtocolLogger);
+        }
+
+        var pooled = PoolingEnabled ? TryRentClient(server, port) : null;
+        if (pooled != null)
+        {
+            Client = pooled;
+        }
+        try {
+            if (!Client.IsConnected)
+            {
+                if (useSsl && secureSocketOptions == SecureSocketOptions.Auto) {
+                    // Maintain backwards compatibility with Send-MailMessage by
+                    // defaulting to StartTls when the UseSsl flag is supplied and
+                    // no explicit option was provided.
+                    secureSocketOptions = SecureSocketOptions.StartTls;
+                }
+                Client.Connect(server, port, secureSocketOptions);
+            }
             LoggingMessages.Logger.WriteVerbose($"Connected to {server} on {port} port using SSL: {secureSocketOptions}");
             return new SmtpResult(true, EmailAction.Connect, SentTo, SentFrom, server, port, Stopwatch.Elapsed, "");
         } catch (Exception ex) {
@@ -309,16 +451,39 @@ public class Smtp {
     /// option is left as <see cref="SecureSocketOptions.Auto"/>.</param>
     /// <returns></returns>
     public async Task<SmtpResult> ConnectAsync(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false) {
+        var oldServer = Server;
+        var oldPort = Port;
         Server = server;
         Port = port;
-        try {
-            if (useSsl && secureSocketOptions == SecureSocketOptions.Auto) {
-                // Maintain backwards compatibility with Send-MailMessage by
-                // defaulting to StartTls when the UseSsl flag is supplied and
-                // no explicit option was provided.
-                secureSocketOptions = SecureSocketOptions.StartTls;
+        if (Client.IsConnected)
+        {
+            if (PoolingEnabled)
+            {
+                ReturnClient(oldServer, oldPort, Client);
             }
-            await Client.ConnectAsync(server, port, secureSocketOptions);
+            else
+            {
+                Client.Disconnect(true);
+            }
+            Client = ClientFactory(Logging?.ProtocolLogger);
+        }
+
+        var pooled = PoolingEnabled ? TryRentClient(server, port) : null;
+        if (pooled != null)
+        {
+            Client = pooled;
+        }
+        try {
+            if (!Client.IsConnected)
+            {
+                if (useSsl && secureSocketOptions == SecureSocketOptions.Auto) {
+                    // Maintain backwards compatibility with Send-MailMessage by
+                    // defaulting to StartTls when the UseSsl flag is supplied and
+                    // no explicit option was provided.
+                    secureSocketOptions = SecureSocketOptions.StartTls;
+                }
+                await Client.ConnectAsync(server, port, secureSocketOptions);
+            }
             LoggingMessages.Logger.WriteVerbose($"Connected to {server} on {port} port using SSL: {secureSocketOptions}");
             return new SmtpResult(true, EmailAction.Connect, SentTo, SentFrom, server, port, Stopwatch.Elapsed, "");
         } catch (Exception ex) {
@@ -539,7 +704,12 @@ public class Smtp {
     /// </summary>
     public void Disconnect() {
         if (Client.IsConnected) {
-            Client.Disconnect(true);
+            if (PoolingEnabled) {
+                ReturnClient(Server, Port, Client);
+                Client = ClientFactory(Logging?.ProtocolLogger);
+            } else {
+                Client.Disconnect(true);
+            }
         }
         Stopwatch.Stop();
     }
@@ -549,7 +719,11 @@ public class Smtp {
     /// </summary>
     public void Dispose() {
         if (Client.IsConnected) {
-            Client.Disconnect(true);
+            if (PoolingEnabled) {
+                ReturnClient(Server, Port, Client);
+            } else {
+                Client.Disconnect(true);
+            }
         }
         Client.Dispose();
         Stopwatch.Stop();

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionInfo.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionInfo.cs
@@ -1,0 +1,35 @@
+using MailKit.Net.Smtp;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents details about an SMTP server retrieved when testing connectivity.
+/// </summary>
+public sealed class SmtpConnectionInfo
+{
+    /// <summary>Server that was tested.</summary>
+    public string Server { get; }
+    /// <summary>Port used during the test.</summary>
+    public int Port { get; }
+    /// <summary>Raw banner line returned by the server.</summary>
+    public string? Banner { get; }
+    /// <summary>Server software parsed from the banner if available.</summary>
+    public string? Software { get; }
+    /// <summary>Capabilities advertised by the server.</summary>
+    public SmtpCapabilities Capabilities { get; }
+    /// <summary>Indicates whether the server kept the connection open after a NOOP.</summary>
+    public bool Persistent { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmtpConnectionInfo"/> class.
+    /// </summary>
+    public SmtpConnectionInfo(string server, int port, string? banner, string? software, SmtpCapabilities capabilities, bool persistent)
+    {
+        Server = server;
+        Port = port;
+        Banner = banner;
+        Software = software;
+        Capabilities = capabilities;
+        Persistent = persistent;
+    }
+}

--- a/Tests/Clear-SmtpConnectionPool.Tests.ps1
+++ b/Tests/Clear-SmtpConnectionPool.Tests.ps1
@@ -1,0 +1,40 @@
+Describe 'Clear-SmtpConnectionPool' {
+    It 'Forces new connection after clearing pool' {
+        Add-Type -TypeDefinition @"
+using Mailozaurr;
+using MailKit.Security;
+using System.Threading;
+public class FakeClientPs2 : ClientSmtp {
+    public int ConnectCalls;
+    private bool _connected;
+    public override bool IsConnected => _connected;
+    public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {
+        ConnectCalls++;
+        _connected = true;
+    }
+    public override void Disconnect(bool quit, CancellationToken cancellationToken = default) {
+        _connected = false;
+    }
+}
+"@
+
+        [Mailozaurr.Smtp]::PoolingEnabled = $true
+        [Mailozaurr.Smtp]::ClearConnectionPool()
+        $fake = [FakeClientPs2]::new()
+        [Mailozaurr.Smtp]::ClientFactory = { $fake }
+
+        $params = @{ From='a@b.com'; To='c@d.com'; Server='h'; Subject='t'; Text='b'; WhatIf=$true; UseConnectionPool=$true }
+        Send-EmailMessage @params | Out-Null
+        Send-EmailMessage @params | Out-Null
+
+        Clear-SmtpConnectionPool
+
+        Send-EmailMessage @params | Out-Null
+
+        $fake.ConnectCalls | Should -Be 2
+
+        [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
+        [Mailozaurr.Smtp]::ClearConnectionPool()
+        [Mailozaurr.Smtp]::PoolingEnabled = $false
+    }
+}

--- a/Tests/Send-EmailMessageConnectionPool.Tests.ps1
+++ b/Tests/Send-EmailMessageConnectionPool.Tests.ps1
@@ -1,0 +1,36 @@
+Describe 'Send-EmailMessage connection pool' {
+    It 'Reuses connection when pool enabled' {
+        Add-Type -TypeDefinition @"
+using Mailozaurr;
+using MailKit.Security;
+using System.Threading;
+public class FakeClientPs : ClientSmtp {
+    public int ConnectCalls;
+    private bool _connected;
+    public override bool IsConnected => _connected;
+    public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {
+        ConnectCalls++;
+        _connected = true;
+    }
+    public override void Disconnect(bool quit, CancellationToken cancellationToken = default) {
+        _connected = false;
+    }
+}
+"@
+
+        [Mailozaurr.Smtp]::PoolingEnabled = $true
+        [Mailozaurr.Smtp]::ClearConnectionPool()
+        $fake = [FakeClientPs]::new()
+        [Mailozaurr.Smtp]::ClientFactory = { $fake }
+
+        $params = @{ From = 'a@b.com'; To = 'c@d.com'; Server = 'h'; Subject = 't'; Text = 'b'; WhatIf = $true; UseConnectionPool = $true }
+        Send-EmailMessage @params | Out-Null
+        Send-EmailMessage @params | Out-Null
+
+        $fake.ConnectCalls | Should -Be 1
+
+        [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
+        [Mailozaurr.Smtp]::ClearConnectionPool()
+        [Mailozaurr.Smtp]::PoolingEnabled = $false
+    }
+}

--- a/Tests/Test-SmtpConnection.Tests.ps1
+++ b/Tests/Test-SmtpConnection.Tests.ps1
@@ -1,0 +1,21 @@
+Describe 'Test-SmtpConnection' {
+    It 'Returns capabilities object' {
+        Add-Type -TypeDefinition @"
+using Mailozaurr;
+using MailKit.Security;
+using System.Threading;
+public class FakeClientPs3 : ClientSmtp {
+    public override bool IsConnected => true;
+    public override SmtpCapabilities Capabilities => SmtpCapabilities.Pipelining;
+    public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {}
+    public override void Disconnect(bool quit, CancellationToken cancellationToken = default) {}
+    public override void NoOp(CancellationToken cancellationToken = default) {}
+}
+"@
+        [Mailozaurr.Smtp]::ClientFactory = { [FakeClientPs3]::new() }
+        $result = Test-SmtpConnection -Server 'h'
+        $result | Should -BeOfType 'Mailozaurr.SmtpConnectionInfo'
+        $result.Capabilities | Should -Match 'Pipelining'
+        [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SmtpConnectionInfo` class to represent banner, capabilities and persistence info
- expose `Smtp.TestConnection` returning typed information
- output typed object in `Test-SmtpConnection` cmdlet
- update Pester tests for new output

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release -v minimal`
- `dotnet build Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687413448458832ebcb0e9fc1e821922