### PR TITLE
Preserve Graph send stack trace

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphExceptionStackTraceTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphExceptionStackTraceTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Management.Automation;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class GraphExceptionStackTraceTests {
+    [Fact]
+    public async Task SendMessageAsync_Failure_PreservesStackTrace() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.BadRequest) {
+            Content = new StringContent("{\"error\":{\"code\":\"BadRequest\",\"message\":\"Invalid\",\"innerError\":{\"requestId\":\"1\",\"date\":\"2020-01-01\"}}}")
+        });
+
+        using var graph = new Graph {
+            AccessToken = "token",
+            TokenType = "Bearer",
+            From = "from@example.com",
+            To = new object[] { "to@example.com" },
+            Subject = "sub",
+            HTML = "body",
+            ContentType = "HTML",
+            ErrorAction = ActionPreference.Stop
+        };
+        var field = typeof(Graph).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(graph, new HttpClient(handler));
+
+        var ex = await Assert.ThrowsAsync<GraphApiException>(() => graph.SendMessageAsync());
+        Assert.Contains(nameof(Graph.SendMessageAsync), ex.StackTrace);
+    }
+
+    [Fact]
+    public async Task SendDraftMessage_Failure_PreservesStackTrace() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.BadRequest) {
+            Content = new StringContent("{\"error\":{\"code\":\"BadRequest\",\"message\":\"Invalid\",\"innerError\":{\"requestId\":\"1\",\"date\":\"2020-01-01\"}}}")
+        });
+
+        using var graph = new Graph {
+            AccessToken = "token",
+            TokenType = "Bearer",
+            From = "from@example.com",
+            To = new object[] { "to@example.com" },
+            Subject = "sub",
+            HTML = "body",
+            ContentType = "HTML",
+            MessageContainer = new GraphMessageContainer {
+                Message = new GraphMessage {
+                    From = new GraphEmailAddress { Email = new GraphEmail { Address = "from@example.com" } }
+                }
+            }
+        };
+        var field = typeof(Graph).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(graph, new HttpClient(handler));
+
+        var draft = new GraphMessage { Id = "id" };
+        var ex = await Assert.ThrowsAsync<GraphApiException>(() => graph.SendDraftMessage(draft));
+        Assert.Contains(nameof(Graph.SendDraftMessage), ex.StackTrace);
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -577,10 +577,12 @@ public class Graph : IDisposable {
             var sendErrorMessage = (sendError == null || sendError.Error == null || sendError.Error.InnerError == null)
                 ? $"Unknown error: {sendContent}"
                 : $"Error code: {sendError.Error.Code}, message: {sendError.Error.Message}, request ID: {sendError.Error.InnerError.RequestId}, date: {sendError.Error.InnerError.Date}";
-            var ex = new GraphApiException(sendResponse.StatusCode, sendErrorMessage, sendContent);
-            var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, sendContent, ex.Message);
+            throw new GraphApiException(sendResponse.StatusCode, sendErrorMessage, sendContent);
+        } catch (GraphApiException ex) {
+            LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Graph API: {ex.Message}");
+            var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, ex.ResponseContent, ex.Message);
             await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
-            throw ex;
+            throw;
         } finally {
             MicrosoftGraphUtils.ConcurrencySemaphore.Release();
         }


### PR DESCRIPTION
## Summary
- Rethrow Graph send exceptions without losing stack trace
- Log Graph send failures before rethrow
- Test that send stack traces include original methods

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `dotnet build Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_68979f303ab8832e91306fb7f92f83e2