### PR TITLE
Add non-delivery report search APIs

### DIFF
--- a/Sources/Mailozaurr.Examples/SearchNonDeliveryReportsExample.cs
+++ b/Sources/Mailozaurr.Examples/SearchNonDeliveryReportsExample.cs
@@ -1,0 +1,33 @@
+using MailKit.Net.Imap;
+using MailKit.Security;
+using Mailozaurr;
+using Mailozaurr.NonDeliveryReports;
+using System;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Demonstrates searching for Non-Delivery Reports in an IMAP mailbox.
+/// </summary>
+public static class SearchNonDeliveryReportsExample {
+    /// <summary>Runs the example.</summary>
+    public static async Task RunAsync() {
+        // === CONFIGURATION ===
+        string server = "imap.example.com";
+        string username = "user@example.com";
+        string password = "Pa55w0rd";
+
+        // === EXAMPLE ===
+        using var client = new ImapClient();
+        await client.ConnectAsync(server, 993, SecureSocketOptions.SslOnConnect);
+        await client.AuthenticateAsync(username, password);
+        var reports = await MailboxSearcher.SearchNonDeliveryReportsAsync(
+            client,
+            folder: null,
+            since: DateTime.UtcNow.AddDays(-7),
+            recipientContains: "user@example.com");
+        foreach (NonDeliveryReport report in reports) {
+            Console.WriteLine($"NDR for {report.FinalRecipient}: {report.Type}");
+        }
+        await client.DisconnectAsync(true);
+    }
+}

--- a/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
@@ -37,4 +37,13 @@ public class NonDeliveryReportTests {
         Assert.NotNull(report.Status);
         Assert.Equal(NonDeliveryReportType.UnknownRecipient, report.Type);
     }
+
+    [Fact]
+    public void ParsesOriginalMessageId() {
+        var headers = new Dictionary<string, string> {
+            ["Original-Message-ID"] = "<msg1@local>"
+        };
+        var report = NonDeliveryReport.FromHeaders(headers);
+        Assert.Equal("<msg1@local>", report.OriginalMessageId);
+    }
 }

--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -1,0 +1,34 @@
+using Mailozaurr;
+using Mailozaurr.NonDeliveryReports;
+using MimeKit;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SearchNonDeliveryReportsTests {
+    private static MimeMessage CreateNdr(string recipient, string messageId, DateTimeOffset date) {
+        string raw = $"Content-Type: multipart/report; report-type=delivery-status; boundary=\"XXX\"\r\n\r\n--XXX\r\nContent-Type: text/plain; charset=utf-8\r\n\r\ntext\r\n\r\n--XXX\r\nContent-Type: message/delivery-status\r\n\r\nOriginal-Recipient: rfc822; {recipient}\r\nFinal-Recipient: rfc822; {recipient}\r\nOriginal-Message-ID: {messageId}\r\nReporting-MTA: dns; mx.example.com\r\nDiagnostic-Code: smtp; 550 5.1.1 User unknown\r\nStatus: 5.1.1\r\nArrival-Date: {date:R}\r\n\r\n--XXX--";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));
+        return MimeMessage.Load(stream);
+    }
+
+    [Fact]
+    public void FilterNonDeliveryReports_FiltersByRecipientAndMessageId() {
+        var now = DateTimeOffset.UtcNow;
+        var msg1 = CreateNdr("user@example.com", "<id1>", now);
+        var msg2 = CreateNdr("other@example.com", "<id2>", now);
+        var list = new List<MimeMessage> { msg1, msg2 };
+        var reports = MailboxSearcher.FilterNonDeliveryReports(
+            list,
+            since: now.AddMinutes(-5).DateTime,
+            before: now.AddMinutes(5).DateTime,
+            recipientContains: "user@example.com",
+            messageId: "<id1>");
+        Assert.Single(reports);
+        Assert.Equal("<id1>", reports[0].OriginalMessageId);
+    }
+}

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
@@ -12,6 +12,9 @@ public sealed class NonDeliveryReport {
     /// <summary>Final recipient that the report refers to.</summary>
     public string? FinalRecipient { get; set; }
 
+    /// <summary>Identifier of the original message associated with this report.</summary>
+    public string? OriginalMessageId { get; set; }
+
     /// <summary>Reporting mail transfer agent.</summary>
     public string? ReportingMta { get; set; }
 
@@ -32,6 +35,7 @@ public sealed class NonDeliveryReport {
         headers.TryGetValue("Original-Recipient", out var originalRecipient);
         headers.TryGetValue("Final-Recipient", out var finalRecipient);
         headers.TryGetValue("Reporting-MTA", out var reportingMta);
+        headers.TryGetValue("Original-Message-ID", out var originalMessageId);
         headers.TryGetValue("Diagnostic-Code", out var diagnosticCode);
         headers.TryGetValue("Status", out var statusCode);
         headers.TryGetValue("Arrival-Date", out var arrivalDate);
@@ -39,6 +43,7 @@ public sealed class NonDeliveryReport {
         var ndr = new NonDeliveryReport {
             OriginalRecipient = originalRecipient,
             FinalRecipient = finalRecipient,
+            OriginalMessageId = originalMessageId,
             ReportingMta = reportingMta,
             DiagnosticCode = diagnosticCode is not null ? DsnDiagnosticCode.Parse(diagnosticCode) : null,
             Status = statusCode is not null && DsnStatus.TryParse(statusCode, out var status) ? status : null,

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Mailozaurr.NonDeliveryReports;
 
 namespace Mailozaurr;
 
@@ -106,6 +107,113 @@ public static class MailboxSearcher {
             if (maxResults > 0 && results.Count >= maxResults) break;
         }
         return results;
+    }
+
+    /// <summary>
+    /// Searches for Non-Delivery Reports in an IMAP mailbox.
+    /// </summary>
+    public static async Task<IList<NonDeliveryReport>> SearchNonDeliveryReportsAsync(
+        ImapClient client,
+        string? folder = null,
+        DateTime? since = null,
+        DateTime? before = null,
+        string? recipientContains = null,
+        string? messageId = null,
+        int maxResults = 0,
+        CancellationToken cancellationToken = default) {
+        var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
+        SearchQuery search = SearchQuery.All;
+        if (since.HasValue) search = search.And(SearchQuery.DeliveredAfter(since.Value));
+        if (before.HasValue) search = search.And(SearchQuery.DeliveredBefore(before.Value));
+        var uids = await mailFolder.SearchAsync(search, cancellationToken).ConfigureAwait(false);
+        var messages = new List<MimeMessage>(uids.Count);
+        foreach (var uid in uids) {
+            var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
+            messages.Add(msg);
+            if (maxResults > 0 && messages.Count >= maxResults) break;
+        }
+        return FilterNonDeliveryReports(messages, since, before, recipientContains, messageId);
+    }
+
+    /// <summary>
+    /// Searches for Non-Delivery Reports in a POP3 mailbox.
+    /// </summary>
+    public static async Task<IList<NonDeliveryReport>> SearchNonDeliveryReportsAsync(
+        Pop3Client client,
+        DateTime? since = null,
+        DateTime? before = null,
+        string? recipientContains = null,
+        string? messageId = null,
+        int maxResults = 0,
+        CancellationToken cancellationToken = default) {
+        var messages = new List<MimeMessage>();
+        for (int i = 0; i < client.Count; i++) {
+            var msg = await client.GetMessageAsync(i, cancellationToken).ConfigureAwait(false);
+            messages.Add(msg);
+            if (maxResults > 0 && messages.Count >= maxResults) break;
+        }
+        return FilterNonDeliveryReports(messages, since, before, recipientContains, messageId);
+    }
+
+    /// <summary>
+    /// Searches for Non-Delivery Reports using Microsoft Graph.
+    /// </summary>
+    public static async Task<IList<NonDeliveryReport>> SearchNonDeliveryReportsAsync(
+        GraphCredential credential,
+        string userPrincipalName,
+        DateTime? since = null,
+        DateTime? before = null,
+        string? recipientContains = null,
+        string? messageId = null,
+        int maxResults = 0,
+        CancellationToken cancellationToken = default) {
+        var filters = new List<string>();
+        if (since.HasValue) filters.Add($"receivedDateTime ge {since.Value:o}");
+        if (before.HasValue) filters.Add($"receivedDateTime le {before.Value:o}");
+        var filter = filters.Count > 0 ? string.Join(" and ", filters) : null;
+        var msgs = await MicrosoftGraphUtils.GetMailMessagesAsync(
+            credential,
+            userPrincipalName,
+            new[] { "id" },
+            filter,
+            maxResults > 0 ? maxResults : (int?)null).ConfigureAwait(false);
+        var mimeMessages = new List<MimeMessage>(msgs.Count);
+        foreach (var m in msgs) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (m.TryGetValue("id", out var idObj) && idObj is string id) {
+                var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                mimeMessages.Add(mime);
+                if (maxResults > 0 && mimeMessages.Count >= maxResults) break;
+            }
+        }
+        return FilterNonDeliveryReports(mimeMessages, since, before, recipientContains, messageId);
+    }
+
+    internal static IList<NonDeliveryReport> FilterNonDeliveryReports(
+        IEnumerable<MimeMessage> messages,
+        DateTime? since,
+        DateTime? before,
+        string? recipientContains,
+        string? messageId) {
+        var results = new List<NonDeliveryReport>();
+        foreach (var message in messages) {
+            var report = MimeKitUtils.GetNonDeliveryReport(message);
+            if (report == null) continue;
+            if (since.HasValue && report.Timestamp.DateTime < since.Value) continue;
+            if (before.HasValue && report.Timestamp.DateTime > before.Value) continue;
+            if (!string.IsNullOrWhiteSpace(recipientContains) && !RecipientMatches(report, recipientContains)) continue;
+            if (!string.IsNullOrWhiteSpace(messageId) && !string.Equals(report.OriginalMessageId, messageId, StringComparison.OrdinalIgnoreCase)) continue;
+            results.Add(report);
+        }
+        return results;
+    }
+
+    private static bool RecipientMatches(NonDeliveryReport report, string filter) {
+        if (!string.IsNullOrWhiteSpace(report.FinalRecipient) &&
+            report.FinalRecipient.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        if (!string.IsNullOrWhiteSpace(report.OriginalRecipient) &&
+            report.OriginalRecipient.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        return false;
     }
 
     private static MimeKit.MessagePriority ConvertPriority(MessagePriority priority)


### PR DESCRIPTION
## Summary
- extend `NonDeliveryReport` with original message ID support
- add `SearchNonDeliveryReportsAsync` for IMAP, POP3, and Graph protocols
- provide example and tests for non-delivery report searching

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `pwsh -NoLogo -NoProfile -File Mailozaurr.Tests.ps1` *(fails: type or namespace name 'Mailozaurr' could not be found, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688dd48f4ba0832ea4205260ea3a0617