### PR TITLE
Support multiple non-delivery reports

### DIFF
--- a/Sources/Mailozaurr.Examples/DetectNonDeliveryReportExample.cs
+++ b/Sources/Mailozaurr.Examples/DetectNonDeliveryReportExample.cs
@@ -13,9 +13,11 @@ public static class DetectNonDeliveryReportExample {
         const string raw = "Content-Type: multipart/report; report-type=delivery-status; boundary=\"XXXX\"\n\n--XXXX\nContent-Type: text/plain; charset=utf-8\n\nThis is the mail system at example.com\n\n--XXXX\nContent-Type: message/delivery-status\n\nOriginal-Recipient: rfc822; orig@example.com\nFinal-Recipient: rfc822; final@example.com\nReporting-MTA: dns; mx.example.com\nDiagnostic-Code: smtp; 550 5.1.1 User unknown\nStatus: 5.1.1\nArrival-Date: Wed, 24 Jul 2024 10:00:00 +0000\n\n--XXXX--";
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));
         var message = MimeMessage.Load(stream);
-        var report = MimeKitUtils.GetNonDeliveryReport(message);
-        if (report != null) {
-            Console.WriteLine($"Detected NDR: {report.Type} with status {report.Status}");
+        var reports = MimeKitUtils.GetNonDeliveryReports(message);
+        if (reports.Count > 0) {
+            foreach (var report in reports) {
+                Console.WriteLine($"Detected NDR: {report.Type} with status {report.Status}");
+            }
         } else {
             Console.WriteLine("No NDR detected.");
         }

--- a/Sources/Mailozaurr.Tests/MimeKitNonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/MimeKitNonDeliveryReportTests.cs
@@ -9,12 +9,23 @@ namespace Mailozaurr.Tests;
 
 public class MimeKitNonDeliveryReportTests {
     [Fact]
-    public void GetNonDeliveryReport_ParsesMessage() {
+    public void GetNonDeliveryReports_ParsesSingleMessage() {
         const string raw = "Content-Type: multipart/report; report-type=delivery-status; boundary=\"XXX\"\n\n--XXX\nContent-Type: text/plain; charset=utf-8\n\ntext\n\n--XXX\nContent-Type: message/delivery-status\n\nOriginal-Recipient: rfc822; user@example.com\nFinal-Recipient: rfc822; user@example.com\nReporting-MTA: dns; mx.example.com\nDiagnostic-Code: smtp; 550 5.1.1 User unknown\nStatus: 5.1.1\nArrival-Date: Wed, 24 Jul 2024 10:00:00 +0000\n\n--XXX--";
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));
         var message = MimeMessage.Load(stream);
-        NonDeliveryReport? report = MimeKitUtils.GetNonDeliveryReport(message);
-        Assert.NotNull(report);
-        Assert.Equal(NonDeliveryReportType.UnknownRecipient, report!.Type);
+        var reports = MimeKitUtils.GetNonDeliveryReports(message);
+        Assert.Single(reports);
+        Assert.Equal(NonDeliveryReportType.UnknownRecipient, reports[0].Type);
+    }
+
+    [Fact]
+    public void GetNonDeliveryReports_ParsesMultipleReports() {
+        const string raw = "Content-Type: multipart/report; report-type=delivery-status; boundary=\"XXX\"\n\n--XXX\nContent-Type: text/plain; charset=utf-8\n\ntext\n\n--XXX\nContent-Type: message/delivery-status\n\nOriginal-Recipient: rfc822; user1@example.com\nFinal-Recipient: rfc822; user1@example.com\nReporting-MTA: dns; mx.example.com\nDiagnostic-Code: smtp; 550 5.1.1 User unknown\nStatus: 5.1.1\nArrival-Date: Wed, 24 Jul 2024 10:00:00 +0000\n\nOriginal-Recipient: rfc822; user2@example.com\nFinal-Recipient: rfc822; user2@example.com\nReporting-MTA: dns; mx.example.com\nDiagnostic-Code: smtp; 550 5.2.2 Mailbox full\nStatus: 5.2.2\nArrival-Date: Wed, 24 Jul 2024 10:00:00 +0000\n\n--XXX--";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));
+        var message = MimeMessage.Load(stream);
+        var reports = MimeKitUtils.GetNonDeliveryReports(message);
+        Assert.Equal(2, reports.Count);
+        Assert.EndsWith("user1@example.com", reports[0].FinalRecipient);
+        Assert.EndsWith("user2@example.com", reports[1].FinalRecipient);
     }
 }

--- a/Sources/Mailozaurr.Tests/NonDeliveryReportDetectionTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportDetectionTests.cs
@@ -19,23 +19,23 @@ public class NonDeliveryReportDetectionTests {
     public void ImapEmailMessageDetectsNdr() {
         var msg = CreateNdrMessage();
         var imap = new ImapEmailMessage(new UniqueId(1), msg);
-        Assert.NotNull(imap.NonDeliveryReport);
-        Assert.Equal(NonDeliveryReportType.UnknownRecipient, imap.NonDeliveryReport!.Type);
+        Assert.Single(imap.NonDeliveryReports);
+        Assert.Equal(NonDeliveryReportType.UnknownRecipient, imap.NonDeliveryReports[0].Type);
     }
 
     [Fact]
     public void Pop3EmailMessageDetectsNdr() {
         var msg = CreateNdrMessage();
         var pop3 = new Pop3EmailMessage(0, msg);
-        Assert.NotNull(pop3.NonDeliveryReport);
-        Assert.Equal(NonDeliveryReportType.UnknownRecipient, pop3.NonDeliveryReport!.Type);
+        Assert.Single(pop3.NonDeliveryReports);
+        Assert.Equal(NonDeliveryReportType.UnknownRecipient, pop3.NonDeliveryReports[0].Type);
     }
 
     [Fact]
     public void GraphEmailMessageDetectsNdr() {
         var msg = CreateNdrMessage();
         var graph = new GraphEmailMessage("id", msg);
-        Assert.NotNull(graph.NonDeliveryReport);
-        Assert.Equal(NonDeliveryReportType.UnknownRecipient, graph.NonDeliveryReport!.Type);
+        Assert.Single(graph.NonDeliveryReports);
+        Assert.Equal(NonDeliveryReportType.UnknownRecipient, graph.NonDeliveryReports[0].Type);
     }
 }

--- a/Sources/Mailozaurr/GraphEmailMessage.cs
+++ b/Sources/Mailozaurr/GraphEmailMessage.cs
@@ -12,11 +12,11 @@ public class GraphEmailMessage {
     /// </summary>
     /// <param name="id">Unique identifier of the message.</param>
     /// <param name="message">The MIME message.</param>
-    public GraphEmailMessage(string id, MimeMessage message, NonDeliveryReport? nonDeliveryReport = null) {
+    public GraphEmailMessage(string id, MimeMessage message, IList<NonDeliveryReport>? nonDeliveryReports = null) {
         Id = id;
         Message = message;
         Encryption = MimeKitUtils.GetEncryption(message);
-        NonDeliveryReport = nonDeliveryReport ?? MimeKitUtils.GetNonDeliveryReport(message);
+        NonDeliveryReports = nonDeliveryReports ?? MimeKitUtils.GetNonDeliveryReports(message);
     }
 
     /// <summary>Unique identifier of the message.</summary>
@@ -29,7 +29,7 @@ public class GraphEmailMessage {
     public EmailEncryption Encryption { get; }
 
     /// <summary>Parsed Non-Delivery Report details, if available.</summary>
-    public NonDeliveryReport? NonDeliveryReport { get; }
+    public IList<NonDeliveryReport> NonDeliveryReports { get; }
 
     /// <inheritdoc />
     public override string ToString() => Message.Subject ?? base.ToString();

--- a/Sources/Mailozaurr/ImapEmailMessage.cs
+++ b/Sources/Mailozaurr/ImapEmailMessage.cs
@@ -16,11 +16,11 @@ public class ImapEmailMessage {
     /// </summary>
     /// <param name="uid">Unique identifier of the message.</param>
     /// <param name="message">The actual MIME message.</param>
-    public ImapEmailMessage(UniqueId uid, MimeMessage message, NonDeliveryReport? nonDeliveryReport = null) {
+    public ImapEmailMessage(UniqueId uid, MimeMessage message, IList<NonDeliveryReport>? nonDeliveryReports = null) {
         Uid = uid;
         Message = message;
         Encryption = MimeKitUtils.GetEncryption(message);
-        NonDeliveryReport = nonDeliveryReport ?? MimeKitUtils.GetNonDeliveryReport(message);
+        NonDeliveryReports = nonDeliveryReports ?? MimeKitUtils.GetNonDeliveryReports(message);
     }
 
     /// <summary>Unique identifier of the message.</summary>
@@ -33,7 +33,7 @@ public class ImapEmailMessage {
     public EmailEncryption Encryption { get; }
 
     /// <summary>Parsed Non-Delivery Report details, if available.</summary>
-    public NonDeliveryReport? NonDeliveryReport { get; }
+    public IList<NonDeliveryReport> NonDeliveryReports { get; }
 
     /// <inheritdoc />
     public override string ToString() => Message.Subject ?? base.ToString();

--- a/Sources/Mailozaurr/MimeKitUtils.cs
+++ b/Sources/Mailozaurr/MimeKitUtils.cs
@@ -30,29 +30,42 @@ public static class MimeKitUtils {
         }
     }
 
-    /// <summary>Attempts to extract a <see cref="NonDeliveryReport"/> from a message.</summary>
-    public static NonDeliveryReport? GetNonDeliveryReport(MimeMessage message) {
+    /// <summary>
+    /// Attempts to extract all <see cref="NonDeliveryReport"/> instances from a message.
+    /// </summary>
+    public static IList<NonDeliveryReport> GetNonDeliveryReports(MimeMessage message) {
+        var reports = new List<NonDeliveryReport>();
         if (message == null) {
-            return null;
+            return reports;
         }
 
         var status = FindDeliveryStatus(message.Body);
         if (status == null && !SubjectIndicatesNdr(message.Subject)) {
-            return null;
+            return reports;
         }
 
-        var headers = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
         if (status != null) {
             foreach (var group in status.StatusGroups) {
+                var headers = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
                 foreach (var header in group) {
                     if (!headers.ContainsKey(header.Field)) {
                         headers[header.Field] = header.Value;
                     }
                 }
+
+                reports.Add(headers.Count > 0 ? NonDeliveryReport.FromHeaders(headers) : new NonDeliveryReport());
             }
+        } else {
+            reports.Add(new NonDeliveryReport());
         }
 
-        return headers.Count > 0 ? NonDeliveryReport.FromHeaders(headers) : new NonDeliveryReport();
+        return reports;
+    }
+
+    /// <summary>Attempts to extract the first <see cref="NonDeliveryReport"/> from a message.</summary>
+    public static NonDeliveryReport? GetNonDeliveryReport(MimeMessage message) {
+        var reports = GetNonDeliveryReports(message);
+        return reports.Count > 0 ? reports[0] : null;
     }
 
     private static MessageDeliveryStatus? FindDeliveryStatus(MimeEntity entity) {

--- a/Sources/Mailozaurr/Pop3EmailMessage.cs
+++ b/Sources/Mailozaurr/Pop3EmailMessage.cs
@@ -15,11 +15,11 @@ public class Pop3EmailMessage {
     /// </summary>
     /// <param name="index">Index of the message within the mailbox.</param>
     /// <param name="message">The actual MIME message.</param>
-    public Pop3EmailMessage(int index, MimeMessage message, NonDeliveryReport? nonDeliveryReport = null) {
+    public Pop3EmailMessage(int index, MimeMessage message, IList<NonDeliveryReport>? nonDeliveryReports = null) {
         Index = index;
         Message = message;
         Encryption = MimeKitUtils.GetEncryption(message);
-        NonDeliveryReport = nonDeliveryReport ?? MimeKitUtils.GetNonDeliveryReport(message);
+        NonDeliveryReports = nonDeliveryReports ?? MimeKitUtils.GetNonDeliveryReports(message);
     }
 
     /// <summary>Index of the message within the mailbox.</summary>
@@ -32,7 +32,7 @@ public class Pop3EmailMessage {
     public EmailEncryption Encryption { get; }
 
     /// <summary>Parsed Non-Delivery Report details, if available.</summary>
-    public NonDeliveryReport? NonDeliveryReport { get; }
+    public IList<NonDeliveryReport> NonDeliveryReports { get; }
 
     /// <inheritdoc />
     public override string ToString() => Message.Subject ?? base.ToString();

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -197,13 +197,13 @@ public static class MailboxSearcher {
         string? messageId) {
         var results = new List<NonDeliveryReport>();
         foreach (var message in messages) {
-            var report = MimeKitUtils.GetNonDeliveryReport(message);
-            if (report == null) continue;
-            if (since.HasValue && report.Timestamp.DateTime < since.Value) continue;
-            if (before.HasValue && report.Timestamp.DateTime > before.Value) continue;
-            if (!string.IsNullOrWhiteSpace(recipientContains) && !RecipientMatches(report, recipientContains)) continue;
-            if (!string.IsNullOrWhiteSpace(messageId) && !string.Equals(report.OriginalMessageId, messageId, StringComparison.OrdinalIgnoreCase)) continue;
-            results.Add(report);
+            foreach (var report in MimeKitUtils.GetNonDeliveryReports(message)) {
+                if (since.HasValue && report.Timestamp.DateTime < since.Value) continue;
+                if (before.HasValue && report.Timestamp.DateTime > before.Value) continue;
+                if (!string.IsNullOrWhiteSpace(recipientContains) && !RecipientMatches(report, recipientContains)) continue;
+                if (!string.IsNullOrWhiteSpace(messageId) && !string.Equals(report.OriginalMessageId, messageId, StringComparison.OrdinalIgnoreCase)) continue;
+                results.Add(report);
+            }
         }
         return results;
     }

--- a/Sources/Mailozaurr/Receive/MessageFetcher.cs
+++ b/Sources/Mailozaurr/Receive/MessageFetcher.cs
@@ -93,8 +93,8 @@ public static class MessageFetcher {
             if (priority.HasValue && msg.Priority != ConvertPriority(priority.Value)) {
                 continue;
             }
-            var ndr = MimeKitUtils.GetNonDeliveryReport(msg);
-            yield return new ImapEmailMessage(uid, msg, ndr);
+            var reports = MimeKitUtils.GetNonDeliveryReports(msg);
+            yield return new ImapEmailMessage(uid, msg, reports);
             if (delete) {
                 await mailFolder.AddFlagsAsync(uid, MessageFlags.Deleted, true, cancellationToken).ConfigureAwait(false);
             }
@@ -164,8 +164,8 @@ public static class MessageFetcher {
                 continue;
             }
 
-            var ndr = MimeKitUtils.GetNonDeliveryReport(message);
-            yield return new Pop3EmailMessage(i, message, ndr);
+            var reports = MimeKitUtils.GetNonDeliveryReports(message);
+            yield return new Pop3EmailMessage(i, message, reports);
             if (delete) {
                 await client.DeleteMessageAsync(i, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
## Summary
- add `GetNonDeliveryReports` to parse every DSN status group
- expose `NonDeliveryReports` collections on message wrappers
- iterate over all reports in `MailboxSearcher` and `MessageFetcher`
- test parsing multiple NDRs

## Testing
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_688e656ddc0c832e84b26780336f8aae