### PR TITLE
Add models for Non-Delivery Reports

### DIFF
--- a/Sources/Mailozaurr.Examples/ParseNonDeliveryReportExample.cs
+++ b/Sources/Mailozaurr.Examples/ParseNonDeliveryReportExample.cs
@@ -1,0 +1,23 @@
+using Mailozaurr.NonDeliveryReports;
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Demonstrates parsing of a Non-Delivery Report from DSN headers.
+/// </summary>
+public static class ParseNonDeliveryReportExample {
+    /// <summary>Runs the example.</summary>
+    public static void Run() {
+        var headers = new Dictionary<string, string> {
+            ["Original-Recipient"] = "rfc822; user@example.com",
+            ["Final-Recipient"] = "rfc822; user@example.com",
+            ["Reporting-MTA"] = "dns; mx.example.com",
+            ["Diagnostic-Code"] = "smtp; 550 5.1.1 User unknown",
+            ["Status"] = "5.1.1",
+            ["Arrival-Date"] = DateTimeOffset.UtcNow.ToString("R")
+        };
+
+        var ndr = NonDeliveryReport.FromHeaders(headers);
+        Console.WriteLine($"NDR Type: {ndr.Type}, Status: {ndr.Status}");
+    }
+}

--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -1,65 +1,57 @@
+using Mailozaurr;
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Mailozaurr;
 
 namespace Mailozaurr.Tests;
 
 /// <summary>
 /// Tests for miscellaneous helper methods.
 /// </summary>
-public class HelpersTests
-{
+public class HelpersTests {
     [Fact]
-    public void GetEmailAddress_ReturnsInputString_WhenStringProvided()
-    {
+    public void GetEmailAddress_ReturnsInputString_WhenStringProvided() {
         var result = Mailozaurr.Helpers.GetEmailAddress("test@example.com");
         Assert.Equal("test@example.com", result);
     }
 
     [Fact]
-    public void GetEmailAddress_ReturnsEmailFromDictionary_WhenEmailKeyPresent()
-    {
+    public void GetEmailAddress_ReturnsEmailFromDictionary_WhenEmailKeyPresent() {
         var dict = new Dictionary<string, object> { { "Email", "dict@example.com" } };
         var result = Mailozaurr.Helpers.GetEmailAddress(dict);
         Assert.Equal("dict@example.com", result);
     }
 
     [Fact]
-    public void GetEmailAddress_ReturnsEmpty_WhenEmailKeyMissing()
-    {
+    public void GetEmailAddress_ReturnsEmpty_WhenEmailKeyMissing() {
         var dict = new Dictionary<string, object> { { "Name", "John" } };
         var result = Mailozaurr.Helpers.GetEmailAddress(dict);
         Assert.Equal(string.Empty, result);
     }
 
-    private class CustomObject
-    {
+    private class CustomObject {
         public override string ToString() => "Custom";
     }
 
     [Fact]
-    public void GetEmailAddress_ReturnsObjectToString_WhenNotStringOrDictionary()
-    {
+    public void GetEmailAddress_ReturnsObjectToString_WhenNotStringOrDictionary() {
         var obj = new CustomObject();
         var result = Mailozaurr.Helpers.GetEmailAddress(obj);
         Assert.Equal("Custom", result);
     }
 
     [Fact]
-    public void ConvertFromOAuth2Credential_ThrowsArgumentNullException_WhenCredentialIsNull()
-    {
+    public void ConvertFromOAuth2Credential_ThrowsArgumentNullException_WhenCredentialIsNull() {
         Assert.Throws<ArgumentNullException>(() => Mailozaurr.Helpers.ConvertFromOAuth2Credential(null!));
     }
 
     [Fact]
-    public void ConvertFromPlainText_ReturnsNetworkCredentialWithSecurePassword()
-    {
+    public void ConvertFromPlainText_ReturnsNetworkCredentialWithSecurePassword() {
         var cred = Mailozaurr.Helpers.ConvertFromPlainText("user", "secret");
 
         Assert.Equal("user", cred.UserName);
@@ -68,8 +60,7 @@ public class HelpersTests
     }
 
     [Fact]
-    public void CredentialToApiKey_ReturnsPassword_WhenNetworkCredential()
-    {
+    public void CredentialToApiKey_ReturnsPassword_WhenNetworkCredential() {
         var cred = new NetworkCredential("apikey", "theKey");
 
         string result = Mailozaurr.Helpers.CredentialToApiKey(cred);
@@ -77,14 +68,12 @@ public class HelpersTests
         Assert.Equal("theKey", result);
     }
 
-    private class DummyCredentials : ICredentials
-    {
+    private class DummyCredentials : ICredentials {
         public NetworkCredential GetCredential(Uri uri, string authType) => new NetworkCredential();
     }
 
     [Fact]
-    public void CredentialToApiKey_ReturnsEmptyString_WhenNotNetworkCredential()
-    {
+    public void CredentialToApiKey_ReturnsEmptyString_WhenNotNetworkCredential() {
         ICredentials creds = new DummyCredentials();
 
         string result = Mailozaurr.Helpers.CredentialToApiKey(creds);
@@ -93,8 +82,7 @@ public class HelpersTests
     }
 
     [Fact]
-    public void GetEmailAndName_ReturnsTuple_WhenDictionaryProvided()
-    {
+    public void GetEmailAndName_ReturnsTuple_WhenDictionaryProvided() {
         var input = new Dictionary<string, object> { { "Email", "a@b.com" }, { "Name", "Alice" } };
 
         var (email, name) = Mailozaurr.Helpers.GetEmailAndName(input);
@@ -104,8 +92,7 @@ public class HelpersTests
     }
 
     [Fact]
-    public void GetEmailAndName_ReturnsEmailAndNullName_WhenStringProvided()
-    {
+    public void GetEmailAndName_ReturnsEmailAndNullName_WhenStringProvided() {
         var (email, name) = Mailozaurr.Helpers.GetEmailAndName("c@d.com");
 
         Assert.Equal("c@d.com", email);
@@ -113,8 +100,7 @@ public class HelpersTests
     }
 
     [Fact]
-    public void UniqueAddresses_RemovesDuplicates_IgnoringCaseAndWhitespace()
-    {
+    public void UniqueAddresses_RemovesDuplicates_IgnoringCaseAndWhitespace() {
         var addresses = new object[]
         {
             " Test@example.com ",
@@ -124,7 +110,7 @@ public class HelpersTests
         };
         var seen = new HashSet<string>();
         var result = Mailozaurr.Helpers
-            .UniqueAddresses(addresses, seen)
+            .UniqueAddresses(addresses!, seen)
             .Select(Mailozaurr.Helpers.GetEmailAddress)
             .ToArray();
 
@@ -132,8 +118,7 @@ public class HelpersTests
     }
 
     [Fact]
-    public void UniqueAddresses_SkipsNullOrInvalidEmails()
-    {
+    public void UniqueAddresses_SkipsNullOrInvalidEmails() {
         var addresses = new object?[]
         {
             null,
@@ -144,7 +129,7 @@ public class HelpersTests
         var seen = new HashSet<string>();
 
         var result = Mailozaurr.Helpers
-            .UniqueAddresses(addresses, seen)
+            .UniqueAddresses(addresses!, seen)
             .Select(Mailozaurr.Helpers.GetEmailAddress)
             .ToArray();
 
@@ -152,8 +137,7 @@ public class HelpersTests
     }
 
     [Fact]
-    public void UniqueAddresses_ReturnsFirstOccurrence_WhenDictionaryEmailsDuplicate()
-    {
+    public void UniqueAddresses_ReturnsFirstOccurrence_WhenDictionaryEmailsDuplicate() {
         var first = new Dictionary<string, object> { { "Email", "d@e.com" }, { "Name", "One" } };
         var second = new Dictionary<string, object> { { "Email", "D@e.com" }, { "Name", "Two" } };
         var addresses = new object[] { first, second };
@@ -167,21 +151,18 @@ public class HelpersTests
         Assert.Same(first, result[0]);
     }
 
-    private class CancelHandler : HttpMessageHandler
-    {
+    private class CancelHandler : HttpMessageHandler {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => Task.FromCanceled<HttpResponseMessage>(cancellationToken);
     }
 
-    private class ThrowHandler : HttpMessageHandler
-    {
+    private class ThrowHandler : HttpMessageHandler {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => throw new HttpRequestException("boom");
     }
 
     [Fact]
-    public async Task PostWebhookAsync_CancellationRequested_ThrowsAsync()
-    {
+    public async Task PostWebhookAsync_CancellationRequested_ThrowsAsync() {
         using var cts = new CancellationTokenSource();
         cts.Cancel();
         var client = new HttpClient(new CancelHandler());
@@ -192,8 +173,7 @@ public class HelpersTests
     }
 
     [Fact]
-    public async Task PostWebhookAsync_HttpRequestException_LogsWarning()
-    {
+    public async Task PostWebhookAsync_HttpRequestException_LogsWarning() {
         var client = new HttpClient(new ThrowHandler());
         var result = new SmtpResult(true, EmailAction.Send, string.Empty, string.Empty, string.Empty, 0, TimeSpan.Zero);
         var messages = new List<string>();

--- a/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
@@ -1,0 +1,40 @@
+using Mailozaurr.NonDeliveryReports;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class NonDeliveryReportTests {
+    [Theory]
+    [InlineData("5.1.1", DsnStatusClass.PermanentFailure, NonDeliveryReportType.UnknownRecipient)]
+    [InlineData("5.2.2", DsnStatusClass.PermanentFailure, NonDeliveryReportType.MailboxFull)]
+    [InlineData("4.2.2", DsnStatusClass.PersistentTransientFailure, NonDeliveryReportType.MailboxFull)]
+    [InlineData("4.1.0", DsnStatusClass.PersistentTransientFailure, NonDeliveryReportType.SoftBounce)]
+    [InlineData("5.0.0", DsnStatusClass.PermanentFailure, NonDeliveryReportType.HardBounce)]
+    public void ParseStatusAndMapType(string code, DsnStatusClass expectedClass, NonDeliveryReportType expectedType) {
+        var status = DsnStatus.Parse(code);
+        Assert.Equal(expectedClass, status.Class);
+        var type = NonDeliveryReport.GetReportType(status);
+        Assert.Equal(expectedType, type);
+    }
+
+    [Fact]
+    public void ParseHeadersCreatesReport() {
+        var headers = new Dictionary<string, string> {
+            ["Original-Recipient"] = "rfc822; orig@example.com",
+            ["Final-Recipient"] = "rfc822; final@example.com",
+            ["Reporting-MTA"] = "dns; mx.example.com",
+            ["Diagnostic-Code"] = "smtp; 550 5.1.1 User unknown",
+            ["Status"] = "5.1.1",
+            ["Arrival-Date"] = DateTimeOffset.UtcNow.ToString("R")
+        };
+        var report = NonDeliveryReport.FromHeaders(headers);
+        Assert.Equal("rfc822; orig@example.com", report.OriginalRecipient);
+        Assert.Equal("rfc822; final@example.com", report.FinalRecipient);
+        Assert.Equal("dns; mx.example.com", report.ReportingMta);
+        Assert.NotNull(report.DiagnosticCode);
+        Assert.NotNull(report.Status);
+        Assert.Equal(NonDeliveryReportType.UnknownRecipient, report.Type);
+    }
+}

--- a/Sources/Mailozaurr/NonDeliveryReports/DsnDiagnosticCode.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/DsnDiagnosticCode.cs
@@ -17,7 +17,7 @@ public sealed class DsnDiagnosticCode {
 
     /// <summary>Parses a diagnostic code string in the form "smtp; 550 5.1.1".</summary>
     public static DsnDiagnosticCode Parse(string value) {
-        var parts = value.Split(';', 2);
+        var parts = value.Split(new[] { ';' }, 2);
         var type = parts[0].Trim();
         var text = parts.Length > 1 ? parts[1].Trim() : string.Empty;
         return new DsnDiagnosticCode(type, text);

--- a/Sources/Mailozaurr/NonDeliveryReports/DsnDiagnosticCode.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/DsnDiagnosticCode.cs
@@ -1,0 +1,28 @@
+namespace Mailozaurr.NonDeliveryReports;
+
+/// <summary>
+/// Represents the diagnostic code from a Delivery Status Notification.
+/// </summary>
+public sealed class DsnDiagnosticCode {
+    /// <summary>The diagnostic code type, e.g. "smtp".</summary>
+    public string Type { get; }
+
+    /// <summary>The textual diagnostic information.</summary>
+    public string Text { get; }
+
+    private DsnDiagnosticCode(string type, string text) {
+        Type = type;
+        Text = text;
+    }
+
+    /// <summary>Parses a diagnostic code string in the form "smtp; 550 5.1.1".</summary>
+    public static DsnDiagnosticCode Parse(string value) {
+        var parts = value.Split(';', 2);
+        var type = parts[0].Trim();
+        var text = parts.Length > 1 ? parts[1].Trim() : string.Empty;
+        return new DsnDiagnosticCode(type, text);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => string.IsNullOrEmpty(Text) ? Type : $"{Type}; {Text}";
+}

--- a/Sources/Mailozaurr/NonDeliveryReports/DsnStatus.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/DsnStatus.cs
@@ -1,0 +1,61 @@
+namespace Mailozaurr.NonDeliveryReports;
+
+/// <summary>
+/// Represents a Delivery Status Notification status code.
+/// </summary>
+public sealed class DsnStatus {
+    /// <summary>Classification of the DSN status code.</summary>
+    public DsnStatusClass Class { get; }
+
+    /// <summary>Subject subcode of the DSN status.</summary>
+    public int Subject { get; }
+
+    /// <summary>Detail subcode of the DSN status.</summary>
+    public int Detail { get; }
+
+    private DsnStatus(DsnStatusClass statusClass, int subject, int detail) {
+        Class = statusClass;
+        Subject = subject;
+        Detail = detail;
+    }
+
+    /// <summary>Parses a DSN status string (e.g. "5.1.1").</summary>
+    public static DsnStatus Parse(string value) {
+        if (!TryParse(value, out var status)) {
+            throw new FormatException($"Invalid DSN status '{value}'.");
+        }
+        return status;
+    }
+
+    /// <summary>Attempts to parse a DSN status string.</summary>
+    public static bool TryParse(string? value, out DsnStatus status) {
+        status = null!;
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+        var parts = value.Trim().Split('.');
+        if (parts.Length != 3 || !int.TryParse(parts[0], out var cls) || !int.TryParse(parts[1], out var subj) || !int.TryParse(parts[2], out var detail)) {
+            return false;
+        }
+        if (!Enum.IsDefined(typeof(DsnStatusClass), cls)) {
+            return false;
+        }
+        status = new DsnStatus((DsnStatusClass)cls, subj, detail);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => $"{(int)Class}.{Subject}.{Detail}";
+}
+
+/// <summary>
+/// Top level DSN status classes as defined in RFC 3463.
+/// </summary>
+public enum DsnStatusClass {
+    /// <summary>Success (2.x.x).</summary>
+    Success = 2,
+    /// <summary>Persistent transient failure (4.x.x).</summary>
+    PersistentTransientFailure = 4,
+    /// <summary>Permanent failure (5.x.x).</summary>
+    PermanentFailure = 5
+}

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
@@ -7,22 +7,22 @@ namespace Mailozaurr.NonDeliveryReports;
 /// </summary>
 public sealed class NonDeliveryReport {
     /// <summary>Original recipient as specified in the NDR.</summary>
-    public string? OriginalRecipient { get; init; }
+    public string? OriginalRecipient { get; set; }
 
     /// <summary>Final recipient that the report refers to.</summary>
-    public string? FinalRecipient { get; init; }
+    public string? FinalRecipient { get; set; }
 
     /// <summary>Reporting mail transfer agent.</summary>
-    public string? ReportingMta { get; init; }
+    public string? ReportingMta { get; set; }
 
     /// <summary>Diagnostic code explaining the failure.</summary>
-    public DsnDiagnosticCode? DiagnosticCode { get; init; }
+    public DsnDiagnosticCode? DiagnosticCode { get; set; }
 
     /// <summary>Status code for the delivery attempt.</summary>
-    public DsnStatus? Status { get; init; }
+    public DsnStatus? Status { get; set; }
 
     /// <summary>The time the message originally arrived at the reporting MTA.</summary>
-    public DateTimeOffset Timestamp { get; init; }
+    public DateTimeOffset Timestamp { get; set; }
 
     /// <summary>Determines the NDR type derived from the status code.</summary>
     public NonDeliveryReportType Type => GetReportType(Status);

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
@@ -1,0 +1,75 @@
+using System.Globalization;
+
+namespace Mailozaurr.NonDeliveryReports;
+
+/// <summary>
+/// Represents a parsed Non-Delivery Report (Delivery Status Notification).
+/// </summary>
+public sealed class NonDeliveryReport {
+    /// <summary>Original recipient as specified in the NDR.</summary>
+    public string? OriginalRecipient { get; init; }
+
+    /// <summary>Final recipient that the report refers to.</summary>
+    public string? FinalRecipient { get; init; }
+
+    /// <summary>Reporting mail transfer agent.</summary>
+    public string? ReportingMta { get; init; }
+
+    /// <summary>Diagnostic code explaining the failure.</summary>
+    public DsnDiagnosticCode? DiagnosticCode { get; init; }
+
+    /// <summary>Status code for the delivery attempt.</summary>
+    public DsnStatus? Status { get; init; }
+
+    /// <summary>The time the message originally arrived at the reporting MTA.</summary>
+    public DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>Determines the NDR type derived from the status code.</summary>
+    public NonDeliveryReportType Type => GetReportType(Status);
+
+    /// <summary>Creates a <see cref="NonDeliveryReport"/> instance from DSN headers.</summary>
+    public static NonDeliveryReport FromHeaders(IDictionary<string, string> headers) {
+        headers.TryGetValue("Original-Recipient", out var originalRecipient);
+        headers.TryGetValue("Final-Recipient", out var finalRecipient);
+        headers.TryGetValue("Reporting-MTA", out var reportingMta);
+        headers.TryGetValue("Diagnostic-Code", out var diagnosticCode);
+        headers.TryGetValue("Status", out var statusCode);
+        headers.TryGetValue("Arrival-Date", out var arrivalDate);
+
+        var ndr = new NonDeliveryReport {
+            OriginalRecipient = originalRecipient,
+            FinalRecipient = finalRecipient,
+            ReportingMta = reportingMta,
+            DiagnosticCode = diagnosticCode is not null ? DsnDiagnosticCode.Parse(diagnosticCode) : null,
+            Status = statusCode is not null && DsnStatus.TryParse(statusCode, out var status) ? status : null,
+            Timestamp = ParseTimestamp(arrivalDate)
+        };
+        return ndr;
+    }
+
+    private static DateTimeOffset ParseTimestamp(string? value) {
+        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt)) {
+            return dt;
+        }
+        return DateTimeOffset.MinValue;
+    }
+
+    /// <summary>Maps a <see cref="DsnStatus"/> to an <see cref="NonDeliveryReportType"/>.</summary>
+    public static NonDeliveryReportType GetReportType(DsnStatus? status) {
+        if (status is null) {
+            return NonDeliveryReportType.Unknown;
+        }
+        var statusCode = status.ToString();
+        if (statusCode == "5.1.1") {
+            return NonDeliveryReportType.UnknownRecipient;
+        }
+        if (statusCode == "5.2.2" || statusCode == "4.2.2") {
+            return NonDeliveryReportType.MailboxFull;
+        }
+        return status.Class switch {
+            DsnStatusClass.PermanentFailure => NonDeliveryReportType.HardBounce,
+            DsnStatusClass.PersistentTransientFailure => NonDeliveryReportType.SoftBounce,
+            _ => NonDeliveryReportType.Unknown
+        };
+    }
+}

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportType.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportType.cs
@@ -1,0 +1,17 @@
+namespace Mailozaurr.NonDeliveryReports;
+
+/// <summary>
+/// Describes common Non-Delivery Report types.
+/// </summary>
+public enum NonDeliveryReportType {
+    /// <summary>Type of the failure couldn't be determined.</summary>
+    Unknown,
+    /// <summary>The message was permanently rejected.</summary>
+    HardBounce,
+    /// <summary>The message failed temporarily and may be retried.</summary>
+    SoftBounce,
+    /// <summary>The recipient's mailbox is full.</summary>
+    MailboxFull,
+    /// <summary>The recipient does not exist.</summary>
+    UnknownRecipient
+}


### PR DESCRIPTION
## Summary
- add delivery status models and NDR type mappings
- parse DSN headers into NonDeliveryReport
- document usage with parsing example and tests

## Testing
- `dotnet build Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688dbfebcf3c832e81182032cf6cd057