### PR TITLE
Ensure meaningful exception on retry exhaustion

### DIFF
--- a/Sources/Mailozaurr.Tests/ConnectorTests.cs
+++ b/Sources/Mailozaurr.Tests/ConnectorTests.cs
@@ -155,6 +155,32 @@ public class ConnectorTests
     }
 
     [Fact]
+    public async Task ImapConnector_NoRetriesThrowsOriginalException()
+    {
+        var fake = new FakeImapClient { FailuresBeforeSuccess = 1 };
+        ImapConnector.ClientFactory = () => fake;
+        await Assert.ThrowsAsync<HttpRequestException>(() => ImapConnector.ConnectAsync(
+            "s", 1, SecureSocketOptions.Auto, 0, false, false,
+            c => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
+            0, 10, 2));
+        ImapConnector.ClientFactory = () => new ImapClient();
+        Assert.Equal(1, fake.ConnectCalls);
+    }
+
+    [Fact]
+    public async Task Pop3Connector_NoRetriesThrowsOriginalException()
+    {
+        var fake = new FakePop3Client { FailuresBeforeSuccess = 1 };
+        Pop3Connector.ClientFactory = () => fake;
+        await Assert.ThrowsAsync<HttpRequestException>(() => Pop3Connector.ConnectAsync(
+            "s", 1, SecureSocketOptions.Auto, 0, false, false,
+            c => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
+            0, 10, 2));
+        Pop3Connector.ClientFactory = () => new Pop3Client();
+        Assert.Equal(1, fake.ConnectCalls);
+    }
+
+    [Fact]
     public async Task ImapConnector_LogsDisconnectException()
     {
         var fake = new FakeImapDisconnectFailClient();

--- a/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
@@ -107,6 +107,17 @@ public class GraphBatchAndRetryTests {
         }
     }
 
+    private class AlwaysFailHandler : HttpMessageHandler {
+        public int CallCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            var json = "{\"error\":\"fail\"}";
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent(json) });
+        }
+    }
+
     [Fact]
     public async Task ConnectO365GraphWithRetryAsync_RetriesUntilSuccess() {
         var handler = new RetryHandler();
@@ -128,6 +139,31 @@ public class GraphBatchAndRetryTests {
             string token = await MicrosoftGraphUtils.ConnectO365GraphWithRetryAsync(credential, "tenant", 2, 0, 1);
             Assert.Equal("Bearer token", token);
             Assert.Equal(3, handler.CallCount);
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+
+    [Fact]
+    public async Task ConnectO365GraphWithRetryAsync_NoRetriesThrowsException() {
+        var handler = new AlwaysFailHandler();
+        var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)field.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
+        cache.Clear();
+        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
+        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+        oauthField?.SetValue(null, null);
+        string cachePath = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
+        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        try {
+            var credential = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            await Assert.ThrowsAsync<GraphApiException>(() => MicrosoftGraphUtils.ConnectO365GraphWithRetryAsync(credential, "tenant", 0, 0, 1));
+            Assert.Equal(1, handler.CallCount);
         } finally {
             handlerField.SetValue(client, original);
         }

--- a/Sources/Mailozaurr/Connections/ImapConnector.cs
+++ b/Sources/Mailozaurr/Connections/ImapConnector.cs
@@ -90,6 +90,6 @@ public static class ImapConnector {
             }
             attempts++;
         } while (attempts <= retryCount);
-        throw lastException!;
+        throw lastException ?? new InvalidOperationException("Operation failed without exception");
     }
 }

--- a/Sources/Mailozaurr/Connections/Pop3Connector.cs
+++ b/Sources/Mailozaurr/Connections/Pop3Connector.cs
@@ -89,6 +89,6 @@ public static class Pop3Connector {
             }
             attempts++;
         } while (attempts <= retryCount);
-        throw lastException!;
+        throw lastException ?? new InvalidOperationException("Operation failed without exception");
     }
 }

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -232,7 +232,7 @@ namespace Mailozaurr {
                 }
                 attempts++;
             } while (attempts <= retryCount);
-            throw lastException!;
+            throw lastException ?? new InvalidOperationException("Operation failed without exception");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- handle null `lastException` in IMAP/POP3 connectors and MicrosoftGraphUtils
- test connectors and Graph zero-retry scenarios to verify exception propagation

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net472`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net9.0` *(fails: project lacks net9.0 target)*
- `dotnet build Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_68979f570a10832eb72e1d8234f0fce7