### PR TITLE
Use MimeKit date parser for DSN timestamps

### DIFF
--- a/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
@@ -1,6 +1,7 @@
 using Mailozaurr.NonDeliveryReports;
 using System;
 using System.Collections.Generic;
+using MimeKit.Utils;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -57,5 +58,20 @@ public class NonDeliveryReportTests {
         };
         var report = NonDeliveryReport.FromHeaders(headers);
         Assert.Equal("<msg1@local>", report.OriginalMessageId);
+    }
+
+    [Theory]
+    [InlineData("Fri, 21 Jun 2024 10:12:34 +0000")]
+    [InlineData("Fri, 21 Jun 2024 10:12:34 +0000 (UTC)")]
+    [InlineData("21 Jun 2024 10:12:34 -0700")]
+    public void ParseTimestampHandlesVariousFormats(string dateHeader) {
+        var headers = new Dictionary<string, string> {
+            ["Arrival-Date"] = dateHeader,
+            ["Last-Attempt-Date"] = dateHeader
+        };
+        var report = NonDeliveryReport.FromHeaders(headers);
+        Assert.True(DateUtils.TryParse(dateHeader, out var expected));
+        Assert.Equal(expected, report.Timestamp);
+        Assert.Equal(expected, report.LastAttemptDate);
     }
 }

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+using MimeKit.Utils;
 
 namespace Mailozaurr.NonDeliveryReports;
 
@@ -89,7 +89,7 @@ public sealed class NonDeliveryReport {
     }
 
     private static DateTimeOffset ParseTimestamp(string? value) {
-        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt)) {
+        if (DateUtils.TryParse(value, out var dt)) {
             return dt;
         }
         return DateTimeOffset.MinValue;


### PR DESCRIPTION
## Summary
- ensure DSN timestamp parsing uses MimeKit's DateUtils
- add tests for various DSN date formats

## Testing
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_688f12451d9c832eb7b5dbcc4575df87