### PR TITLE
Normalize recipient matching in NDR filtering

### DIFF
--- a/Sources/Mailozaurr.Tests/NonDeliveryReportDetectionTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportDetectionTests.cs
@@ -38,4 +38,15 @@ public class NonDeliveryReportDetectionTests {
         Assert.Single(graph.NonDeliveryReports);
         Assert.Equal(NonDeliveryReportType.UnknownRecipient, graph.NonDeliveryReports[0].Type);
     }
+
+    [Fact]
+    public void FilterNonDeliveryReports_IgnoresRecipientPrefixes() {
+        var msg = CreateNdrMessage();
+        var reports = MailboxSearcher.FilterNonDeliveryReports(new[] { msg }, null, null, "final@example.com", null);
+        Assert.Single(reports);
+        reports = MailboxSearcher.FilterNonDeliveryReports(new[] { msg }, null, null, "orig@example.com", null);
+        Assert.Single(reports);
+        reports = MailboxSearcher.FilterNonDeliveryReports(new[] { msg }, null, null, "rfc822", null);
+        Assert.Empty(reports);
+    }
 }

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -217,10 +217,10 @@ public static class MailboxSearcher {
     }
 
     private static bool RecipientMatches(NonDeliveryReport report, string filter) {
-        if (!string.IsNullOrWhiteSpace(report.FinalRecipient) &&
-            report.FinalRecipient.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
-        if (!string.IsNullOrWhiteSpace(report.OriginalRecipient) &&
-            report.OriginalRecipient.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        if (!string.IsNullOrWhiteSpace(report.FinalRecipientAddress) &&
+            report.FinalRecipientAddress.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        if (!string.IsNullOrWhiteSpace(report.OriginalRecipientAddress) &&
+            report.OriginalRecipientAddress.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
         return false;
     }
 


### PR DESCRIPTION
## Summary
- match NDR recipients using parsed email addresses
- test that recipient filters ignore address type prefixes

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688f122ba63c832eb79b17a62e75e531