### PR TITLE
Handle null API responses

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -145,4 +145,23 @@ public class GmailApiClientTests {
         cts.Cancel();
         await Assert.ThrowsAnyAsync<System.OperationCanceledException>(() => client.DownloadAttachmentAsync("me", "m", "a", cts.Token));
     }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SendAsync_NullResponse_Throws() {
+        var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("null") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        var message = new MimeKit.MimeMessage();
+        await Assert.ThrowsAsync<System.IO.InvalidDataException>(() => client.SendAsync("me", message));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetAsync_NullResponse_Throws() {
+        var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("null") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        await Assert.ThrowsAsync<System.IO.InvalidDataException>(() => client.GetAsync("me", "id"));
+    }
 }

--- a/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsNullResponseTests.cs
+++ b/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsNullResponseTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+[Collection("GraphCollection")]
+public class MicrosoftGraphUtilsNullResponseTests {
+    private sealed class NullContentHandler : HttpMessageHandler {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            if (request.RequestUri!.AbsoluteUri.Contains("oauth2")) {
+                var json = "{\"access_token\":\"token\",\"token_type\":\"Bearer\"}";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) });
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("null") });
+        }
+    }
+
+    private static FieldInfo GetHandlerField() =>
+        typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? typeof(HttpMessageInvoker).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("HttpClient handler field not found");
+
+    [Fact]
+    public async Task NewRuleAsync_NullResponse_Throws() {
+        var handler = new NullContentHandler();
+        var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)field.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        try {
+            var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
+            var rule = new GraphInboxRule();
+            await Assert.ThrowsAsync<System.IO.InvalidDataException>(() =>
+                MicrosoftGraphUtils.NewRuleAsync(cred, "user@example.com", rule));
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+
+    [Fact]
+    public async Task NewEventAsync_NullResponse_Throws() {
+        var handler = new NullContentHandler();
+        var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)field.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        try {
+            var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
+            var ev = new GraphEvent();
+            await Assert.ThrowsAsync<System.IO.InvalidDataException>(() =>
+                MicrosoftGraphUtils.NewEventAsync(cred, "user@example.com", ev));
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+}

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -65,7 +65,11 @@ public sealed class GmailApiClient {
 #else
         var resultJson = await response.Content.ReadAsStringAsync();
 #endif
-        return JsonSerializer.Deserialize<GmailMessage>(resultJson, s_jsonOptions)!;
+        var result = JsonSerializer.Deserialize<GmailMessage>(resultJson, s_jsonOptions);
+        if (result is null) {
+            throw new InvalidDataException("Gmail API returned an invalid send response.");
+        }
+        return result;
     }
 
     /// <summary>
@@ -113,7 +117,11 @@ public sealed class GmailApiClient {
 #else
         var json = await response.Content.ReadAsStringAsync();
 #endif
-        return JsonSerializer.Deserialize<GmailMessage>(json, s_jsonOptions)!;
+        var message = JsonSerializer.Deserialize<GmailMessage>(json, s_jsonOptions);
+        if (message is null) {
+            throw new InvalidDataException("Gmail API returned an invalid message response.");
+        }
+        return message;
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -1088,7 +1088,11 @@ namespace Mailozaurr {
             var body = JsonSerializer.Serialize(rule, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/inbox/messageRules");
             var doc = await InvokeGraphApiAsync("POST", uri, headers, body);
-            return JsonSerializer.Deserialize<GraphInboxRule>(doc.RootElement.GetRawText())!;
+            var created = JsonSerializer.Deserialize<GraphInboxRule>(doc.RootElement.GetRawText());
+            if (created is null) {
+                throw new InvalidDataException("Microsoft Graph returned an invalid inbox rule response.");
+            }
+            return created;
         }
 
         /// <summary>
@@ -1105,7 +1109,11 @@ namespace Mailozaurr {
             var body = JsonSerializer.Serialize(rule, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/inbox/messageRules/{ruleId}");
             var doc = await InvokeGraphApiAsync("PATCH", uri, headers, body);
-            return JsonSerializer.Deserialize<GraphInboxRule>(doc.RootElement.GetRawText())!;
+            var updated = JsonSerializer.Deserialize<GraphInboxRule>(doc.RootElement.GetRawText());
+            if (updated is null) {
+                throw new InvalidDataException("Microsoft Graph returned an invalid inbox rule response.");
+            }
+            return updated;
         }
 
         /// <summary>
@@ -1167,7 +1175,11 @@ namespace Mailozaurr {
             var body = JsonSerializer.Serialize(ev, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
             var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/events");
             var doc = await InvokeGraphApiAsync("POST", uri, headers, body);
-            return JsonSerializer.Deserialize<GraphEvent>(doc.RootElement.GetRawText())!;
+            var created = JsonSerializer.Deserialize<GraphEvent>(doc.RootElement.GetRawText());
+            if (created is null) {
+                throw new InvalidDataException("Microsoft Graph returned an invalid event response.");
+            }
+            return created;
         }
 
         /// <summary>
@@ -1184,7 +1196,11 @@ namespace Mailozaurr {
             var body = JsonSerializer.Serialize(ev, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
             var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/events/{eventId}");
             var doc = await InvokeGraphApiAsync("PATCH", uri, headers, body);
-            return JsonSerializer.Deserialize<GraphEvent>(doc.RootElement.GetRawText())!;
+            var updated = JsonSerializer.Deserialize<GraphEvent>(doc.RootElement.GetRawText());
+            if (updated is null) {
+                throw new InvalidDataException("Microsoft Graph returned an invalid event response.");
+            }
+            return updated;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- throw `InvalidDataException` when Gmail API send/get responses deserialize to null
- validate Microsoft Graph rule/event responses for null and raise descriptive errors
- test malformed API responses to ensure null deserialization is handled

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net472` *(fails: Mailozaurr.Tests.SesClientTests.BuildMessage_WithValidData_ReturnsMimeMessage)*
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0`


------
https://chatgpt.com/codex/tasks/task_e_6897bd423268832e8127bd834d513369