### PR TITLE
Fix POP3 SSL forwarding

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -95,6 +95,14 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
     public SecureSocketOptions Options { get; set; } = SecureSocketOptions.Auto;
 
     /// <summary>
+    /// <para type="description">When <see cref="Options"/> remains <c>Auto</c>, this switch forces the use of <c>StartTls</c>.</para>
+    /// </summary>
+    [Parameter(ParameterSetName = "OAuth2")]
+    [Parameter(ParameterSetName = "Credential")]
+    [Parameter(ParameterSetName = "ClearText")]
+    public SwitchParameter EnableExplicit { get; set; }
+
+    /// <summary>
     /// <para type="description">Specifies the connection timeout in milliseconds. Default is 120000 (2 minutes).</para>
     /// </summary>
     [Parameter(ParameterSetName = "OAuth2")]
@@ -157,11 +165,15 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
         }
 
         Pop3Client client;
+        var opts = Options;
+        if (EnableExplicit.IsPresent && opts == SecureSocketOptions.Auto) {
+            opts = SecureSocketOptions.StartTls;
+        }
         try {
             client = await Pop3Connector.ConnectAsync(
                 Server,
                 Port,
-                Options,
+                opts,
                 TimeOut,
                 SkipCertificateRevocation.IsPresent,
                 SkipCertificateValidation.IsPresent,

--- a/Tests/Connect-POP3.Tests.ps1
+++ b/Tests/Connect-POP3.Tests.ps1
@@ -1,0 +1,79 @@
+Describe 'Connect-POP3 SSL Options' {
+    It 'Forwards provided enum to Pop3Connector' {
+        $csc = Get-ChildItem "$HOME/.dotnet/sdk/*/Roslyn/bincore/csc.dll" | Sort-Object FullName -Descending | Select-Object -First 1
+        $csPath = Join-Path $TestDrive 'FakePop3Client.cs'
+        @"
+using MailKit.Net.Pop3;
+using MailKit.Security;
+using System.Threading;
+using System.Threading.Tasks;
+public class FakePop3Client : Pop3Client {
+    public SecureSocketOptions Passed;
+    public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {
+        Passed = options;
+        return Task.CompletedTask;
+    }
+    public override Task AuthenticateAsync(string userName, string password, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public override bool IsConnected => true;
+    public override bool IsAuthenticated => true;
+}
+"@ | Set-Content $csPath
+        $dllPath = Join-Path $TestDrive 'FakePop3Client.dll'
+        $refs = @(
+            "$HOME/.nuget/packages/mailkit/4.12.1/lib/netstandard2.0/MailKit.dll",
+            "$HOME/.dotnet/packs/NETStandard.Library.Ref/2.1.0/ref/netstandard2.1/netstandard.dll"
+        )
+        $refArgs = $refs | ForEach-Object { "-r:" + $_ }
+        & dotnet $csc.FullName $csPath -target:library -out:$dllPath $refArgs | Out-Null
+        Add-Type -Path $dllPath
+
+        $fake = [FakePop3Client]::new()
+        [Mailozaurr.Pop3Connector]::ClientFactory = { $fake }
+
+        $cred = [System.Management.Automation.PSCredential]::new('u',(ConvertTo-SecureString 'p' -AsPlainText -Force))
+        Connect-POP3 -Server 'h' -Credential $cred -Port 995 -Options SslOnConnect | Out-Null
+
+        $fake.Passed | Should -Be ([MailKit.Security.SecureSocketOptions]::SslOnConnect)
+
+        [Mailozaurr.Pop3Connector]::ClientFactory = { [MailKit.Net.Pop3.Pop3Client]::new() }
+    }
+
+    It 'Uses StartTls when EnableExplicit set and Auto option' {
+        $csc = Get-ChildItem "$HOME/.dotnet/sdk/*/Roslyn/bincore/csc.dll" | Sort-Object FullName -Descending | Select-Object -First 1
+        $csPath = Join-Path $TestDrive 'FakePop3Client.cs'
+        @"
+using MailKit.Net.Pop3;
+using MailKit.Security;
+using System.Threading;
+using System.Threading.Tasks;
+public class FakePop3Client : Pop3Client {
+    public SecureSocketOptions Passed;
+    public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {
+        Passed = options;
+        return Task.CompletedTask;
+    }
+    public override Task AuthenticateAsync(string userName, string password, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public override bool IsConnected => true;
+    public override bool IsAuthenticated => true;
+}
+"@ | Set-Content $csPath
+        $dllPath = Join-Path $TestDrive 'FakePop3Client.dll'
+        $refs = @(
+            "$HOME/.nuget/packages/mailkit/4.12.1/lib/netstandard2.0/MailKit.dll",
+            "$HOME/.dotnet/packs/NETStandard.Library.Ref/2.1.0/ref/netstandard2.1/netstandard.dll"
+        )
+        $refArgs = $refs | ForEach-Object { "-r:" + $_ }
+        & dotnet $csc.FullName $csPath -target:library -out:$dllPath $refArgs | Out-Null
+        Add-Type -Path $dllPath
+
+        $fake = [FakePop3Client]::new()
+        [Mailozaurr.Pop3Connector]::ClientFactory = { $fake }
+
+        $cred = [System.Management.Automation.PSCredential]::new('u',(ConvertTo-SecureString 'p' -AsPlainText -Force))
+        Connect-POP3 -Server 'h' -Credential $cred -Port 995 -EnableExplicit | Out-Null
+
+        $fake.Passed | Should -Be ([MailKit.Security.SecureSocketOptions]::StartTls)
+
+        [Mailozaurr.Pop3Connector]::ClientFactory = { [MailKit.Net.Pop3.Pop3Client]::new() }
+    }
+}


### PR DESCRIPTION
## Summary
- allow Connect-POP3 to force StartTLS via `-EnableExplicit`
- honour chosen SecureSocketOptions when opening a POP3 connection
- test SSL handling for Connect-POP3

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File Mailozaurr.Tests.ps1` *(fails: Unprotect-MimeMessage not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_687f5f06e7d0832eb086f7a14d029211