### PR TITLE
Dispose HtmlUtils HttpClient on process exit

### DIFF
--- a/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
@@ -53,10 +53,11 @@ public class HtmlAutoEmbedImageTests {
                 Headers = { ContentType = new MediaTypeHeaderValue("image/png") }
             }
         });
-        var property = typeof(HtmlUtils).GetProperty("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var client = new HttpClient(handler);
-        var original = (HttpClient)property.GetValue(null)!;
-        property.SetValue(null, client);
+        var client = HtmlUtils.HttpClient;
+        var handlerField = typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? typeof(HttpMessageInvoker).GetField("handler", BindingFlags.Instance | BindingFlags.NonPublic);
+        var original = (HttpMessageHandler)handlerField!.GetValue(client)!;
+        handlerField.SetValue(client, handler);
         try {
             var smtp = new Smtp { AutoEmbedRemoteImages = true };
             smtp.From = "a@b.com";
@@ -70,7 +71,7 @@ public class HtmlAutoEmbedImageTests {
             Assert.Contains("cid:img.png", smtp.HtmlBody);
             Assert.Single(handler.Requests);
         } finally {
-            property.SetValue(null, original);
+            handlerField.SetValue(client, original);
         }
     }
 }

--- a/Sources/Mailozaurr.Tests/HtmlUtilsTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlUtilsTests.cs
@@ -39,9 +39,11 @@ public class HtmlUtilsTests
                 Headers = { ContentType = new MediaTypeHeaderValue("image/png") }
             }
         });
-        var property = typeof(HtmlUtils).GetProperty("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var original = (HttpClient)property.GetValue(null)!;
-        property.SetValue(null, new HttpClient(handler));
+        var client = HtmlUtils.HttpClient;
+        var handlerField = typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? typeof(HttpMessageInvoker).GetField("handler", BindingFlags.Instance | BindingFlags.NonPublic);
+        var original = (HttpMessageHandler)handlerField!.GetValue(client)!;
+        handlerField.SetValue(client, handler);
         try
         {
             var (result, images) = await HtmlUtils.DownloadRemoteImagesAsync(html);
@@ -53,7 +55,38 @@ public class HtmlUtilsTests
         }
         finally
         {
-            property.SetValue(null, original);
+            handlerField.SetValue(client, original);
+        }
+    }
+
+    [Fact]
+    public async Task DownloadRemoteImagesAsync_DoesNotCreateExtraHandlers()
+    {
+        const string url = "https://example.com/img.png";
+        var html = $"<img src=\"{url}\">";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(new byte[] { 1, 2, 3 })
+            {
+                Headers = { ContentType = new MediaTypeHeaderValue("image/png") }
+            }
+        });
+        var client = HtmlUtils.HttpClient;
+        var handlerField = typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? typeof(HttpMessageInvoker).GetField("handler", BindingFlags.Instance | BindingFlags.NonPublic);
+        var original = (HttpMessageHandler)handlerField!.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        try
+        {
+            await HtmlUtils.DownloadRemoteImagesAsync(html);
+            await HtmlUtils.DownloadRemoteImagesAsync(html);
+
+            Assert.Equal(2, handler.Requests.Count);
+            Assert.Same(handler, handlerField!.GetValue(HtmlUtils.HttpClient));
+        }
+        finally
+        {
+            handlerField.SetValue(client, original);
         }
     }
 }

--- a/Sources/Mailozaurr/Helpers/HtmlUtils.cs
+++ b/Sources/Mailozaurr/Helpers/HtmlUtils.cs
@@ -12,10 +12,10 @@ namespace Mailozaurr;
 /// performing minor HTML transformations.
 /// </remarks>
 public static class HtmlUtils {
-    internal static HttpClient HttpClient { get; set; }
+    internal static HttpClient HttpClient { get; } = new HttpClient();
 
     static HtmlUtils() {
-        HttpClient = new HttpClient();
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => HttpClient.Dispose();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- dispose HtmlUtils HttpClient when the process exits and expose it as immutable
- adjust tests to inject handlers and add coverage ensuring handler reuse

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68979f3cf618832eb198705627900286