### PR TITLE
Add XML docs for cmdlets

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletClearGraphJunk.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletClearGraphJunk.cs
@@ -104,6 +104,10 @@ public sealed class CmdletClearGraphJunk : AsyncPSCmdlet {
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Executes the cmdlet logic based on the provided parameter set.
+    /// </summary>
+    /// <returns>The asynchronous task representing the operation.</returns>
     protected override Task ProcessRecordAsync() {
         switch (ParameterSetName) {
             case "Graph":

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -116,12 +116,22 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     [Parameter]
     public double RetryDelayBackoff { get; set; } = 1.0;
 
+    /// <summary>
+    /// Request timeout for Microsoft Graph operations in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Maximum number of concurrent Microsoft Graph requests.
+    /// </summary>
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 
+    /// <summary>
+    /// Connects to Microsoft Graph using the provided authentication details.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync() {
         GraphCredential cred;
         OAuthCredential? oauth = null;

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCertificateCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCertificateCredential.cs
@@ -52,6 +52,9 @@ public class CmdletConvertToGraphCertificateCredential : PSCmdlet {
     [Parameter]
     public string[]? Scopes { get; set; }
 
+    /// <summary>
+    /// Acquires an app-only access token using certificate authentication and returns it as a credential.
+    /// </summary>
     protected override void ProcessRecord() {
         GraphAuthorization token;
         try {

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToMailgunCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToMailgunCredential.cs
@@ -21,6 +21,9 @@ public class CmdletConvertToMailgunCredential : PSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? ApiKey { get; set; }
 
+    /// <summary>
+    /// Converts the provided API key into a PSCredential for Mailgun.
+    /// </summary>
     protected override void ProcessRecord() {
         SecureString secret = CredentialHelpers.ToSecureString(ApiKey);
         var credential = new PSCredential("Mailgun", secret);

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphFolder.cs
@@ -35,22 +35,40 @@ public class CmdletGetEmailGraphFolder : AsyncPSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Graph connection context to use when performing the request.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph", ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Switch indicating that Invoke-MgGraphRequest should be used.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Maximum parallel Microsoft Graph requests.
+    /// </summary>
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 
+    /// <summary>
+    /// Number of retry attempts when requests fail.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retry attempts in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
@@ -136,6 +136,10 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Retrieves messages using either built-in logic or Invoke-MgGraphRequest.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         if (ParameterSetName == "MgGraphRequest") {
             return ProcessMgGraph();
@@ -150,6 +154,9 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
         return ProcessGraphAsync(conn.Credential);
     }
 
+    /// <summary>
+    /// Executes the Graph API calls to fetch messages.
+    /// </summary>
     private async Task ProcessGraphAsync(GraphCredential cred) {
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
         MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
@@ -195,6 +202,9 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
         }
     }
 
+    /// <summary>
+    /// Uses Invoke-MgGraphRequest to retrieve messages.
+    /// </summary>
     private Task ProcessMgGraph() {
         var filter = BuildFilter(Filter);
         var query = new Dictionary<string, object>();

--- a/Sources/Mailozaurr.PowerShell/CmdletGetGmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetGmailMessage.cs
@@ -10,22 +10,41 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.Get, "GmailMessage")]
 [OutputType(typeof(GmailMessage))]
 public sealed class CmdletGetGmailMessage : AsyncPSCmdlet {
+    /// <summary>
+    /// Gmail account address to operate on.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? GmailAccount { get; set; }
 
+    /// <summary>
+    /// OAuth credential used to authenticate to Gmail.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNull]
     public PSCredential? Credential { get; set; }
 
+    /// <summary>
+    /// Search query used when listing messages.
+    /// </summary>
     [Parameter(ParameterSetName = "List")]
     public string? Query { get; set; }
 
+    /// <summary>
+    /// Maximum number of messages to return when listing.
+    /// </summary>
     [Parameter(ParameterSetName = "List")]
     public int? MaxResults { get; set; }
 
+    /// <summary>
+    /// Identifier of a specific Gmail message.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Id")]
     public string? Id { get; set; }
 
+    /// <summary>
+    /// Retrieves Gmail messages based on the specified parameters.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync() {
         var net = Credential!.GetNetworkCredential();
         var oauth = new OAuthCredential {

--- a/Sources/Mailozaurr.PowerShell/CmdletGetGraphEvent.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetGraphEvent.cs
@@ -11,31 +11,59 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.Get, "GraphEvent")]
 [OutputType(typeof(Dictionary<string, object>))]
 public sealed class CmdletGetGraphEvent : AsyncPSCmdlet {
+    /// <summary>
+    /// User principal name whose calendar events are retrieved.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Graph connection information to use for the request.
+    /// </summary>
     [Parameter(ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Additional event properties to select.
+    /// </summary>
     [Parameter]
     public string[]? Property { get; set; }
 
+    /// <summary>
+    /// OData filter string applied to the query.
+    /// </summary>
     [Parameter]
     public string? Filter { get; set; }
 
+    /// <summary>
+    /// Maximum number of events to return.
+    /// </summary>
     [Parameter]
     public int? Limit { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Number of retry attempts on transient errors.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retry attempts in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Retrieves events for the specified user.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         var conn = Connection ?? DefaultSessions.GraphSession;
         if (conn == null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletGetGraphInboxRule.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetGraphInboxRule.cs
@@ -58,6 +58,10 @@ public sealed class CmdletGetGraphInboxRule : AsyncPSCmdlet {
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Retrieves inbox rules using Graph or Invoke-MgGraphRequest.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         if (ParameterSetName == "MgGraphRequest") {
             return ProcessMgGraph();

--- a/Sources/Mailozaurr.PowerShell/CmdletGetGraphMailboxStatistics.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetGraphMailboxStatistics.cs
@@ -12,23 +12,42 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.Get, "GraphMailboxStatistics")]
 [OutputType(typeof(GraphMailboxStatistics))]
 public class CmdletGetGraphMailboxStatistics : AsyncPSCmdlet {
+    /// <summary>
+    /// User principal name for the mailbox being queried.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Existing Graph connection to use for requests.
+    /// </summary>
     [Parameter(ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Retrieves mailbox statistics for the specified user.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         var conn = Connection ?? DefaultSessions.GraphSession;
         if (conn == null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveGraphFolder.cs
@@ -56,6 +56,10 @@ public class CmdletMoveGraphFolder : AsyncPSCmdlet {
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Moves a folder within a mailbox using Microsoft Graph.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         switch (ParameterSetName) {
             case ParentParameterSet:

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveGraphMessage.cs
@@ -46,15 +46,27 @@ public class CmdletMoveGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Maximum number of concurrent Graph requests.
+    /// </summary>
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 
+    /// <summary>
+    /// Number of retry attempts when moving fails.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retry attempts in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPFolder.cs
@@ -31,6 +31,10 @@ public sealed class CmdletMoveIMAPFolder : AsyncPSCmdlet {
     [Parameter(ParameterSetName = RootParameterSet)]
     public SwitchParameter Root { get; set; }
 
+    /// <summary>
+    /// Moves an IMAP folder to the specified destination.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null && conn.Data != null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphEvent.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphEvent.cs
@@ -11,30 +11,55 @@ namespace Mailozaurr.PowerShell;
 [OutputType(typeof(GraphEvent))]
 public sealed class CmdletNewGraphEvent : AsyncPSCmdlet
 {
+    /// <summary>
+    /// User principal name owning the calendar.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Event object to create.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Event")]
     [ValidateNotNull]
     public GraphEvent? Event { get; set; }
 
+    /// <summary>
+    /// Builder used to construct the event.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Builder")]
     [ValidateNotNull]
     public GraphEventBuilder? EventBuilder { get; set; }
 
+    /// <summary>
+    /// Graph connection context for the request.
+    /// </summary>
     [Parameter(ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Creates the event using Microsoft Graph.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         var conn = Connection ?? DefaultSessions.GraphSession;
         if (conn == null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphEventBuilder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphEventBuilder.cs
@@ -11,30 +11,57 @@ namespace Mailozaurr.PowerShell;
 [OutputType(typeof(GraphEventBuilder))]
 public sealed class CmdletNewGraphEventBuilder : PSCmdlet
 {
+    /// <summary>
+    /// Subject of the new event.
+    /// </summary>
     [Parameter]
     public string? Subject { get; set; }
 
+    /// <summary>
+    /// Start time of the event.
+    /// </summary>
     [Parameter]
     public DateTime? Start { get; set; }
 
+    /// <summary>
+    /// Time zone for the start time.
+    /// </summary>
     [Parameter]
     public string StartTimeZone { get; set; } = "UTC";
 
+    /// <summary>
+    /// End time of the event.
+    /// </summary>
     [Parameter]
     public DateTime? End { get; set; }
 
+    /// <summary>
+    /// Time zone for the end time.
+    /// </summary>
     [Parameter]
     public string EndTimeZone { get; set; } = "UTC";
 
+    /// <summary>
+    /// Body content of the event.
+    /// </summary>
     [Parameter]
     public string? Body { get; set; }
 
+    /// <summary>
+    /// Type of the body content: HTML or Text.
+    /// </summary>
     [Parameter]
     public string BodyType { get; set; } = "HTML";
 
+    /// <summary>
+    /// List of attendee email addresses.
+    /// </summary>
     [Parameter]
     public string[]? Attendees { get; set; }
 
+    /// <summary>
+    /// Builds the <see cref="GraphEventBuilder"/> object from provided parameters.
+    /// </summary>
     protected override void ProcessRecord()
     {
         var builder = new GraphEventBuilder();

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleBuilder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleBuilder.cs
@@ -89,6 +89,9 @@ public sealed class CmdletNewGraphInboxRuleBuilder : PSCmdlet
     [Parameter]
     public string? Importance { get; set; }
 
+    /// <summary>
+    /// Builds the <see cref="GraphInboxRule"/> based on provided parameters.
+    /// </summary>
     protected override void ProcessRecord()
     {
         var builder = new GraphInboxRuleBuilder()

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleObject.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleObject.cs
@@ -96,6 +96,9 @@ public sealed class CmdletNewGraphInboxRuleObject : PSCmdlet
     [Parameter(ParameterSetName = "Params")]
     public string? Importance { get; set; }
 
+    /// <summary>
+    /// Creates a <see cref="GraphInboxRule"/> instance from the supplied parameters.
+    /// </summary>
     protected override void ProcessRecord()
     {
         if (ParameterSetName == "Builder")

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphMailboxPermissionBuilder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphMailboxPermissionBuilder.cs
@@ -9,18 +9,33 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.New, "GraphMailboxPermissionBuilder")]
 [OutputType(typeof(GraphMailboxPermissionBuilder))]
 public sealed class CmdletNewGraphMailboxPermissionBuilder : PSCmdlet {
+    /// <summary>
+    /// Mailbox owner user principal name.
+    /// </summary>
     [Parameter]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// User to grant permissions to.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string GrantedToUser { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Roles to assign on the mailbox.
+    /// </summary>
     [Parameter]
     public GraphMailboxRole[]? Roles { get; set; }
 
+    /// <summary>
+    /// Optional permission identifier.
+    /// </summary>
     [Parameter]
     public string? Id { get; set; }
 
+    /// <summary>
+    /// Builds the <see cref="GraphMailboxPermission"/> from parameters.
+    /// </summary>
     protected override void ProcessRecord() {
         var builder = new GraphMailboxPermissionBuilder();
         if (UserPrincipalName != null)

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphMailboxPermissionObject.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphMailboxPermissionObject.cs
@@ -39,6 +39,9 @@ public sealed class CmdletNewGraphMailboxPermissionObject : PSCmdlet {
     [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = "Builder")]
     public GraphMailboxPermissionBuilder? Builder { get; set; }
 
+    /// <summary>
+    /// Constructs the <see cref="GraphMailboxPermission"/> from parameters or builder.
+    /// </summary>
     protected override void ProcessRecord() {
         GraphMailboxPermission permission;
         if (ParameterSetName == "Builder") {

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGmailMessage.cs
@@ -8,16 +8,29 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsCommon.Remove, "GmailMessage", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
 public sealed class CmdletRemoveGmailMessage : AsyncPSCmdlet {
+    /// <summary>
+    /// Gmail account containing the message.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? GmailAccount { get; set; }
 
+    /// <summary>
+    /// OAuth credential used to authenticate.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNull]
     public PSCredential? Credential { get; set; }
 
+    /// <summary>
+    /// Identifier of the Gmail message to remove.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? Id { get; set; }
 
+    /// <summary>
+    /// Deletes the specified Gmail message.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync() {
         if (!ShouldProcess(Id!, "Deleting Gmail message")) {
             return;

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphEvent.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphEvent.cs
@@ -9,25 +9,47 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsCommon.Remove, "GraphEvent", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
 public sealed class CmdletRemoveGraphEvent : AsyncPSCmdlet {
+    /// <summary>
+    /// User principal name owning the event.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Identifier of the event to remove.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? EventId { get; set; }
 
+    /// <summary>
+    /// Graph connection context.
+    /// </summary>
     [Parameter(ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Removes the specified event via Microsoft Graph.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         var conn = Connection ?? DefaultSessions.GraphSession;
         if (conn == null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphFolder.cs
@@ -51,6 +51,10 @@ public class CmdletRemoveGraphFolder : AsyncPSCmdlet {
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Removes the specified folder using Microsoft Graph.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         switch (ParameterSetName) {
             case "Graph":

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphInboxRule.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphInboxRule.cs
@@ -11,14 +11,23 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsCommon.Remove, "GraphInboxRule", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
 public sealed class CmdletRemoveGraphInboxRule : AsyncPSCmdlet {
+    /// <summary>
+    /// User principal name owning the inbox rule.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Identifier of the rule to remove.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? RuleId { get; set; }
 
+    /// <summary>
+    /// Graph connection context.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph", ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMailboxPermission.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMailboxPermission.cs
@@ -13,13 +13,22 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.Remove, "GraphMailboxPermission", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
 public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
     [Parameter(Mandatory = true)]
+    /// <summary>
+    /// Mailbox owner user principal name.
+    /// </summary>
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Identifier of permissions to remove.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNullOrEmpty]
     public string[]? PermissionId { get; set; }
 
+    /// <summary>
+    /// Mailbox permission objects to remove.
+    /// </summary>
     [Parameter(ParameterSetName = "Object", ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphMailboxPermission[]? MailboxPermission { get; set; }
@@ -30,10 +39,16 @@ public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
     [Parameter(ParameterSetName = "Filter")]
     public string[]? GrantedToUser { get; set; }
 
+    /// <summary>
+    /// Path to CSV file containing permission entries.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Csv")]
     [ValidateNotNullOrEmpty]
     public string? CsvPath { get; set; }
 
+    /// <summary>
+    /// Graph connection to use for the request.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph", ValueFromPipeline = true)]
     [Parameter(ParameterSetName = "Object", ValueFromPipeline = true)]
     [Parameter(ParameterSetName = "Csv", ValueFromPipeline = true)]
@@ -43,15 +58,28 @@ public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Removes mailbox permissions based on the provided input.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync() {
         if (ParameterSetName == "MgGraphRequest") {
             ProcessMgGraph();

--- a/Sources/Mailozaurr.PowerShell/CmdletRenameGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRenameGraphFolder.cs
@@ -50,6 +50,10 @@ public class CmdletRenameGraphFolder : AsyncPSCmdlet {
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Renames a folder using Microsoft Graph.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         switch (ParameterSetName) {
             case "Graph":

--- a/Sources/Mailozaurr.PowerShell/CmdletRenameIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRenameIMAPFolder.cs
@@ -25,6 +25,10 @@ public sealed class CmdletRenameIMAPFolder : AsyncPSCmdlet {
     [ValidateNotNullOrEmpty]
     public string? NewName { get; set; }
 
+    /// <summary>
+    /// Renames an IMAP folder on the connected server.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null && conn.Data != null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveGmailMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveGmailMessageAttachment.cs
@@ -9,20 +9,36 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsData.Save, "GmailMessageAttachment")]
 public sealed class CmdletSaveGmailMessageAttachment : AsyncPSCmdlet {
+    /// <summary>
+    /// Gmail account containing the message.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? GmailAccount { get; set; }
 
+    /// <summary>
+    /// OAuth credential used for authentication.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNull]
     public PSCredential? Credential { get; set; }
 
+    /// <summary>
+    /// Identifier of the Gmail message.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? Id { get; set; }
 
+    /// <summary>
+    /// Destination path for saving attachments.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? Path { get; set; }
 
+    /// <summary>
+    /// Downloads attachments from the specified Gmail message.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync() {
         var net = Credential!.GetNetworkCredential();
         var oauth = new OAuthCredential {

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchIMAPMailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchIMAPMailbox.cs
@@ -86,6 +86,10 @@ public sealed class CmdletSearchIMAPMailbox : AsyncPSCmdlet {
     [ValidateRange(1, int.MaxValue)]
     public int Count { get; set; }
 
+    /// <summary>
+    /// Searches the IMAP mailbox using the specified criteria.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null && conn.Data != null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchPOP3Mailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchPOP3Mailbox.cs
@@ -73,6 +73,10 @@ public sealed class CmdletSearchPOP3Mailbox : AsyncPSCmdlet {
     [ValidateRange(1, int.MaxValue)]
     public int Count { get; set; }
 
+    /// <summary>
+    /// Searches the POP3 mailbox using the specified criteria.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.Pop3Session;
         if (conn != null && conn.Data != null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -304,6 +304,9 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "MgGraphRequest")]
     [Parameter(Mandatory = false, ParameterSetName = "Compatibility")]
     [Parameter(Mandatory = false, ParameterSetName = "SendGrid")]
+    /// <summary>
+    /// Custom message headers to include with the email.
+    /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "EmailProviders")]
     public Hashtable? Headers { get; set; }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletSendGmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendGmailMessage.cs
@@ -11,16 +11,28 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommunications.Send, "GmailMessage")]
 [OutputType(typeof(GmailMessage))]
 public sealed class CmdletSendGmailMessage : AsyncPSCmdlet {
+    /// <summary>
+    /// Gmail account used to send the message.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? GmailAccount { get; set; }
 
+    /// <summary>
+    /// OAuth credential used for authentication.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNull]
     public PSCredential? Credential { get; set; }
 
+    /// <summary>
+    /// Address used in the From header.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public object? From { get; set; }
 
+    /// <summary>
+    /// Recipients of the message.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public object[]? To { get; set; }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletSetGraphEvent.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetGraphEvent.cs
@@ -10,29 +10,54 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.Set, "GraphEvent", SupportsShouldProcess = true)]
 [OutputType(typeof(GraphEvent))]
 public sealed class CmdletSetGraphEvent : AsyncPSCmdlet {
+    /// <summary>
+    /// User principal name owning the event.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Identifier of the event to update.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? EventId { get; set; }
 
+    /// <summary>
+    /// Updated event object.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNull]
     public GraphEvent? Event { get; set; }
 
+    /// <summary>
+    /// Graph connection context.
+    /// </summary>
     [Parameter(ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 
+    /// <summary>
+    /// Updates the specified event via Microsoft Graph.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         var conn = Connection ?? DefaultSessions.GraphSession;
         if (conn == null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletSetGraphInboxRule.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSetGraphInboxRule.cs
@@ -17,20 +17,35 @@ namespace Mailozaurr.PowerShell;
 [OutputType(typeof(GraphInboxRule))]
 public sealed class CmdletSetGraphInboxRule : AsyncPSCmdlet
 {
+    /// <summary>
+    /// User principal name owning the rule.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Identifier of the rule to update.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? RuleId { get; set; }
 
+    /// <summary>
+    /// Hashtable representing the rule properties.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public Hashtable? Rule { get; set; }
 
+    /// <summary>
+    /// Existing rule object used for update.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public GraphInboxRule? RuleObject { get; set; }
 
+    /// <summary>
+    /// Graph connection context used for the update.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph", ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }

--- a/Sources/Mailozaurr.PowerShell/CmdletTestSmtpConnection.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletTestSmtpConnection.cs
@@ -18,15 +18,28 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsDiagnostic.Test, "SmtpConnection")]
 public sealed class CmdletTestSmtpConnection : AsyncPSCmdlet {
+    /// <summary>
+    /// SMTP server hostname to test.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string? Server { get; set; }
 
+    /// <summary>
+    /// TCP port used for the SMTP connection.
+    /// </summary>
     [Parameter]
     public int Port { get; set; } = 587;
 
+    /// <summary>
+    /// Indicates whether to test SSL connectivity.
+    /// </summary>
     [Parameter]
     public SwitchParameter UseSsl { get; set; }
 
+    /// <summary>
+    /// Tests the SMTP server connection and outputs capability information.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
         var info = Smtp.TestConnection(Server!, Port, SecureSocketOptions.Auto, UseSsl.IsPresent);
         WriteObject(info);

--- a/Sources/Mailozaurr/Helpers/HtmlUtils.cs
+++ b/Sources/Mailozaurr/Helpers/HtmlUtils.cs
@@ -58,6 +58,12 @@ public static class HtmlUtils {
         return (html, paths);
     }
 
+    /// <summary>
+    /// Downloads externally referenced images and replaces their sources with cid links.
+    /// </summary>
+    /// <param name="html">HTML content to inspect.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>Modified HTML and list of downloaded images.</returns>
     public static async Task<(string Html, List<RemoteImage> Images)> DownloadRemoteImagesAsync(string html, CancellationToken cancellationToken = default) {
         var images = new List<RemoteImage>();
         if (string.IsNullOrWhiteSpace(html)) return (html, images);

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -296,6 +296,9 @@ public class Smtp {
         }
     }
 
+    /// <summary>
+    /// Disposes all SMTP clients stored in the connection pool.
+    /// </summary>
     public static void ClearConnectionPool()
     {
         foreach (var bag in _connectionPool.Values)


### PR DESCRIPTION
## Summary
- add XML doc comments to many cmdlets and helpers
- document HTML utility and SMTP pool methods

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release` *(fails: warnings remain)*

------
https://chatgpt.com/codex/tasks/task_e_6875fa93edc0832ea6aa433061d835b7