### PR TITLE
Fix SMTP connection pool reuse of closed clients

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
@@ -1,26 +1,23 @@
-using System.Threading;
 using MailKit.Security;
+using System.Threading;
 using Xunit;
 
 namespace Mailozaurr.Tests;
 
-public class SmtpConnectionPoolTests
-{
-    private class FakeClient : ClientSmtp
-    {
+public class SmtpConnectionPoolTests {
+    private class FakeClient : ClientSmtp {
         public int ConnectCalls;
         private bool _connected;
         public override bool IsConnected => _connected;
-        public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
-        {
+        public void SetConnected(bool value) => _connected = value;
+        public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {
             ConnectCalls++;
             _connected = true;
         }
     }
 
     [Fact]
-    public void Disconnect_ReturnsClientToPool()
-    {
+    public void Disconnect_ReturnsClientToPool() {
         SmtpConnectionPool.PoolingEnabled = true;
         SmtpConnectionPool.ClearConnectionPool();
         var fake = new FakeClient();
@@ -38,6 +35,22 @@ public class SmtpConnectionPoolTests
         Assert.Equal(1, fake.ConnectCalls);
 
         Smtp.ClientFactory = logger => new ClientSmtp();
+        SmtpConnectionPool.ClearConnectionPool();
+        SmtpConnectionPool.PoolingEnabled = false;
+    }
+
+    [Fact]
+    public void ReturnClosedClient_IsDiscarded() {
+        SmtpConnectionPool.PoolingEnabled = true;
+        SmtpConnectionPool.ClearConnectionPool();
+
+        var fake = new FakeClient();
+        fake.SetConnected(false);
+        SmtpConnectionPool.ReturnClient("h", 25, fake);
+
+        var pooled = SmtpConnectionPool.TryRentClient("h", 25);
+        Assert.Null(pooled);
+
         SmtpConnectionPool.ClearConnectionPool();
         SmtpConnectionPool.PoolingEnabled = false;
     }

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
@@ -5,8 +5,7 @@ using System.Collections.Concurrent;
 /// <summary>
 /// Manages SMTP connection pooling.
 /// </summary>
-public static class SmtpConnectionPool
-{
+public static class SmtpConnectionPool {
     private static readonly ConcurrentDictionary<string, ConcurrentBag<ClientSmtp>> _connectionPool = new();
 
     /// <summary>Maximum number of pooled connections per server/port.</summary>
@@ -15,20 +14,15 @@ public static class SmtpConnectionPool
     /// <summary>Enables or disables connection pooling.</summary>
     public static bool PoolingEnabled { get; set; } = false;
 
-    internal static ClientSmtp? TryRentClient(string server, int port)
-    {
-        if (!PoolingEnabled)
-        {
+    internal static ClientSmtp? TryRentClient(string server, int port) {
+        if (!PoolingEnabled) {
             return null;
         }
 
         var key = $"{server}:{port}";
-        if (_connectionPool.TryGetValue(key, out var bag))
-        {
-            while (bag.TryTake(out var pooled))
-            {
-                if (pooled.IsConnected)
-                {
+        if (_connectionPool.TryGetValue(key, out var bag)) {
+            while (bag.TryTake(out var pooled)) {
+                if (pooled.IsConnected) {
                     return pooled;
                 }
 
@@ -39,33 +33,35 @@ public static class SmtpConnectionPool
         return null;
     }
 
-    internal static void ReturnClient(string server, int port, ClientSmtp client)
-    {
-        if (!PoolingEnabled)
-        {
+    internal static void ReturnClient(string server, int port, ClientSmtp client) {
+        if (!PoolingEnabled) {
+            client.Dispose();
+            return;
+        }
+
+        if (!client.IsConnected) {
             client.Dispose();
             return;
         }
 
         var key = $"{server}:{port}";
         var bag = _connectionPool.GetOrAdd(key, _ => new ConcurrentBag<ClientSmtp>());
-        if (bag.Count >= MaxPoolSize)
-        {
+        if (bag.Count >= MaxPoolSize) {
             client.Dispose();
-        }
-        else
-        {
+        } else {
             bag.Add(client);
         }
     }
 
     /// <summary>Disposes all SMTP clients stored in the connection pool.</summary>
-    public static void ClearConnectionPool()
-    {
-        foreach (var bag in _connectionPool.Values)
-        {
-            while (bag.TryTake(out var client))
-            {
+    public static void ClearConnectionPool() {
+        foreach (var bag in _connectionPool.Values) {
+            while (bag.TryTake(out var client)) {
+                if (!client.IsConnected) {
+                    client.Dispose();
+                    continue;
+                }
+
                 client.Dispose();
             }
         }


### PR DESCRIPTION
## Summary
- ensure ReturnClient checks connection status before pooling
- validate connectivity when clearing the pool
- unit test confirms closed clients are discarded

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --no-build --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_687ff8b74f4c832e96f499919c945c56