### PR TITLE
Allow null login for OAuth token helpers

### DIFF
--- a/Sources/Mailozaurr.Examples/AcquireO365TokenInteractive.cs
+++ b/Sources/Mailozaurr.Examples/AcquireO365TokenInteractive.cs
@@ -9,7 +9,7 @@ public static class AcquireO365TokenInteractive {
     /// <summary>Runs the example.</summary>
     public static async Task RunAsync() {
         // === CONFIGURATION ===
-        string login = "user@example.com";
+        string? login = "user@example.com";
         string clientId = "your-client-id";
         string tenantId = "your-tenant-id";
         string redirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";

--- a/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class OAuthHelpersCachedTokenTests {
+    [Fact]
+    public async Task AcquireO365TokenCachedAsync_ReturnsCachedToken() {
+        var cacheKey = "o365:test@example.com";
+        var credential = new OAuthCredential {
+            UserName = "test@example.com",
+            AccessToken = "token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        OAuthTokenCache.Set(cacheKey, credential);
+
+        var result = await OAuthHelpers.AcquireO365TokenCachedAsync(
+            "test@example.com",
+            "client-id",
+            "tenant-id",
+            "https://login.microsoftonline.com/common/oauth2/nativeclient",
+            Array.Empty<string>());
+
+        Assert.Equal(credential.AccessToken, result.AccessToken);
+        Assert.Equal(credential.UserName, result.UserName);
+    }
+}
+

--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -24,7 +24,7 @@ public static class OAuthHelpers {
     /// <param name="scopes">The scopes to request for the token.</param>
     /// <returns>A credential containing the access token.</returns>
     public static async Task<OAuthCredential> AcquireO365TokenInteractiveAsync(
-        string login,
+        string? login,
         string clientId,
         string tenantId,
         string redirectUri,
@@ -70,7 +70,7 @@ public static class OAuthHelpers {
     /// Attempts to silently acquire a new Office 365 access token using the cached refresh token.
     /// </summary>
     private static async Task<OAuthCredential?> AcquireO365TokenSilentAsync(
-        string login,
+        string? login,
         string clientId,
         string tenantId,
         string redirectUri,
@@ -147,26 +147,30 @@ public static class OAuthHelpers {
     /// Attempts to retrieve a cached Office 365 token or acquire a new one if necessary.
     /// </summary>
     public static async Task<OAuthCredential> AcquireO365TokenCachedAsync(
-        string login,
+        string? login,
         string clientId,
         string tenantId,
         string redirectUri,
         IEnumerable<string> scopes) {
-        var cacheKey = $"o365:{login}";
-        var cached = OAuthTokenCache.Get(cacheKey);
-        if (cached != null && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
-            return cached;
-        }
-        if (cached != null) {
-            var refreshed = await AcquireO365TokenSilentAsync(login, clientId, tenantId, redirectUri, scopes);
-            if (refreshed != null) {
-                OAuthTokenCache.Set(cacheKey, refreshed);
-                return refreshed;
+        var cacheKey = string.IsNullOrWhiteSpace(login) ? null : $"o365:{login}";
+        if (cacheKey != null) {
+            var cached = OAuthTokenCache.Get(cacheKey);
+            if (cached != null && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
+                return cached;
+            }
+            if (cached != null) {
+                var refreshed = await AcquireO365TokenSilentAsync(login, clientId, tenantId, redirectUri, scopes);
+                if (refreshed != null) {
+                    OAuthTokenCache.Set(cacheKey, refreshed);
+                    return refreshed;
+                }
             }
         }
 
         var cred = await AcquireO365TokenInteractiveAsync(login, clientId, tenantId, redirectUri, scopes);
-        OAuthTokenCache.Set(cacheKey, cred);
+        if (cacheKey != null) {
+            OAuthTokenCache.Set(cacheKey, cred);
+        }
         return cred;
     }
 


### PR DESCRIPTION
## Summary
- permit `OAuthHelpers` to accept optional login hints
- update Office 365 interactive example for nullable login
- add unit test covering cached token retrieval

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln` *(fails: BadImageFormatException in several crypto-related tests)*
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --filter OAuthHelpersCachedTokenTests`


------
https://chatgpt.com/codex/tasks/task_e_68978bbe1b14832eb3c6e76e40ca1e37