### PR TITLE
Throw ArgumentException for invalid API credentials

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -73,12 +73,10 @@ public class HelpersTests {
     }
 
     [Fact]
-    public void CredentialToApiKey_ReturnsEmptyString_WhenNotNetworkCredential() {
+    public void CredentialToApiKey_ThrowsArgumentException_WhenNotNetworkCredential() {
         ICredentials creds = new DummyCredentials();
 
-        string result = Mailozaurr.Helpers.CredentialToApiKey(creds);
-
-        Assert.Equal(string.Empty, result);
+        Assert.Throws<ArgumentException>(() => Mailozaurr.Helpers.CredentialToApiKey(creds));
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -9,6 +10,11 @@ namespace Mailozaurr.Tests;
 
 public class MailgunClientTests
 {
+    private class DummyCredentials : ICredentials
+    {
+        public NetworkCredential GetCredential(Uri uri, string authType) => new NetworkCredential();
+    }
+
     [Fact]
     public void EmailDomain_InvalidAddress_ThrowsArgumentException()
     {
@@ -35,5 +41,18 @@ public class MailgunClientTests
         string body = await content.ReadAsStringAsync();
         Assert.Contains("h:X-Test", body, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("123", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_InvalidCredentials_ThrowsInvalidOperationException()
+    {
+        using var client = new MailgunClient
+        {
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            Credentials = new DummyCredentials()
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendEmailAsync());
     }
 }

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -39,11 +39,14 @@ public static class Helpers {
     /// <summary>Extracts the API key from a credential object.</summary>
     /// <param name="credentials">Credential containing the key.</param>
     /// <returns>The API key.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="credentials"/> is not a <see cref="NetworkCredential"/>.
+    /// </exception>
     public static string CredentialToApiKey(ICredentials credentials) {
         if (credentials is NetworkCredential networkCredential) {
             return networkCredential.Password;
         }
-        return string.Empty;
+        throw new ArgumentException("Credential must be of type NetworkCredential", nameof(credentials));
     }
 
     /// <summary>Retrieves the email address string from various types of objects.</summary>

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Diagnostics;
 using System.Threading;
@@ -14,7 +15,15 @@ public class MailgunClient : IDisposable {
     /// <summary>Measures total time spent sending.</summary>
     public readonly Stopwatch Stopwatch;
 
-    private string ApiKey => Helpers.CredentialToApiKey(Credentials);
+    private string ApiKey {
+        get {
+            try {
+                return Helpers.CredentialToApiKey(Credentials);
+            } catch (ArgumentException ex) {
+                throw new InvalidOperationException("Credentials must be a NetworkCredential", ex);
+            }
+        }
+    }
     private string EmailDomain {
         get {
             var address = Helpers.GetEmailAddress(From);
@@ -26,6 +35,7 @@ public class MailgunClient : IDisposable {
     }
 
     /// <summary>Credentials used to authenticate to the API.</summary>
+    /// <remarks>Must be <see cref="NetworkCredential"/>.</remarks>
     public ICredentials Credentials { get; set; }
     /// <summary>Determines how errors are handled.</summary>
     public ActionPreference? ErrorAction { get; set; }


### PR DESCRIPTION
## Summary
- throw `ArgumentException` when extracting API key from non-`NetworkCredential`
- wrap invalid Mailgun credentials in `InvalidOperationException`
- update tests for new credential validation behavior

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_68978f09d10c832eaf0f5481aa25fbcb