### PR TITLE
Parallelize NDR search downloads

### DIFF
--- a/Examples/Example-GetEmailDeliveryStatus.ps1
+++ b/Examples/Example-GetEmailDeliveryStatus.ps1
@@ -2,5 +2,5 @@ Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
 # Search recent non-delivery reports via IMAP
 Connect-IMAP -Server 'imap.example.com' -Credential (Get-Credential) | Out-Null
-Get-EmailDeliveryStatus -Protocol Imap -Recipient 'user@contoso.com' -Since (Get-Date).AddDays(-7)
+Get-EmailDeliveryStatus -Protocol Imap -Recipient 'user@contoso.com' -Since (Get-Date).AddDays(-7) -ParallelDownloadLimit 8
 Disconnect-IMAP

--- a/Examples/Example-RetrieveAndCorrelateNdr.ps1
+++ b/Examples/Example-RetrieveAndCorrelateNdr.ps1
@@ -4,7 +4,7 @@ Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 $repo = [Mailozaurr.FileSentMessageRepository]::new("$env:TEMP\sendlog.json")
 $resolver = [Mailozaurr.SendLogResolver]::new($repo)
 Connect-IMAP -Server 'imap.example.com' -Credential (Get-Credential) | Out-Null
-$ndrs = Get-EmailDeliveryStatus -Protocol Imap -Since (Get-Date).AddDays(-7)
+$ndrs = Get-EmailDeliveryStatus -Protocol Imap -Since (Get-Date).AddDays(-7) -ParallelDownloadLimit 8
 Get-EmailDeliveryMatch -Protocol Imap -Resolver $resolver -Since (Get-Date).AddDays(-7) | ForEach-Object {
     Write-Host "NDR for $($_.Report.FinalRecipient) matches message '$($_.SentMessage.Subject)'"
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailDeliveryStatus.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailDeliveryStatus.cs
@@ -82,7 +82,7 @@ public sealed class CmdletGetEmailDeliveryStatus : AsyncPSCmdlet
                         Recipient,
                         MessageId,
                         max,
-                        CancelToken);
+                        cancellationToken: CancelToken);
                     foreach (var report in reports)
                     {
                         WriteObject(report);
@@ -111,7 +111,7 @@ public sealed class CmdletGetEmailDeliveryStatus : AsyncPSCmdlet
                         Recipient,
                         MessageId,
                         max,
-                        CancelToken);
+                        cancellationToken: CancelToken);
                     foreach (var report in reports)
                     {
                         WriteObject(report);
@@ -141,7 +141,7 @@ public sealed class CmdletGetEmailDeliveryStatus : AsyncPSCmdlet
                         Recipient,
                         MessageId,
                         max,
-                        CancelToken);
+                        cancellationToken: CancelToken);
                     foreach (var report in reports)
                     {
                         WriteObject(report);

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailDeliveryStatus.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailDeliveryStatus.cs
@@ -63,6 +63,13 @@ public sealed class CmdletGetEmailDeliveryStatus : AsyncPSCmdlet
     [Parameter]
     public string? UserPrincipalName { get; set; }
 
+    /// <summary>
+    /// <para type="description">Maximum concurrent MIME downloads; set to 1 to disable parallelism.</para>
+    /// </summary>
+    [Parameter]
+    [ValidateRange(1, int.MaxValue)]
+    public int ParallelDownloadLimit { get; set; } = 4;
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync()
     {
@@ -82,6 +89,7 @@ public sealed class CmdletGetEmailDeliveryStatus : AsyncPSCmdlet
                         Recipient,
                         MessageId,
                         max,
+                        parallelDownloadLimit: ParallelDownloadLimit,
                         cancellationToken: CancelToken);
                     foreach (var report in reports)
                     {
@@ -111,6 +119,7 @@ public sealed class CmdletGetEmailDeliveryStatus : AsyncPSCmdlet
                         Recipient,
                         MessageId,
                         max,
+                        parallelDownloadLimit: ParallelDownloadLimit,
                         cancellationToken: CancelToken);
                     foreach (var report in reports)
                     {
@@ -141,6 +150,7 @@ public sealed class CmdletGetEmailDeliveryStatus : AsyncPSCmdlet
                         Recipient,
                         MessageId,
                         max,
+                        parallelDownloadLimit: ParallelDownloadLimit,
                         cancellationToken: CancelToken);
                     foreach (var report in reports)
                     {

--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -6,6 +6,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using MailKit.Search;
+using MailKit.Net.Pop3;
+using MailKit;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -80,5 +85,43 @@ public class SearchNonDeliveryReportsTests {
             return false;
         });
         Assert.True(hasSubject);
+    }
+
+    private class FakePop3Client : Pop3Client {
+        private readonly List<MimeMessage> _messages;
+        private readonly int _delay;
+        public FakePop3Client(IEnumerable<MimeMessage> messages, int delay) {
+            _messages = new List<MimeMessage>(messages);
+            _delay = delay;
+        }
+        public override bool IsConnected => true;
+        public override bool IsAuthenticated => true;
+        public override int Count => _messages.Count;
+        public override async Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {
+            await Task.Delay(_delay, cancellationToken).ConfigureAwait(false);
+            return _messages[index];
+        }
+    }
+
+    [Fact]
+    public async Task SearchNonDeliveryReportsAsync_Pop3_DownloadsInParallel() {
+        var now = DateTimeOffset.UtcNow;
+        var msgs = new List<MimeMessage>();
+        for (int i = 0; i < 4; i++) msgs.Add(CreateNdr($"u{i}@example.com", $"<id{i}>", now));
+        var client = new FakePop3Client(msgs, 500);
+        var seq = Stopwatch.StartNew();
+        _ = await MailboxSearcher.SearchNonDeliveryReportsAsync(
+            client,
+            parallelDownloadLimit: 0,
+            cancellationToken: CancellationToken.None);
+        seq.Stop();
+        var sw = Stopwatch.StartNew();
+        var reports = await MailboxSearcher.SearchNonDeliveryReportsAsync(
+            client,
+            parallelDownloadLimit: 4,
+            cancellationToken: CancellationToken.None);
+        sw.Stop();
+        Assert.Equal(4, reports.Count);
+        Assert.True(sw.Elapsed < seq.Elapsed, $"sequential: {seq.ElapsedMilliseconds}, parallel: {sw.ElapsedMilliseconds}");
     }
 }

--- a/Sources/Mailozaurr/NonDeliveryReports/GraphNonDeliveryReportService.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/GraphNonDeliveryReportService.cs
@@ -21,5 +21,5 @@ public sealed class GraphNonDeliveryReportService : NonDeliveryReportServiceBase
         string? messageId,
         int maxResults,
         CancellationToken cancellationToken) =>
-        MailboxSearcher.SearchNonDeliveryReportsAsync(credential, userPrincipalName, since, before, recipientContains, messageId, maxResults, cancellationToken);
+        MailboxSearcher.SearchNonDeliveryReportsAsync(credential, userPrincipalName, since, before, recipientContains, messageId, maxResults, cancellationToken: cancellationToken);
 }

--- a/Sources/Mailozaurr/NonDeliveryReports/ImapNonDeliveryReportService.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/ImapNonDeliveryReportService.cs
@@ -22,5 +22,5 @@ public sealed class ImapNonDeliveryReportService : NonDeliveryReportServiceBase 
         string? messageId,
         int maxResults,
         CancellationToken cancellationToken) =>
-        MailboxSearcher.SearchNonDeliveryReportsAsync(client, folder, since, before, recipientContains, messageId, maxResults, cancellationToken);
+        MailboxSearcher.SearchNonDeliveryReportsAsync(client, folder, since, before, recipientContains, messageId, maxResults, cancellationToken: cancellationToken);
 }

--- a/Sources/Mailozaurr/NonDeliveryReports/Pop3NonDeliveryReportService.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/Pop3NonDeliveryReportService.cs
@@ -18,5 +18,5 @@ public sealed class Pop3NonDeliveryReportService : NonDeliveryReportServiceBase 
         string? messageId,
         int maxResults,
         CancellationToken cancellationToken) =>
-        MailboxSearcher.SearchNonDeliveryReportsAsync(client, since, before, recipientContains, messageId, maxResults, cancellationToken);
+        MailboxSearcher.SearchNonDeliveryReportsAsync(client, since, before, recipientContains, messageId, maxResults, cancellationToken: cancellationToken);
 }

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -120,15 +120,37 @@ public static class MailboxSearcher {
         string? recipientContains = null,
         string? messageId = null,
         int maxResults = 0,
+        int parallelDownloadLimit = 4,
         CancellationToken cancellationToken = default) {
         var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
         var search = BuildNonDeliveryReportSearchQuery(since, before);
         var uids = await mailFolder.SearchAsync(search, cancellationToken).ConfigureAwait(false);
         var messages = new List<MimeMessage>(uids.Count);
-        foreach (var uid in uids) {
-            var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-            messages.Add(msg);
-            if (maxResults > 0 && messages.Count >= maxResults) break;
+        if (parallelDownloadLimit <= 1) {
+            foreach (var uid in uids) {
+                cancellationToken.ThrowIfCancellationRequested();
+                var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
+                messages.Add(msg);
+                if (maxResults > 0 && messages.Count >= maxResults) break;
+            }
+        } else {
+            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
+            var tasks = new List<Task>();
+            foreach (var uid in uids) {
+                cancellationToken.ThrowIfCancellationRequested();
+                tasks.Add(Task.Run(async () => {
+                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
+                        lock (messages) messages.Add(msg);
+                    } finally {
+                        semaphore.Release();
+                    }
+                }, cancellationToken));
+                if (maxResults > 0 && tasks.Count >= maxResults) break;
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
         return FilterNonDeliveryReports(messages, since, before, recipientContains, messageId);
     }
@@ -143,12 +165,37 @@ public static class MailboxSearcher {
         string? recipientContains = null,
         string? messageId = null,
         int maxResults = 0,
+        int parallelDownloadLimit = 4,
         CancellationToken cancellationToken = default) {
-        var messages = new List<MimeMessage>();
-        for (int i = 0; i < client.Count; i++) {
-            var msg = await client.GetMessageAsync(i, cancellationToken).ConfigureAwait(false);
-            messages.Add(msg);
-            if (maxResults > 0 && messages.Count >= maxResults) break;
+        var count = client.Count;
+        var indices = new List<int>(count);
+        for (int i = 0; i < count; i++) indices.Add(i);
+        var messages = new List<MimeMessage>(indices.Count);
+        if (parallelDownloadLimit <= 1) {
+            foreach (var idx in indices) {
+                cancellationToken.ThrowIfCancellationRequested();
+                var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
+                messages.Add(msg);
+                if (maxResults > 0 && messages.Count >= maxResults) break;
+            }
+        } else {
+            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
+            var tasks = new List<Task>();
+            foreach (var idx in indices) {
+                cancellationToken.ThrowIfCancellationRequested();
+                tasks.Add(Task.Run(async () => {
+                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
+                        lock (messages) messages.Add(msg);
+                    } finally {
+                        semaphore.Release();
+                    }
+                }, cancellationToken));
+                if (maxResults > 0 && tasks.Count >= maxResults) break;
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
         return FilterNonDeliveryReports(messages, since, before, recipientContains, messageId);
     }
@@ -164,6 +211,7 @@ public static class MailboxSearcher {
         string? recipientContains = null,
         string? messageId = null,
         int maxResults = 0,
+        int parallelDownloadLimit = 4,
         CancellationToken cancellationToken = default) {
         var filters = new List<string>();
         if (since.HasValue) filters.Add($"receivedDateTime ge {since.Value:o}");
@@ -176,24 +224,34 @@ public static class MailboxSearcher {
             filter,
             maxResults > 0 ? maxResults : (int?)null).ConfigureAwait(false);
         var mimeMessages = new List<MimeMessage>(msgs.Count);
-        using var semaphore = new SemaphoreSlim(4);
-        var tasks = new List<Task>();
-        foreach (var m in msgs) {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (m.TryGetValue("id", out var idObj) && idObj is string id) {
-                tasks.Add(Task.Run(async () => {
-                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    try {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
-                        lock (mimeMessages) mimeMessages.Add(mime);
-                    } finally {
-                        semaphore.Release();
-                    }
-                }, cancellationToken));
+        if (parallelDownloadLimit <= 1) {
+            foreach (var m in msgs) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (m.TryGetValue("id", out var idObj) && idObj is string id) {
+                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                    mimeMessages.Add(mime);
+                }
             }
+        } else {
+            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
+            var tasks = new List<Task>();
+            foreach (var m in msgs) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (m.TryGetValue("id", out var idObj) && idObj is string id) {
+                    tasks.Add(Task.Run(async () => {
+                        await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                        try {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                            lock (mimeMessages) mimeMessages.Add(mime);
+                        } finally {
+                            semaphore.Release();
+                        }
+                    }, cancellationToken));
+                }
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
-        await Task.WhenAll(tasks).ConfigureAwait(false);
         return FilterNonDeliveryReports(mimeMessages, since, before, recipientContains, messageId);
     }
 

--- a/Tests/Get-EmailDeliveryStatus.Tests.ps1
+++ b/Tests/Get-EmailDeliveryStatus.Tests.ps1
@@ -8,4 +8,8 @@ Describe 'Get-EmailDeliveryStatus' {
     It 'Throws when Graph connection missing' {
         { Get-EmailDeliveryStatus -Protocol Graph -UserPrincipalName 'user@example.com' } | Should -Throw
     }
+
+    It 'Accepts ParallelDownloadLimit parameter' {
+        { Get-EmailDeliveryStatus -Protocol Imap -ParallelDownloadLimit 2 } | Should -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- parallelize IMAP, POP3 and Graph non-delivery report searches using SemaphoreSlim
- add optional `parallelDownloadLimit` parameter to cap or disable concurrent MIME fetches
- extend unit test to compare sequential vs parallel POP3 retrieval

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_688f121aa858832e8268a0a83f50306a