### PR TITLE
Parse GraphMessageInfo importance as enum

### DIFF
--- a/Sources/Mailozaurr.Tests/MessageInfoTests.cs
+++ b/Sources/Mailozaurr.Tests/MessageInfoTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using MimeKit;
 using MailKit;
+using Mailozaurr;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -75,6 +76,6 @@ public class MessageInfoTests {
         Assert.Equal("preview", info.BodyPreview);
         Assert.Equal("gcontent", info.Content);
         Assert.True(info.IsRead);
-        Assert.Equal("high", info.Importance);
+        Assert.Equal(GraphImportance.High, info.Importance);
     }
 }

--- a/Sources/Mailozaurr/Enums/GraphImportance.cs
+++ b/Sources/Mailozaurr/Enums/GraphImportance.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Specifies the importance level of a Microsoft Graph message.
+/// </summary>
+public enum GraphImportance {
+    /// <summary>Low importance.</summary>
+    Low,
+
+    /// <summary>Normal importance.</summary>
+    Normal,
+
+    /// <summary>High importance.</summary>
+    High
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMessageInfo.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMessageInfo.cs
@@ -45,7 +45,10 @@ public class GraphMessageInfo {
         if (raw.TryGetValue("isRead", out var readObj) && bool.TryParse(readObj?.ToString(), out var read)) {
             IsRead = read;
         }
-        if (raw.TryGetValue("importance", out var importanceObj)) Importance = importanceObj as string;
+        if (raw.TryGetValue("importance", out var importanceObj) &&
+            Enum.TryParse<GraphImportance>(importanceObj?.ToString(), true, out var importance)) {
+            Importance = importance;
+        }
     }
 
     /// <summary>The dictionary returned from Microsoft Graph.</summary>
@@ -82,7 +85,7 @@ public class GraphMessageInfo {
     public bool? IsRead { get; set; }
 
     /// <summary>Message importance.</summary>
-    public string? Importance { get; set; }
+    public GraphImportance? Importance { get; set; }
 
     /// <summary>Snippet extracted by the search service highlighting the match.</summary>
     public string? Summary { get; set; }


### PR DESCRIPTION
## Summary
- add `GraphImportance` enum
- parse importance from raw dictionary via `Enum.TryParse`
- update message info tests for enum type

## Testing
- `dotnet test Sources/Mailozaurr.sln --verbosity minimal`
- `dotnet build Sources/Mailozaurr.sln --no-restore --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_687cac44cb78832eb4b6b95672cbba7b