### PR TITLE
Add XML documentation to PowerShell cmdlets

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletMoveGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveGraphFolder.cs
@@ -45,6 +45,9 @@ public class CmdletMoveGraphFolder : AsyncPSCmdlet {
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Maximum number of concurrent requests during the move operation.
+    /// </summary>
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRule.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRule.cs
@@ -16,75 +16,141 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommon.New, "GraphInboxRule")]
 [OutputType(typeof(GraphInboxRule))]
 public sealed class CmdletNewGraphInboxRule : AsyncPSCmdlet {
+    /// <summary>
+    /// User principal name owning the mailbox.
+    /// </summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// Hashtable definition of the rule.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public Hashtable? Rule { get; set; }
 
+    /// <summary>
+    /// Rule object describing the inbox rule.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public GraphInboxRule? RuleObject { get; set; }
 
+    /// <summary>
+    /// Builder used to create a rule object.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph")]
     [ValidateNotNull]
     public GraphInboxRuleBuilder? RuleBuilder { get; set; }
 
+    /// <summary>
+    /// Display name for the new rule.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Params")]
     public string DisplayName { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Order in which the rule is processed.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public int Sequence { get; set; }
 
+    /// <summary>
+    /// Determines if the rule is enabled.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public SwitchParameter Enabled { get; set; }
 
+    /// <summary>
+    /// Destination folder to move messages to.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string? MoveToFolder { get; set; }
 
+    /// <summary>
+    /// Destination folder to copy messages to.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string? CopyToFolder { get; set; }
 
+    /// <summary>
+    /// Deletes messages matching the rule.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public SwitchParameter Delete { get; set; }
 
+    /// <summary>
+    /// Addresses to forward matching messages to.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string[]? ForwardTo { get; set; }
 
+    /// <summary>
+    /// Stops processing additional rules when this rule matches.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public SwitchParameter StopProcessing { get; set; }
 
+    /// <summary>
+    /// Sender addresses that trigger the rule.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string[]? SenderContains { get; set; }
 
+    /// <summary>
+    /// Recipients that trigger the rule.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string[]? RecipientContains { get; set; }
 
+    /// <summary>
+    /// Strings that must appear in the subject.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string[]? SubjectContains { get; set; }
 
+    /// <summary>
+    /// Strings that must appear in the body.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string[]? BodyContains { get; set; }
 
+    /// <summary>
+    /// Message importance level to match.
+    /// </summary>
     [Parameter(ParameterSetName = "Params")]
     public string? Importance { get; set; }
 
+    /// <summary>
+    /// Connection information for Microsoft Graph.
+    /// </summary>
     [Parameter(ParameterSetName = "Graph", ValueFromPipeline = true)]
     [Parameter(ParameterSetName = "Params", ValueFromPipeline = true)]
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Use <c>Invoke-MgGraphRequest</c> for sending requests.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphInboxRule.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphInboxRule.cs
@@ -32,15 +32,27 @@ public sealed class CmdletRemoveGraphInboxRule : AsyncPSCmdlet {
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Use <c>Invoke-MgGraphRequest</c> instead of built-in logic.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Number of retry attempts on failure.
+    /// </summary>
     [Parameter]
     public int RetryCount { get; set; } = 0;
 
+    /// <summary>
+    /// Delay between retries in milliseconds.
+    /// </summary>
     [Parameter]
     public int RetryDelayMilliseconds { get; set; } = 0;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMailboxPermission.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMailboxPermission.cs
@@ -12,10 +12,10 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsCommon.Remove, "GraphMailboxPermission", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
 public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
-    [Parameter(Mandatory = true)]
     /// <summary>
     /// Mailbox owner user principal name.
     /// </summary>
+    [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? UserPrincipalName { get; set; }
 
@@ -33,9 +33,15 @@ public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
     [ValidateNotNull]
     public GraphMailboxPermission[]? MailboxPermission { get; set; }
 
+    /// <summary>
+    /// Filters permissions by mailbox role.
+    /// </summary>
     [Parameter(ParameterSetName = "Filter")]
     public GraphMailboxRole[]? Role { get; set; }
 
+    /// <summary>
+    /// Filters permissions by assigned users.
+    /// </summary>
     [Parameter(ParameterSetName = "Filter")]
     public string[]? GrantedToUser { get; set; }
 
@@ -55,6 +61,9 @@ public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
     [ValidateNotNull]
     public GraphConnectionInfo? Connection { get; set; }
 
+    /// <summary>
+    /// Switch to use <c>Invoke-MgGraphRequest</c> instead of built-in logic.
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     public SwitchParameter MgGraphRequest { get; set; }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveIMAPFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveIMAPFolder.cs
@@ -24,6 +24,9 @@ public sealed class CmdletRemoveIMAPFolder : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Recursive { get; set; }
 
+    /// <summary>
+    /// Removes the specified folder from the connected IMAP server.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         var conn = Client ?? DefaultSessions.ImapSession;
         if (conn != null && conn.Data != null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletRenameGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRenameGraphFolder.cs
@@ -39,6 +39,9 @@ public class CmdletRenameGraphFolder : AsyncPSCmdlet {
     [Parameter]
     public int TimeoutSeconds { get; set; } = 100;
 
+    /// <summary>
+    /// Maximum number of concurrent requests during rename.
+    /// </summary>
     [Parameter]
     public int MaxConcurrentRequests { get; set; } = 5;
 

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -297,6 +297,9 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     [Alias("InlineAttachments")]
     public object[]? InlineAttachment { get; set; }
 
+    /// <summary>
+    /// Custom message headers to include with the email.
+    /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
     [Parameter(Mandatory = false, ParameterSetName = "SecureString")]
     [Parameter(Mandatory = false, ParameterSetName = "oAuth")]
@@ -304,9 +307,6 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "MgGraphRequest")]
     [Parameter(Mandatory = false, ParameterSetName = "Compatibility")]
     [Parameter(Mandatory = false, ParameterSetName = "SendGrid")]
-    /// <summary>
-    /// Custom message headers to include with the email.
-    /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "EmailProviders")]
     public Hashtable? Headers { get; set; }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletSendGmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendGmailMessage.cs
@@ -36,15 +36,27 @@ public sealed class CmdletSendGmailMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true)]
     public object[]? To { get; set; }
 
+    /// <summary>
+    /// Subject line for the email message.
+    /// </summary>
     [Parameter]
     public string? Subject { get; set; }
 
+    /// <summary>
+    /// HTML body content of the message.
+    /// </summary>
     [Parameter]
     public string[]? HtmlBody { get; set; }
 
+    /// <summary>
+    /// Plain text body content of the message.
+    /// </summary>
     [Parameter]
     public string[]? TextBody { get; set; }
 
+    /// <summary>
+    /// Attachments to include with the message.
+    /// </summary>
     [Parameter]
     public object[]? Attachment { get; set; }
 


### PR DESCRIPTION
## Summary
- add XML comments for several PowerShell cmdlets
- move misplaced comments above their attributes

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -v:n`

------
https://chatgpt.com/codex/tasks/task_e_6878d38d6f44832eac98e4b0371c51e6