### PR TITLE
refactor: centralize NDR subject patterns

### DIFF
--- a/Sources/Mailozaurr.Tests/MimeKitNonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/MimeKitNonDeliveryReportTests.cs
@@ -28,4 +28,13 @@ public class MimeKitNonDeliveryReportTests {
         Assert.EndsWith("user1@example.com", reports[0].FinalRecipient);
         Assert.EndsWith("user2@example.com", reports[1].FinalRecipient);
     }
+
+    [Fact]
+    public void GetNonDeliveryReports_DetectsReportViaSubject() {
+        const string raw = "Subject: Mail Delivery Subsystem\n\ntext";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));
+        var message = MimeMessage.Load(stream);
+        var reports = MimeKitUtils.GetNonDeliveryReports(message);
+        Assert.Single(reports);
+    }
 }

--- a/Sources/Mailozaurr/MimeKitUtils.cs
+++ b/Sources/Mailozaurr/MimeKitUtils.cs
@@ -87,16 +87,7 @@ public static class MimeKitUtils {
         if (string.IsNullOrWhiteSpace(subject)) {
             return false;
         }
-        string[] patterns = {
-            "Undelivered Mail Returned to Sender",
-            "Mail delivery failed",
-            "Delivery Status Notification",
-            "Mail Delivery Subsystem",
-            "failure notice",
-            "Delivery failure"
-        };
-
-        foreach (var p in patterns) {
+        foreach (var p in NonDeliveryReportSubjectPatterns.Values) {
             if (subject.IndexOf(p, System.StringComparison.OrdinalIgnoreCase) >= 0) {
                 return true;
             }

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportSubjectPatterns.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportSubjectPatterns.cs
@@ -1,0 +1,13 @@
+namespace Mailozaurr.NonDeliveryReports;
+
+internal static class NonDeliveryReportSubjectPatterns {
+    internal static readonly string[] Values = {
+        "Undelivered Mail Returned to Sender",
+        "Delivery Status Notification",
+        "Mail delivery failed",
+        "Mail Delivery Subsystem",
+        "Failure Notice",
+        "Delivery failure",
+    };
+}
+

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -297,18 +297,10 @@ public static class MailboxSearcher {
         return false;
     }
 
-    private static readonly string[] NdrSubjectPatterns = new[] {
-        "Undelivered Mail Returned to Sender",
-        "Delivery Status Notification",
-        "Mail delivery failed",
-        "Mail Delivery Subsystem",
-        "Failure Notice"
-    };
-
     internal static SearchQuery BuildNonDeliveryReportSearchQuery(DateTime? since, DateTime? before) {
         SearchQuery search = SearchQuery.HeaderContains("Content-Type", "delivery-status");
         SearchQuery? subjectQuery = null;
-        foreach (var pattern in NdrSubjectPatterns) {
+        foreach (var pattern in NonDeliveryReportSubjectPatterns.Values) {
             var q = SearchQuery.SubjectContains(pattern);
             subjectQuery = subjectQuery == null ? q : subjectQuery.Or(q);
         }


### PR DESCRIPTION
## Summary
- centralize non-delivery report subject patterns
- reuse shared pattern list in MailboxSearcher and MimeKitUtils
- add regression test for subject-based NDR detection

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_688fb7a9c368832ebe637a6567d19dd4