### PR TITLE
Serialize NonDeliveryReport searches

### DIFF
--- a/Sources/Mailozaurr.Tests/NonDeliveryReportServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportServiceTests.cs
@@ -1,6 +1,7 @@
 using Mailozaurr;
 using Mailozaurr.NonDeliveryReports;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -36,6 +37,36 @@ public class NonDeliveryReportServiceTests {
             CancellationToken cancellationToken) => Task.FromResult(reports);
     }
 
+    private sealed class ConcurrencyTestService : NonDeliveryReportServiceBase {
+        private int current;
+        private int maxConcurrent;
+
+        public ConcurrencyTestService(SendLogResolver resolver) : base(resolver) { }
+
+        public int MaxConcurrency => maxConcurrent;
+
+        protected override async Task<IList<NonDeliveryReport>> SearchInternalAsync(
+            DateTime? since,
+            DateTime? before,
+            string? recipientContains,
+            string? messageId,
+            int maxResults,
+            CancellationToken cancellationToken) {
+            int concurrency = Interlocked.Increment(ref current);
+            int initial;
+            do {
+                initial = maxConcurrent;
+                if (concurrency <= initial) {
+                    break;
+                }
+            }
+            while (Interlocked.CompareExchange(ref maxConcurrent, concurrency, initial) != initial);
+            await Task.Delay(50, cancellationToken);
+            Interlocked.Decrement(ref current);
+            return Array.Empty<NonDeliveryReport>();
+        }
+    }
+
     [Fact]
     public async Task SearchAsync_ResolvesSentMessage() {
         var repo = new InMemorySentMessageRepository();
@@ -49,5 +80,17 @@ public class NonDeliveryReportServiceTests {
         Assert.Single(results);
         Assert.Equal(report, results[0].Report);
         Assert.Equal(record, results[0].SentMessage);
+    }
+
+    [Fact]
+    public async Task SearchAsync_SerializesInternalCalls() {
+        var repo = new InMemorySentMessageRepository();
+        var resolver = new SendLogResolver(repo);
+        var service = new ConcurrencyTestService(resolver);
+
+        Task[] tasks = Enumerable.Range(0, 5).Select(_ => service.SearchAsync()).ToArray();
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(1, service.MaxConcurrency);
     }
 }

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportServiceBase.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportServiceBase.cs
@@ -7,6 +7,7 @@ namespace Mailozaurr.NonDeliveryReports;
 
 public abstract class NonDeliveryReportServiceBase : INonDeliveryReportService {
     private readonly SendLogResolver resolver;
+    private readonly SemaphoreSlim gate = new(1, 1);
 
     protected NonDeliveryReportServiceBase(SendLogResolver resolver) => this.resolver = resolver;
 
@@ -17,7 +18,14 @@ public abstract class NonDeliveryReportServiceBase : INonDeliveryReportService {
         string? messageId = null,
         int maxResults = 0,
         CancellationToken cancellationToken = default) {
-        IList<NonDeliveryReport> reports = await SearchInternalAsync(since, before, recipientContains, messageId, maxResults, cancellationToken).ConfigureAwait(false);
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        IList<NonDeliveryReport> reports;
+        try {
+            reports = await SearchInternalAsync(since, before, recipientContains, messageId, maxResults, cancellationToken).ConfigureAwait(false);
+        }
+        finally {
+            gate.Release();
+        }
         var results = new List<NonDeliveryReportResult>(reports.Count);
         foreach (NonDeliveryReport report in reports) {
             SentMessageRecord? record = await resolver.ResolveAsync(report, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- ensure only one NonDeliveryReport search runs at a time via SemaphoreSlim
- add test verifying concurrent SearchAsync calls are serialized

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688e75f6f86c832e90ec0a0d0305008e