### PR TITLE
Validate Gmail attachment data before decoding

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -49,6 +49,26 @@ public class GmailApiClientTests {
         Assert.Equal("https://gmail.googleapis.com/gmail/v1/users/me/messages/123/attachments/att", handler.Requests[0].RequestUri!.ToString());
     }
 
+    [Fact]
+    public async System.Threading.Tasks.Task DownloadAttachmentAsync_NoData_ReturnsEmptyArray() {
+        var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("{}") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        var data = await client.DownloadAttachmentAsync("me", "123", "att");
+        Assert.Empty(data);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task DownloadAttachmentAsync_InvalidData_Throws() {
+        var json = "{\"data\":\"abcde\"}"; // invalid length base64url
+        var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(json) });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        await Assert.ThrowsAsync<System.IO.InvalidDataException>(() => client.DownloadAttachmentAsync("me", "123", "att"));
+    }
+
     [Theory]
     [InlineData(System.Net.HttpStatusCode.Unauthorized)]
     [InlineData(System.Net.HttpStatusCode.Forbidden)]

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -157,11 +157,27 @@ public sealed class GmailApiClient {
 #else
         var json = await response.Content.ReadAsStringAsync();
 #endif
-        var result = JsonSerializer.Deserialize<AttachmentResponse>(json, s_jsonOptions)!;
-        var data = result.Data?.Replace('-', '+').Replace('_', '/') ?? string.Empty;
+        var result = JsonSerializer.Deserialize<AttachmentResponse>(json, s_jsonOptions);
+        if (string.IsNullOrEmpty(result?.Data)) {
+            return Array.Empty<byte>();
+        }
+
+        var data = result.Data.Replace('-', '+').Replace('_', '/');
+
+        if (data.Length % 4 == 1) {
+            throw new InvalidDataException("Attachment data is not a valid Base64 string.");
+        }
+
         int padding = (4 - data.Length % 4) % 4;
-        if (padding > 0) data = data.PadRight(data.Length + padding, '=');
-        return Convert.FromBase64String(data);
+        if (padding > 0) {
+            data = data.PadRight(data.Length + padding, '=');
+        }
+
+        try {
+            return Convert.FromBase64String(data);
+        } catch (FormatException ex) {
+            throw new InvalidDataException("Attachment data is not a valid Base64 string.", ex);
+        }
     }
 
     private static void ExtractAttachments(JsonElement part, List<GmailAttachmentInfo> list) {


### PR DESCRIPTION
## Summary
- ensure `GmailApiClient.DownloadAttachmentAsync` checks for missing or invalid attachment data
- add unit tests covering empty and malformed attachment responses

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68978bb49cd4832ea0b72d779e8118a5