### PR TITLE
Serialize SMTP sends to avoid concurrent operations

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpConcurrencyTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConcurrencyTests.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MimeKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpConcurrencyTests
+{
+    private class CountingClient : ClientSmtp
+    {
+        private int _active;
+        public int Max;
+
+        public override async Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken = default, ITransferProgress? progress = null)
+        {
+            var current = Interlocked.Increment(ref _active);
+            int initialMax;
+            do
+            {
+                initialMax = Max;
+                if (current <= initialMax)
+                {
+                    break;
+                }
+            }
+            while (Interlocked.CompareExchange(ref Max, current, initialMax) != initialMax);
+
+            await Task.Delay(100, cancellationToken);
+            Interlocked.Decrement(ref _active);
+            return string.Empty;
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_SerializesConcurrentCalls()
+    {
+        var smtp = new Smtp();
+        var fake = new CountingClient();
+        var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(smtp, fake);
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "b@c.com" };
+        smtp.Subject = "test";
+        smtp.TextBody = "body";
+        smtp.WebhookUrl = null;
+        smtp.CreateMessage();
+
+        var tasks = new[]
+        {
+            smtp.SendAsync(),
+            smtp.SendAsync(),
+            smtp.SendAsync()
+        };
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(1, fake.Max);
+    }
+}
+

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -16,6 +16,9 @@ namespace Mailozaurr;
 /// <remarks>
 /// Provides connection pooling and supports authentication using
 /// multiple mechanisms depending on server capabilities.
+/// <para>Instances are not thread-safe for concurrent operations. Calls to
+/// <see cref="Send"/> or <see cref="SendAsync(System.Threading.CancellationToken)"/>
+/// are serialized so that only one send executes at a time per instance.</para>
 /// </remarks>
 public class Smtp {
 
@@ -164,6 +167,7 @@ public class Smtp {
     }
 
     private bool _skipCertificateValidation;
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
     /// <summary>Skip server certificate validation.</summary>
     public bool SkipCertificateValidation {
         get => _skipCertificateValidation;
@@ -607,17 +611,35 @@ public class Smtp {
     /// <summary>
     /// Send the email message.
     /// </summary>
+    /// <remarks>
+    /// Concurrent calls are serialized so that only one send executes at a time for a
+    /// given instance.
+    /// </remarks>
     /// <returns></returns>
     public SmtpResult Send() {
-        return SendCoreAsync().GetAwaiter().GetResult();
+        _sendLock.Wait();
+        try {
+            return SendCoreAsync().GetAwaiter().GetResult();
+        } finally {
+            _sendLock.Release();
+        }
     }
 
     /// <summary>
     /// Send the email message asynchronously.
     /// </summary>
+    /// <remarks>
+    /// Concurrent calls are serialized so that only one send executes at a time for a
+    /// given instance.
+    /// </remarks>
     /// <returns></returns>
-    public Task<SmtpResult> SendAsync(CancellationToken cancellationToken = default) {
-        return SendCoreAsync(cancellationToken);
+    public async Task<SmtpResult> SendAsync(CancellationToken cancellationToken = default) {
+        await _sendLock.WaitAsync(cancellationToken);
+        try {
+            return await SendCoreAsync(cancellationToken);
+        } finally {
+            _sendLock.Release();
+        }
     }
 
     private async Task<SmtpResult> SendCoreAsync(CancellationToken cancellationToken = default) {


### PR DESCRIPTION
## Summary
- document that Smtp serializes concurrent sends
- guard Send and SendAsync with a semaphore to prevent parallel sends
- add tests ensuring only one send runs at a time

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688f9c17f9b0832e89efd5770de52b25