### PR TITLE
Speed up sent message lookups with file index

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
@@ -1,4 +1,7 @@
 using Mailozaurr.NonDeliveryReports;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
 
 namespace Mailozaurr.Tests;
 
@@ -38,5 +41,55 @@ public class SentMessageRepositoryTests {
         } finally {
             if (File.Exists(path)) File.Delete(path);
         }
+    }
+
+    [Fact]
+    public async Task GetByMessageIdAsync_FastLookupInLargeLog() {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+        try {
+            const int count = 10000;
+            var newline = Encoding.UTF8.GetBytes(Environment.NewLine);
+            using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read)) {
+                for (int i = 0; i < count; i++) {
+                    var record = new SentMessageRecord {
+                        MessageId = i.ToString(),
+                        Recipients = "a@b.com",
+                        Subject = "s",
+                        Timestamp = DateTimeOffset.UtcNow
+                    };
+                    await JsonSerializer.SerializeAsync(stream, record);
+                    await stream.WriteAsync(newline, 0, newline.Length);
+                }
+            }
+            // Reinitialize repository to rebuild the index
+            var repo = new FileSentMessageRepository(path);
+            var targetId = (count - 1).ToString();
+            var seqWatch = Stopwatch.StartNew();
+            _ = await SequentialSearchAsync(path, targetId);
+            seqWatch.Stop();
+            var idxWatch = Stopwatch.StartNew();
+            var recordFound = await repo.GetByMessageIdAsync(targetId);
+            idxWatch.Stop();
+            Assert.NotNull(recordFound);
+            Assert.True(idxWatch.Elapsed < seqWatch.Elapsed);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    private static async Task<SentMessageRecord?> SequentialSearchAsync(string path, string messageId) {
+        using var read = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(read);
+        while (!reader.EndOfStream) {
+            string? line = await reader.ReadLineAsync();
+            if (string.IsNullOrWhiteSpace(line)) {
+                continue;
+            }
+            var record = JsonSerializer.Deserialize<SentMessageRecord>(line);
+            if (record != null && string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
+                return record;
+            }
+        }
+        return null;
     }
 }

--- a/Sources/Mailozaurr/SentMessages/FileSentMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FileSentMessageRepository.cs
@@ -6,12 +6,34 @@ namespace Mailozaurr;
 public sealed class FileSentMessageRepository : ISentMessageRepository {
     private readonly string filePath;
     private readonly SemaphoreSlim gate = new(1, 1);
+    private readonly Dictionary<string, long> index = new(StringComparer.OrdinalIgnoreCase);
+    private readonly byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
 
     /// <summary>
     /// Creates a new repository using the specified file path.
     /// </summary>
     /// <param name="filePath">Path to the log file that stores sent message records.</param>
-    public FileSentMessageRepository(string filePath) => this.filePath = filePath;
+    public FileSentMessageRepository(string filePath) {
+        this.filePath = filePath;
+        if (File.Exists(filePath)) {
+            BuildIndex();
+        }
+    }
+
+    private void BuildIndex() {
+        long position = 0;
+        foreach (var line in File.ReadLines(filePath)) {
+            if (string.IsNullOrWhiteSpace(line)) {
+                position += newlineBytes.Length;
+                continue;
+            }
+            var record = JsonSerializer.Deserialize<SentMessageRecord>(line);
+            if (record != null && !string.IsNullOrEmpty(record.MessageId)) {
+                index[record.MessageId] = position;
+            }
+            position += Encoding.UTF8.GetByteCount(line) + newlineBytes.Length;
+        }
+    }
 
     /// <summary>Saves a record to the log file.</summary>
     public async Task SaveAsync(SentMessageRecord record, CancellationToken cancellationToken = default) {
@@ -22,9 +44,10 @@ public sealed class FileSentMessageRepository : ISentMessageRepository {
                 Directory.CreateDirectory(directory);
             }
             using var write = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+            var offset = write.Position;
             await JsonSerializer.SerializeAsync(write, record, cancellationToken: cancellationToken);
-            var newline = Encoding.UTF8.GetBytes(Environment.NewLine);
-            await write.WriteAsync(newline, 0, newline.Length, cancellationToken);
+            await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
+            index[record.MessageId] = offset;
         } finally {
             gate.Release();
         }
@@ -37,18 +60,19 @@ public sealed class FileSentMessageRepository : ISentMessageRepository {
         }
         await gate.WaitAsync(cancellationToken);
         try {
+            if (!index.TryGetValue(messageId, out var offset)) {
+                return null;
+            }
             using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var reader = new StreamReader(read);
-            while (!reader.EndOfStream) {
-                cancellationToken.ThrowIfCancellationRequested();
-                string? line = await reader.ReadLineAsync();
-                if (string.IsNullOrWhiteSpace(line)) {
-                    continue;
-                }
-                var record = JsonSerializer.Deserialize<SentMessageRecord>(line);
-                if (record != null && string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
-                    return record;
-                }
+            read.Seek(offset, SeekOrigin.Begin);
+            using var reader = new StreamReader(read, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
+            string? line = await reader.ReadLineAsync();
+            if (string.IsNullOrWhiteSpace(line)) {
+                return null;
+            }
+            var record = JsonSerializer.Deserialize<SentMessageRecord>(line);
+            if (record != null && string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
+                return record;
             }
             return null;
         } finally {


### PR DESCRIPTION
## Summary
- maintain an index of message IDs to byte offsets and rebuild it on repository startup
- save operations update the index and lookups seek directly to the stored offset
- add a large-log performance test verifying indexed lookup is faster than sequential search
- remove unused PowerShell example script

## Testing
- `dotnet build Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688fb7b211a8832e9c7c507c5f80d001