### PR TITLE
Fix UseSsl override and add test

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -365,7 +365,8 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             return;
         }
 
-        var status = smtpClient.Connect(Server, Port, SecureSocketOptions, UseSsl);
+        var useSslFlag = UseSsl.IsPresent && !this.MyInvocation.BoundParameters.ContainsKey(nameof(SecureSocketOptions));
+        var status = smtpClient.Connect(Server, Port, SecureSocketOptions, useSslFlag);
         if (!status.Status) {
             if (!Suppress) {
                 WriteObject(status);

--- a/Sources/Mailozaurr.Tests/SmtpSslOptionTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSslOptionTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using System.Threading.Tasks;
+using MailKit.Security;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpSslOptionTests
+{
+    private class FakeClient : ClientSmtp
+    {
+        public SecureSocketOptions? Options;
+        public override void Connect(string host, int port, SecureSocketOptions options, System.Threading.CancellationToken cancellationToken = default)
+            => Options = options;
+        public override Task ConnectAsync(string host, int port, SecureSocketOptions options, System.Threading.CancellationToken cancellationToken = default)
+        {
+            Options = options;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public void Connect_WithUseSslAndExplicitOption_DoesNotOverride()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeClient();
+        typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(smtp, fake);
+
+        smtp.Connect("h", 25, SecureSocketOptions.SslOnConnect, true);
+
+        Assert.Equal(SecureSocketOptions.SslOnConnect, fake.Options);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_WithUseSslAndExplicitOption_DoesNotOverride()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeClient();
+        typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(smtp, fake);
+
+        _ = await smtp.ConnectAsync("h", 25, SecureSocketOptions.SslOnConnect, true);
+
+        Assert.Equal(SecureSocketOptions.SslOnConnect, fake.Options);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid overriding explicit secure socket options
- test `UseSsl` with explicit option

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release -v minimal`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1 -Quiet` *(fails: Unable to find type [Mailozaurr.PowerShell.ImapConnectionInfo])*

------
https://chatgpt.com/codex/tasks/task_e_687f5f299f10832eb01504d7fa4f4a6a