### PR TITLE
Optimize NDR search filters

### DIFF
--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using MailKit.Search;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -41,5 +42,43 @@ public class SearchNonDeliveryReportsTests {
         var reports = MailboxSearcher.FilterNonDeliveryReports(list, since: now.AddMinutes(-5).DateTime, before: null, recipientContains: null, messageId: null);
         Assert.Single(reports);
         Assert.Equal("<id2>", reports[0].OriginalMessageId);
+    }
+
+    private static bool Contains(SearchQuery query, Func<SearchQuery, bool> predicate) {
+        if (predicate(query)) return true;
+        var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic;
+        var leftProp = query.GetType().GetProperty("Left", flags);
+        var rightProp = query.GetType().GetProperty("Right", flags);
+        var left = leftProp?.GetValue(query) as SearchQuery;
+        var right = rightProp?.GetValue(query) as SearchQuery;
+        if (left != null && Contains(left, predicate)) return true;
+        if (right != null && Contains(right, predicate)) return true;
+        return false;
+    }
+
+    [Fact]
+    public void BuildNonDeliveryReportSearchQuery_ContainsFilters() {
+        var query = MailboxSearcher.BuildNonDeliveryReportSearchQuery(null, null);
+        var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic;
+        bool hasHeader = Contains(query, q => {
+            var term = q.GetType().GetProperty("Term", flags)?.GetValue(q)?.ToString();
+            if (term == "HeaderContains") {
+                var field = q.GetType().GetProperty("Field", flags)?.GetValue(q)?.ToString();
+                var value = q.GetType().GetProperty("Value", flags)?.GetValue(q)?.ToString();
+                return string.Equals(field, "Content-Type", StringComparison.OrdinalIgnoreCase) &&
+                    value?.IndexOf("delivery-status", StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+            return false;
+        });
+        Assert.True(hasHeader);
+        bool hasSubject = Contains(query, q => {
+            var term = q.GetType().GetProperty("Term", flags)?.GetValue(q)?.ToString();
+            if (term == "SubjectContains") {
+                var text = q.GetType().GetProperty("Text", flags)?.GetValue(q)?.ToString();
+                return text?.IndexOf("Mail delivery failed", StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+            return false;
+        });
+        Assert.True(hasSubject);
     }
 }

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -122,9 +122,7 @@ public static class MailboxSearcher {
         int maxResults = 0,
         CancellationToken cancellationToken = default) {
         var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
-        SearchQuery search = SearchQuery.All;
-        if (since.HasValue) search = search.And(SearchQuery.DeliveredAfter(since.Value));
-        if (before.HasValue) search = search.And(SearchQuery.DeliveredBefore(before.Value));
+        var search = BuildNonDeliveryReportSearchQuery(since, before);
         var uids = await mailFolder.SearchAsync(search, cancellationToken).ConfigureAwait(false);
         var messages = new List<MimeMessage>(uids.Count);
         foreach (var uid in uids) {
@@ -178,14 +176,24 @@ public static class MailboxSearcher {
             filter,
             maxResults > 0 ? maxResults : (int?)null).ConfigureAwait(false);
         var mimeMessages = new List<MimeMessage>(msgs.Count);
+        using var semaphore = new SemaphoreSlim(4);
+        var tasks = new List<Task>();
         foreach (var m in msgs) {
             cancellationToken.ThrowIfCancellationRequested();
             if (m.TryGetValue("id", out var idObj) && idObj is string id) {
-                var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
-                mimeMessages.Add(mime);
-                if (maxResults > 0 && mimeMessages.Count >= maxResults) break;
+                tasks.Add(Task.Run(async () => {
+                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                        lock (mimeMessages) mimeMessages.Add(mime);
+                    } finally {
+                        semaphore.Release();
+                    }
+                }, cancellationToken));
             }
         }
+        await Task.WhenAll(tasks).ConfigureAwait(false);
         return FilterNonDeliveryReports(mimeMessages, since, before, recipientContains, messageId);
     }
 
@@ -229,6 +237,27 @@ public static class MailboxSearcher {
             if (!string.IsNullOrWhiteSpace(addr.Name) && addr.Name.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
         }
         return false;
+    }
+
+    private static readonly string[] NdrSubjectPatterns = new[] {
+        "Undelivered Mail Returned to Sender",
+        "Delivery Status Notification",
+        "Mail delivery failed",
+        "Mail Delivery Subsystem",
+        "Failure Notice"
+    };
+
+    internal static SearchQuery BuildNonDeliveryReportSearchQuery(DateTime? since, DateTime? before) {
+        SearchQuery search = SearchQuery.HeaderContains("Content-Type", "delivery-status");
+        SearchQuery? subjectQuery = null;
+        foreach (var pattern in NdrSubjectPatterns) {
+            var q = SearchQuery.SubjectContains(pattern);
+            subjectQuery = subjectQuery == null ? q : subjectQuery.Or(q);
+        }
+        if (subjectQuery != null) search = search.Or(subjectQuery);
+        if (since.HasValue) search = search.And(SearchQuery.DeliveredAfter(since.Value));
+        if (before.HasValue) search = search.And(SearchQuery.DeliveredBefore(before.Value));
+        return search;
     }
 
     internal sealed class ParsedQuery {


### PR DESCRIPTION
## Summary
- refine IMAP NDR search to pre-filter by delivery-status header and common subject patterns
- fetch Graph message MIME bodies in parallel with capped concurrency
- add tests validating NDR search query includes header and subject filters

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_688e701b249c832ea20fdae1f71ba3f5