### PR TITLE
Log sent message metadata

### DIFF
--- a/Examples/Example-SendEmail-SentLog.ps1
+++ b/Examples/Example-SendEmail-SentLog.ps1
@@ -1,0 +1,7 @@
+$path = Join-Path $PSScriptRoot 'sentlog.json'
+Send-EmailMessage -From 'from@example.com' -To 'to@example.com' -Server 'smtp.server' -Subject 'demo' -Text 'body' -SentLogPath $path -WhatIf
+# $ndr = Get-NonDeliveryReport -Path 'ndr.eml'
+# $repo = [Mailozaurr.FileSentMessageRepository]::new($path)
+# $resolver = [Mailozaurr.SendLogResolver]::new($repo)
+# $match = $resolver.ResolveAsync($ndr).GetAwaiter().GetResult()
+# $match | Format-List

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
@@ -426,6 +426,12 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
     public string? LogPath { get; set; }
 
     /// <summary>
+    /// <para>Specifies the path used to persist sent message metadata.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public string? SentLogPath { get; set; }
+
+    /// <summary>
     /// <para>Enables logging of communication with the server to the console.</para>
     /// </summary>
     [Parameter(Mandatory = false)]

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -332,6 +332,10 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
 
     private void ProcessSmtp(string? fromEmail, string? fromName) {
         Smtp smtpClient = new Smtp(LogPath, LogConsole, LogObject, LogTimestamps, LogSecrets, LogTimeStampsFormat, LogServerPrefix, LogClientPrefix, LogOverwrite);
+        var sentLogPath = string.IsNullOrWhiteSpace(SentLogPath)
+            ? Path.Combine(Path.GetTempPath(), "Mailozaurr", "sentlog.json")
+            : SentLogPath;
+        smtpClient.SentMessageRepository = new FileSentMessageRepository(sentLogPath);
         smtpClient.From = Helpers.GetFromObject(fromEmail, fromName);
         smtpClient.ReplyTo = ReplyTo;
         smtpClient.Cc = Cc;

--- a/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
@@ -1,0 +1,27 @@
+using Mailozaurr.NonDeliveryReports;
+
+namespace Mailozaurr.Tests;
+
+public class SentMessageRepositoryTests {
+    [Fact]
+    public async Task ResolverMatchesSavedRecord() {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+        try {
+            var repo = new FileSentMessageRepository(path);
+            var record = new SentMessageRecord {
+                MessageId = "id1",
+                Recipients = "c@d.com",
+                Subject = "subject",
+                Timestamp = DateTimeOffset.UtcNow
+            };
+            await repo.SaveAsync(record);
+            var resolver = new SendLogResolver(repo);
+            var ndr = new NonDeliveryReport { OriginalMessageId = "id1", FinalRecipient = "c@d.com" };
+            var resolved = await resolver.ResolveAsync(ndr);
+            Assert.NotNull(resolved);
+            Assert.Equal("subject", resolved!.Subject);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/FileSentMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FileSentMessageRepository.cs
@@ -1,0 +1,44 @@
+namespace Mailozaurr;
+
+public sealed class FileSentMessageRepository : ISentMessageRepository {
+    private readonly string filePath;
+    private readonly SemaphoreSlim gate = new(1, 1);
+
+    public FileSentMessageRepository(string filePath) => this.filePath = filePath;
+
+    public async Task SaveAsync(SentMessageRecord record, CancellationToken cancellationToken = default) {
+        await gate.WaitAsync(cancellationToken);
+        try {
+            List<SentMessageRecord> records;
+            if (File.Exists(filePath)) {
+                using var read = File.OpenRead(filePath);
+                records = await JsonSerializer.DeserializeAsync<List<SentMessageRecord>>(read, cancellationToken: cancellationToken) ?? new List<SentMessageRecord>();
+            } else {
+                records = new List<SentMessageRecord>();
+            }
+            records.Add(record);
+            var directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
+                Directory.CreateDirectory(directory);
+            }
+            using var write = File.Create(filePath);
+            await JsonSerializer.SerializeAsync(write, records, cancellationToken: cancellationToken);
+        } finally {
+            gate.Release();
+        }
+    }
+
+    public async Task<SentMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+        if (!File.Exists(filePath)) {
+            return null;
+        }
+        await gate.WaitAsync(cancellationToken);
+        try {
+            using var read = File.OpenRead(filePath);
+            var records = await JsonSerializer.DeserializeAsync<List<SentMessageRecord>>(read, cancellationToken: cancellationToken);
+            return records?.FirstOrDefault(r => string.Equals(r.MessageId, messageId, StringComparison.OrdinalIgnoreCase));
+        } finally {
+            gate.Release();
+        }
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/ISentMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/ISentMessageRepository.cs
@@ -1,0 +1,6 @@
+namespace Mailozaurr;
+
+public interface ISentMessageRepository {
+    Task SaveAsync(SentMessageRecord record, CancellationToken cancellationToken = default);
+    Task<SentMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr/SentMessages/SendLogResolver.cs
+++ b/Sources/Mailozaurr/SentMessages/SendLogResolver.cs
@@ -1,0 +1,23 @@
+using Mailozaurr.NonDeliveryReports;
+
+namespace Mailozaurr;
+
+public sealed class SendLogResolver {
+    private readonly ISentMessageRepository repository;
+
+    public SendLogResolver(ISentMessageRepository repository) => this.repository = repository;
+
+    public async Task<SentMessageRecord?> ResolveAsync(NonDeliveryReport report, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(report?.OriginalMessageId)) {
+            return null;
+        }
+        var record = await repository.GetByMessageIdAsync(report.OriginalMessageId!, cancellationToken);
+        if (record != null && !string.IsNullOrWhiteSpace(report.FinalRecipient)) {
+            var recipients = record.Recipients.Split(',');
+            if (!recipients.Any(r => string.Equals(r, report.FinalRecipient, StringComparison.OrdinalIgnoreCase))) {
+                return null;
+            }
+        }
+        return record;
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/SentMessageRecord.cs
+++ b/Sources/Mailozaurr/SentMessages/SentMessageRecord.cs
@@ -1,0 +1,8 @@
+namespace Mailozaurr;
+
+public sealed class SentMessageRecord {
+    public string MessageId { get; set; } = string.Empty;
+    public string Recipients { get; set; } = string.Empty;
+    public string Subject { get; set; } = string.Empty;
+    public DateTimeOffset Timestamp { get; set; }
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -24,6 +24,9 @@ public class Smtp {
     /// <summary>Configuration used for protocol logging.</summary>
     public LoggingConfigurator? Logging;
 
+    /// <summary>Repository used to persist sent message metadata.</summary>
+    public ISentMessageRepository? SentMessageRepository { get; set; }
+
     /// <summary>Underlying SMTP client used to send messages.</summary>
     public ClientSmtp Client { get; private set; }
 
@@ -624,6 +627,15 @@ public class Smtp {
             try {
                 await Client.SendAsync(Message, cancellationToken);
                 LoggingMessages.Logger.WriteVerbose($"Send-EmailMessage - Sent email to {SentTo}");
+                if (SentMessageRepository != null) {
+                    var record = new SentMessageRecord {
+                        MessageId = Message.MessageId ?? string.Empty,
+                        Recipients = SentTo,
+                        Subject = Subject,
+                        Timestamp = DateTimeOffset.UtcNow
+                    };
+                    await SentMessageRepository.SaveAsync(record, cancellationToken);
+                }
                 var result = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
                 await Helpers.PostWebhookAsync(WebhookUrl, result, cancellationToken);
                 return result;

--- a/Tests/SendLogResolver.Tests.ps1
+++ b/Tests/SendLogResolver.Tests.ps1
@@ -1,0 +1,18 @@
+Describe 'SendLogResolver' {
+    It 'Resolves saved record' {
+        $path = Join-Path $TestDrive 'sentlog.json'
+        $repo = [Mailozaurr.FileSentMessageRepository]::new($path)
+        $record = [Mailozaurr.SentMessageRecord]::new()
+        $record.MessageId = 'id1'
+        $record.Recipients = 'c@d.com'
+        $record.Subject = 'subject'
+        $record.Timestamp = [DateTimeOffset]::UtcNow
+        $repo.SaveAsync($record).GetAwaiter().GetResult() | Out-Null
+        $resolver = [Mailozaurr.SendLogResolver]::new($repo)
+        $ndr = [Mailozaurr.NonDeliveryReports.NonDeliveryReport]::new()
+        $ndr.OriginalMessageId = 'id1'
+        $ndr.FinalRecipient = 'c@d.com'
+        $resolved = $resolver.ResolveAsync($ndr).GetAwaiter().GetResult()
+        $resolved.Subject | Should -Be 'subject'
+    }
+}


### PR DESCRIPTION
## Summary
- persist Message-Id, recipients and subject for sent mail
- provide file-backed storage and resolver for sent message logs
- expose optional SentLogPath in Send-EmailMessage and wire into SMTP pipeline
- add tests and example of resolving NonDeliveryReports

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh -NoLogo -NoProfile -File Mailozaurr.Tests.ps1` *(failed: 19 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688df037f020832eb790029412a53391