### PR TITLE
Use scoped regex replacements for HTML image sources

### DIFF
--- a/Examples/Example-ExtractLocalImagePaths.ps1
+++ b/Examples/Example-ExtractLocalImagePaths.ps1
@@ -1,0 +1,12 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$tmp = New-TemporaryFile
+Set-Content -Path $tmp -Value "data"
+$html = "<img src='$tmp'><p>$tmp</p>"
+
+$result = [Mailozaurr.HtmlUtils]::ExtractLocalImagePaths($html)
+$result.Html
+$result.Paths
+
+Remove-Item $tmp
+

--- a/Sources/Mailozaurr.Tests/HtmlUtilsTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlUtilsTests.cs
@@ -1,0 +1,60 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class HtmlUtilsTests
+{
+    [Fact]
+    public void ExtractLocalImagePaths_ReplacesOnlySrcValues()
+    {
+        var tmp = Path.GetTempFileName();
+        File.WriteAllText(tmp, "data");
+        var html = $"<img src=\"{tmp}\"><p>{tmp}</p>";
+
+        var (result, paths) = HtmlUtils.ExtractLocalImagePaths(html);
+
+        Assert.Contains($"cid:{Path.GetFileName(tmp)}", result);
+        Assert.Contains($"<p>{tmp}</p>", result);
+        var path = Assert.Single(paths);
+        Assert.Equal(tmp, path);
+
+        File.Delete(tmp);
+    }
+
+    [Fact]
+    public async Task DownloadRemoteImagesAsync_ReplacesOnlySrcValuesAsync()
+    {
+        const string url = "https://example.com/img.png";
+        var html = $"<img src=\"{url}\"><p>{url}</p>";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(new byte[] { 1, 2, 3 })
+            {
+                Headers = { ContentType = new MediaTypeHeaderValue("image/png") }
+            }
+        });
+        var property = typeof(HtmlUtils).GetProperty("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var original = (HttpClient)property.GetValue(null)!;
+        property.SetValue(null, new HttpClient(handler));
+        try
+        {
+            var (result, images) = await HtmlUtils.DownloadRemoteImagesAsync(html);
+
+            Assert.Contains("cid:img.png", result);
+            Assert.Contains($"<p>{url}</p>", result);
+            var image = Assert.Single(images);
+            Assert.Equal("image/png", image.MediaType);
+        }
+        finally
+        {
+            property.SetValue(null, original);
+        }
+    }
+}
+

--- a/Sources/Mailozaurr/Helpers/HtmlUtils.cs
+++ b/Sources/Mailozaurr/Helpers/HtmlUtils.cs
@@ -40,21 +40,22 @@ public static class HtmlUtils {
         var paths = new List<string>();
         if (string.IsNullOrWhiteSpace(html)) return (html, paths);
 
-        string pattern = "<img[^>]+src=[\"']([^\"']+)[\"']";
-        foreach (Match match in Regex.Matches(html, pattern, RegexOptions.IgnoreCase)) {
-            var path = match.Groups[1].Value;
-            if (string.IsNullOrWhiteSpace(path)) continue;
+        string pattern = "(?<=<img[^>]+src=[\"'])([^\"']+)(?=[\"'])";
+        html = Regex.Replace(html, pattern, match => {
+            var path = match.Value;
+            if (string.IsNullOrWhiteSpace(path)) return path;
             if (path.StartsWith("http", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("cid:", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) {
-                continue;
+                return path;
             }
             if (File.Exists(path)) {
                 var fileName = Path.GetFileName(path);
-                html = html.Replace(path, $"cid:{fileName}");
                 paths.Add(path);
+                return $"cid:{fileName}";
             }
-        }
+            return path;
+        }, RegexOptions.IgnoreCase);
         return (html, paths);
     }
 
@@ -68,11 +69,15 @@ public static class HtmlUtils {
         var images = new List<RemoteImage>();
         if (string.IsNullOrWhiteSpace(html)) return (html, images);
 
-        string pattern = "<img[^>]+src=['\"]([^'\"]+)['\"]";
-        foreach (Match match in Regex.Matches(html, pattern, RegexOptions.IgnoreCase)) {
-            var url = match.Groups[1].Value;
+        string pattern = "(?<=<img[^>]+src=['\"])([^'\"]+)(?=['\"])";
+        var matches = Regex.Matches(html, pattern, RegexOptions.IgnoreCase);
+        var replacements = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (Match match in matches) {
+            var url = match.Value;
             if (string.IsNullOrWhiteSpace(url)) continue;
             if (!url.StartsWith("http", StringComparison.OrdinalIgnoreCase)) continue;
+            if (replacements.ContainsKey(url)) continue;
             try {
                 using var response = await HttpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode) continue;
@@ -84,12 +89,14 @@ public static class HtmlUtils {
                 var mediaType = response.Content.Headers.ContentType?.MediaType ?? MimeTypes.GetMimeType(Path.GetFileName(url));
                 var fileName = Path.GetFileName(new Uri(url).AbsolutePath);
                 if (string.IsNullOrEmpty(fileName)) fileName = Guid.NewGuid().ToString("N");
-                html = html.Replace(url, $"cid:{fileName}");
+                replacements[url] = $"cid:{fileName}";
                 images.Add(new RemoteImage { ContentId = fileName, Data = data, MediaType = mediaType });
             } catch (Exception ex) {
                 LoggingMessages.Logger.WriteWarning($"Failed to download image '{url}': {ex.Message}");
             }
         }
+
+        html = Regex.Replace(html, pattern, m => replacements.TryGetValue(m.Value, out var value) ? value : m.Value, RegexOptions.IgnoreCase);
 
         return (html, images);
     }


### PR DESCRIPTION
## Summary
- replace global string substitution with scoped regex replacement for local image paths
- download remote images once and rewrite only matched src attributes
- add unit tests and a PowerShell example covering image path extraction

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68978bcc7074832e9edb8ca58e6fde2c