### PR TITLE
feat: add non-delivery report services

### DIFF
--- a/Examples/Example-SendEmail-SentLog.ps1
+++ b/Examples/Example-SendEmail-SentLog.ps1
@@ -1,4 +1,5 @@
 $path = Join-Path $PSScriptRoot 'sentlog.json'
+# The file collects all sent message records and is appended to on each send.
 Send-EmailMessage -From 'from@example.com' -To 'to@example.com' -Server 'smtp.server' -Subject 'demo' -Text 'body' -SentLogPath $path -WhatIf
 # $ndr = Get-NonDeliveryReport -Path 'ndr.eml'
 # $repo = [Mailozaurr.FileSentMessageRepository]::new($path)

--- a/Sources/Mailozaurr.Examples/NonDeliveryReportServiceExample.cs
+++ b/Sources/Mailozaurr.Examples/NonDeliveryReportServiceExample.cs
@@ -1,0 +1,31 @@
+using MailKit.Net.Imap;
+using MailKit.Security;
+using Mailozaurr;
+using Mailozaurr.NonDeliveryReports;
+using System;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Demonstrates using the non-delivery report service with IMAP.
+/// </summary>
+public static class NonDeliveryReportServiceExample {
+    /// <summary>Runs the example.</summary>
+    public static async Task RunAsync() {
+        string server = "imap.example.com";
+        string username = "user@example.com";
+        string password = "Pa55w0rd";
+
+        using var client = new ImapClient();
+        await client.ConnectAsync(server, 993, SecureSocketOptions.SslOnConnect);
+        await client.AuthenticateAsync(username, password);
+
+        var repository = new FileSentMessageRepository("sent.json");
+        var resolver = new SendLogResolver(repository);
+        var service = new ImapNonDeliveryReportService(client, resolver);
+        var results = await service.SearchAsync(DateTime.UtcNow.AddDays(-7));
+        foreach (NonDeliveryReportResult result in results) {
+            Console.WriteLine($"NDR for {result.Report.FinalRecipient}: {result.Report.Type}");
+        }
+        await client.DisconnectAsync(true);
+    }
+}

--- a/Sources/Mailozaurr.Tests/NonDeliveryReportServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportServiceTests.cs
@@ -1,0 +1,53 @@
+using Mailozaurr;
+using Mailozaurr.NonDeliveryReports;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class NonDeliveryReportServiceTests {
+    private sealed class InMemorySentMessageRepository : ISentMessageRepository {
+        private readonly Dictionary<string, SentMessageRecord> store = new();
+
+        public Task SaveAsync(SentMessageRecord record, CancellationToken cancellationToken = default) {
+            store[record.MessageId] = record;
+            return Task.CompletedTask;
+        }
+
+        public Task<SentMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+            store.TryGetValue(messageId, out SentMessageRecord? record);
+            return Task.FromResult(record);
+        }
+    }
+
+    private sealed class TestService : NonDeliveryReportServiceBase {
+        private readonly IList<NonDeliveryReport> reports;
+
+        public TestService(IList<NonDeliveryReport> reports, SendLogResolver resolver) : base(resolver) => this.reports = reports;
+
+        protected override Task<IList<NonDeliveryReport>> SearchInternalAsync(
+            DateTime? since,
+            DateTime? before,
+            string? recipientContains,
+            string? messageId,
+            int maxResults,
+            CancellationToken cancellationToken) => Task.FromResult(reports);
+    }
+
+    [Fact]
+    public async Task SearchAsync_ResolvesSentMessage() {
+        var repo = new InMemorySentMessageRepository();
+        var record = new SentMessageRecord { MessageId = "<id1>", Recipients = "user@example.com", Subject = "s", Timestamp = DateTimeOffset.UtcNow };
+        await repo.SaveAsync(record);
+        var resolver = new SendLogResolver(repo);
+        var report = new NonDeliveryReport { OriginalMessageId = "<id1>", FinalRecipient = "user@example.com", Timestamp = DateTimeOffset.UtcNow };
+        var service = new TestService(new List<NonDeliveryReport> { report }, resolver);
+
+        IList<NonDeliveryReportResult> results = await service.SearchAsync();
+        Assert.Single(results);
+        Assert.Equal(report, results[0].Report);
+        Assert.Equal(record, results[0].SentMessage);
+    }
+}

--- a/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
@@ -24,4 +24,19 @@ public class SentMessageRepositoryTests {
             if (File.Exists(path)) File.Delete(path);
         }
     }
+
+    [Fact]
+    public async Task SaveAsync_AppendsMultipleRecords() {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+        try {
+            var repo = new FileSentMessageRepository(path);
+            await repo.SaveAsync(new SentMessageRecord { MessageId = "1", Recipients = "a@b.com", Subject = "s1", Timestamp = DateTimeOffset.UtcNow });
+            await repo.SaveAsync(new SentMessageRecord { MessageId = "2", Recipients = "c@d.com", Subject = "s2", Timestamp = DateTimeOffset.UtcNow });
+            var record = await repo.GetByMessageIdAsync("2");
+            Assert.NotNull(record);
+            Assert.Equal("s2", record!.Subject);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
 }

--- a/Sources/Mailozaurr/INonDeliveryReportService.cs
+++ b/Sources/Mailozaurr/INonDeliveryReportService.cs
@@ -1,0 +1,13 @@
+using Mailozaurr.NonDeliveryReports;
+
+namespace Mailozaurr;
+
+public interface INonDeliveryReportService {
+    Task<IList<NonDeliveryReportResult>> SearchAsync(
+        DateTime? since = null,
+        DateTime? before = null,
+        string? recipientContains = null,
+        string? messageId = null,
+        int maxResults = 0,
+        CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr/NonDeliveryReports/GraphNonDeliveryReportService.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/GraphNonDeliveryReportService.cs
@@ -1,0 +1,25 @@
+using Mailozaurr;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.NonDeliveryReports;
+
+public sealed class GraphNonDeliveryReportService : NonDeliveryReportServiceBase {
+    private readonly GraphCredential credential;
+    private readonly string userPrincipalName;
+
+    public GraphNonDeliveryReportService(GraphCredential credential, string userPrincipalName, SendLogResolver resolver) : base(resolver) {
+        this.credential = credential;
+        this.userPrincipalName = userPrincipalName;
+    }
+
+    protected override Task<IList<NonDeliveryReport>> SearchInternalAsync(
+        DateTime? since,
+        DateTime? before,
+        string? recipientContains,
+        string? messageId,
+        int maxResults,
+        CancellationToken cancellationToken) =>
+        MailboxSearcher.SearchNonDeliveryReportsAsync(credential, userPrincipalName, since, before, recipientContains, messageId, maxResults, cancellationToken);
+}

--- a/Sources/Mailozaurr/NonDeliveryReports/ImapNonDeliveryReportService.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/ImapNonDeliveryReportService.cs
@@ -1,0 +1,26 @@
+using Mailozaurr;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Imap;
+
+namespace Mailozaurr.NonDeliveryReports;
+
+public sealed class ImapNonDeliveryReportService : NonDeliveryReportServiceBase {
+    private readonly ImapClient client;
+    private readonly string? folder;
+
+    public ImapNonDeliveryReportService(ImapClient client, SendLogResolver resolver, string? folder = null) : base(resolver) {
+        this.client = client;
+        this.folder = folder;
+    }
+
+    protected override Task<IList<NonDeliveryReport>> SearchInternalAsync(
+        DateTime? since,
+        DateTime? before,
+        string? recipientContains,
+        string? messageId,
+        int maxResults,
+        CancellationToken cancellationToken) =>
+        MailboxSearcher.SearchNonDeliveryReportsAsync(client, folder, since, before, recipientContains, messageId, maxResults, cancellationToken);
+}

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportResult.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportResult.cs
@@ -1,0 +1,14 @@
+using Mailozaurr;
+
+namespace Mailozaurr.NonDeliveryReports;
+
+public sealed class NonDeliveryReportResult {
+    public NonDeliveryReportResult(NonDeliveryReport report, SentMessageRecord? sentMessage) {
+        Report = report;
+        SentMessage = sentMessage;
+    }
+
+    public NonDeliveryReport Report { get; }
+
+    public SentMessageRecord? SentMessage { get; }
+}

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportServiceBase.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportServiceBase.cs
@@ -1,0 +1,36 @@
+using Mailozaurr;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.NonDeliveryReports;
+
+public abstract class NonDeliveryReportServiceBase : INonDeliveryReportService {
+    private readonly SendLogResolver resolver;
+
+    protected NonDeliveryReportServiceBase(SendLogResolver resolver) => this.resolver = resolver;
+
+    public async Task<IList<NonDeliveryReportResult>> SearchAsync(
+        DateTime? since = null,
+        DateTime? before = null,
+        string? recipientContains = null,
+        string? messageId = null,
+        int maxResults = 0,
+        CancellationToken cancellationToken = default) {
+        IList<NonDeliveryReport> reports = await SearchInternalAsync(since, before, recipientContains, messageId, maxResults, cancellationToken).ConfigureAwait(false);
+        var results = new List<NonDeliveryReportResult>(reports.Count);
+        foreach (NonDeliveryReport report in reports) {
+            SentMessageRecord? record = await resolver.ResolveAsync(report, cancellationToken).ConfigureAwait(false);
+            results.Add(new NonDeliveryReportResult(report, record));
+        }
+        return results;
+    }
+
+    protected abstract Task<IList<NonDeliveryReport>> SearchInternalAsync(
+        DateTime? since,
+        DateTime? before,
+        string? recipientContains,
+        string? messageId,
+        int maxResults,
+        CancellationToken cancellationToken);
+}

--- a/Sources/Mailozaurr/NonDeliveryReports/Pop3NonDeliveryReportService.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/Pop3NonDeliveryReportService.cs
@@ -1,0 +1,22 @@
+using Mailozaurr;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Pop3;
+
+namespace Mailozaurr.NonDeliveryReports;
+
+public sealed class Pop3NonDeliveryReportService : NonDeliveryReportServiceBase {
+    private readonly Pop3Client client;
+
+    public Pop3NonDeliveryReportService(Pop3Client client, SendLogResolver resolver) : base(resolver) => this.client = client;
+
+    protected override Task<IList<NonDeliveryReport>> SearchInternalAsync(
+        DateTime? since,
+        DateTime? before,
+        string? recipientContains,
+        string? messageId,
+        int maxResults,
+        CancellationToken cancellationToken) =>
+        MailboxSearcher.SearchNonDeliveryReportsAsync(client, since, before, recipientContains, messageId, maxResults, cancellationToken);
+}

--- a/Sources/Mailozaurr/SentMessages/FileSentMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FileSentMessageRepository.cs
@@ -1,42 +1,56 @@
 namespace Mailozaurr;
 
+/// <summary>
+/// Stores sent message records in a single newline-delimited JSON file.
+/// </summary>
 public sealed class FileSentMessageRepository : ISentMessageRepository {
     private readonly string filePath;
     private readonly SemaphoreSlim gate = new(1, 1);
 
+    /// <summary>
+    /// Creates a new repository using the specified file path.
+    /// </summary>
+    /// <param name="filePath">Path to the log file that stores sent message records.</param>
     public FileSentMessageRepository(string filePath) => this.filePath = filePath;
 
+    /// <summary>Saves a record to the log file.</summary>
     public async Task SaveAsync(SentMessageRecord record, CancellationToken cancellationToken = default) {
         await gate.WaitAsync(cancellationToken);
         try {
-            List<SentMessageRecord> records;
-            if (File.Exists(filePath)) {
-                using var read = File.OpenRead(filePath);
-                records = await JsonSerializer.DeserializeAsync<List<SentMessageRecord>>(read, cancellationToken: cancellationToken) ?? new List<SentMessageRecord>();
-            } else {
-                records = new List<SentMessageRecord>();
-            }
-            records.Add(record);
             var directory = Path.GetDirectoryName(filePath);
             if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
                 Directory.CreateDirectory(directory);
             }
-            using var write = File.Create(filePath);
-            await JsonSerializer.SerializeAsync(write, records, cancellationToken: cancellationToken);
+            using var write = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+            await JsonSerializer.SerializeAsync(write, record, cancellationToken: cancellationToken);
+            var newline = Encoding.UTF8.GetBytes(Environment.NewLine);
+            await write.WriteAsync(newline, 0, newline.Length, cancellationToken);
         } finally {
             gate.Release();
         }
     }
 
+    /// <summary>Retrieves a record by message ID from the log file.</summary>
     public async Task<SentMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
         if (!File.Exists(filePath)) {
             return null;
         }
         await gate.WaitAsync(cancellationToken);
         try {
-            using var read = File.OpenRead(filePath);
-            var records = await JsonSerializer.DeserializeAsync<List<SentMessageRecord>>(read, cancellationToken: cancellationToken);
-            return records?.FirstOrDefault(r => string.Equals(r.MessageId, messageId, StringComparison.OrdinalIgnoreCase));
+            using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(read);
+            while (!reader.EndOfStream) {
+                cancellationToken.ThrowIfCancellationRequested();
+                string? line = await reader.ReadLineAsync();
+                if (string.IsNullOrWhiteSpace(line)) {
+                    continue;
+                }
+                var record = JsonSerializer.Deserialize<SentMessageRecord>(line);
+                if (record != null && string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
+                    return record;
+                }
+            }
+            return null;
         } finally {
             gate.Release();
         }


### PR DESCRIPTION
## Summary
- add INonDeliveryReportService interface and protocol-specific implementations
- log sent messages to a single JSON file and provide example and tests
- remove optional dependency injection package

## Testing
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_688e2f7abec8832ea9d92fa844f6007b