### PR TITLE
Log failures when cleaning up temporary PGP keys

### DIFF
--- a/Sources/Mailozaurr.Tests/TemporaryPgpKeyPairTests.cs
+++ b/Sources/Mailozaurr.Tests/TemporaryPgpKeyPairTests.cs
@@ -1,5 +1,8 @@
 using Mailozaurr;
+using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Reflection;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -65,5 +68,39 @@ public class TemporaryPgpKeyPairTests
         Assert.False(File.Exists(pub));
         Assert.False(File.Exists(priv));
         Assert.False(Directory.Exists(dir));
+    }
+
+    [Fact]
+    public void Dispose_WhenDeletionFails_LogsWarnings()
+    {
+        var pair = TemporaryPgpKeyPair.Create("a@b.com");
+        string originalDir = Path.GetDirectoryName(pair.PublicKeyPath)!;
+
+        string protectedFile = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? Path.Combine(Environment.SystemDirectory, "kernel32.dll")
+            : "/proc/version";
+        string protectedDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? Path.Combine(Environment.SystemDirectory, "drivers")
+            : "/proc/self/fd";
+
+        var type = typeof(TemporaryPgpKeyPair);
+        type.GetField("<PublicKeyPath>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(pair, protectedFile);
+        type.GetField("_tempDirectory", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(pair, protectedDir);
+
+        var messages = new List<string>();
+        void Handler(object? _, LogEventArgs e) => messages.Add(e.Message);
+        LoggingMessages.Logger.OnWarningMessage += Handler;
+
+        pair.Dispose();
+
+        LoggingMessages.Logger.OnWarningMessage -= Handler;
+
+        if (Directory.Exists(originalDir))
+            Directory.Delete(originalDir, true);
+
+        Assert.Contains(messages, static m => m.Contains("Failed to delete public key"));
+        Assert.Contains(messages, static m => m.Contains("Failed to delete temporary directory"));
     }
 }

--- a/Sources/Mailozaurr.Tests/TemporaryPgpKeyPairTests.cs
+++ b/Sources/Mailozaurr.Tests/TemporaryPgpKeyPairTests.cs
@@ -76,12 +76,23 @@ public class TemporaryPgpKeyPairTests
         var pair = TemporaryPgpKeyPair.Create("a@b.com");
         string originalDir = Path.GetDirectoryName(pair.PublicKeyPath)!;
 
-        string protectedFile = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? Path.Combine(Environment.SystemDirectory, "kernel32.dll")
-            : "/proc/version";
-        string protectedDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? Path.Combine(Environment.SystemDirectory, "drivers")
-            : "/proc/self/fd";
+        string protectedFile;
+        string protectedDir;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            protectedFile = Path.Combine(Environment.SystemDirectory, "kernel32.dll");
+            protectedDir = Path.Combine(Environment.SystemDirectory, "drivers");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            protectedFile = "/System/Library/CoreServices/SystemVersion.plist";
+            protectedDir = "/System/Library";
+        }
+        else
+        {
+            protectedFile = "/proc/version";
+            protectedDir = "/proc/self/fd";
+        }
 
         var type = typeof(TemporaryPgpKeyPair);
         type.GetField("<PublicKeyPath>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!

--- a/Sources/Mailozaurr/Cryptography/TemporaryPgpKeyPair.cs
+++ b/Sources/Mailozaurr/Cryptography/TemporaryPgpKeyPair.cs
@@ -92,11 +92,52 @@ public sealed class TemporaryPgpKeyPair : IDisposable
     {
         if (_deleteOnDispose)
         {
-            try { File.Delete(PublicKeyPath); } catch { }
-            try { File.Delete(PrivateKeyPath); } catch { }
-            if (_removeDirectory)
+            if (File.Exists(PublicKeyPath))
             {
-                try { Directory.Delete(_tempDirectory, true); } catch { }
+                try
+                {
+                    File.Delete(PublicKeyPath);
+                }
+                catch (IOException ex)
+                {
+                    LoggingMessages.Logger.WriteWarning($"Failed to delete public key: {ex.Message}");
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    LoggingMessages.Logger.WriteWarning($"Failed to delete public key due to unauthorized access: {ex.Message}");
+                }
+            }
+
+            if (File.Exists(PrivateKeyPath))
+            {
+                try
+                {
+                    File.Delete(PrivateKeyPath);
+                }
+                catch (IOException ex)
+                {
+                    LoggingMessages.Logger.WriteWarning($"Failed to delete private key: {ex.Message}");
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    LoggingMessages.Logger.WriteWarning($"Failed to delete private key due to unauthorized access: {ex.Message}");
+                }
+            }
+
+            if (_removeDirectory && Directory.Exists(_tempDirectory))
+            {
+                try
+                {
+                    Directory.Delete(_tempDirectory, true);
+                }
+                catch (IOException ex)
+                {
+                    LoggingMessages.Logger.WriteWarning($"Failed to delete temporary directory: {ex.Message}");
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    LoggingMessages.Logger.WriteWarning($"Failed to delete temporary directory due to unauthorized access: {ex.Message}");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- log IO exceptions when deleting temporary PGP keys and directories
- add unit test simulating cleanup failures and warning logging

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_68979f36ea38832e8ea849f9782e777b