### PR TITLE
Handle Gmail API pagination

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -52,4 +52,23 @@ public class GmailApiClientTests {
         await Assert.ThrowsAsync<GmailAuthenticationException>(() => client.SendAsync("me", message));
         Assert.Single(handler.Requests);
     }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ListAsync_PaginatesUntilTokenNull() {
+        var page1 = "{\"messages\":[{\"id\":\"1\"}],\"nextPageToken\":\"tok\"}";
+        var page2 = "{\"messages\":[{\"id\":\"2\"}]}";
+        var handler = new RecordingHandler(
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(page1) },
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(page2) });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        var list = await client.ListAsync("me");
+        Assert.Equal(2, list.Count);
+        Assert.Equal("1", list[0].Id);
+        Assert.Equal("2", list[1].Id);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?pageToken=tok", handler.Requests[1].RequestUri!.Query);
+    }
 }

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -64,19 +64,29 @@ public sealed class GmailApiClient {
     /// Lists messages matching the supplied query.
     /// </summary>
     public async Task<IList<GmailMessage>> ListAsync(string userId, string? query = null, int? maxResults = null, CancellationToken cancellationToken = default) {
-        var url = new StringBuilder($"users/{userId}/messages");
-        var qs = new List<string>();
-        if (!string.IsNullOrWhiteSpace(query)) qs.Add($"q={Uri.EscapeDataString(query)}");
-        if (maxResults.HasValue) qs.Add($"maxResults={maxResults.Value}");
-        if (qs.Count > 0) {
-            url.Append('?').Append(string.Join("&", qs));
-        }
-        using var response = await _client.GetAsync(url.ToString(), cancellationToken);
-        await ThrowIfAuthErrorAsync(response);
-        response.EnsureSuccessStatusCode();
-        var json = await response.Content.ReadAsStringAsync();
-        var list = JsonSerializer.Deserialize<GmailListResponse>(json, s_jsonOptions);
-        return list?.Messages ?? new List<GmailMessage>();
+        var messages = new List<GmailMessage>();
+        string? pageToken = null;
+        do {
+            var url = new StringBuilder($"users/{userId}/messages");
+            var qs = new List<string>();
+            if (!string.IsNullOrWhiteSpace(query)) qs.Add($"q={Uri.EscapeDataString(query)}");
+            if (maxResults.HasValue) qs.Add($"maxResults={maxResults.Value}");
+            if (!string.IsNullOrEmpty(pageToken)) qs.Add($"pageToken={pageToken}");
+            if (qs.Count > 0) {
+                url.Append('?').Append(string.Join("&", qs));
+            }
+            using var response = await _client.GetAsync(url.ToString(), cancellationToken);
+            await ThrowIfAuthErrorAsync(response);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync();
+            var list = JsonSerializer.Deserialize<GmailListResponse>(json, s_jsonOptions);
+            if (list?.Messages != null) {
+                messages.AddRange(list.Messages);
+            }
+            pageToken = list?.NextPageToken;
+        } while (!string.IsNullOrEmpty(pageToken));
+
+        return messages;
     }
 
     /// <summary>
@@ -153,5 +163,7 @@ public sealed class GmailApiClient {
     private sealed class GmailListResponse {
         /// <summary>Messages returned by the API.</summary>
         public List<GmailMessage>? Messages { get; set; }
+        /// <summary>Token for the next page of results.</summary>
+        public string? NextPageToken { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- accumulate messages from all Gmail API pages
- expose NextPageToken in Gmail list response
- test pagination handling

## Testing
- `dotnet test Sources/Mailozaurr.sln --verbosity minimal` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_687f5f1e9f04832ea45aacce3c21b268