### PR TITLE
Add GraphHttpMethod enum and update batch request handling

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -594,7 +594,7 @@ public class Graph : IDisposable {
         var bodyObj = JsonSerializer.Deserialize<object>(MessageJson);
         var request = new GraphBatchRequest {
             Id = "1",
-            Method = "POST",
+            Method = GraphHttpMethod.POST,
             Url = $"/users/{MessageContainer.Message.From.Email.Address}/sendMail",
             Headers = new Dictionary<string, string> { ["Content-Type"] = "application/json" },
             Body = bodyObj

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphBatchRequest.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphBatchRequest.cs
@@ -8,7 +8,7 @@ public class GraphBatchRequest {
     /// <summary>Unique request identifier.</summary>
     public string Id { get; set; } = string.Empty;
     /// <summary>HTTP method to execute.</summary>
-    public string Method { get; set; } = string.Empty;
+    public GraphHttpMethod Method { get; set; }
     /// <summary>Relative request URL (e.g. <c>/me/messages</c>).</summary>
     public string Url { get; set; } = string.Empty;
     /// <summary>Optional headers to include with the request.</summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphHttpMethod.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphHttpMethod.cs
@@ -1,0 +1,17 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// HTTP methods supported by Microsoft Graph batch requests.
+/// </summary>
+public enum GraphHttpMethod {
+    /// <summary>HTTP GET method.</summary>
+    GET,
+    /// <summary>HTTP POST method.</summary>
+    POST,
+    /// <summary>HTTP PATCH method.</summary>
+    PATCH,
+    /// <summary>HTTP PUT method.</summary>
+    PUT,
+    /// <summary>HTTP DELETE method.</summary>
+    DELETE
+}

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -314,7 +314,7 @@ namespace Mailozaurr {
         public static async Task<IReadOnlyList<GraphBatchResult>> SendBatchAsync(GraphCredential credential, IEnumerable<GraphBatchRequest> requests) {
             var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
             var headers = new Dictionary<string, string> { { "Authorization", token } };
-            var batchPayload = new { requests = requests.Select(r => new { id = r.Id, method = r.Method, url = r.Url.TrimStart('/') , headers = r.Headers, body = r.Body }) };
+            var batchPayload = new { requests = requests.Select(r => new { id = r.Id, method = r.Method.ToString(), url = r.Url.TrimStart('/') , headers = r.Headers, body = r.Body }) };
             var jsonBody = JsonSerializer.Serialize(batchPayload);
             var batchUri = BuildGraphUri(GraphEndpoint.V1, "/$batch");
             var doc = await InvokeGraphApiAsync("POST", batchUri, headers, jsonBody);


### PR DESCRIPTION
## Summary
- add `GraphHttpMethod` enum for batch requests
- switch `GraphBatchRequest.Method` to new enum
- adjust `MicrosoftGraphUtils` to serialize enum names
- update batch request creation in `Graph`

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: 88 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687cac2fadb0832ea8d0f92468d59992