### PR TITLE
Enforce 4MB Graph upload chunks

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
@@ -341,11 +341,12 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
 
 
     /// <summary>
-    /// <para>Specifies chunk size in bytes used for Graph attachment uploads. Default is 9MB.</para>
+    /// <para>Specifies chunk size in bytes used for Graph attachment uploads. Default is 4MB.</para>
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "Graph")]
     [Parameter(Mandatory = false, ParameterSetName = "MgGraphRequest")]
-    public int ChunkSize { get; set; } = 9000000;
+    [ValidateRange(1, Mailozaurr.Graph.MaxChunkSize)]
+    public int ChunkSize { get; set; } = Mailozaurr.Graph.MaxChunkSize;
 
     /// <summary>
     /// <para>Enables sending email via OAuth2 authentication for SMTP.</para>

--- a/Sources/Mailozaurr.Tests/GraphChunkSizeLimitTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphChunkSizeLimitTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class GraphChunkSizeLimitTests
+{
+    [Fact]
+    public void ChunkSize_SetAboveLimit_IsCapped()
+    {
+        using Graph graph = new();
+        graph.ChunkSize = Graph.MaxChunkSize * 2;
+        Assert.Equal(Graph.MaxChunkSize, graph.ChunkSize);
+    }
+
+    [Fact]
+    public async Task PrepareByteArrayContentForUpload_EnforcesMaxChunkSize()
+    {
+        string tmp = Path.GetTempFileName();
+        int fileSize = Graph.MaxChunkSize + 1024;
+        File.WriteAllBytes(tmp, new byte[fileSize]);
+        using Graph graph = new();
+        MethodInfo? method = typeof(Graph).GetMethod(
+            "PrepareByteArrayContentForUpload",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        List<StreamContent> chunks = (List<StreamContent>)method!.Invoke(
+            graph,
+            new object[] { tmp, graph.ChunkSize * 2, default(System.Threading.CancellationToken) })!;
+        File.Delete(tmp);
+        Assert.Equal(2, chunks.Count);
+        byte[] chunk0 = await chunks[0].ReadAsByteArrayAsync();
+        byte[] chunk1 = await chunks[1].ReadAsByteArrayAsync();
+        Assert.Equal(Graph.MaxChunkSize, chunk0.Length);
+        Assert.Equal(fileSize - Graph.MaxChunkSize, chunk1.Length);
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -13,6 +13,8 @@ namespace Mailozaurr;
 /// </remarks>
 public class Graph : IDisposable {
     private readonly HttpClient _client;
+    public const int MaxChunkSize = 4 * 1024 * 1024;
+    private int _chunkSize = MaxChunkSize;
     /// <summary>
     /// Serialized JSON representation of the current Graph message.
     /// </summary>
@@ -164,9 +166,12 @@ public class Graph : IDisposable {
 
     /// <summary>
     /// Size in bytes of the chunks used when uploading attachments. Defaults to
-    /// 9MB.
+    /// <see cref="MaxChunkSize"/> and cannot exceed this value.
     /// </summary>
-    public int ChunkSize { get; set; } = 9000000;
+    public int ChunkSize {
+        get => _chunkSize;
+        set => _chunkSize = value > MaxChunkSize ? MaxChunkSize : value;
+    }
 
     /// <summary>
     /// The type of token that was issued.
@@ -773,12 +778,13 @@ public class Graph : IDisposable {
     }
 
     /// <summary>
-    /// 9000000 = 9MB
+    /// Splits <paramref name="filePath"/> into chunks no larger than <see cref="MaxChunkSize"/>.
     /// </summary>
     /// <param name="filePath"></param>
     /// <param name="chunkSize"></param>
     /// <returns></returns>
-    private List<StreamContent> PrepareByteArrayContentForUpload(string filePath, int chunkSize = 9000000, CancellationToken cancellationToken = default) {
+    private List<StreamContent> PrepareByteArrayContentForUpload(string filePath, int chunkSize = MaxChunkSize, CancellationToken cancellationToken = default) {
+        chunkSize = Math.Min(chunkSize, MaxChunkSize);
         var fileContents = new List<StreamContent>();
         var fileSize = new FileInfo(filePath).Length;
 


### PR DESCRIPTION
## Summary
- limit Graph file upload chunk size to 4MB
- cap `ChunkSize` values larger than 4MB
- validate cmdlet parameter to match new limit
- add unit test covering the cap behavior

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: 17 tests failed)*
- `dotnet test Sources/Mailozaurr.sln --no-build` *(fails: Failed: 41, Passed: 92)*

------
https://chatgpt.com/codex/tasks/task_e_687f5f53b6f0832e87abc6c81fa1424d