### PR TITLE
Add cmdlets for email delivery reports

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailDeliveryStatus.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailDeliveryStatus.cs
@@ -1,0 +1,285 @@
+using System;
+
+using System.Management.Automation;
+
+using System.Threading.Tasks;
+
+using Mailozaurr;
+
+using Mailozaurr.NonDeliveryReports;
+
+
+
+namespace Mailozaurr.PowerShell;
+
+
+
+/// <summary>
+
+/// Searches for non-delivery reports in a mailbox.
+
+/// </summary>
+
+[Cmdlet(VerbsCommon.Get, "EmailDeliveryStatus")]
+
+[OutputType(typeof(NonDeliveryReport))]
+
+public sealed class CmdletGetEmailDeliveryStatus : AsyncPSCmdlet {
+
+    /// <summary>
+
+    /// Mail protocol to use.
+
+    /// </summary>
+
+    [Parameter(Mandatory = true)]
+
+    public EmailProtocol Protocol { get; set; }
+
+
+
+    /// <summary>
+
+    /// Only reports for recipients containing this value are returned.
+
+    /// </summary>
+
+    [Parameter]
+
+    public string? Recipient { get; set; }
+
+
+
+    /// <summary>
+
+    /// Only reports matching this message ID are returned.
+
+    /// </summary>
+
+    [Parameter]
+
+    public string? MessageId { get; set; }
+
+
+
+    /// <summary>
+
+    /// Only reports since this time are returned.
+
+    /// </summary>
+
+    [Parameter]
+
+    public DateTime? Since { get; set; }
+
+
+
+    /// <summary>
+
+    /// Only reports before this time are returned.
+
+    /// </summary>
+
+    [Parameter]
+
+    public DateTime? Before { get; set; }
+
+
+
+    /// <summary>
+
+    /// Maximum number of reports to return.
+
+    /// </summary>
+
+    [Parameter]
+
+    [ValidateRange(1, int.MaxValue)]
+
+    public int Count { get; set; }
+
+
+
+    /// <summary>
+
+    /// IMAP folder to search.
+
+    /// </summary>
+
+    [Parameter]
+
+    public string? Folder { get; set; }
+
+
+
+    /// <summary>
+
+    /// User principal name when using Microsoft Graph.
+
+    /// </summary>
+
+    [Parameter]
+
+    public string? UserPrincipalName { get; set; }
+
+
+
+    /// <summary>
+
+    /// Searches for non-delivery reports using the specified protocol.
+
+    /// </summary>
+
+    protected override async Task ProcessRecordAsync() {
+
+        int max = Count > 0 ? Count : int.MaxValue;
+
+        switch (Protocol) {
+
+            case EmailProtocol.Imap: {
+
+                var conn = DefaultSessions.ImapSession;
+
+                if (conn != null && conn.Data != null) {
+
+                    var reports = await MailboxSearcher.SearchNonDeliveryReportsAsync(
+
+                        conn.Data,
+
+                        Folder,
+
+                        Since,
+
+                        Before,
+
+                        Recipient,
+
+                        MessageId,
+
+                        max,
+
+                        CancelToken);
+
+                    foreach (var report in reports) {
+
+                        WriteObject(report);
+
+                    }
+
+                } else {
+
+                    ThrowTerminatingError(new ErrorRecord(
+
+                        new InvalidOperationException("Get-EmailDeliveryStatus - IMAP client not provided or not connected."),
+
+                        "ClientNotConnected",
+
+                        ErrorCategory.InvalidOperation,
+
+                        null));
+
+                }
+
+                break;
+
+            }
+
+            case EmailProtocol.Pop3: {
+
+                var conn = DefaultSessions.Pop3Session;
+
+                if (conn != null && conn.Data != null) {
+
+                    var reports = await MailboxSearcher.SearchNonDeliveryReportsAsync(
+
+                        conn.Data,
+
+                        Since,
+
+                        Before,
+
+                        Recipient,
+
+                        MessageId,
+
+                        max,
+
+                        CancelToken);
+
+                    foreach (var report in reports) {
+
+                        WriteObject(report);
+
+                    }
+
+                } else {
+
+                    ThrowTerminatingError(new ErrorRecord(
+
+                        new InvalidOperationException("Get-EmailDeliveryStatus - POP3 client not provided or not connected."),
+
+                        "ClientNotConnected",
+
+                        ErrorCategory.InvalidOperation,
+
+                        null));
+
+                }
+
+                break;
+
+            }
+
+            case EmailProtocol.Graph: {
+
+                var conn = DefaultSessions.GraphSession;
+
+                if (conn != null && conn.Credential != null && !string.IsNullOrWhiteSpace(UserPrincipalName)) {
+
+                    var reports = await MailboxSearcher.SearchNonDeliveryReportsAsync(
+
+                        conn.Credential,
+
+                        UserPrincipalName!,
+
+                        Since,
+
+                        Before,
+
+                        Recipient,
+
+                        MessageId,
+
+                        max,
+
+                        CancelToken);
+
+                    foreach (var report in reports) {
+
+                        WriteObject(report);
+
+                    }
+
+                } else {
+
+                    ThrowTerminatingError(new ErrorRecord(
+
+                        new InvalidOperationException("Get-EmailDeliveryStatus - Graph connection or UserPrincipalName missing."),
+
+                        "ClientNotConnected",
+
+                        ErrorCategory.InvalidOperation,
+
+                        null));
+
+                }
+
+                break;
+
+            }
+
+        }
+
+    }
+
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletMatchEmailDelivery.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletMatchEmailDelivery.cs
@@ -1,0 +1,275 @@
+using System;
+
+using System.Management.Automation;
+
+using System.Threading.Tasks;
+
+using Mailozaurr;
+
+using Mailozaurr.NonDeliveryReports;
+
+
+
+namespace Mailozaurr.PowerShell;
+
+
+
+/// <summary>
+
+/// Searches for non-delivery reports and matches them to sent messages.
+
+/// </summary>
+
+[Cmdlet("Match", "EmailDelivery")]
+
+[OutputType(typeof(NonDeliveryReportResult))]
+
+public sealed class CmdletMatchEmailDelivery : AsyncPSCmdlet {
+
+    /// <summary>
+
+    /// Mail protocol to use.
+
+    /// </summary>
+
+    [Parameter(Mandatory = true)]
+
+    public EmailProtocol Protocol { get; set; }
+
+
+
+    /// <summary>
+
+    /// Resolver used to correlate NDRs with sent messages.
+
+    /// </summary>
+
+    [Parameter(Mandatory = true)]
+
+    [ValidateNotNull]
+
+    public SendLogResolver? Resolver { get; set; }
+
+
+
+    /// <summary>
+
+    /// Only reports for recipients containing this value are returned.
+
+    /// </summary>
+
+    [Parameter]
+
+    public string? Recipient { get; set; }
+
+
+
+    /// <summary>
+
+    /// Only reports matching this message ID are returned.
+
+    /// </summary>
+
+    [Parameter]
+
+    public string? MessageId { get; set; }
+
+
+
+    /// <summary>
+
+    /// Only reports since this time are returned.
+
+    /// </summary>
+
+    [Parameter]
+
+    public DateTime? Since { get; set; }
+
+
+
+    /// <summary>
+
+    /// Only reports before this time are returned.
+
+    /// </summary>
+
+    [Parameter]
+
+    public DateTime? Before { get; set; }
+
+
+
+    /// <summary>
+
+    /// Maximum number of reports to return.
+
+    /// </summary>
+
+    [Parameter]
+
+    [ValidateRange(1, int.MaxValue)]
+
+    public int Count { get; set; }
+
+
+
+    /// <summary>
+
+    /// IMAP folder to search.
+
+    /// </summary>
+
+    [Parameter]
+
+    public string? Folder { get; set; }
+
+
+
+    /// <summary>
+
+    /// User principal name when using Microsoft Graph.
+
+    /// </summary>
+
+    [Parameter]
+
+    public string? UserPrincipalName { get; set; }
+
+
+
+    /// <summary>
+
+    /// Searches for non-delivery reports and matches them using the resolver.
+
+    /// </summary>
+
+    protected override async Task ProcessRecordAsync() {
+
+        if (Resolver == null) {
+
+            ThrowTerminatingError(new ErrorRecord(
+
+                new InvalidOperationException("Match-EmailDelivery - Resolver is required."),
+
+                "ResolverMissing",
+
+                ErrorCategory.InvalidArgument,
+
+                null));
+
+        }
+
+
+
+        int max = Count > 0 ? Count : int.MaxValue;
+
+        switch (Protocol) {
+
+            case EmailProtocol.Imap: {
+
+                var conn = DefaultSessions.ImapSession;
+
+                if (conn != null && conn.Data != null) {
+
+                    var service = new ImapNonDeliveryReportService(conn.Data, Resolver!, Folder);
+
+                    var results = await service.SearchAsync(Since, Before, Recipient, MessageId, max, CancelToken);
+
+                    foreach (var result in results) {
+
+                        WriteObject(result);
+
+                    }
+
+                } else {
+
+                    ThrowTerminatingError(new ErrorRecord(
+
+                        new InvalidOperationException("Match-EmailDelivery - IMAP client not provided or not connected."),
+
+                        "ClientNotConnected",
+
+                        ErrorCategory.InvalidOperation,
+
+                        null));
+
+                }
+
+                break;
+
+            }
+
+            case EmailProtocol.Pop3: {
+
+                var conn = DefaultSessions.Pop3Session;
+
+                if (conn != null && conn.Data != null) {
+
+                    var service = new Pop3NonDeliveryReportService(conn.Data, Resolver!);
+
+                    var results = await service.SearchAsync(Since, Before, Recipient, MessageId, max, CancelToken);
+
+                    foreach (var result in results) {
+
+                        WriteObject(result);
+
+                    }
+
+                } else {
+
+                    ThrowTerminatingError(new ErrorRecord(
+
+                        new InvalidOperationException("Match-EmailDelivery - POP3 client not provided or not connected."),
+
+                        "ClientNotConnected",
+
+                        ErrorCategory.InvalidOperation,
+
+                        null));
+
+                }
+
+                break;
+
+            }
+
+            case EmailProtocol.Graph: {
+
+                var conn = DefaultSessions.GraphSession;
+
+                if (conn != null && conn.Credential != null && !string.IsNullOrWhiteSpace(UserPrincipalName)) {
+
+                    var service = new GraphNonDeliveryReportService(conn.Credential, UserPrincipalName!, Resolver!);
+
+                    var results = await service.SearchAsync(Since, Before, Recipient, MessageId, max, CancelToken);
+
+                    foreach (var result in results) {
+
+                        WriteObject(result);
+
+                    }
+
+                } else {
+
+                    ThrowTerminatingError(new ErrorRecord(
+
+                        new InvalidOperationException("Match-EmailDelivery - Graph connection or UserPrincipalName missing."),
+
+                        "ClientNotConnected",
+
+                        ErrorCategory.InvalidOperation,
+
+                        null));
+
+                }
+
+                break;
+
+            }
+
+        }
+
+    }
+
+}

--- a/Sources/Mailozaurr.PowerShell/Definitions/EmailProtocol.cs
+++ b/Sources/Mailozaurr.PowerShell/Definitions/EmailProtocol.cs
@@ -1,0 +1,7 @@
+namespace Mailozaurr.PowerShell;
+
+public enum EmailProtocol {
+    Imap,
+    Pop3,
+    Graph
+}

--- a/Tests/Get-EmailDeliveryStatus.Tests.ps1
+++ b/Tests/Get-EmailDeliveryStatus.Tests.ps1
@@ -1,0 +1,5 @@
+Describe 'Get-EmailDeliveryStatus' {
+    It 'Throws when connection missing' {
+        { Get-EmailDeliveryStatus -Protocol Imap } | Should -Throw
+    }
+}

--- a/Tests/Match-EmailDelivery.Tests.ps1
+++ b/Tests/Match-EmailDelivery.Tests.ps1
@@ -1,0 +1,7 @@
+Describe 'Match-EmailDelivery' {
+    It 'Throws when connection missing' {
+        $repo = [Mailozaurr.FileSentMessageRepository]::new([IO.Path]::GetTempFileName())
+        $resolver = [Mailozaurr.SendLogResolver]::new($repo)
+        { Match-EmailDelivery -Protocol Imap -Resolver $resolver } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Summary
- add Get-EmailDeliveryStatus cmdlet to search for non-delivery reports
- add Match-EmailDelivery cmdlet that correlates reports with sent messages
- expose EmailProtocol enum and basic Pester coverage

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh -NoLogo -File Mailozaurr.Tests.ps1` *(fails: 19 tests failed)*


------
https://chatgpt.com/codex/tasks/task_e_688e49be30c0832e9ac9a0bd4c8e459e