### PR TITLE
Fix event listener cleanup

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConvertFromEmlToMsg.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertFromEmlToMsg.cs
@@ -18,6 +18,8 @@
 /// </summary>
 [Cmdlet(VerbsData.ConvertFrom, "EmlToMsg")]
 public sealed class CmdletConvertFromEmlToMsg : AsyncPSCmdlet {
+    private InternalLogger? _logger;
+    private InternalLoggerPowerShell? _listener;
 
     /// <summary>
     /// <para type="description">Specifies the paths to the EML files to convert. Accepts an array of strings. This parameter is mandatory.</para>
@@ -45,9 +47,9 @@ public sealed class CmdletConvertFromEmlToMsg : AsyncPSCmdlet {
     /// </summary>
     protected override Task BeginProcessingAsync() {
         // Initialize the logger to be able to see verbose, warning, debug, error, progress, and information messages.
-        var internalLogger = new InternalLogger();
-        var internalLoggerPowerShell = new InternalLoggerPowerShell(internalLogger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
-        LoggingMessages.Logger = internalLogger;
+        _logger = new InternalLogger();
+        _listener = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+        LoggingMessages.Logger = _logger;
         return Task.CompletedTask;
     }
     /// <summary>
@@ -58,6 +60,12 @@ public sealed class CmdletConvertFromEmlToMsg : AsyncPSCmdlet {
         foreach (var obj in outputMessage) {
             WriteObject(obj);
         }
+        return Task.CompletedTask;
+    }
+
+    protected override Task EndProcessingAsync() {
+        _listener?.Dispose();
+        _listener = null;
         return Task.CompletedTask;
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertFromMsgToEml.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertFromMsgToEml.cs
@@ -14,6 +14,8 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet(VerbsData.ConvertFrom, "MsgToEml")]
 public sealed class CmdletConvertFromMsgToEml : AsyncPSCmdlet {
+    private InternalLogger? _logger;
+    private InternalLoggerPowerShell? _listener;
     /// <summary>
     /// <para type="description">Paths to the MSG files to convert.</para>
     /// </summary>
@@ -39,9 +41,9 @@ public sealed class CmdletConvertFromMsgToEml : AsyncPSCmdlet {
     /// Initializes logging for the conversion process.
     /// </summary>
     protected override Task BeginProcessingAsync() {
-        var internalLogger = new InternalLogger();
-        var internalLoggerPowerShell = new InternalLoggerPowerShell(internalLogger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
-        LoggingMessages.Logger = internalLogger;
+        _logger = new InternalLogger();
+        _listener = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+        LoggingMessages.Logger = _logger;
         return Task.CompletedTask;
     }
 
@@ -53,6 +55,12 @@ public sealed class CmdletConvertFromMsgToEml : AsyncPSCmdlet {
         foreach (var obj in outputMessage) {
             WriteObject(obj);
         }
+        return Task.CompletedTask;
+    }
+
+    protected override Task EndProcessingAsync() {
+        _listener?.Dispose();
+        _listener = null;
         return Task.CompletedTask;
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -9,15 +9,17 @@ namespace Mailozaurr.PowerShell;
 public sealed partial class CmdletSendEmailMessage : PSCmdlet
 {
     private ActionPreference errorAction;
+    private InternalLogger? _logger;
+    private InternalLoggerPowerShell? _listener;
 
     /// <summary>
     /// Begin block
     /// </summary>
     protected override void BeginProcessing() {
         // Initialize the logger to be able to see verbose, warning, debug, error, progress, and information messages.
-        var internalLogger = new InternalLogger();
-        var internalLoggerPowerShell = new InternalLoggerPowerShell(internalLogger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
-        LoggingMessages.Logger = internalLogger;
+        _logger = new InternalLogger();
+        _listener = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+        LoggingMessages.Logger = _logger;
 
         // Get the error action preference as user requested
         // It first sets the error action to the default error action preference
@@ -639,5 +641,11 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         }
 
         return valid.Count > 0 ? valid.ToArray() : null;
+    }
+
+    protected override void EndProcessing()
+    {
+        _listener?.Dispose();
+        _listener = null;
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletTestEmailAddress.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletTestEmailAddress.cs
@@ -47,6 +47,7 @@ public sealed class CmdletTestEmailAddress : AsyncPSCmdlet {
     public SwitchParameter AllowTopLevelDomains { get; set; }
 
     private InternalLogger _logger;
+    private InternalLoggerPowerShell? _listener;
 
     /// <summary>
     /// Initializes the logger for verbose, warning, debug, error, progress, and information messages.
@@ -54,7 +55,7 @@ public sealed class CmdletTestEmailAddress : AsyncPSCmdlet {
     protected override Task BeginProcessingAsync() {
         // Initialize the logger to be able to see verbose, warning, debug, error, progress, and information messages.
         _logger = new InternalLogger(false);
-        var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+        _listener = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
         return Task.CompletedTask;
     }
 
@@ -66,5 +67,11 @@ public sealed class CmdletTestEmailAddress : AsyncPSCmdlet {
             _logger.WriteVerbose("Processing email: {0}", email);
             WriteObject(Validator.ValidateEmail(email, AllowInternational, AllowTopLevelDomains));
         }
+    }
+
+    protected override Task EndProcessingAsync() {
+        _listener?.Dispose();
+        _listener = null;
+        return Task.CompletedTask;
     }
 }

--- a/Sources/Mailozaurr.Tests/CmdletWaitImapMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/CmdletWaitImapMessageTests.cs
@@ -1,0 +1,28 @@
+using MailKit.Net.Imap;
+using System;
+using System.Reflection;
+using Xunit;
+using Mailozaurr.PowerShell;
+
+namespace Mailozaurr.Tests;
+
+public class CmdletWaitImapMessageTests
+{
+    [Fact]
+    public void EndProcessing_DisposesListenerAndDetachesEvents()
+    {
+        var cmd = new CmdletWaitIMAPMessage();
+        var listener = new ImapIdleListener(new ImapClient());
+        var field = typeof(CmdletWaitIMAPMessage).GetField("_listener", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(cmd, listener);
+
+        var method = typeof(CmdletWaitIMAPMessage).GetMethod("OnMessageArrived", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var handler = (EventHandler<ImapEmailMessage>)Delegate.CreateDelegate(typeof(EventHandler<ImapEmailMessage>), cmd, method);
+        listener.MessageArrived += handler;
+
+        typeof(CmdletWaitIMAPMessage).GetMethod("EndProcessing", BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(cmd, null);
+
+        var eventField = typeof(ImapIdleListener).GetField("MessageArrived", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Assert.Null(eventField.GetValue(listener));
+    }
+}

--- a/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
+++ b/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
         <PackageReference Include="xunit" Version="2.5.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     </ItemGroup>


### PR DESCRIPTION
## Summary
- cleanup logger event listeners in cmdlets
- add EndProcessing disposal for logger listeners
- include PowerShellStandard.Library in test project
- add test to verify listeners are removed

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: 19 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687ff88bbec8832eb7c1b20942da6c67