### PR TITLE
Use TryAdd for NDR headers and verify duplicates

### DIFF
--- a/Sources/Mailozaurr.Tests/MimeKitNonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/MimeKitNonDeliveryReportTests.cs
@@ -3,6 +3,7 @@ using Mailozaurr.NonDeliveryReports;
 using MimeKit;
 using System.IO;
 using System.Text;
+using System;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -36,5 +37,16 @@ public class MimeKitNonDeliveryReportTests {
         var message = MimeMessage.Load(stream);
         var reports = MimeKitUtils.GetNonDeliveryReports(message);
         Assert.Single(reports);
+    }
+
+    [Fact]
+    public void GetNonDeliveryReports_IgnoresDuplicateHeaders() {
+        const string raw = "Content-Type: multipart/report; report-type=delivery-status; boundary=\"XXX\"\n\n--XXX\nContent-Type: text/plain; charset=utf-8\n\ntext\n\n--XXX\nContent-Type: message/delivery-status\n\nFinal-Recipient: rfc822; user@example.com\nFinal-Recipient: rfc822; other@example.com\nStatus: 5.1.1\n\n--XXX--";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));
+        var message = MimeMessage.Load(stream);
+        var reports = MimeKitUtils.GetNonDeliveryReports(message);
+        Assert.Single(reports);
+        Assert.EndsWith("user@example.com", reports[0].FinalRecipient);
+        Assert.DoesNotContain("other@example.com", reports[0].FinalRecipient, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Sources/Mailozaurr/Helpers/DictionaryExtensions.cs
+++ b/Sources/Mailozaurr/Helpers/DictionaryExtensions.cs
@@ -1,0 +1,13 @@
+#if NETSTANDARD2_0 || NET472
+namespace System.Collections.Generic;
+
+public static class DictionaryExtensions {
+    public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value) {
+        if (dictionary.ContainsKey(key)) {
+            return false;
+        }
+        dictionary[key] = value;
+        return true;
+    }
+}
+#endif

--- a/Sources/Mailozaurr/Helpers/DictionaryExtensions.cs
+++ b/Sources/Mailozaurr/Helpers/DictionaryExtensions.cs
@@ -1,13 +1,20 @@
 #if NETSTANDARD2_0 || NET472
-namespace System.Collections.Generic;
+using System.Collections.Generic;
 
-public static class DictionaryExtensions {
-    public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value) {
-        if (dictionary.ContainsKey(key)) {
-            return false;
+namespace Mailozaurr
+{
+    internal static class DictionaryExtensions
+    {
+        public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        {
+            if (dictionary.ContainsKey(key))
+            {
+                return false;
+            }
+
+            dictionary[key] = value;
+            return true;
         }
-        dictionary[key] = value;
-        return true;
     }
 }
 #endif

--- a/Sources/Mailozaurr/MimeKitUtils.cs
+++ b/Sources/Mailozaurr/MimeKitUtils.cs
@@ -48,9 +48,7 @@ public static class MimeKitUtils {
             foreach (var group in status.StatusGroups) {
                 var headers = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
                 foreach (var header in group) {
-                    if (!headers.ContainsKey(header.Field)) {
-                        headers[header.Field] = header.Value;
-                    }
+                    headers.TryAdd(header.Field, header.Value);
                 }
 
                 reports.Add(headers.Count > 0 ? NonDeliveryReport.FromHeaders(headers) : new NonDeliveryReport());


### PR DESCRIPTION
## Summary
- use `Dictionary.TryAdd` when collecting delivery-status headers
- add `TryAdd` extension for legacy target frameworks
- test that duplicate headers are not stored twice

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6897bd3675c0832e8f61314afa2b25b7