### PR TITLE
Parse DSN recipient headers

### DIFF
--- a/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
@@ -32,6 +32,8 @@ public class NonDeliveryReportTests {
         var report = NonDeliveryReport.FromHeaders(headers);
         Assert.Equal("rfc822; orig@example.com", report.OriginalRecipient);
         Assert.Equal("rfc822; final@example.com", report.FinalRecipient);
+        Assert.Equal("orig@example.com", report.OriginalRecipientAddress);
+        Assert.Equal("final@example.com", report.FinalRecipientAddress);
         Assert.Equal("dns; mx.example.com", report.ReportingMta);
         Assert.NotNull(report.DiagnosticCode);
         Assert.NotNull(report.Status);

--- a/Sources/Mailozaurr.Tests/SendLogResolverTests.cs
+++ b/Sources/Mailozaurr.Tests/SendLogResolverTests.cs
@@ -34,4 +34,18 @@ public class SendLogResolverTests {
         var result = await resolver.ResolveAsync(report);
         Assert.Null(result);
     }
+
+    [Fact]
+    public async Task ResolveAsync_MatchesRecipientWithPrefix() {
+        var record = new SentMessageRecord { MessageId = "<id1>", Recipients = "user@example.com" };
+        var repo = new InMemoryRepository(record);
+        var resolver = new SendLogResolver(repo);
+        var headers = new Dictionary<string, string> {
+            ["Original-Message-ID"] = "<id1>",
+            ["Final-Recipient"] = "rfc822; user@example.com"
+        };
+        var report = NonDeliveryReport.FromHeaders(headers);
+        var result = await resolver.ResolveAsync(report);
+        Assert.Equal(record, result);
+    }
 }

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
@@ -9,8 +9,14 @@ public sealed class NonDeliveryReport {
     /// <summary>Original recipient as specified in the NDR.</summary>
     public string? OriginalRecipient { get; set; }
 
+    /// <summary>Normalized address extracted from <see cref="OriginalRecipient"/>.</summary>
+    public string? OriginalRecipientAddress { get; set; }
+
     /// <summary>Final recipient that the report refers to.</summary>
     public string? FinalRecipient { get; set; }
+
+    /// <summary>Normalized address extracted from <see cref="FinalRecipient"/>.</summary>
+    public string? FinalRecipientAddress { get; set; }
 
     /// <summary>Identifier of the original message associated with this report.</summary>
     public string? OriginalMessageId { get; set; }
@@ -42,7 +48,9 @@ public sealed class NonDeliveryReport {
 
         var ndr = new NonDeliveryReport {
             OriginalRecipient = originalRecipient,
+            OriginalRecipientAddress = ExtractAddress(originalRecipient),
             FinalRecipient = finalRecipient,
+            FinalRecipientAddress = ExtractAddress(finalRecipient),
             OriginalMessageId = originalMessageId,
             ReportingMta = reportingMta,
             DiagnosticCode = diagnosticCode is not null ? DsnDiagnosticCode.Parse(diagnosticCode) : null,
@@ -50,6 +58,14 @@ public sealed class NonDeliveryReport {
             Timestamp = ParseTimestamp(arrivalDate)
         };
         return ndr;
+    }
+
+    private static string? ExtractAddress(string? header) {
+        if (string.IsNullOrWhiteSpace(header)) {
+            return null;
+        }
+        var idx = header.IndexOf(';');
+        return idx >= 0 ? header.Substring(idx + 1).Trim() : header.Trim();
     }
 
     private static DateTimeOffset ParseTimestamp(string? value) {

--- a/Sources/Mailozaurr/SentMessages/SendLogResolver.cs
+++ b/Sources/Mailozaurr/SentMessages/SendLogResolver.cs
@@ -12,10 +12,13 @@ public sealed class SendLogResolver {
             return null;
         }
         var record = await repository.GetByMessageIdAsync(report.OriginalMessageId!, cancellationToken);
-        if (record != null && !string.IsNullOrWhiteSpace(report.FinalRecipient)) {
-            var recipients = record.Recipients.Split(',');
-            if (!recipients.Any(r => string.Equals(r, report.FinalRecipient, StringComparison.OrdinalIgnoreCase))) {
-                return null;
+        if (record != null) {
+            var recipient = report.FinalRecipientAddress ?? report.OriginalRecipientAddress;
+            if (!string.IsNullOrWhiteSpace(recipient)) {
+                var recipients = record.Recipients.Split(',').Select(r => r.Trim());
+                if (!recipients.Any(r => string.Equals(r, recipient, StringComparison.OrdinalIgnoreCase))) {
+                    return null;
+                }
             }
         }
         return record;


### PR DESCRIPTION
## Summary
- parse `Original-Recipient` and `Final-Recipient` DSN headers and store normalized addresses
- match sent logs using normalized DSN recipient
- test coverage for `rfc822;` DSN headers

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net472`


------
https://chatgpt.com/codex/tasks/task_e_688e61615620832e953e65b7a5ceae09