### PR TITLE
Fix netstandard build

### DIFF
--- a/Sources/Mailozaurr.Tests/AdditionalCoverageTests.cs
+++ b/Sources/Mailozaurr.Tests/AdditionalCoverageTests.cs
@@ -39,10 +39,10 @@ public class AdditionalCoverageTests
     }
 
     [Fact]
-    public void MessageFlagSetter_Pop3ReadState()
+    public async Task MessageFlagSetter_Pop3ReadState()
     {
         var client = new MailKit.Net.Pop3.Pop3Client();
-        MessageFlagSetter.SetReadAsync(client, 5, true).Wait();
+        await MessageFlagSetter.SetReadAsync(client, 5, true);
         Assert.True(MessageFlagSetter.TryGetPop3Read(client, 5, out var read) && read);
     }
 

--- a/Sources/Mailozaurr/Cryptography/TemporarySmimeCertificate.cs
+++ b/Sources/Mailozaurr/Cryptography/TemporarySmimeCertificate.cs
@@ -47,6 +47,7 @@ public static class TemporarySmimeCertificate
 #endif
     }
 
+#if !NETSTANDARD2_0
     private static X509Certificate2 CreateWithCertificateRequest(string subjectName, int validDays, string? outputPath)
     {
         using RSA rsa = RSA.Create();
@@ -80,6 +81,7 @@ public static class TemporarySmimeCertificate
 
         return result;
     }
+#endif
 
     private static X509Certificate2 CreateWithBouncyCastle(string subjectName, int validDays, string? outputPath)
     {


### PR DESCRIPTION
## Summary
- conditionally compile CertificateRequest usage
- update test to async to avoid blocking calls

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_687550d82608832eb07d7712aa85a7bb