### PR TITLE
feat: limit concurrent image downloads

### DIFF
--- a/Sources/Mailozaurr.Examples/SendEmailRemoteImages.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailRemoteImages.cs
@@ -7,7 +7,7 @@ public static class SendEmailRemoteImages
 {
     public static void Run()
     {
-        var smtp = new Smtp { AutoEmbedRemoteImages = true };
+        var smtp = new Smtp { AutoEmbedRemoteImages = true, RemoteImageDownloadParallelism = 2 };
         smtp.From = "sender@example.com";
         smtp.To = new[] { "recipient@example.com" };
         smtp.Subject = "Remote Images";

--- a/Sources/Mailozaurr.Tests/CountingHandler.cs
+++ b/Sources/Mailozaurr.Tests/CountingHandler.cs
@@ -1,0 +1,38 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.Tests;
+
+public class CountingHandler : HttpMessageHandler
+{
+    private readonly TimeSpan _delay;
+    private int _current;
+    public int MaxConcurrency { get; private set; }
+
+    public CountingHandler(TimeSpan delay)
+    {
+        _delay = delay;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var concurrency = Interlocked.Increment(ref _current);
+        if (concurrency > MaxConcurrency)
+        {
+            MaxConcurrency = concurrency;
+        }
+        await Task.Delay(_delay, cancellationToken);
+        Interlocked.Decrement(ref _current);
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(new byte[] { 1 })
+            {
+                Headers = { ContentType = new MediaTypeHeaderValue("image/png") }
+            }
+        };
+        return response;
+    }
+}

--- a/Sources/Mailozaurr.Tests/DownloadRemoteImagesTests.cs
+++ b/Sources/Mailozaurr.Tests/DownloadRemoteImagesTests.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class DownloadRemoteImagesTests
+{
+    [Fact]
+    public async Task DownloadRemoteImagesAsync_LimitsConcurrency()
+    {
+        var handler = new CountingHandler(TimeSpan.FromMilliseconds(100));
+        var client = new HttpClient(handler);
+        var property = typeof(HtmlUtils).GetProperty("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var original = (HttpClient)property.GetValue(null)!;
+        property.SetValue(null, client);
+        try
+        {
+            var html = string.Join("", Enumerable.Range(0, 5).Select(i => $"<img src=\"https://example.com/{i}.png\">"));
+            var (_, images) = await HtmlUtils.DownloadRemoteImagesAsync(html, 2);
+            Assert.Equal(5, images.Count);
+            Assert.True(handler.MaxConcurrency <= 2);
+            Assert.True(handler.MaxConcurrency > 1);
+        }
+        finally
+        {
+            property.SetValue(null, original);
+        }
+    }
+}

--- a/Sources/Mailozaurr/Helpers/HtmlUtils.cs
+++ b/Sources/Mailozaurr/Helpers/HtmlUtils.cs
@@ -62,20 +62,33 @@ public static class HtmlUtils {
     /// Downloads externally referenced images and replaces their sources with cid links.
     /// </summary>
     /// <param name="html">HTML content to inspect.</param>
+    /// <param name="maxParallelism">Maximum number of concurrent downloads.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>Modified HTML and list of downloaded images.</returns>
-    public static async Task<(string Html, List<RemoteImage> Images)> DownloadRemoteImagesAsync(string html, CancellationToken cancellationToken = default) {
+    public static async Task<(string Html, List<RemoteImage> Images)> DownloadRemoteImagesAsync(string html, int maxParallelism = 4, CancellationToken cancellationToken = default) {
         var images = new List<RemoteImage>();
         if (string.IsNullOrWhiteSpace(html)) return (html, images);
 
         string pattern = "<img[^>]+src=['\"]([^'\"]+)['\"]";
+        var urls = new List<string>();
         foreach (Match match in Regex.Matches(html, pattern, RegexOptions.IgnoreCase)) {
             var url = match.Groups[1].Value;
             if (string.IsNullOrWhiteSpace(url)) continue;
             if (!url.StartsWith("http", StringComparison.OrdinalIgnoreCase)) continue;
+            urls.Add(url);
+        }
+
+        var semaphore = new SemaphoreSlim(maxParallelism <= 0 ? 1 : maxParallelism);
+        var tasks = new List<Task<(string Url, RemoteImage? Image)>>();
+        foreach (var url in urls) {
+            tasks.Add(DownloadAsync(url));
+        }
+
+        async Task<(string Url, RemoteImage? Image)> DownloadAsync(string url) {
+            await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try {
                 using var response = await HttpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
-                if (!response.IsSuccessStatusCode) continue;
+                if (!response.IsSuccessStatusCode) return (url, null);
 #if NETFRAMEWORK || NETSTANDARD2_0
                 var data = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 #else
@@ -84,11 +97,20 @@ public static class HtmlUtils {
                 var mediaType = response.Content.Headers.ContentType?.MediaType ?? MimeTypes.GetMimeType(Path.GetFileName(url));
                 var fileName = Path.GetFileName(new Uri(url).AbsolutePath);
                 if (string.IsNullOrEmpty(fileName)) fileName = Guid.NewGuid().ToString("N");
-                html = html.Replace(url, $"cid:{fileName}");
-                images.Add(new RemoteImage { ContentId = fileName, Data = data, MediaType = mediaType });
+                return (url, new RemoteImage { ContentId = fileName, Data = data, MediaType = mediaType });
             } catch (Exception ex) {
                 LoggingMessages.Logger.WriteWarning($"Failed to download image '{url}': {ex.Message}");
+                return (url, null);
+            } finally {
+                semaphore.Release();
             }
+        }
+
+        var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+        foreach (var (url, image) in results) {
+            if (image == null) continue;
+            html = html.Replace(url, $"cid:{image.ContentId}");
+            images.Add(image);
         }
 
         return (html, images);

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -36,6 +36,8 @@ public partial class ClientSmtp : SmtpClient {
     public IDictionary<string, string>? Headers { get; set; }
     /// <summary>Download remote images referenced in HtmlBody and embed them.</summary>
     public bool AutoEmbedRemoteImages { get; set; } = false;
+    /// <summary>Maximum number of remote images to download in parallel.</summary>
+    public int RemoteImageDownloadParallelism { get; set; } = 4;
     /// <summary>Comma separated list of all recipients.</summary>
     public string SentTo {
         get {
@@ -229,7 +231,7 @@ public partial class ClientSmtp : SmtpClient {
             }
         }
         if (AutoEmbedRemoteImages && !string.IsNullOrWhiteSpace(bodyBuilder.HtmlBody)) {
-            var (html, images) = HtmlUtils.DownloadRemoteImagesAsync(bodyBuilder.HtmlBody).GetAwaiter().GetResult();
+            var (html, images) = HtmlUtils.DownloadRemoteImagesAsync(bodyBuilder.HtmlBody, RemoteImageDownloadParallelism).GetAwaiter().GetResult();
             bodyBuilder.HtmlBody = html;
             HtmlBody = html;
             foreach (var img in images) {

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -152,6 +152,14 @@ public class Smtp {
     }
 
     /// <summary>
+    /// Maximum number of remote images to download in parallel when embedding.
+    /// </summary>
+    public int RemoteImageDownloadParallelism {
+        get => Client.RemoteImageDownloadParallelism;
+        set => Client.RemoteImageDownloadParallelism = value;
+    }
+
+    /// <summary>
     /// Forces retries even when the encountered error is not considered
     /// transient. By default retries occur only for transient failures.
     /// </summary>


### PR DESCRIPTION
## Summary
- cap concurrent downloads in HtmlUtils using SemaphoreSlim
- allow configuring remote image download parallelism in Smtp
- add test ensuring concurrency limit

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68978f1faef4832e836185dfefdafd64