### PR TITLE
Ensure folders closed after moving

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMoveIMAPMessage.cs
@@ -62,6 +62,11 @@ public sealed class CmdletMoveIMAPMessage : AsyncPSCmdlet {
             conn.Folders[source.FullName] = (ImapFolder)source;
             conn.Folders[dest.FullName] = (ImapFolder)dest;
             source.MoveTo(uid, dest);
+            if (source.IsOpen)
+                source.Close(false);
+            if (dest.IsOpen)
+                dest.Close(false);
+            conn.Data.ClearFolderCache();
         } else {
             ThrowTerminatingError(new ErrorRecord(
                 new InvalidOperationException("Move-IMAPMessage - IMAP client not provided or not connected."),

--- a/Sources/Mailozaurr.Tests/FolderOperationsTests.cs
+++ b/Sources/Mailozaurr.Tests/FolderOperationsTests.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Net.Imap;
+using Moq;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class FolderOperationsTests {
+    [Fact]
+    public async Task MoveFolderAsync_ClosesFolders() {
+        var source = new Mock<IMailFolder>();
+        var dest = new Mock<IMailFolder>();
+
+        source.SetupGet(f => f.FullName).Returns("source");
+        source.SetupGet(f => f.Name).Returns("source");
+        source.SetupGet(f => f.IsOpen).Returns(true);
+        source.Setup(f => f.Open(It.IsAny<FolderAccess>(), It.IsAny<CancellationToken>()));
+        source.Setup(f => f.RenameAsync(dest.Object, "source", It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        source.Setup(f => f.CloseAsync(false, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask).Verifiable();
+
+        dest.SetupGet(f => f.FullName).Returns("dest");
+        dest.SetupGet(f => f.IsOpen).Returns(true);
+        dest.Setup(f => f.Open(It.IsAny<FolderAccess>(), It.IsAny<CancellationToken>()));
+        dest.Setup(f => f.CloseAsync(false, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask).Verifiable();
+
+        var client = new Mock<ImapClient> { CallBase = true };
+        client.Setup(c => c.Inbox).Returns(source.Object);
+        client.Setup(c => c.GetFolder(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(dest.Object);
+        client.Setup(c => c.PersonalNamespaces).Returns(new FolderNamespaceCollection());
+
+        await FolderOperations.MoveFolderAsync(client.Object, "source", "dest");
+
+        source.Verify(f => f.CloseAsync(false, It.IsAny<CancellationToken>()), Times.Once());
+        dest.Verify(f => f.CloseAsync(false, It.IsAny<CancellationToken>()), Times.Once());
+    }
+}

--- a/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
+++ b/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
@@ -12,6 +12,7 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="xunit" Version="2.5.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     </ItemGroup>

--- a/Sources/Mailozaurr/Receive/FolderOperations.cs
+++ b/Sources/Mailozaurr/Receive/FolderOperations.cs
@@ -34,6 +34,10 @@ public static class FolderOperations {
             destParent = client.GetCachedFolder(destinationFolder, FolderAccess.ReadWrite);
         }
         await source.RenameAsync(destParent, source.Name, cancellationToken).ConfigureAwait(false);
+        if (source.IsOpen)
+            await source.CloseAsync(false, cancellationToken).ConfigureAwait(false);
+        if (destParent.IsOpen)
+            await destParent.CloseAsync(false, cancellationToken).ConfigureAwait(false);
         client.ClearFolderCache();
     }
 


### PR DESCRIPTION
## Summary
- close IMAP folders after moving
- clear folder cache after moving messages
- verify closing logic with regression test
- add Moq dependency for tests

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --verbosity minimal`
- `pwsh -File Mailozaurr.Tests.ps1` *(fails: 17 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f5f0e2e50832e9eaeaa929bba98fb