### PR TITLE
Use async file I/O for OAuth token cache

### DIFF
--- a/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
@@ -13,7 +13,7 @@ public class OAuthHelpersCachedTokenTests {
             AccessToken = "token",
             ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
         };
-        OAuthTokenCache.Set(cacheKey, credential);
+        await OAuthTokenCache.SetAsync(cacheKey, credential);
 
         var result = await OAuthHelpers.AcquireO365TokenCachedAsync(
             "test@example.com",

--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -62,7 +62,7 @@ public static class OAuthHelpers {
             AccessToken = result.AccessToken,
             ExpiresOn = result.ExpiresOn
         };
-        OAuthTokenCache.Set($"o365:{cred.UserName}", cred);
+        await OAuthTokenCache.SetAsync($"o365:{cred.UserName}", cred);
         return cred;
     }
 
@@ -139,7 +139,7 @@ public static class OAuthHelpers {
             RefreshToken = credential.Token.RefreshToken,
             ExpiresOn = credential.Token.IssuedUtc + TimeSpan.FromSeconds(credential.Token.ExpiresInSeconds ?? 0)
         };
-        OAuthTokenCache.Set($"google:{cred.UserName}", cred);
+        await OAuthTokenCache.SetAsync($"google:{cred.UserName}", cred);
         return cred;
     }
 
@@ -154,14 +154,14 @@ public static class OAuthHelpers {
         IEnumerable<string> scopes) {
         var cacheKey = string.IsNullOrWhiteSpace(login) ? null : $"o365:{login}";
         if (cacheKey != null) {
-            var cached = OAuthTokenCache.Get(cacheKey);
+            var cached = await OAuthTokenCache.GetAsync(cacheKey);
             if (cached != null && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
                 return cached;
             }
             if (cached != null) {
                 var refreshed = await AcquireO365TokenSilentAsync(login, clientId, tenantId, redirectUri, scopes);
                 if (refreshed != null) {
-                    OAuthTokenCache.Set(cacheKey, refreshed);
+                    await OAuthTokenCache.SetAsync(cacheKey, refreshed);
                     return refreshed;
                 }
             }
@@ -169,7 +169,7 @@ public static class OAuthHelpers {
 
         var cred = await AcquireO365TokenInteractiveAsync(login, clientId, tenantId, redirectUri, scopes);
         if (cacheKey != null) {
-            OAuthTokenCache.Set(cacheKey, cred);
+            await OAuthTokenCache.SetAsync(cacheKey, cred);
         }
         return cred;
     }
@@ -183,7 +183,7 @@ public static class OAuthHelpers {
         string clientSecret,
         IEnumerable<string> scopes) {
         var cacheKey = $"google:{gmailAccount}";
-        var cached = OAuthTokenCache.Get(cacheKey);
+        var cached = await OAuthTokenCache.GetAsync(cacheKey);
         if (cached != null && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
             return cached;
         }
@@ -205,13 +205,13 @@ public static class OAuthHelpers {
                     RefreshToken = userCred.Token.RefreshToken,
                     ExpiresOn = userCred.Token.IssuedUtc + TimeSpan.FromSeconds(userCred.Token.ExpiresInSeconds ?? 0)
                 };
-                OAuthTokenCache.Set(cacheKey, newCred);
+                await OAuthTokenCache.SetAsync(cacheKey, newCred);
                 return newCred;
             }
         }
 
         var cred = await AcquireGoogleTokenInteractiveAsync(gmailAccount, clientId, clientSecret, scopes);
-        OAuthTokenCache.Set(cacheKey, cred);
+        await OAuthTokenCache.SetAsync(cacheKey, cred);
         return cred;
     }
 
@@ -244,7 +244,7 @@ public static class OAuthHelpers {
             AccessToken = result.AccessToken,
             ExpiresOn = result.ExpiresOn
         };
-        OAuthTokenCache.Set($"o365:{cred.UserName}", cred);
+        await OAuthTokenCache.SetAsync($"o365:{cred.UserName}", cred);
         return cred;
     }
 

--- a/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace Mailozaurr;
 
@@ -17,17 +18,27 @@ internal static class OAuthTokenCache {
 
     private static Dictionary<string, OAuthCredential>? _cache;
 
-    private static Dictionary<string, OAuthCredential> LoadCache() {
+    private static async Task<Dictionary<string, OAuthCredential>> LoadCacheAsync() {
+        if (_cache != null) {
+            return _cache;
+        }
+        Dictionary<string, OAuthCredential> cache;
+        if (File.Exists(CacheFilePath)) {
+#if NETFRAMEWORK || NETSTANDARD2_0
+            string json;
+            using (var stream = new FileStream(CacheFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true))
+            using (var reader = new StreamReader(stream)) {
+                json = await reader.ReadToEndAsync().ConfigureAwait(false);
+            }
+#else
+            var json = await File.ReadAllTextAsync(CacheFilePath).ConfigureAwait(false);
+#endif
+            cache = JsonSerializer.Deserialize<Dictionary<string, OAuthCredential>>(json) ?? new();
+        } else {
+            cache = new Dictionary<string, OAuthCredential>();
+        }
         lock (LockObj) {
-            if (_cache != null) {
-                return _cache;
-            }
-            if (File.Exists(CacheFilePath)) {
-                var json = File.ReadAllText(CacheFilePath);
-                _cache = JsonSerializer.Deserialize<Dictionary<string, OAuthCredential>>(json) ?? new();
-            } else {
-                _cache = new Dictionary<string, OAuthCredential>();
-            }
+            _cache ??= cache;
             return _cache;
         }
     }
@@ -37,10 +48,12 @@ internal static class OAuthTokenCache {
     /// </summary>
     /// <param name="key">Unique cache key.</param>
     /// <returns>The cached credential or <c>null</c> if not found.</returns>
-    public static OAuthCredential? Get(string key) {
-        var cache = LoadCache();
-        cache.TryGetValue(key, out var cred);
-        return cred;
+    public static async Task<OAuthCredential?> GetAsync(string key) {
+        var cache = await LoadCacheAsync().ConfigureAwait(false);
+        lock (LockObj) {
+            cache.TryGetValue(key, out var cred);
+            return cred;
+        }
     }
 
     /// <summary>
@@ -48,16 +61,25 @@ internal static class OAuthTokenCache {
     /// </summary>
     /// <param name="key">Unique cache key.</param>
     /// <param name="credential">Credential to cache.</param>
-    public static void Set(string key, OAuthCredential credential) {
-        var cache = LoadCache();
-        cache[key] = credential;
+    public static async Task SetAsync(string key, OAuthCredential credential) {
+        var cache = await LoadCacheAsync().ConfigureAwait(false);
+        string? dir;
+        string json;
         lock (LockObj) {
-            var dir = Path.GetDirectoryName(CacheFilePath);
+            cache[key] = credential;
+            dir = Path.GetDirectoryName(CacheFilePath);
             if (!Directory.Exists(dir)) {
                 Directory.CreateDirectory(dir!);
             }
-            var json = JsonSerializer.Serialize(cache);
-            File.WriteAllText(CacheFilePath, json);
+            json = JsonSerializer.Serialize(cache);
         }
+#if NETFRAMEWORK || NETSTANDARD2_0
+        using (var stream = new FileStream(CacheFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true))
+        using (var writer = new StreamWriter(stream)) {
+            await writer.WriteAsync(json).ConfigureAwait(false);
+        }
+#else
+        await File.WriteAllTextAsync(CacheFilePath, json).ConfigureAwait(false);
+#endif
     }
 }

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -115,7 +115,7 @@ namespace Mailozaurr {
             if (TokenCache.TryGetValue(key, out var cached) && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
                 return $"{cached.TokenType} {cached.AccessToken}";
             }
-            var cachedFile = OAuthTokenCache.Get($"graph:{key}");
+            var cachedFile = await OAuthTokenCache.GetAsync($"graph:{key}");
             if (cachedFile != null && cachedFile.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
                 TokenCache[key] = new GraphAuthorization { AccessToken = cachedFile.AccessToken, TokenType = "Bearer", ExpiresOn = cachedFile.ExpiresOn };
                 return $"Bearer {cachedFile.AccessToken}";
@@ -192,7 +192,7 @@ namespace Mailozaurr {
                     }
                 }
                 TokenCache[key] = new GraphAuthorization { AccessToken = accessToken, TokenType = tokenType, ExpiresOn = expiresOn };
-                OAuthTokenCache.Set($"graph:{key}", new OAuthCredential {
+                await OAuthTokenCache.SetAsync($"graph:{key}", new OAuthCredential {
                     UserName = credential.ClientId,
                     AccessToken = accessToken,
                     ExpiresOn = expiresOn


### PR DESCRIPTION
## Summary
- switch OAuth token cache to async file reading and writing
- expose async `LoadCacheAsync`, `GetAsync`, and `SetAsync`
- await the async cache methods from OAuth helpers and Microsoft Graph utilities

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68979ba2f884832eb82da7bfdb31b93e