### PR TITLE
chore: bump XmlDoc2CmdletDoc to 0.7.0

### DIFF
--- a/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
+++ b/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
@@ -57,7 +57,7 @@
 
     <ItemGroup>
         <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.6.0">
+        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
## Summary
- bump MatejKafka.XmlDoc2CmdletDoc to 0.7.0

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh ./Mailozaurr.Tests.ps1` *(fails: Unprotect-MimeMessage command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689661095750832e8be30a9a150e062d