### PR TITLE
Enforce Get-IMAPMessage parameter exclusivity

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetIMAPMessage.cs
@@ -25,9 +25,16 @@ namespace Mailozaurr.PowerShell;
 /// <seealso cref="CmdletConnectIMAP"/>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "IMAPMessage", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+[Cmdlet(
+    VerbsCommon.Get,
+    "IMAPMessage",
+    DefaultParameterSetName = SequenceParameterSet,
+    SupportsShouldProcess = true,
+    ConfirmImpact = ConfirmImpact.High)]
 [OutputType(typeof(ImapMessageInfo))]
 public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
+    private const string SequenceParameterSet = "Sequence";
+    private const string UidParameterSet = "Uid";
     /// <summary>
     /// <para type="description">The <see cref="ImapConnectionInfo"/> object representing the active IMAP connection. This is the object returned by <c>Connect-IMAP</c>.</para>
     /// </summary>
@@ -44,25 +51,25 @@ public sealed class CmdletGetIMAPMessage : AsyncPSCmdlet {
     /// <summary>
     /// <para type="description">Specifies the starting sequence number of messages to retrieve.</para>
     /// </summary>
-    [Parameter(Position = 2)]
+    [Parameter(Position = 2, ParameterSetName = SequenceParameterSet)]
     public int? SequenceStart { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the ending sequence number of messages to retrieve. If not provided, only <c>SequenceStart</c> is fetched.</para>
     /// </summary>
-    [Parameter(Position = 3)]
+    [Parameter(Position = 3, ParameterSetName = SequenceParameterSet)]
     public int? SequenceEnd { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the starting UID of messages to retrieve.</para>
     /// </summary>
-    [Parameter(Position = 2)]
+    [Parameter(Position = 2, ParameterSetName = UidParameterSet)]
     public uint? UidStart { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the ending UID of messages to retrieve. If not provided, only <c>UidStart</c> is fetched.</para>
     /// </summary>
-    [Parameter(Position = 3)]
+    [Parameter(Position = 3, ParameterSetName = UidParameterSet)]
     public uint? UidEnd { get; set; }
 
     /// <summary>

--- a/Tests/Get-IMAPMessage.Tests.ps1
+++ b/Tests/Get-IMAPMessage.Tests.ps1
@@ -7,4 +7,8 @@ Describe 'Get-IMAPMessage' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
         { Get-IMAPMessage -Client $info -Delete } | Should -Throw
     }
+    It 'Throws when mixing UID and sequence parameters' {
+        $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
+        { Get-IMAPMessage -Client $info -SequenceStart 1 -UidStart 1 } | Should -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- use parameter sets to ensure sequence and UID parameters are exclusive
- add test for mixed sequence and UID parameters

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: 19 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687ff885babc832eb0102802e8d5e476