### PR TITLE
Parse extra DSN headers

### DIFF
--- a/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
@@ -21,10 +21,16 @@ public class NonDeliveryReportTests {
 
     [Fact]
     public void ParseHeadersCreatesReport() {
+        var lastAttempt = DateTimeOffset.UtcNow;
+        var lastAttemptHeader = lastAttempt.ToString("R");
         var headers = new Dictionary<string, string> {
             ["Original-Recipient"] = "rfc822; orig@example.com",
             ["Final-Recipient"] = "rfc822; final@example.com",
             ["Reporting-MTA"] = "dns; mx.example.com",
+            ["Action"] = "failed",
+            ["Remote-MTA"] = "dns; remote.example.com",
+            ["Last-Attempt-Date"] = lastAttemptHeader,
+            ["Final-Log-ID"] = "ABC123",
             ["Diagnostic-Code"] = "smtp; 550 5.1.1 User unknown",
             ["Status"] = "5.1.1",
             ["Arrival-Date"] = DateTimeOffset.UtcNow.ToString("R")
@@ -35,6 +41,10 @@ public class NonDeliveryReportTests {
         Assert.Equal("orig@example.com", report.OriginalRecipientAddress);
         Assert.Equal("final@example.com", report.FinalRecipientAddress);
         Assert.Equal("dns; mx.example.com", report.ReportingMta);
+        Assert.Equal("failed", report.Action);
+        Assert.Equal("dns; remote.example.com", report.RemoteMta);
+        Assert.Equal(DateTimeOffset.Parse(lastAttemptHeader), report.LastAttemptDate);
+        Assert.Equal("ABC123", report.FinalLogId);
         Assert.NotNull(report.DiagnosticCode);
         Assert.NotNull(report.Status);
         Assert.Equal(NonDeliveryReportType.UnknownRecipient, report.Type);

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
@@ -24,6 +24,18 @@ public sealed class NonDeliveryReport {
     /// <summary>Reporting mail transfer agent.</summary>
     public string? ReportingMta { get; set; }
 
+    /// <summary>Action taken by the server for the delivery attempt.</summary>
+    public string? Action { get; set; }
+
+    /// <summary>Remote mail transfer agent involved in the delivery.</summary>
+    public string? RemoteMta { get; set; }
+
+    /// <summary>Date of the last delivery attempt.</summary>
+    public DateTimeOffset LastAttemptDate { get; set; }
+
+    /// <summary>Identifier of the final log entry.</summary>
+    public string? FinalLogId { get; set; }
+
     /// <summary>Diagnostic code explaining the failure.</summary>
     public DsnDiagnosticCode? DiagnosticCode { get; set; }
 
@@ -41,6 +53,10 @@ public sealed class NonDeliveryReport {
         headers.TryGetValue("Original-Recipient", out var originalRecipient);
         headers.TryGetValue("Final-Recipient", out var finalRecipient);
         headers.TryGetValue("Reporting-MTA", out var reportingMta);
+        headers.TryGetValue("Action", out var action);
+        headers.TryGetValue("Remote-MTA", out var remoteMta);
+        headers.TryGetValue("Last-Attempt-Date", out var lastAttemptDate);
+        headers.TryGetValue("Final-Log-ID", out var finalLogId);
         headers.TryGetValue("Original-Message-ID", out var originalMessageId);
         headers.TryGetValue("Diagnostic-Code", out var diagnosticCode);
         headers.TryGetValue("Status", out var statusCode);
@@ -53,6 +69,10 @@ public sealed class NonDeliveryReport {
             FinalRecipientAddress = ExtractAddress(finalRecipient),
             OriginalMessageId = originalMessageId,
             ReportingMta = reportingMta,
+            Action = action,
+            RemoteMta = remoteMta,
+            LastAttemptDate = ParseTimestamp(lastAttemptDate),
+            FinalLogId = finalLogId,
             DiagnosticCode = diagnosticCode is not null ? DsnDiagnosticCode.Parse(diagnosticCode) : null,
             Status = statusCode is not null && DsnStatus.TryParse(statusCode, out var status) ? status : null,
             Timestamp = ParseTimestamp(arrivalDate)


### PR DESCRIPTION
## Summary
- parse additional DSN headers (Action, Remote-MTA, Last-Attempt-Date, Final-Log-ID)
- test that NonDeliveryReport exposes the new properties

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688e6b652130832ea7e2f0e745ca1afb