### PR TITLE
Log webhook failures for webhook posts

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -161,6 +161,11 @@ public class HelpersTests {
             => throw new HttpRequestException("boom");
     }
 
+    private class FailStatusHandler : HttpMessageHandler {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+    }
+
     [Fact]
     public async Task PostWebhookAsync_CancellationRequested_ThrowsAsync() {
         using var cts = new CancellationTokenSource();
@@ -175,6 +180,20 @@ public class HelpersTests {
     [Fact]
     public async Task PostWebhookAsync_HttpRequestException_LogsWarning() {
         var client = new HttpClient(new ThrowHandler());
+        var result = new SmtpResult(true, EmailAction.Send, string.Empty, string.Empty, string.Empty, 0, TimeSpan.Zero);
+        var messages = new List<string>();
+        void Handler(object? _, LogEventArgs e) => messages.Add(e.Message);
+        Mailozaurr.LoggingMessages.Logger.OnWarningMessage += Handler;
+
+        await Mailozaurr.Helpers.PostWebhookAsync("http://localhost", result, default, client);
+
+        Mailozaurr.LoggingMessages.Logger.OnWarningMessage -= Handler;
+        Assert.Contains(messages, static m => m.Contains("Failed to post webhook"));
+    }
+
+    [Fact]
+    public async Task PostWebhookAsync_NonSuccessStatus_LogsWarning() {
+        var client = new HttpClient(new FailStatusHandler());
         var result = new SmtpResult(true, EmailAction.Send, string.Empty, string.Empty, string.Empty, 0, TimeSpan.Zero);
         var messages = new List<string>();
         void Handler(object? _, LogEventArgs e) => messages.Add(e.Message);

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -161,6 +161,10 @@ public static class Helpers {
             var json = JsonSerializer.Serialize(result);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
             using var response = await client.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) {
+                LoggingMessages.Logger.WriteWarning(
+                    $"Failed to post webhook: {(int)response.StatusCode} {response.ReasonPhrase}");
+            }
         } catch (HttpRequestException ex) {
             LoggingMessages.Logger.WriteWarning($"Failed to post webhook: {ex.Message}");
         } finally {


### PR DESCRIPTION
## Summary
- check webhook post responses and log when the call fails
- test webhook posting logs warning on non-success status

## Testing
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_68978bd4bc44832ea87f09f08e6f695d