### PR TITLE
Introduce SmtpConnectionPool

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletClearSmtpConnectionPool.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletClearSmtpConnectionPool.cs
@@ -18,7 +18,7 @@ namespace Mailozaurr.PowerShell;
 public sealed class CmdletClearSmtpConnectionPool : AsyncPSCmdlet {
     /// <summary>Clears all connections from the pool.</summary>
     protected override Task ProcessRecordAsync() {
-        Smtp.ClearConnectionPool();
+        SmtpConnectionPool.ClearConnectionPool();
         return Task.CompletedTask;
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -644,8 +644,8 @@ public sealed class CmdletSendEmailMessage : PSCmdlet {
             }
         }
 
-        Smtp.MaxPoolSize = ConnectionPoolSize;
-        Smtp.PoolingEnabled = UseConnectionPool.IsPresent;
+        SmtpConnectionPool.MaxPoolSize = ConnectionPoolSize;
+        SmtpConnectionPool.PoolingEnabled = UseConnectionPool.IsPresent;
     }
     /// <summary>
     /// Process the record.

--- a/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
@@ -21,8 +21,8 @@ public class SmtpConnectionPoolTests
     [Fact]
     public void Disconnect_ReturnsClientToPool()
     {
-        Smtp.PoolingEnabled = true;
-        Smtp.ClearConnectionPool();
+        SmtpConnectionPool.PoolingEnabled = true;
+        SmtpConnectionPool.ClearConnectionPool();
         var fake = new FakeClient();
         Smtp.ClientFactory = _ => fake;
 
@@ -38,7 +38,7 @@ public class SmtpConnectionPoolTests
         Assert.Equal(1, fake.ConnectCalls);
 
         Smtp.ClientFactory = logger => new ClientSmtp();
-        Smtp.ClearConnectionPool();
-        Smtp.PoolingEnabled = false;
+        SmtpConnectionPool.ClearConnectionPool();
+        SmtpConnectionPool.PoolingEnabled = false;
     }
 }

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using Org.BouncyCastle.Bcpg.OpenPgp;
-using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using System.Threading;
 
@@ -19,11 +18,6 @@ namespace Mailozaurr;
 /// multiple mechanisms depending on server capabilities.
 /// </remarks>
 public class Smtp {
-    private static readonly ConcurrentDictionary<string, ConcurrentBag<ClientSmtp>> _connectionPool = new();
-    /// <summary>Maximum number of pooled connections per server/port.</summary>
-    public static int MaxPoolSize { get; set; } = 2;
-    /// <summary>Enables or disables connection pooling.</summary>
-    public static bool PoolingEnabled { get; set; } = false;
 
     /// <summary>Factory used to create <see cref="ClientSmtp"/> instances.</summary>
     internal static Func<ProtocolLogger?, ClientSmtp> ClientFactory { get; set; } = logger => logger == null ? new ClientSmtp() : new ClientSmtp(logger);
@@ -254,62 +248,6 @@ public class Smtp {
         Stopwatch = Stopwatch.StartNew();
     }
 
-    private ClientSmtp? TryRentClient(string server, int port)
-    {
-        if (!PoolingEnabled)
-        {
-            return null;
-        }
-
-        var key = $"{server}:{port}";
-        if (_connectionPool.TryGetValue(key, out var bag))
-        {
-            while (bag.TryTake(out var pooled))
-            {
-                if (pooled.IsConnected)
-                {
-                    return pooled;
-                }
-                pooled.Dispose();
-            }
-        }
-        return null;
-    }
-
-    private static void ReturnClient(string server, int port, ClientSmtp client)
-    {
-        if (!PoolingEnabled)
-        {
-            client.Dispose();
-            return;
-        }
-
-        var key = $"{server}:{port}";
-        var bag = _connectionPool.GetOrAdd(key, _ => new ConcurrentBag<ClientSmtp>());
-        if (bag.Count >= MaxPoolSize)
-        {
-            client.Dispose();
-        }
-        else
-        {
-            bag.Add(client);
-        }
-    }
-
-    /// <summary>
-    /// Disposes all SMTP clients stored in the connection pool.
-    /// </summary>
-    public static void ClearConnectionPool()
-    {
-        foreach (var bag in _connectionPool.Values)
-        {
-            while (bag.TryTake(out var client))
-            {
-                client.Dispose();
-            }
-        }
-        _connectionPool.Clear();
-    }
 
     /// <summary>
     /// Connects to the specified SMTP server and returns detailed information about the connection.
@@ -415,9 +353,9 @@ public class Smtp {
         Port = port;
         if (Client.IsConnected)
         {
-            if (PoolingEnabled)
+            if (SmtpConnectionPool.PoolingEnabled)
             {
-                ReturnClient(oldServer, oldPort, Client);
+                SmtpConnectionPool.ReturnClient(oldServer, oldPort, Client);
             }
             else
             {
@@ -426,7 +364,7 @@ public class Smtp {
             Client = ClientFactory(Logging?.ProtocolLogger);
         }
 
-        var pooled = PoolingEnabled ? TryRentClient(server, port) : null;
+        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port) : null;
         if (pooled != null)
         {
             Client = pooled;
@@ -473,9 +411,9 @@ public class Smtp {
         Port = port;
         if (Client.IsConnected)
         {
-            if (PoolingEnabled)
+            if (SmtpConnectionPool.PoolingEnabled)
             {
-                ReturnClient(oldServer, oldPort, Client);
+                SmtpConnectionPool.ReturnClient(oldServer, oldPort, Client);
             }
             else
             {
@@ -484,7 +422,7 @@ public class Smtp {
             Client = ClientFactory(Logging?.ProtocolLogger);
         }
 
-        var pooled = PoolingEnabled ? TryRentClient(server, port) : null;
+        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port) : null;
         if (pooled != null)
         {
             Client = pooled;
@@ -720,8 +658,8 @@ public class Smtp {
     /// </summary>
     public void Disconnect() {
         if (Client.IsConnected) {
-            if (PoolingEnabled) {
-                ReturnClient(Server, Port, Client);
+            if (SmtpConnectionPool.PoolingEnabled) {
+                SmtpConnectionPool.ReturnClient(Server, Port, Client);
                 Client = ClientFactory(Logging?.ProtocolLogger);
             } else {
                 Client.Disconnect(true);
@@ -735,8 +673,8 @@ public class Smtp {
     /// </summary>
     public void Dispose() {
         if (Client.IsConnected) {
-            if (PoolingEnabled) {
-                ReturnClient(Server, Port, Client);
+            if (SmtpConnectionPool.PoolingEnabled) {
+                SmtpConnectionPool.ReturnClient(Server, Port, Client);
             } else {
                 Client.Disconnect(true);
             }

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
@@ -1,0 +1,75 @@
+namespace Mailozaurr;
+
+using System.Collections.Concurrent;
+
+/// <summary>
+/// Manages SMTP connection pooling.
+/// </summary>
+public static class SmtpConnectionPool
+{
+    private static readonly ConcurrentDictionary<string, ConcurrentBag<ClientSmtp>> _connectionPool = new();
+
+    /// <summary>Maximum number of pooled connections per server/port.</summary>
+    public static int MaxPoolSize { get; set; } = 2;
+
+    /// <summary>Enables or disables connection pooling.</summary>
+    public static bool PoolingEnabled { get; set; } = false;
+
+    internal static ClientSmtp? TryRentClient(string server, int port)
+    {
+        if (!PoolingEnabled)
+        {
+            return null;
+        }
+
+        var key = $"{server}:{port}";
+        if (_connectionPool.TryGetValue(key, out var bag))
+        {
+            while (bag.TryTake(out var pooled))
+            {
+                if (pooled.IsConnected)
+                {
+                    return pooled;
+                }
+
+                pooled.Dispose();
+            }
+        }
+
+        return null;
+    }
+
+    internal static void ReturnClient(string server, int port, ClientSmtp client)
+    {
+        if (!PoolingEnabled)
+        {
+            client.Dispose();
+            return;
+        }
+
+        var key = $"{server}:{port}";
+        var bag = _connectionPool.GetOrAdd(key, _ => new ConcurrentBag<ClientSmtp>());
+        if (bag.Count >= MaxPoolSize)
+        {
+            client.Dispose();
+        }
+        else
+        {
+            bag.Add(client);
+        }
+    }
+
+    /// <summary>Disposes all SMTP clients stored in the connection pool.</summary>
+    public static void ClearConnectionPool()
+    {
+        foreach (var bag in _connectionPool.Values)
+        {
+            while (bag.TryTake(out var client))
+            {
+                client.Dispose();
+            }
+        }
+
+        _connectionPool.Clear();
+    }
+}

--- a/Tests/Clear-SmtpConnectionPool.Tests.ps1
+++ b/Tests/Clear-SmtpConnectionPool.Tests.ps1
@@ -18,8 +18,8 @@ public class FakeClientPs2 : ClientSmtp {
 }
 "@
 
-        [Mailozaurr.Smtp]::PoolingEnabled = $true
-        [Mailozaurr.Smtp]::ClearConnectionPool()
+        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $true
+        [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
         $fake = [FakeClientPs2]::new()
         [Mailozaurr.Smtp]::ClientFactory = { $fake }
 
@@ -34,7 +34,7 @@ public class FakeClientPs2 : ClientSmtp {
         $fake.ConnectCalls | Should -Be 2
 
         [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
-        [Mailozaurr.Smtp]::ClearConnectionPool()
-        [Mailozaurr.Smtp]::PoolingEnabled = $false
+        [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
+        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $false
     }
 }

--- a/Tests/Send-EmailMessageConnectionPool.Tests.ps1
+++ b/Tests/Send-EmailMessageConnectionPool.Tests.ps1
@@ -18,8 +18,8 @@ public class FakeClientPs : ClientSmtp {
 }
 "@
 
-        [Mailozaurr.Smtp]::PoolingEnabled = $true
-        [Mailozaurr.Smtp]::ClearConnectionPool()
+        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $true
+        [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
         $fake = [FakeClientPs]::new()
         [Mailozaurr.Smtp]::ClientFactory = { $fake }
 
@@ -30,7 +30,7 @@ public class FakeClientPs : ClientSmtp {
         $fake.ConnectCalls | Should -Be 1
 
         [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
-        [Mailozaurr.Smtp]::ClearConnectionPool()
-        [Mailozaurr.Smtp]::PoolingEnabled = $false
+        [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
+        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $false
     }
 }


### PR DESCRIPTION
## Summary
- move connection pool logic from `Smtp` into new `SmtpConnectionPool`
- update cmdlets and tests to reference `SmtpConnectionPool`
- wire up pooling in `Smtp` via the new class

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.sln -c Release`
- `pwsh -NoProfile -Command "& './Mailozaurr.Tests.ps1'"` *(fails: Unable to find type [Mailozaurr.PowerShell.ImapConnectionInfo])*

------
https://chatgpt.com/codex/tasks/task_e_687dff9dca3c832eb0465aa7cf29aafd