### PR TITLE
Detect non delivery reports

### DIFF
--- a/Sources/Mailozaurr.Examples/DetectNonDeliveryReportExample.cs
+++ b/Sources/Mailozaurr.Examples/DetectNonDeliveryReportExample.cs
@@ -1,0 +1,23 @@
+using Mailozaurr;
+using MimeKit;
+using System;
+using System.IO;
+using System.Text;
+
+/// <summary>
+/// Demonstrates detecting a Non-Delivery Report from a MIME message.
+/// </summary>
+public static class DetectNonDeliveryReportExample {
+    /// <summary>Runs the example.</summary>
+    public static void Run() {
+        const string raw = "Content-Type: multipart/report; report-type=delivery-status; boundary=\"XXXX\"\n\n--XXXX\nContent-Type: text/plain; charset=utf-8\n\nThis is the mail system at example.com\n\n--XXXX\nContent-Type: message/delivery-status\n\nOriginal-Recipient: rfc822; orig@example.com\nFinal-Recipient: rfc822; final@example.com\nReporting-MTA: dns; mx.example.com\nDiagnostic-Code: smtp; 550 5.1.1 User unknown\nStatus: 5.1.1\nArrival-Date: Wed, 24 Jul 2024 10:00:00 +0000\n\n--XXXX--";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));
+        var message = MimeMessage.Load(stream);
+        var report = MimeKitUtils.GetNonDeliveryReport(message);
+        if (report != null) {
+            Console.WriteLine($"Detected NDR: {report.Type} with status {report.Status}");
+        } else {
+            Console.WriteLine("No NDR detected.");
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/NonDeliveryReportDetectionTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportDetectionTests.cs
@@ -1,0 +1,41 @@
+using MailKit;
+using Mailozaurr;
+using Mailozaurr.NonDeliveryReports;
+using MimeKit;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class NonDeliveryReportDetectionTests {
+    private static MimeMessage CreateNdrMessage() {
+        const string raw = "Content-Type: multipart/report; report-type=delivery-status; boundary=\"XXX\"\n\n--XXX\nContent-Type: text/plain; charset=utf-8\n\ntext\n\n--XXX\nContent-Type: message/delivery-status\n\nOriginal-Recipient: rfc822; orig@example.com\nFinal-Recipient: rfc822; final@example.com\nReporting-MTA: dns; mx.example.com\nDiagnostic-Code: smtp; 550 5.1.1 User unknown\nStatus: 5.1.1\nArrival-Date: Wed, 24 Jul 2024 10:00:00 +0000\n\n--XXX--";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));
+        return MimeMessage.Load(stream);
+    }
+
+    [Fact]
+    public void ImapEmailMessageDetectsNdr() {
+        var msg = CreateNdrMessage();
+        var imap = new ImapEmailMessage(new UniqueId(1), msg);
+        Assert.NotNull(imap.NonDeliveryReport);
+        Assert.Equal(NonDeliveryReportType.UnknownRecipient, imap.NonDeliveryReport!.Type);
+    }
+
+    [Fact]
+    public void Pop3EmailMessageDetectsNdr() {
+        var msg = CreateNdrMessage();
+        var pop3 = new Pop3EmailMessage(0, msg);
+        Assert.NotNull(pop3.NonDeliveryReport);
+        Assert.Equal(NonDeliveryReportType.UnknownRecipient, pop3.NonDeliveryReport!.Type);
+    }
+
+    [Fact]
+    public void GraphEmailMessageDetectsNdr() {
+        var msg = CreateNdrMessage();
+        var graph = new GraphEmailMessage("id", msg);
+        Assert.NotNull(graph.NonDeliveryReport);
+        Assert.Equal(NonDeliveryReportType.UnknownRecipient, graph.NonDeliveryReport!.Type);
+    }
+}

--- a/Sources/Mailozaurr/GraphEmailMessage.cs
+++ b/Sources/Mailozaurr/GraphEmailMessage.cs
@@ -1,5 +1,6 @@
 namespace Mailozaurr;
 
+using Mailozaurr.NonDeliveryReports;
 using MimeKit;
 
 /// <summary>
@@ -11,10 +12,11 @@ public class GraphEmailMessage {
     /// </summary>
     /// <param name="id">Unique identifier of the message.</param>
     /// <param name="message">The MIME message.</param>
-    public GraphEmailMessage(string id, MimeMessage message) {
+    public GraphEmailMessage(string id, MimeMessage message, NonDeliveryReport? nonDeliveryReport = null) {
         Id = id;
         Message = message;
         Encryption = MimeKitUtils.GetEncryption(message);
+        NonDeliveryReport = nonDeliveryReport ?? MimeKitUtils.GetNonDeliveryReport(message);
     }
 
     /// <summary>Unique identifier of the message.</summary>
@@ -25,6 +27,9 @@ public class GraphEmailMessage {
 
     /// <summary>Detected encryption or signature type.</summary>
     public EmailEncryption Encryption { get; }
+
+    /// <summary>Parsed Non-Delivery Report details, if available.</summary>
+    public NonDeliveryReport? NonDeliveryReport { get; }
 
     /// <inheritdoc />
     public override string ToString() => Message.Subject ?? base.ToString();

--- a/Sources/Mailozaurr/ImapEmailMessage.cs
+++ b/Sources/Mailozaurr/ImapEmailMessage.cs
@@ -1,4 +1,5 @@
 using MailKit;
+using Mailozaurr.NonDeliveryReports;
 
 namespace Mailozaurr;
 
@@ -15,10 +16,11 @@ public class ImapEmailMessage {
     /// </summary>
     /// <param name="uid">Unique identifier of the message.</param>
     /// <param name="message">The actual MIME message.</param>
-    public ImapEmailMessage(UniqueId uid, MimeMessage message) {
+    public ImapEmailMessage(UniqueId uid, MimeMessage message, NonDeliveryReport? nonDeliveryReport = null) {
         Uid = uid;
         Message = message;
         Encryption = MimeKitUtils.GetEncryption(message);
+        NonDeliveryReport = nonDeliveryReport ?? MimeKitUtils.GetNonDeliveryReport(message);
     }
 
     /// <summary>Unique identifier of the message.</summary>
@@ -29,6 +31,9 @@ public class ImapEmailMessage {
 
     /// <summary>Detected encryption or signature type.</summary>
     public EmailEncryption Encryption { get; }
+
+    /// <summary>Parsed Non-Delivery Report details, if available.</summary>
+    public NonDeliveryReport? NonDeliveryReport { get; }
 
     /// <inheritdoc />
     public override string ToString() => Message.Subject ?? base.ToString();

--- a/Sources/Mailozaurr/MimeKitUtils.cs
+++ b/Sources/Mailozaurr/MimeKitUtils.cs
@@ -1,3 +1,4 @@
+using Mailozaurr.NonDeliveryReports;
 using MimeKit;
 using System.Collections.Generic;
 using System.IO;
@@ -27,6 +28,67 @@ public static class MimeKitUtils {
                 msgPart.Message.WriteTo(file);
             }
         }
+    }
+
+    /// <summary>Attempts to extract a <see cref="NonDeliveryReport"/> from a message.</summary>
+    public static NonDeliveryReport? GetNonDeliveryReport(MimeMessage message) {
+        if (message == null) {
+            return null;
+        }
+
+        var status = FindDeliveryStatus(message.Body);
+        if (status == null && !SubjectIndicatesNdr(message.Subject)) {
+            return null;
+        }
+
+        var headers = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
+        if (status != null) {
+            foreach (var group in status.StatusGroups) {
+                foreach (var header in group) {
+                    if (!headers.ContainsKey(header.Field)) {
+                        headers[header.Field] = header.Value;
+                    }
+                }
+            }
+        }
+
+        return headers.Count > 0 ? NonDeliveryReport.FromHeaders(headers) : new NonDeliveryReport();
+    }
+
+    private static MessageDeliveryStatus? FindDeliveryStatus(MimeEntity entity) {
+        if (entity is MessageDeliveryStatus mds) {
+            return mds;
+        }
+        if (entity is Multipart multipart) {
+            foreach (var part in multipart) {
+                var found = FindDeliveryStatus(part);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static bool SubjectIndicatesNdr(string? subject) {
+        if (string.IsNullOrWhiteSpace(subject)) {
+            return false;
+        }
+        string[] patterns = {
+            "Undelivered Mail Returned to Sender",
+            "Mail delivery failed",
+            "Delivery Status Notification",
+            "Mail Delivery Subsystem",
+            "failure notice",
+            "Delivery failure"
+        };
+
+        foreach (var p in patterns) {
+            if (subject.IndexOf(p, System.StringComparison.OrdinalIgnoreCase) >= 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /// <summary>Determines the encryption or signing type of a message.</summary>

--- a/Sources/Mailozaurr/Pop3EmailMessage.cs
+++ b/Sources/Mailozaurr/Pop3EmailMessage.cs
@@ -1,3 +1,5 @@
+using Mailozaurr.NonDeliveryReports;
+
 namespace Mailozaurr;
 
 /// <summary>
@@ -13,10 +15,11 @@ public class Pop3EmailMessage {
     /// </summary>
     /// <param name="index">Index of the message within the mailbox.</param>
     /// <param name="message">The actual MIME message.</param>
-    public Pop3EmailMessage(int index, MimeMessage message) {
+    public Pop3EmailMessage(int index, MimeMessage message, NonDeliveryReport? nonDeliveryReport = null) {
         Index = index;
         Message = message;
         Encryption = MimeKitUtils.GetEncryption(message);
+        NonDeliveryReport = nonDeliveryReport ?? MimeKitUtils.GetNonDeliveryReport(message);
     }
 
     /// <summary>Index of the message within the mailbox.</summary>
@@ -27,6 +30,9 @@ public class Pop3EmailMessage {
 
     /// <summary>Detected encryption or signature type.</summary>
     public EmailEncryption Encryption { get; }
+
+    /// <summary>Parsed Non-Delivery Report details, if available.</summary>
+    public NonDeliveryReport? NonDeliveryReport { get; }
 
     /// <inheritdoc />
     public override string ToString() => Message.Subject ?? base.ToString();

--- a/Sources/Mailozaurr/Receive/MessageFetcher.cs
+++ b/Sources/Mailozaurr/Receive/MessageFetcher.cs
@@ -93,7 +93,8 @@ public static class MessageFetcher {
             if (priority.HasValue && msg.Priority != ConvertPriority(priority.Value)) {
                 continue;
             }
-            yield return new ImapEmailMessage(uid, msg);
+            var ndr = MimeKitUtils.GetNonDeliveryReport(msg);
+            yield return new ImapEmailMessage(uid, msg, ndr);
             if (delete) {
                 await mailFolder.AddFlagsAsync(uid, MessageFlags.Deleted, true, cancellationToken).ConfigureAwait(false);
             }
@@ -163,7 +164,8 @@ public static class MessageFetcher {
                 continue;
             }
 
-            yield return new Pop3EmailMessage(i, message);
+            var ndr = MimeKitUtils.GetNonDeliveryReport(message);
+            yield return new Pop3EmailMessage(i, message, ndr);
             if (delete) {
                 await client.DeleteMessageAsync(i, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
## Summary
- parse `message/delivery-status` parts and NDR subjects via MimeKit
- surface `NonDeliveryReport` information on IMAP, POP3, and Graph messages
- add example and tests for NDR detection

## Testing
- `dotnet format Sources/Mailozaurr.sln --include Sources/Mailozaurr/MimeKitUtils.cs Sources/Mailozaurr/ImapEmailMessage.cs Sources/Mailozaurr/Pop3EmailMessage.cs Sources/Mailozaurr/GraphEmailMessage.cs Sources/Mailozaurr/Receive/MessageFetcher.cs Sources/Mailozaurr.Examples/DetectNonDeliveryReportExample.cs Sources/Mailozaurr.Tests/NonDeliveryReportDetectionTests.cs`
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh -File ./Mailozaurr.Tests.ps1` *(failed: CommandNotFoundException: The term 'Unprotect-MimeMessage' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_688dcb1a622c832eb1bf33e785311cb3