### PR TITLE
Fix Gmail client cancellation support

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -1,9 +1,18 @@
 using System.Reflection;
+using System.Net.Http;
 using Xunit;
 
 namespace Mailozaurr.Tests;
 
 public class GmailApiClientTests {
+    private sealed class CancelAwareHandler : HttpMessageHandler {
+        private readonly HttpResponseMessage _response;
+        public CancelAwareHandler(HttpResponseMessage response) => _response = response;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_response);
+        }
+    }
     [Fact]
     public void Constructor_SetsAuthorizationHeader() {
         var cred = new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue };
@@ -70,5 +79,50 @@ public class GmailApiClientTests {
         Assert.Equal(2, handler.Requests.Count);
         Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
         Assert.Equal("?pageToken=tok", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SendAsync_CanBeCancelled() {
+        var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK));
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        using var cts = new System.Threading.CancellationTokenSource();
+        cts.Cancel();
+        var message = new MimeKit.MimeMessage();
+        await Assert.ThrowsAnyAsync<System.OperationCanceledException>(() => client.SendAsync("me", message, cts.Token));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ListAsync_CanBeCancelled() {
+        var handler = new CancelAwareHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("{}") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        using var cts = new System.Threading.CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<System.OperationCanceledException>(() => client.ListAsync("me", cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetAsync_CanBeCancelled() {
+        var handler = new CancelAwareHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("{}") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        using var cts = new System.Threading.CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<System.OperationCanceledException>(() => client.GetAsync("me", "id", cts.Token));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task DownloadAttachmentAsync_CanBeCancelled() {
+        var handler = new CancelAwareHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("{\"data\":\"dGVzdA\"}") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        using var cts = new System.Threading.CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<System.OperationCanceledException>(() => client.DownloadAttachmentAsync("me", "m", "a", cts.Token));
     }
 }

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -33,10 +33,14 @@ public sealed class GmailApiClient {
         _client = client;
     }
 
-    private static async Task ThrowIfAuthErrorAsync(HttpResponseMessage response) {
+    private static async Task ThrowIfAuthErrorAsync(HttpResponseMessage response, CancellationToken cancellationToken) {
         if (response.StatusCode == HttpStatusCode.Unauthorized ||
             response.StatusCode == HttpStatusCode.Forbidden) {
+#if NET5_0_OR_GREATER
+            string content = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
             string content = await response.Content.ReadAsStringAsync();
+#endif
             throw new GmailAuthenticationException(response.StatusCode, content);
         }
     }
@@ -54,9 +58,13 @@ public sealed class GmailApiClient {
         var json = JsonSerializer.Serialize(new { raw }, s_jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _client.PostAsync($"users/{userId}/messages/send", content, cancellationToken);
-        await ThrowIfAuthErrorAsync(response);
+        await ThrowIfAuthErrorAsync(response, cancellationToken);
         response.EnsureSuccessStatusCode();
+#if NET5_0_OR_GREATER
+        var resultJson = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
         var resultJson = await response.Content.ReadAsStringAsync();
+#endif
         return JsonSerializer.Deserialize<GmailMessage>(resultJson, s_jsonOptions)!;
     }
 
@@ -76,9 +84,13 @@ public sealed class GmailApiClient {
                 url.Append('?').Append(string.Join("&", qs));
             }
             using var response = await _client.GetAsync(url.ToString(), cancellationToken);
-            await ThrowIfAuthErrorAsync(response);
+            await ThrowIfAuthErrorAsync(response, cancellationToken);
             response.EnsureSuccessStatusCode();
+#if NET5_0_OR_GREATER
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
             var json = await response.Content.ReadAsStringAsync();
+#endif
             var list = JsonSerializer.Deserialize<GmailListResponse>(json, s_jsonOptions);
             if (list?.Messages != null) {
                 messages.AddRange(list.Messages);
@@ -94,9 +106,13 @@ public sealed class GmailApiClient {
     /// </summary>
     public async Task<GmailMessage> GetAsync(string userId, string id, CancellationToken cancellationToken = default) {
         using var response = await _client.GetAsync($"users/{userId}/messages/{id}", cancellationToken);
-        await ThrowIfAuthErrorAsync(response);
+        await ThrowIfAuthErrorAsync(response, cancellationToken);
         response.EnsureSuccessStatusCode();
+#if NET5_0_OR_GREATER
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
         var json = await response.Content.ReadAsStringAsync();
+#endif
         return JsonSerializer.Deserialize<GmailMessage>(json, s_jsonOptions)!;
     }
 
@@ -105,7 +121,7 @@ public sealed class GmailApiClient {
     /// </summary>
     public async Task DeleteAsync(string userId, string id, CancellationToken cancellationToken = default) {
         using var response = await _client.DeleteAsync($"users/{userId}/messages/{id}", cancellationToken);
-        await ThrowIfAuthErrorAsync(response);
+        await ThrowIfAuthErrorAsync(response, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
 
@@ -114,9 +130,13 @@ public sealed class GmailApiClient {
     /// </summary>
     public async Task<IList<GmailAttachmentInfo>> ListAttachmentsAsync(string userId, string id, CancellationToken cancellationToken = default) {
         using var response = await _client.GetAsync($"users/{userId}/messages/{id}?format=full", cancellationToken);
-        await ThrowIfAuthErrorAsync(response);
+        await ThrowIfAuthErrorAsync(response, cancellationToken);
         response.EnsureSuccessStatusCode();
+#if NET5_0_OR_GREATER
+        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+#else
         using var stream = await response.Content.ReadAsStreamAsync();
+#endif
         using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
         var list = new List<GmailAttachmentInfo>();
         if (doc.RootElement.TryGetProperty("payload", out var payload)) {
@@ -130,9 +150,13 @@ public sealed class GmailApiClient {
     /// </summary>
     public async Task<byte[]> DownloadAttachmentAsync(string userId, string messageId, string attachmentId, CancellationToken cancellationToken = default) {
         using var response = await _client.GetAsync($"users/{userId}/messages/{messageId}/attachments/{attachmentId}", cancellationToken);
-        await ThrowIfAuthErrorAsync(response);
+        await ThrowIfAuthErrorAsync(response, cancellationToken);
         response.EnsureSuccessStatusCode();
+#if NET5_0_OR_GREATER
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
         var json = await response.Content.ReadAsStringAsync();
+#endif
         var result = JsonSerializer.Deserialize<AttachmentResponse>(json, s_jsonOptions)!;
         var data = result.Data?.Replace('-', '+').Replace('_', '/') ?? string.Empty;
         int padding = (4 - data.Length % 4) % 4;


### PR DESCRIPTION
## Summary
- propagate cancellation tokens when reading Gmail API responses
- ensure Gmail API methods throw when token is canceled
- test cancellation for SendAsync, ListAsync, GetAsync and DownloadAttachmentAsync

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687ff8c021b8832ea3507f8d8d997e6e