### PR TITLE
Handle Gmail API auth errors

### DIFF
--- a/Sources/Mailozaurr.Examples/SendEmailGmailApi.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailGmailApi.cs
@@ -29,6 +29,8 @@ public static class SendEmailGmailApi {
             message.Body = new TextPart("plain") { Text = "Hello from Mailozaurr via Gmail API!" };
             var sent = await client.SendAsync("me", message);
             Console.WriteLine($"Gmail API: sent id {sent.Id}");
+        } catch (GmailAuthenticationException ex) {
+            Console.WriteLine($"Gmail API Authentication Error: {ex.Message}");
         } catch (Exception ex) {
             Console.WriteLine($"Gmail API Example Error: {ex.Message}");
         }

--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -39,4 +39,17 @@ public class GmailApiClientTests {
         Assert.Single(handler.Requests);
         Assert.Equal("https://gmail.googleapis.com/gmail/v1/users/me/messages/123/attachments/att", handler.Requests[0].RequestUri!.ToString());
     }
+
+    [Theory]
+    [InlineData(System.Net.HttpStatusCode.Unauthorized)]
+    [InlineData(System.Net.HttpStatusCode.Forbidden)]
+    public async System.Threading.Tasks.Task SendAsync_AuthError_ThrowsGmailAuthenticationException(System.Net.HttpStatusCode status) {
+        var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(status) { Content = new System.Net.Http.StringContent("error") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        var message = new MimeKit.MimeMessage();
+        await Assert.ThrowsAsync<GmailAuthenticationException>(() => client.SendAsync("me", message));
+        Assert.Single(handler.Requests);
+    }
 }

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -32,6 +33,14 @@ public sealed class GmailApiClient {
         _client = client;
     }
 
+    private static async Task ThrowIfAuthErrorAsync(HttpResponseMessage response) {
+        if (response.StatusCode == HttpStatusCode.Unauthorized ||
+            response.StatusCode == HttpStatusCode.Forbidden) {
+            string content = await response.Content.ReadAsStringAsync();
+            throw new GmailAuthenticationException(response.StatusCode, content);
+        }
+    }
+
     /// <summary>
     /// Sends the specified MIME message via Gmail API.
     /// </summary>
@@ -45,6 +54,7 @@ public sealed class GmailApiClient {
         var json = JsonSerializer.Serialize(new { raw }, s_jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _client.PostAsync($"users/{userId}/messages/send", content, cancellationToken);
+        await ThrowIfAuthErrorAsync(response);
         response.EnsureSuccessStatusCode();
         var resultJson = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<GmailMessage>(resultJson, s_jsonOptions)!;
@@ -62,6 +72,7 @@ public sealed class GmailApiClient {
             url.Append('?').Append(string.Join("&", qs));
         }
         using var response = await _client.GetAsync(url.ToString(), cancellationToken);
+        await ThrowIfAuthErrorAsync(response);
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync();
         var list = JsonSerializer.Deserialize<GmailListResponse>(json, s_jsonOptions);
@@ -73,6 +84,7 @@ public sealed class GmailApiClient {
     /// </summary>
     public async Task<GmailMessage> GetAsync(string userId, string id, CancellationToken cancellationToken = default) {
         using var response = await _client.GetAsync($"users/{userId}/messages/{id}", cancellationToken);
+        await ThrowIfAuthErrorAsync(response);
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<GmailMessage>(json, s_jsonOptions)!;
@@ -83,6 +95,7 @@ public sealed class GmailApiClient {
     /// </summary>
     public async Task DeleteAsync(string userId, string id, CancellationToken cancellationToken = default) {
         using var response = await _client.DeleteAsync($"users/{userId}/messages/{id}", cancellationToken);
+        await ThrowIfAuthErrorAsync(response);
         response.EnsureSuccessStatusCode();
     }
 
@@ -91,6 +104,7 @@ public sealed class GmailApiClient {
     /// </summary>
     public async Task<IList<GmailAttachmentInfo>> ListAttachmentsAsync(string userId, string id, CancellationToken cancellationToken = default) {
         using var response = await _client.GetAsync($"users/{userId}/messages/{id}?format=full", cancellationToken);
+        await ThrowIfAuthErrorAsync(response);
         response.EnsureSuccessStatusCode();
         using var stream = await response.Content.ReadAsStreamAsync();
         using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
@@ -106,6 +120,7 @@ public sealed class GmailApiClient {
     /// </summary>
     public async Task<byte[]> DownloadAttachmentAsync(string userId, string messageId, string attachmentId, CancellationToken cancellationToken = default) {
         using var response = await _client.GetAsync($"users/{userId}/messages/{messageId}/attachments/{attachmentId}", cancellationToken);
+        await ThrowIfAuthErrorAsync(response);
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<AttachmentResponse>(json, s_jsonOptions)!;

--- a/Sources/Mailozaurr/Gmail/GmailAuthenticationException.cs
+++ b/Sources/Mailozaurr/Gmail/GmailAuthenticationException.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Net;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Exception thrown when Gmail API authentication fails.
+/// </summary>
+public class GmailAuthenticationException : Exception
+{
+    /// <summary>
+    /// HTTP status code returned by the Gmail API.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// Raw response content returned by the Gmail API.
+    /// </summary>
+    public string ResponseContent { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GmailAuthenticationException"/> class.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <param name="responseContent">Raw response content from the server.</param>
+    public GmailAuthenticationException(HttpStatusCode statusCode, string responseContent)
+        : base($"Gmail API authentication failed with status {(int)statusCode} ({statusCode}).")
+    {
+        StatusCode = statusCode;
+        ResponseContent = responseContent;
+    }
+}


### PR DESCRIPTION
## Summary
- detect Gmail API auth failure
- throw `GmailAuthenticationException`
- test auth error handling
- mention the exception in Gmail API example

## Testing
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_687e6aadc7d8832ebfba2769619e1b19