### PR TITLE
Fix default priority

### DIFF
--- a/Sources/Mailozaurr.Tests/ClientSmtpTests.cs
+++ b/Sources/Mailozaurr.Tests/ClientSmtpTests.cs
@@ -4,11 +4,18 @@ using System.Collections.Generic;
 using System.Linq;
 using MimeKit;
 using Xunit;
+using Mailozaurr;
 
 namespace Mailozaurr.Tests;
 
 public class ClientSmtpTests
 {
+    [Fact]
+    public void Ctor_DefaultsPriorityToNormal()
+    {
+        var client = new ClientSmtp();
+        Assert.Equal(MessagePriority.Normal, client.Priority);
+    }
     [Fact]
     public void ConvertToMailboxAddress_InvalidType_IncludesValueInException()
     {

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -63,11 +63,15 @@ public partial class ClientSmtp : SmtpClient {
     }
 
     /// <summary>Initializes a new instance of the <see cref="ClientSmtp"/> class.</summary>
-    public ClientSmtp() { }
+    public ClientSmtp() {
+        Priority = MessagePriority.Normal;
+    }
 
     /// <summary>Initializes a new instance of the <see cref="ClientSmtp"/> class using the specified logger.</summary>
     /// <param name="protocolLogger">The protocol logger.</param>
-    public ClientSmtp(ProtocolLogger protocolLogger) : base(protocolLogger) { }
+    public ClientSmtp(ProtocolLogger protocolLogger) : base(protocolLogger) {
+        Priority = MessagePriority.Normal;
+    }
 
     /// <summary>
     /// Determines which delivery status notifications should be requested for the specified recipient.


### PR DESCRIPTION
## Summary
- set default `MessagePriority` to `Normal` in `ClientSmtp`
- cover constructor behaviour with test

## Testing
- `dotnet test Sources/Mailozaurr.sln -v minimal`
- `pwsh -NoLogo -Command ./Mailozaurr.Tests.ps1` *(fails: `Unprotect-MimeMessage` cmdlet not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff8ab9028832ea3287ed68d3ff73d