### PR TITLE
Refactor mail connectors to share retry helper

### DIFF
--- a/Sources/Mailozaurr.Tests/ConnectorTests.cs
+++ b/Sources/Mailozaurr.Tests/ConnectorTests.cs
@@ -55,6 +55,7 @@ public class ConnectorTests
         private int _timeout;
         public override bool IsConnected => _connected;
         public override int Timeout { get => _timeout; set => _timeout = value; }
+        public bool Disposed { get; private set; }
         public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
         {
             ConnectCalls++;
@@ -69,6 +70,11 @@ public class ConnectorTests
         {
             _connected = false;
             return Task.CompletedTask;
+        }
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
         }
     }
 
@@ -253,5 +259,42 @@ public class ConnectorTests
         LoggingMessages.Logger.OnWarningMessage -= Handler;
         Pop3Connector.ClientFactory = () => new Pop3Client();
         Assert.Contains(messages, static m => m.Contains("disconnect"));
+    }
+
+    [Fact]
+    public async Task Pop3Connector_DisposesClientBeforeRetry()
+    {
+        var first = new FakePop3Client { FailuresBeforeSuccess = 1 };
+        var second = new FakePop3Client();
+        var call = 0;
+        Pop3Connector.ClientFactory = () =>
+        {
+            call++;
+            if (call == 2)
+            {
+                Assert.True(first.Disposed);
+                return second;
+            }
+            return first;
+        };
+        var client = await Pop3Connector.ConnectAsync(
+            "s", 1, SecureSocketOptions.Auto, 0, false, false,
+            c => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
+            1, 0, 1);
+        Pop3Connector.ClientFactory = () => new Pop3Client();
+        Assert.Same(second, client);
+    }
+
+    [Fact]
+    public async Task Pop3Connector_DisposesClientAfterFinalFailure()
+    {
+        var fake = new FakePop3Client { FailuresBeforeSuccess = 1 };
+        Pop3Connector.ClientFactory = () => fake;
+        await Assert.ThrowsAsync<HttpRequestException>(() => Pop3Connector.ConnectAsync(
+            "s", 1, SecureSocketOptions.Auto, 0, false, false,
+            c => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
+            0, 0, 1));
+        Pop3Connector.ClientFactory = () => new Pop3Client();
+        Assert.True(fake.Disposed);
     }
 }

--- a/Sources/Mailozaurr/Connections/ConnectionRetrier.cs
+++ b/Sources/Mailozaurr/Connections/ConnectionRetrier.cs
@@ -1,0 +1,94 @@
+using MailKit;
+using MailKit.Security;
+using System;
+using System.Threading.Tasks;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Provides retry logic for MailKit connections.
+/// </summary>
+internal static class ConnectionRetrier {
+    /// <summary>
+    /// Connects and authenticates to a mail server with retry support.
+    /// </summary>
+    /// <typeparam name="TClient">Type of mail client.</typeparam>
+    /// <param name="clientFactory">Factory creating client instances.</param>
+    /// <param name="protocolName">Protocol name for logging.</param>
+    /// <param name="server">Server hostname.</param>
+    /// <param name="port">Server port.</param>
+    /// <param name="options">Secure socket options.</param>
+    /// <param name="timeout">Connection timeout.</param>
+    /// <param name="skipCertificateRevocation">Skip certificate revocation check.</param>
+    /// <param name="skipCertificateValidation">Skip certificate validation.</param>
+    /// <param name="authenticateAsync">Delegate performing authentication.</param>
+    /// <param name="retryCount">Number of retry attempts.</param>
+    /// <param name="retryDelayMilliseconds">Initial delay between retries.</param>
+    /// <param name="retryDelayBackoff">Multiplier for delay backoff.</param>
+    /// <param name="delayAsync">Delegate used to introduce delay between retries.</param>
+    /// <returns>Authenticated client instance.</returns>
+    internal static async Task<TClient> ConnectAsync<TClient>(
+        Func<TClient> clientFactory,
+        string protocolName,
+        string server,
+        int port,
+        SecureSocketOptions options,
+        int timeout,
+        bool skipCertificateRevocation,
+        bool skipCertificateValidation,
+        Func<TClient, Task> authenticateAsync,
+        int retryCount,
+        int retryDelayMilliseconds,
+        double retryDelayBackoff,
+        Func<int, Task>? delayAsync)
+        where TClient : MailService {
+        int attempts = 0;
+        Exception? lastException = null;
+        do {
+            var client = clientFactory();
+            try {
+                await client.ConnectAsync(server, port, options).ConfigureAwait(false);
+                if (skipCertificateRevocation) {
+                    client.CheckCertificateRevocation = false;
+                }
+                if (skipCertificateValidation) {
+                    client.ServerCertificateValidationCallback = (s, c, h, e) => true;
+                }
+                if (client.Timeout != timeout) {
+                    client.Timeout = timeout;
+                }
+                await authenticateAsync(client).ConfigureAwait(false);
+                if (!client.IsAuthenticated) {
+                    throw new InvalidOperationException("Authentication failed.");
+                }
+                return client;
+            } catch (Exception ex) {
+                lastException = ex;
+                LoggingMessages.Logger.WriteWarning($"Connect-{protocolName} - {ex.Message}");
+                try {
+                    if (client.IsConnected) {
+                        await client.DisconnectAsync(true).ConfigureAwait(false);
+                    }
+                } catch (Exception ex2) {
+                    LoggingMessages.Logger.WriteWarning($"Connect-{protocolName} - {ex2.Message}");
+                } finally {
+                    client.Dispose();
+                }
+                if ((!Helpers.IsTransient(ex)) || attempts >= retryCount) {
+                    throw;
+                }
+                var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
+                if (delay > 0) {
+                    if (delayAsync != null) {
+                        await delayAsync(delay).ConfigureAwait(false);
+                    } else {
+                        await Task.Delay(delay).ConfigureAwait(false);
+                    }
+                }
+            }
+            attempts++;
+        } while (attempts <= retryCount);
+        throw lastException ?? new InvalidOperationException("Operation failed without exception");
+    }
+}
+

--- a/Sources/Mailozaurr/Connections/ImapConnector.cs
+++ b/Sources/Mailozaurr/Connections/ImapConnector.cs
@@ -33,7 +33,7 @@ public static class ImapConnector {
     /// <param name="retryDelayMilliseconds">Initial delay between retries.</param>
     /// <param name="retryDelayBackoff">Multiplier for delay backoff.</param>
     /// <returns>Authenticated <see cref="ImapClient"/> instance.</returns>
-    public static async Task<ImapClient> ConnectAsync(
+    public static Task<ImapClient> ConnectAsync(
         string server,
         int port,
         SecureSocketOptions options,
@@ -43,53 +43,19 @@ public static class ImapConnector {
         Func<ImapClient, Task> authenticateAsync,
         int retryCount,
         int retryDelayMilliseconds,
-        double retryDelayBackoff) {
-        int attempts = 0;
-        Exception? lastException = null;
-        do {
-            var client = ClientFactory();
-            try {
-                await client.ConnectAsync(server, port, options).ConfigureAwait(false);
-                if (skipCertificateRevocation) {
-                    client.CheckCertificateRevocation = false;
-                }
-                if (skipCertificateValidation) {
-                    client.ServerCertificateValidationCallback = (s, c, h, e) => true;
-                }
-                if (client.Timeout != timeout) {
-                    client.Timeout = timeout;
-                }
-                await authenticateAsync(client).ConfigureAwait(false);
-                if (!client.IsAuthenticated) {
-                    throw new InvalidOperationException("Authentication failed.");
-                }
-                return client;
-            } catch (Exception ex) {
-                lastException = ex;
-                LoggingMessages.Logger.WriteWarning($"Connect-IMAP - {ex.Message}");
-                try {
-                    if (client.IsConnected) {
-                        await client.DisconnectAsync(true).ConfigureAwait(false);
-                    }
-                } catch (Exception ex2) {
-                    LoggingMessages.Logger.WriteWarning($"Connect-IMAP - {ex2.Message}");
-                } finally {
-                    client.Dispose();
-                }
-                if ((!Helpers.IsTransient(ex)) || attempts >= retryCount) {
-                    throw;
-                }
-                var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
-                if (delay > 0) {
-                    if (DelayAsync != null) {
-                        await DelayAsync(delay).ConfigureAwait(false);
-                    } else {
-                        await Task.Delay(delay).ConfigureAwait(false);
-                    }
-                }
-            }
-            attempts++;
-        } while (attempts <= retryCount);
-        throw lastException ?? new InvalidOperationException("Operation failed without exception");
-    }
+        double retryDelayBackoff) =>
+        ConnectionRetrier.ConnectAsync(
+            ClientFactory,
+            "IMAP",
+            server,
+            port,
+            options,
+            timeout,
+            skipCertificateRevocation,
+            skipCertificateValidation,
+            authenticateAsync,
+            retryCount,
+            retryDelayMilliseconds,
+            retryDelayBackoff,
+            DelayAsync);
 }

--- a/Sources/Mailozaurr/Connections/Pop3Connector.cs
+++ b/Sources/Mailozaurr/Connections/Pop3Connector.cs
@@ -32,7 +32,7 @@ public static class Pop3Connector {
     /// <param name="retryDelayMilliseconds">Initial delay between retries.</param>
     /// <param name="retryDelayBackoff">Multiplier for delay backoff.</param>
     /// <returns>Authenticated <see cref="Pop3Client"/> instance.</returns>
-    public static async Task<Pop3Client> ConnectAsync(
+    public static Task<Pop3Client> ConnectAsync(
         string server,
         int port,
         SecureSocketOptions options,
@@ -42,53 +42,19 @@ public static class Pop3Connector {
         Func<Pop3Client, Task> authenticateAsync,
         int retryCount,
         int retryDelayMilliseconds,
-        double retryDelayBackoff) {
-        int attempts = 0;
-        Exception? lastException = null;
-        do {
-            var client = ClientFactory();
-            try {
-                await client.ConnectAsync(server, port, options).ConfigureAwait(false);
-                if (skipCertificateRevocation) {
-                    client.CheckCertificateRevocation = false;
-                }
-                if (skipCertificateValidation) {
-                    client.ServerCertificateValidationCallback = (s, c, h, e) => true;
-                }
-                if (client.Timeout != timeout) {
-                    client.Timeout = timeout;
-                }
-                await authenticateAsync(client).ConfigureAwait(false);
-                if (!client.IsAuthenticated) {
-                    throw new InvalidOperationException("Authentication failed.");
-                }
-                return client;
-            } catch (Exception ex) {
-                lastException = ex;
-                LoggingMessages.Logger.WriteWarning($"Connect-POP3 - {ex.Message}");
-                try {
-                    if (client.IsConnected) {
-                        await client.DisconnectAsync(true).ConfigureAwait(false);
-                    }
-                } catch (Exception ex2) {
-                    LoggingMessages.Logger.WriteWarning($"Connect-POP3 - {ex2.Message}");
-                } finally {
-                    client.Dispose();
-                }
-                if ((!Helpers.IsTransient(ex)) || attempts >= retryCount) {
-                    throw;
-                }
-                var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
-                if (delay > 0) {
-                    if (DelayAsync != null) {
-                        await DelayAsync(delay).ConfigureAwait(false);
-                    } else {
-                        await Task.Delay(delay).ConfigureAwait(false);
-                    }
-                }
-            }
-            attempts++;
-        } while (attempts <= retryCount);
-        throw lastException ?? new InvalidOperationException("Operation failed without exception");
-    }
+        double retryDelayBackoff) =>
+        ConnectionRetrier.ConnectAsync(
+            ClientFactory,
+            "POP3",
+            server,
+            port,
+            options,
+            timeout,
+            skipCertificateRevocation,
+            skipCertificateValidation,
+            authenticateAsync,
+            retryCount,
+            retryDelayMilliseconds,
+            retryDelayBackoff,
+            DelayAsync);
 }


### PR DESCRIPTION
## Summary
- add `ConnectionRetrier` helper for shared retry logic
- refactor IMAP and POP3 connectors to use common retrier
- expand POP3 connector tests for disposal scenarios

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `pwsh Mailozaurr.Tests.ps1` *(fails: Cannot find path '/tmp/.../FakePop3Client.dll' because it does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6897bd2d17a4832eba53898a069b9052