### PR TITLE
Ensure conversion output directories exist

### DIFF
--- a/Sources/Mailozaurr.Tests/EmailMessageConversionTests.cs
+++ b/Sources/Mailozaurr.Tests/EmailMessageConversionTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class EmailMessageConversionTests {
+    [Fact]
+    public void ConvertEmlToMsg_CreatesOutputDirectory() {
+        var emlDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(emlDir);
+        var emlPath = Path.Combine(emlDir, "sample.eml");
+        File.WriteAllText(emlPath, "From: a@example.com\r\nTo: a@example.com\r\nSubject: Test\r\nDate: Mon, 21 Jun 2021 10:00:00 +0000\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nHello");
+
+        var outputDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var results = EmailMessage.ConvertEmlToMsg(new[] { emlPath }, outputDir, true).ToList();
+        Assert.True(results[0].Status);
+        Assert.True(Directory.Exists(outputDir));
+        Assert.True(File.Exists(Path.Combine(outputDir, "sample.msg")));
+
+        Directory.Delete(emlDir, true);
+        Directory.Delete(outputDir, true);
+    }
+
+    [Fact]
+    public void ConvertMsgToEml_CreatesOutputDirectory() {
+        var tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tmpDir);
+        var emlPath = Path.Combine(tmpDir, "sample.eml");
+        File.WriteAllText(emlPath, "From: a@example.com\r\nTo: a@example.com\r\nSubject: Test\r\nDate: Mon, 21 Jun 2021 10:00:00 +0000\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nHello");
+
+        var msgDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(msgDir);
+        EmailMessage.ConvertEmlToMsg(new[] { emlPath }, msgDir, true).ToList();
+        var msgPath = Path.Combine(msgDir, "sample.msg");
+
+        var outputDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Assert.Throws<NotImplementedException>(() => EmailMessage.ConvertMsgToEml(new[] { msgPath }, outputDir, true).ToList());
+        Assert.True(Directory.Exists(outputDir));
+
+
+        Directory.Delete(tmpDir, true);
+        Directory.Delete(msgDir, true);
+        Directory.Delete(outputDir, true);
+    }
+}
+

--- a/Sources/Mailozaurr/EmailMessage.cs
+++ b/Sources/Mailozaurr/EmailMessage.cs
@@ -16,6 +16,9 @@ public static class EmailMessage {
     /// <returns>A collection of conversion results for each processed file.</returns>
     public static IEnumerable<EmlConversionResult> ConvertEmlToMsg(string[] emlFile, string outputFolder, bool force) {
         LoggingMessages.Logger.WriteVerbose($"Converting {emlFile.Length} EML file(s) to MSG file(s)...");
+        if (!Directory.Exists(outputFolder)) {
+            Directory.CreateDirectory(outputFolder);
+        }
         foreach (var eml in emlFile) {
             var fileName = Path.GetFileNameWithoutExtension(eml);
             var targetFile = Path.Combine(outputFolder, $"{fileName}.msg");
@@ -34,6 +37,10 @@ public static class EmailMessage {
     public static EmlConversionResult ConvertEmlToMsg(FileInfo emlFile, FileInfo msgFile, bool force) {
         if (File.Exists(emlFile.FullName)) {
             LoggingMessages.Logger.WriteVerbose("Processing EML file: {0}", emlFile);
+            var dir = msgFile.DirectoryName;
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) {
+                Directory.CreateDirectory(dir);
+            }
             try {
                 if (File.Exists(msgFile.FullName) && !force) {
                     LoggingMessages.Logger.WriteWarning("MSG file already exists: {0}", msgFile);
@@ -63,6 +70,9 @@ public static class EmailMessage {
     /// <returns>A collection of conversion results for each processed file.</returns>
     public static IEnumerable<MsgConversionResult> ConvertMsgToEml(string[] msgFile, string outputFolder, bool force) {
         LoggingMessages.Logger.WriteVerbose($"Converting {msgFile.Length} MSG file(s) to EML file(s)...");
+        if (!Directory.Exists(outputFolder)) {
+            Directory.CreateDirectory(outputFolder);
+        }
         foreach (var msg in msgFile) {
             var fileName = Path.GetFileNameWithoutExtension(msg);
             var targetFile = Path.Combine(outputFolder, $"{fileName}.eml");
@@ -81,6 +91,10 @@ public static class EmailMessage {
     public static MsgConversionResult ConvertMsgToEml(FileInfo msgFile, FileInfo emlFile, bool force) {
         if (File.Exists(msgFile.FullName)) {
             LoggingMessages.Logger.WriteVerbose("Processing MSG file: {0}", msgFile);
+            var dir = emlFile.DirectoryName;
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) {
+                Directory.CreateDirectory(dir);
+            }
             try {
                 if (File.Exists(emlFile.FullName) && !force) {
                     LoggingMessages.Logger.WriteWarning("EML file already exists: {0}", emlFile);


### PR DESCRIPTION
## Summary
- Create missing destination directories before converting EML/MSG files
- Add tests for conversions when output folder is absent

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -f net472`
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -f net8.0`
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -p:TargetFrameworks=net9.0`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net472`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68979f427734832eb351b4b41db127c1