### PR TITLE
Avoid ConfigureAwait in MgGraph PowerShell path

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletAddGraphMailboxPermission.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletAddGraphMailboxPermission.cs
@@ -89,7 +89,7 @@ public class CmdletAddGraphMailboxPermission : AsyncPSCmdlet {
         }
 
         if (ParameterSetName == "Csv") {
-            await ProcessCsvAsync(conn.Credential).ConfigureAwait(false);
+            await ProcessCsvAsync(conn.Credential);
             return;
         }
 
@@ -97,13 +97,13 @@ public class CmdletAddGraphMailboxPermission : AsyncPSCmdlet {
             foreach (var perm in MailboxPermission!) {
                 if (perm.UserPrincipalName == null)
                     perm.UserPrincipalName = UserPrincipalName;
-                await ProcessGraphAsync(conn.Credential, perm).ConfigureAwait(false);
+                await ProcessGraphAsync(conn.Credential, perm);
             }
             return;
         }
 
         foreach (var ht in Permission!)
-            await ProcessGraphAsync(conn.Credential, ht).ConfigureAwait(false);
+            await ProcessGraphAsync(conn.Credential, ht);
         return;
     }
 
@@ -113,7 +113,7 @@ public class CmdletAddGraphMailboxPermission : AsyncPSCmdlet {
         var rows = ps.Invoke();
         foreach (var row in rows.OfType<PSObject>()) {
             var dict = row.Properties.ToDictionary(p => p.Name, p => p.Value);
-            await ProcessGraphAsync(cred, new Hashtable(dict)).ConfigureAwait(false);
+            await ProcessGraphAsync(cred, new Hashtable(dict));
         }
     }
 

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMailboxPermission.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMailboxPermission.cs
@@ -102,7 +102,7 @@ public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
         }
 
         if (ParameterSetName == "Csv") {
-            await ProcessCsvAsync(conn.Credential).ConfigureAwait(false);
+            await ProcessCsvAsync(conn.Credential);
             return;
         }
 
@@ -110,18 +110,18 @@ public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
             foreach (var perm in MailboxPermission!) {
                 if (perm.UserPrincipalName == null)
                     perm.UserPrincipalName = UserPrincipalName;
-                await ProcessGraphAsync(conn.Credential, perm).ConfigureAwait(false);
+                await ProcessGraphAsync(conn.Credential, perm);
             }
             return;
         }
 
         if (ParameterSetName == "Filter") {
-            await ProcessFilterAsync(conn.Credential).ConfigureAwait(false);
+            await ProcessFilterAsync(conn.Credential);
             return;
         }
 
         foreach (var id in PermissionId!)
-            await ProcessGraphAsync(conn.Credential, id).ConfigureAwait(false);
+            await ProcessGraphAsync(conn.Credential, id);
         return;
     }
 
@@ -132,19 +132,19 @@ public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
         foreach (var row in rows.OfType<PSObject>()) {
             var id = row.Properties["PermissionId"].Value?.ToString();
             if (!string.IsNullOrWhiteSpace(id))
-                await ProcessGraphAsync(cred, id).ConfigureAwait(false);
+                await ProcessGraphAsync(cred, id);
         }
     }
 
     private async Task ProcessFilterAsync(GraphCredential cred) {
-        var perms = await MicrosoftGraphUtils.GetMailboxPermissionsAsync(cred, UserPrincipalName!).ConfigureAwait(false);
+        var perms = await MicrosoftGraphUtils.GetMailboxPermissionsAsync(cred, UserPrincipalName!);
         var filtered = perms.AsEnumerable();
         if (Role != null && Role.Length > 0)
             filtered = filtered.Where(p => p.Roles != null && p.Roles.Intersect(Role).Any());
         if (GrantedToUser != null && GrantedToUser.Length > 0)
             filtered = filtered.Where(p => p.GrantedTo?.User != null && GrantedToUser.Contains(p.GrantedTo.User, StringComparer.OrdinalIgnoreCase));
         foreach (var p in filtered)
-            await ProcessGraphAsync(cred, p).ConfigureAwait(false);
+            await ProcessGraphAsync(cred, p);
     }
 
     private async Task ProcessGraphAsync(GraphCredential cred, object permission) {

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -2,6 +2,7 @@ using System;
 using System.Management.Automation;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Mailozaurr;
 
 namespace Mailozaurr.PowerShell;
@@ -54,7 +55,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         } else if (Graph) {
             ProcessGraph(fromEmail, fromName);
         } else if (MgGraphRequest) {
-            ProcessMgGraphRequest(fromEmail, fromName);
+            ProcessMgGraphRequest(fromEmail, fromName).GetAwaiter().GetResult();
         } else {
             ProcessSmtp(fromEmail, fromName);
         }
@@ -275,7 +276,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         LogEmitter.EmitLogs(graph.LogCollector, this);
     }
 
-    private void ProcessMgGraphRequest(string? fromEmail, string? fromName) {
+    private async Task ProcessMgGraphRequest(string? fromEmail, string? fromName) {
         using Graph graph = new Graph();
         graph.ChunkSize = ChunkSize;
         graph.From = Helpers.GetFromObject(fromEmail, fromName);
@@ -309,11 +310,11 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         if (graph.IsLargerAttachment) {
             var json = graph.CreateDraftForMg();
             var draftMessageId = InvokeMgGraphRequestPOST1($"v1.0/users/{graph.From}/mailfolders/drafts/messages", EmailAction.SendDraftMessage, json, graph.SentFrom, graph.SentTo, graph.Stopwatch.Elapsed);
-            graph.PrepareAttachments().GetAwaiter().GetResult();
+            await graph.PrepareAttachments();
             foreach (var attachment in graph.AttachmentsPlaceHolders) {
                 var uploadUrl = InvokeMgGraphRequestPOST(attachment.Json, EmailAction.Send, attachment.Json, graph.SentFrom, graph.SentTo, graph.Stopwatch.Elapsed);
                 if (uploadUrl != string.Empty) {
-                    InvokeMgGraphRequestPUT(uploadUrl, EmailAction.SendAttachment, attachment, graph.SentFrom, graph.SentTo, graph.Stopwatch.Elapsed);
+                    await InvokeMgGraphRequestPUT(uploadUrl, EmailAction.SendAttachment, attachment, graph.SentFrom, graph.SentTo, graph.Stopwatch.Elapsed);
                 } else {
                     graph.LogCollector.LogVerbose("PlaceHolders not working?");
                 }
@@ -478,13 +479,13 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         }
     }
 
-    private void InvokeMgGraphRequestPUT(string uri, EmailAction action, GraphAttachmentPlaceHolder attachment, string sentFrom, string sentTo, TimeSpan elapsed) {
+    private async Task InvokeMgGraphRequestPUT(string uri, EmailAction action, GraphAttachmentPlaceHolder attachment, string sentFrom, string sentTo, TimeSpan elapsed) {
         foreach (var body in attachment.Content) {
             var parameters = new Hashtable {
                 { "Method", "PUT" },
                 { "Uri", uri },
                 { "ContentType", "application/json; charset=UTF-8" },
-                { "Body",  body.ReadAsByteArrayAsync().Result },
+                { "Body",  await body.ReadAsByteArrayAsync() },
                 { "Headers", new Hashtable {
                          { "Content-Range", body.Headers.ContentRange },
                         // { "AnchorMailbox", sentFrom }


### PR DESCRIPTION
## Summary
- ensure MgGraph request handling awaits without ConfigureAwait to keep PowerShell runspace context
- remove ConfigureAwait from Graph mailbox permission cmdlets

## Testing
- `dotnet test Sources/Mailozaurr.sln -f net472`
- `dotnet test Sources/Mailozaurr.sln -f net8.0`
- `dotnet test Sources/Mailozaurr.sln -f net9.0` *(fails: Assets file doesn't have a target for net9.0)*
- `pwsh -NoLogo -NoProfile -File Mailozaurr.Tests.ps1` *(fails: 21 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6897bb213600832ea9e69b3d78504975