### PR TITLE
Configure Codecov checks as informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+    changes:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary
- add `codecov.yml` so Codecov checks only report coverage

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_68750fd357c8832eaf2344a3c89121b3