### PR TITLE
Add 10 minute timeout to CI test jobs

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -22,6 +22,7 @@ jobs:
   test-windows:
     name: 'Windows'
     runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -62,6 +63,7 @@ jobs:
   test-ubuntu:
     name: 'Ubuntu'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -106,6 +108,7 @@ jobs:
   test-macos:
     name: 'macOS'
     runs-on: macos-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/powershell-tests-all.yml
+++ b/.github/workflows/powershell-tests-all.yml
@@ -13,6 +13,7 @@ jobs:
   refresh-psd1:
     name: 'Refresh PSD1'
     runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -50,6 +51,7 @@ jobs:
     needs: refresh-psd1
     name: 'Windows PowerShell 5.1'
     runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -85,6 +87,7 @@ jobs:
     needs: refresh-psd1
     name: 'Windows PowerShell 7'
     runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -120,6 +123,7 @@ jobs:
     needs: refresh-psd1
     name: 'Ubuntu PowerShell 7'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -162,6 +166,7 @@ jobs:
     needs: refresh-psd1
     name: 'macOS PowerShell 7'
     runs-on: macos-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- cancel GitHub Actions test jobs if they run longer than 10 minutes
- confirmed the project builds on `net8.0`

## Testing
- `dotnet restore Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln --configuration Debug --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_687931369f84832e85cfa4253ed2d8f5