### PR TITLE
Fix disposal event handling

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletWaitGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWaitGraphMessage.cs
@@ -105,7 +105,10 @@ public sealed class CmdletWaitGraphMessage : AsyncPSCmdlet, IDisposable {
 
     /// <inheritdoc />
     protected override Task EndProcessingAsync() {
-        _listener?.Dispose();
+        if (_listener != null) {
+            _listener.MessageArrived -= OnMessageArrived;
+            _listener.Dispose();
+        }
         _timeoutSource?.Dispose();
         _linkedSource?.Dispose();
         return Task.CompletedTask;
@@ -113,7 +116,10 @@ public sealed class CmdletWaitGraphMessage : AsyncPSCmdlet, IDisposable {
 
     /// <inheritdoc />
     public void Dispose() {
-        _listener?.Dispose();
+        if (_listener != null) {
+            _listener.MessageArrived -= OnMessageArrived;
+            _listener.Dispose();
+        }
         _timeoutSource?.Dispose();
         _linkedSource?.Dispose();
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletWaitIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWaitIMAPMessage.cs
@@ -113,7 +113,10 @@ public sealed class CmdletWaitIMAPMessage : AsyncPSCmdlet, System.IDisposable {
 
     /// <inheritdoc />
     protected override Task EndProcessingAsync() {
-        _listener?.Dispose();
+        if (_listener != null) {
+            _listener.MessageArrived -= OnMessageArrived;
+            _listener.Dispose();
+        }
         _timeoutSource?.Dispose();
         _linkedSource?.Dispose();
         return Task.CompletedTask;
@@ -121,7 +124,10 @@ public sealed class CmdletWaitIMAPMessage : AsyncPSCmdlet, System.IDisposable {
 
     /// <inheritdoc />
     public void Dispose() {
-        _listener?.Dispose();
+        if (_listener != null) {
+            _listener.MessageArrived -= OnMessageArrived;
+            _listener.Dispose();
+        }
         _timeoutSource?.Dispose();
         _linkedSource?.Dispose();
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletWaitPOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWaitPOP3Message.cs
@@ -96,7 +96,10 @@ public sealed class CmdletWaitPOP3Message : AsyncPSCmdlet, IDisposable {
 
     /// <inheritdoc />
     protected override Task EndProcessingAsync() {
-        _listener?.Dispose();
+        if (_listener != null) {
+            _listener.MessageArrived -= OnMessageArrived;
+            _listener.Dispose();
+        }
         _timeoutSource?.Dispose();
         _linkedSource?.Dispose();
         return Task.CompletedTask;
@@ -104,7 +107,10 @@ public sealed class CmdletWaitPOP3Message : AsyncPSCmdlet, IDisposable {
 
     /// <inheritdoc />
     public void Dispose() {
-        _listener?.Dispose();
+        if (_listener != null) {
+            _listener.MessageArrived -= OnMessageArrived;
+            _listener.Dispose();
+        }
         _timeoutSource?.Dispose();
         _linkedSource?.Dispose();
     }

--- a/Sources/Mailozaurr.PowerShell/Communication/InternalLoggerPowerShell.cs
+++ b/Sources/Mailozaurr.PowerShell/Communication/InternalLoggerPowerShell.cs
@@ -2,7 +2,7 @@
 /// <summary>
 /// This class allow connecting to the InternalLogger class of ADPlayground and act on events from it in different streams
 /// </summary>
-public class InternalLoggerPowerShell {
+public class InternalLoggerPowerShell : IDisposable {
     private readonly InternalLogger _logger;
     private readonly Action<string> _writeVerboseAction;
     private readonly Action<string> _writeDebugAction;
@@ -154,5 +154,27 @@ public class InternalLoggerPowerShell {
     private void WriteProgress(ProgressRecord progressRecord) {
         // Write to PowerShell progress stream
         _writeProgressAction?.Invoke(progressRecord);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        if (_writeVerboseAction != null) {
+            _logger.OnVerboseMessage -= Logger_OnVerboseMessage;
+        }
+        if (_writeWarningAction != null) {
+            _logger.OnWarningMessage -= Logger_OnWarningMessage;
+        }
+        if (_writeDebugAction != null) {
+            _logger.OnDebugMessage -= Logger_OnDebugMessage;
+        }
+        if (_writeErrorAction != null) {
+            _logger.OnErrorMessage -= Logger_OnErrorMessage;
+        }
+        if (_writeProgressAction != null) {
+            _logger.OnProgressMessage -= Logger_OnProgressMessage;
+        }
+        if (_writeInformationAction != null) {
+            _logger.OnInformationMessage -= Logger_OnInformationMessage;
+        }
     }
 }

--- a/Tests/Wait-GraphMessage.Tests.ps1
+++ b/Tests/Wait-GraphMessage.Tests.ps1
@@ -20,4 +20,10 @@ Describe 'Wait-GraphMessage' {
         $field = $cmd.GetType().BaseType.GetField('_cancelSource', [System.Reflection.BindingFlags] 'NonPublic, Instance')
         ($field.GetValue($cmd)).IsCancellationRequested | Should -Be $true
     }
+
+    It 'Dispose can be called multiple times' {
+        $cmd = [Mailozaurr.PowerShell.CmdletWaitGraphMessage]::new()
+        $cmd.Dispose()
+        { $cmd.Dispose() } | Should -Not -Throw
+    }
 }

--- a/Tests/Wait-IMAPMessage.Tests.ps1
+++ b/Tests/Wait-IMAPMessage.Tests.ps1
@@ -17,4 +17,10 @@ Describe 'Wait-IMAPMessage' {
         $field = $cmd.GetType().BaseType.GetField('_cancelSource', [System.Reflection.BindingFlags] 'NonPublic, Instance')
         ($field.GetValue($cmd)).IsCancellationRequested | Should -Be $true
     }
+
+    It 'Dispose can be called multiple times' {
+        $cmd = [Mailozaurr.PowerShell.CmdletWaitIMAPMessage]::new()
+        $cmd.Dispose()
+        { $cmd.Dispose() } | Should -Not -Throw
+    }
 }

--- a/Tests/Wait-POP3Message.Tests.ps1
+++ b/Tests/Wait-POP3Message.Tests.ps1
@@ -17,4 +17,10 @@ Describe 'Wait-POP3Message' {
         $field = $cmd.GetType().BaseType.GetField('_cancelSource', [System.Reflection.BindingFlags] 'NonPublic, Instance')
         ($field.GetValue($cmd)).IsCancellationRequested | Should -Be $true
     }
+
+    It 'Dispose can be called multiple times' {
+        $cmd = [Mailozaurr.PowerShell.CmdletWaitPOP3Message]::new()
+        $cmd.Dispose()
+        { $cmd.Dispose() } | Should -Not -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- unsubscribe logger events on disposal
- detach listener callbacks when cmdlets are disposed
- test disposing the wait cmdlets multiple times

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release -f net8.0` *(fails: Unable to resolve packages)*
- `pwsh -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: RuntimeException: Unable to find types)*

------
https://chatgpt.com/codex/tasks/task_e_687f5f3579c0832e9a6b3d3c3debaaec