### PR TITLE
Expand DSN report type mapping

### DIFF
--- a/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
@@ -12,6 +12,9 @@ public class NonDeliveryReportTests {
     [InlineData("4.2.2", DsnStatusClass.PersistentTransientFailure, NonDeliveryReportType.MailboxFull)]
     [InlineData("4.1.0", DsnStatusClass.PersistentTransientFailure, NonDeliveryReportType.SoftBounce)]
     [InlineData("5.0.0", DsnStatusClass.PermanentFailure, NonDeliveryReportType.HardBounce)]
+    [InlineData("5.7.1", DsnStatusClass.PermanentFailure, NonDeliveryReportType.PolicyBlock)]
+    [InlineData("5.6.1", DsnStatusClass.PermanentFailure, NonDeliveryReportType.ContentRejected)]
+    [InlineData("4.4.1", DsnStatusClass.PersistentTransientFailure, NonDeliveryReportType.DnsFailure)]
     public void ParseStatusAndMapType(string code, DsnStatusClass expectedClass, NonDeliveryReportType expectedType) {
         var status = DsnStatus.Parse(code);
         Assert.Equal(expectedClass, status.Class);

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
@@ -100,16 +100,14 @@ public sealed class NonDeliveryReport {
         if (status is null) {
             return NonDeliveryReportType.Unknown;
         }
-        var statusCode = status.ToString();
-        if (statusCode == "5.1.1") {
-            return NonDeliveryReportType.UnknownRecipient;
-        }
-        if (statusCode == "5.2.2" || statusCode == "4.2.2") {
-            return NonDeliveryReportType.MailboxFull;
-        }
-        return status.Class switch {
-            DsnStatusClass.PermanentFailure => NonDeliveryReportType.HardBounce,
-            DsnStatusClass.PersistentTransientFailure => NonDeliveryReportType.SoftBounce,
+        return status switch {
+            { Subject: 1, Detail: 1 } => NonDeliveryReportType.UnknownRecipient,
+            { Subject: 2, Detail: 2 } => NonDeliveryReportType.MailboxFull,
+            { Subject: 7 } => NonDeliveryReportType.PolicyBlock,
+            { Subject: 6 } => NonDeliveryReportType.ContentRejected,
+            { Subject: 4 } => NonDeliveryReportType.DnsFailure,
+            { Class: DsnStatusClass.PermanentFailure } => NonDeliveryReportType.HardBounce,
+            { Class: DsnStatusClass.PersistentTransientFailure } => NonDeliveryReportType.SoftBounce,
             _ => NonDeliveryReportType.Unknown
         };
     }

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportType.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportType.cs
@@ -13,5 +13,11 @@ public enum NonDeliveryReportType {
     /// <summary>The recipient's mailbox is full.</summary>
     MailboxFull,
     /// <summary>The recipient does not exist.</summary>
-    UnknownRecipient
+    UnknownRecipient,
+    /// <summary>The message was blocked due to policy or security settings.</summary>
+    PolicyBlock,
+    /// <summary>The message content was rejected or unsupported.</summary>
+    ContentRejected,
+    /// <summary>The message could not be delivered due to DNS or routing failures.</summary>
+    DnsFailure
 }


### PR DESCRIPTION
## Summary
- add report types for policy blocks, content rejections, and DNS failures
- map DSN status codes to report types via pattern matching
- test updated report type mappings

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --filter NonDeliveryReportTests -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_688f1236cf78832e9e07ba3c0c71ccf3