### PR TITLE
Fix stream usage in ConvertFromMsgToEml

### DIFF
--- a/Examples/Example-ConvertFromMsgToEml.ps1
+++ b/Examples/Example-ConvertFromMsgToEml.ps1
@@ -1,0 +1,9 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$Conversion = ConvertFrom-MsgToEml -InputPath "$PSScriptRoot\Input\Sample.msg" -OutputFolder "$PSScriptRoot\Output" -Verbose -Force
+$Conversion | Format-Table
+if ($Conversion.Status) {
+    $Eml = Import-MailFile -FilePath $Conversion.EmlFile
+    $Eml | Format-Table
+    $Eml.Dispose()
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertFromMsgToEml.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertFromMsgToEml.cs
@@ -1,3 +1,7 @@
+using System.IO;
+using MsgReader.Outlook.Storage;
+using MimeKit;
+
 namespace Mailozaurr.PowerShell;
 
 /// <summary>
@@ -49,10 +53,49 @@ public sealed class CmdletConvertFromMsgToEml : AsyncPSCmdlet {
     /// Converts the specified MSG files to EML format.
     /// </summary>
     protected override Task ProcessRecordAsync() {
-        var outputMessage = EmailMessage.ConvertMsgToEml(InputPath, OutputFolder, Force);
-        foreach (var obj in outputMessage) {
-            WriteObject(obj);
+        if (InputPath == null || string.IsNullOrEmpty(OutputFolder)) {
+            return Task.CompletedTask;
         }
+
+        foreach (var msgPath in InputPath) {
+            var fileName = Path.GetFileNameWithoutExtension(msgPath);
+            var targetFile = Path.Combine(OutputFolder, $"{fileName}.eml");
+
+            try {
+                if (File.Exists(targetFile)) {
+                    if (!Force) {
+                        WriteObject(new MsgConversionResult {
+                            MsgFile = msgPath,
+                            EmlFile = targetFile,
+                            Status = false,
+                            Error = "EML file already exists"
+                        });
+                        continue;
+                    }
+                    File.Delete(targetFile);
+                }
+
+                using (var message = new Message(msgPath)) {
+                    using var stream = File.Create(targetFile);
+                    var mime = message.ToMimeMessage();
+                    mime.WriteTo(stream);
+                }
+
+                WriteObject(new MsgConversionResult {
+                    MsgFile = msgPath,
+                    EmlFile = targetFile,
+                    Status = true
+                });
+            } catch (IOException ex) {
+                WriteObject(new MsgConversionResult {
+                    MsgFile = msgPath,
+                    EmlFile = targetFile,
+                    Status = false,
+                    Error = ex.Message
+                });
+            }
+        }
+
         return Task.CompletedTask;
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertFromMsgToEml.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertFromMsgToEml.cs
@@ -1,7 +1,3 @@
-using System.IO;
-using MsgReader.Outlook.Storage;
-using MimeKit;
-
 namespace Mailozaurr.PowerShell;
 
 /// <summary>
@@ -53,49 +49,10 @@ public sealed class CmdletConvertFromMsgToEml : AsyncPSCmdlet {
     /// Converts the specified MSG files to EML format.
     /// </summary>
     protected override Task ProcessRecordAsync() {
-        if (InputPath == null || string.IsNullOrEmpty(OutputFolder)) {
-            return Task.CompletedTask;
+        using var enumerator = EmailMessage.ConvertMsgToEml(InputPath, OutputFolder, Force).GetEnumerator();
+        while (enumerator.MoveNext()) {
+            WriteObject(enumerator.Current);
         }
-
-        foreach (var msgPath in InputPath) {
-            var fileName = Path.GetFileNameWithoutExtension(msgPath);
-            var targetFile = Path.Combine(OutputFolder, $"{fileName}.eml");
-
-            try {
-                if (File.Exists(targetFile)) {
-                    if (!Force) {
-                        WriteObject(new MsgConversionResult {
-                            MsgFile = msgPath,
-                            EmlFile = targetFile,
-                            Status = false,
-                            Error = "EML file already exists"
-                        });
-                        continue;
-                    }
-                    File.Delete(targetFile);
-                }
-
-                using (var message = new Message(msgPath)) {
-                    using var stream = File.Create(targetFile);
-                    var mime = message.ToMimeMessage();
-                    mime.WriteTo(stream);
-                }
-
-                WriteObject(new MsgConversionResult {
-                    MsgFile = msgPath,
-                    EmlFile = targetFile,
-                    Status = true
-                });
-            } catch (IOException ex) {
-                WriteObject(new MsgConversionResult {
-                    MsgFile = msgPath,
-                    EmlFile = targetFile,
-                    Status = false,
-                    Error = ex.Message
-                });
-            }
-        }
-
         return Task.CompletedTask;
     }
 }

--- a/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
+++ b/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
@@ -9,11 +9,12 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="xunit" Version="2.5.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/Mailozaurr.Tests/MsgToEmlHandleTests.cs
+++ b/Sources/Mailozaurr.Tests/MsgToEmlHandleTests.cs
@@ -1,0 +1,41 @@
+using System.IO;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class MsgToEmlHandleTests
+{
+    [Fact]
+    public void ConvertFromMsgToEml_ReleasesFileHandle()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        var emlFile = Path.Combine(tempDir, "mail.eml");
+        var msgFile = Path.Combine(tempDir, "mail.msg");
+        var outputDir = Path.Combine(tempDir, "out");
+        Directory.CreateDirectory(outputDir);
+
+        var message = new MimeKit.MimeMessage();
+        message.Subject = "test";
+        message.Body = new MimeKit.TextPart("plain") { Text = "body" };
+        message.WriteTo(emlFile);
+
+        Mailozaurr.EmailMessage.ConvertEmlToMsg(new FileInfo(emlFile), new FileInfo(msgFile), true);
+
+        var cmd = new Mailozaurr.PowerShell.CmdletConvertFromMsgToEml
+        {
+            InputPath = new[] { msgFile },
+            OutputFolder = outputDir,
+            Force = true
+        };
+
+        cmd.BeginProcessing();
+        cmd.ProcessRecord();
+        cmd.EndProcessing();
+
+        File.Delete(msgFile);
+        Assert.False(File.Exists(msgFile));
+
+        Directory.Delete(tempDir, true);
+    }
+}

--- a/Sources/Mailozaurr.Tests/MsgToEmlHandleTests.cs
+++ b/Sources/Mailozaurr.Tests/MsgToEmlHandleTests.cs
@@ -29,9 +29,13 @@ public class MsgToEmlHandleTests
             Force = true
         };
 
-        cmd.BeginProcessing();
-        cmd.ProcessRecord();
-        cmd.EndProcessing();
+        var type = typeof(Mailozaurr.PowerShell.CmdletConvertFromMsgToEml);
+        type.GetMethod("BeginProcessing", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .Invoke(cmd, null);
+        type.GetMethod("ProcessRecord", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .Invoke(cmd, null);
+        type.GetMethod("EndProcessing", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .Invoke(cmd, null);
 
         File.Delete(msgFile);
         Assert.False(File.Exists(msgFile));

--- a/Tests/ConvertFrom-MsgToEml.Handle.Tests.ps1
+++ b/Tests/ConvertFrom-MsgToEml.Handle.Tests.ps1
@@ -1,0 +1,24 @@
+Describe 'ConvertFrom-MsgToEml handle management' {
+    It 'Releases file handle after conversion' {
+        $temp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+        New-Item -ItemType Directory -Path $temp | Out-Null
+        $eml = Join-Path $temp 'mail.eml'
+        $msg = Join-Path $temp 'mail.msg'
+        $out = Join-Path $temp 'out'
+        New-Item -ItemType Directory -Path $out | Out-Null
+
+        $message = [MimeKit.MimeMessage]::new()
+        $message.Subject = 'test'
+        $message.Body = [MimeKit.TextPart]::new('plain', 'body')
+        $message.WriteTo($eml)
+
+        [Mailozaurr.EmailMessage]::ConvertEmlToMsg([System.IO.FileInfo]$eml, [System.IO.FileInfo]$msg, $true) | Out-Null
+
+        ConvertFrom-MsgToEml -InputPath $msg -OutputFolder $out -Force
+
+        Remove-Item $msg
+        Test-Path $msg | Should -BeFalse
+
+        Remove-Item -Recurse -Force $temp
+    }
+}


### PR DESCRIPTION
## Summary
- ensure streams are disposed in `ConvertFrom-MsgToEml`
- add test to verify handles are released

## Testing
- `dotnet test Sources/Mailozaurr.sln` *(fails: Restore canceled)*

------
https://chatgpt.com/codex/tasks/task_e_687e6abb8fc4832eadf4ae64fd1e9496