### PR TITLE
Fix cross-platform S/MIME certificate tests

### DIFF
--- a/Sources/Mailozaurr/Cryptography/TemporarySmimeCertificate.cs
+++ b/Sources/Mailozaurr/Cryptography/TemporarySmimeCertificate.cs
@@ -2,6 +2,15 @@ using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.IO;
+using System.Runtime.InteropServices;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Extension;
+using Org.BouncyCastle.Pkcs;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Operators;
 
 namespace Mailozaurr;
 
@@ -20,7 +29,15 @@ public static class TemporarySmimeCertificate
     {
 #if NETSTANDARD2_0
         throw new NotSupportedException("Temporary S/MIME certificates require .NET Framework 4.7.2 or later.");
+#elif NETFRAMEWORK
+        return CreateWithBouncyCastle(subjectName, validDays, outputPath);
 #else
+        // CertificateRequest is unavailable on some platforms such as Mono.
+        if (Type.GetType("System.Security.Cryptography.X509Certificates.CertificateRequest") == null)
+        {
+            return CreateWithBouncyCastle(subjectName, validDays, outputPath);
+        }
+
         using RSA rsa = RSA.Create();
         rsa.KeySize = 2048;
         var req = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
@@ -34,16 +51,64 @@ public static class TemporarySmimeCertificate
         var notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
         var notAfter = notBefore.AddDays(validDays);
         using X509Certificate2 cert = req.CreateSelfSigned(notBefore, notAfter);
+
+        var flags = X509KeyStorageFlags.Exportable;
 #if NET5_0_OR_GREATER
-        var result = new X509Certificate2(cert.Export(X509ContentType.Pfx), string.Empty, X509KeyStorageFlags.EphemeralKeySet | X509KeyStorageFlags.Exportable);
-#else
-        var result = new X509Certificate2(cert.Export(X509ContentType.Pfx), string.Empty, X509KeyStorageFlags.Exportable);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            flags |= X509KeyStorageFlags.EphemeralKeySet;
+        }
 #endif
+
+        var result = new X509Certificate2(cert.Export(X509ContentType.Pfx), string.Empty, flags);
+
         if (outputPath != null)
         {
             File.WriteAllBytes(outputPath, cert.Export(X509ContentType.Pfx));
         }
+
         return result;
 #endif
+    }
+
+    private static X509Certificate2 CreateWithBouncyCastle(string subjectName, int validDays, string? outputPath)
+    {
+        var random = new SecureRandom();
+        var keyGen = new Org.BouncyCastle.Crypto.Generators.RsaKeyPairGenerator();
+        keyGen.Init(new Org.BouncyCastle.Crypto.KeyGenerationParameters(random, 2048));
+        AsymmetricCipherKeyPair keyPair = keyGen.GenerateKeyPair();
+
+        var certGen = new X509V3CertificateGenerator();
+        var name = new X509Name(subjectName);
+        var serial = Org.BouncyCastle.Math.BigInteger.ProbablePrime(120, random);
+        certGen.SetSerialNumber(serial);
+        certGen.SetIssuerDN(name);
+        certGen.SetNotBefore(DateTime.UtcNow.AddMinutes(-5));
+        certGen.SetNotAfter(DateTime.UtcNow.AddDays(validDays));
+        certGen.SetSubjectDN(name);
+        certGen.SetPublicKey(keyPair.Public);
+        certGen.AddExtension(X509Extensions.BasicConstraints, true, new BasicConstraints(false));
+        certGen.AddExtension(X509Extensions.KeyUsage, true, new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment));
+        certGen.AddExtension(X509Extensions.SubjectKeyIdentifier, false, new SubjectKeyIdentifierStructure(keyPair.Public));
+
+        var signatureFactory = new Asn1SignatureFactory("SHA256WithRSA", keyPair.Private);
+        Org.BouncyCastle.X509.X509Certificate bouncyCert = certGen.Generate(signatureFactory);
+
+        var store = new Pkcs12StoreBuilder().Build();
+        string friendlyName = subjectName;
+        var certEntry = new X509CertificateEntry(bouncyCert);
+        store.SetCertificateEntry(friendlyName, certEntry);
+        store.SetKeyEntry(friendlyName, new AsymmetricKeyEntry(keyPair.Private), new[] { certEntry });
+
+        using var ms = new MemoryStream();
+        store.Save(ms, Array.Empty<char>(), random);
+        var raw = ms.ToArray();
+
+        if (outputPath != null)
+        {
+            File.WriteAllBytes(outputPath, raw);
+        }
+
+        return new X509Certificate2(raw, string.Empty, X509KeyStorageFlags.Exportable);
     }
 }

--- a/Sources/Mailozaurr/Mailozaurr.csproj
+++ b/Sources/Mailozaurr/Mailozaurr.csproj
@@ -35,6 +35,7 @@
         <PackageReference Include="System.Data.SQLite" Version="1.0.119" />
         <PackageReference Include="MsgReader" Version="5.7.3" />
         <PackageReference Include="System.Text.Json" Version="8.0.5" />
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
     </ItemGroup>
 
 


### PR DESCRIPTION
## Summary
- add BouncyCastle fallback for temporary S/MIME certificate generation
- only use `CertificateRequest` on supported runtimes
- avoid ephemeral keyset on non-Windows platforms
- reference BouncyCastle package

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6875458829d8832eb14047df6786be91