### PR TITLE
Fix BouncyCastle cert on macOS

### DIFF
--- a/Sources/Mailozaurr/Cryptography/TemporarySmimeCertificate.cs
+++ b/Sources/Mailozaurr/Cryptography/TemporarySmimeCertificate.cs
@@ -95,13 +95,14 @@ public static class TemporarySmimeCertificate
         Org.BouncyCastle.X509.X509Certificate bouncyCert = certGen.Generate(signatureFactory);
 
         var store = new Pkcs12StoreBuilder().Build();
+        const string pfxPassword = "pass";
         string friendlyName = subjectName;
         var certEntry = new X509CertificateEntry(bouncyCert);
         store.SetCertificateEntry(friendlyName, certEntry);
         store.SetKeyEntry(friendlyName, new AsymmetricKeyEntry(keyPair.Private), new[] { certEntry });
 
         using var ms = new MemoryStream();
-        store.Save(ms, Array.Empty<char>(), random);
+        store.Save(ms, pfxPassword.ToCharArray(), random);
         var raw = ms.ToArray();
 
         if (outputPath != null)
@@ -109,6 +110,6 @@ public static class TemporarySmimeCertificate
             File.WriteAllBytes(outputPath, raw);
         }
 
-        return new X509Certificate2(raw, string.Empty, X509KeyStorageFlags.Exportable);
+        return new X509Certificate2(raw, pfxPassword, X509KeyStorageFlags.Exportable);
     }
 }


### PR DESCRIPTION
## Summary
- adjust TemporarySmimeCertificate to use password-protected PKCS#12 files

## Testing
- `dotnet build Sources/Mailozaurr.sln -v minimal`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68754ada8640832e9778d5b9aa6fe835