### PR TITLE
Refactor file conversion loops

### DIFF
--- a/Sources/Mailozaurr.Tests/EmailMessageConversionTests.cs
+++ b/Sources/Mailozaurr.Tests/EmailMessageConversionTests.cs
@@ -24,6 +24,28 @@ public class EmailMessageConversionTests {
     }
 
     [Fact]
+    public void ConvertEmlToMsg_MultipleFiles() {
+        var tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tmpDir);
+
+        var eml1 = Path.Combine(tmpDir, "a.eml");
+        File.WriteAllText(eml1, "From: a@example.com\r\nTo: a@example.com\r\nSubject: A\r\nDate: Mon, 21 Jun 2021 10:00:00 +0000\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nHello");
+        var eml2 = Path.Combine(tmpDir, "b.eml");
+        File.WriteAllText(eml2, "From: b@example.com\r\nTo: b@example.com\r\nSubject: B\r\nDate: Mon, 21 Jun 2021 10:00:00 +0000\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nWorld");
+
+        var outputDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var results = EmailMessage.ConvertEmlToMsg(new[] { eml1, eml2 }, outputDir, true).ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.True(r.Status));
+        Assert.True(File.Exists(Path.Combine(outputDir, "a.msg")));
+        Assert.True(File.Exists(Path.Combine(outputDir, "b.msg")));
+
+        Directory.Delete(tmpDir, true);
+        Directory.Delete(outputDir, true);
+    }
+
+    [Fact]
     public void ConvertMsgToEml_CreatesOutputDirectory() {
         var tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         Directory.CreateDirectory(tmpDir);
@@ -45,4 +67,3 @@ public class EmailMessageConversionTests {
         Directory.Delete(outputDir, true);
     }
 }
-

--- a/Sources/Mailozaurr/EmailMessage.cs
+++ b/Sources/Mailozaurr/EmailMessage.cs
@@ -16,15 +16,7 @@ public static class EmailMessage {
     /// <returns>A collection of conversion results for each processed file.</returns>
     public static IEnumerable<EmlConversionResult> ConvertEmlToMsg(string[] emlFile, string outputFolder, bool force) {
         LoggingMessages.Logger.WriteVerbose($"Converting {emlFile.Length} EML file(s) to MSG file(s)...");
-        if (!Directory.Exists(outputFolder)) {
-            Directory.CreateDirectory(outputFolder);
-        }
-        foreach (var eml in emlFile) {
-            var fileName = Path.GetFileNameWithoutExtension(eml);
-            var targetFile = Path.Combine(outputFolder, $"{fileName}.msg");
-            var msg = ConvertEmlToMsg(new FileInfo(eml), new FileInfo(targetFile), force);
-            yield return msg;
-        }
+        return ConvertFiles(emlFile, outputFolder, ".msg", ConvertEmlToMsg, force);
     }
 
     /// <summary>
@@ -70,15 +62,7 @@ public static class EmailMessage {
     /// <returns>A collection of conversion results for each processed file.</returns>
     public static IEnumerable<MsgConversionResult> ConvertMsgToEml(string[] msgFile, string outputFolder, bool force) {
         LoggingMessages.Logger.WriteVerbose($"Converting {msgFile.Length} MSG file(s) to EML file(s)...");
-        if (!Directory.Exists(outputFolder)) {
-            Directory.CreateDirectory(outputFolder);
-        }
-        foreach (var msg in msgFile) {
-            var fileName = Path.GetFileNameWithoutExtension(msg);
-            var targetFile = Path.Combine(outputFolder, $"{fileName}.eml");
-            var eml = ConvertMsgToEml(new FileInfo(msg), new FileInfo(targetFile), force);
-            yield return eml;
-        }
+        return ConvertFiles(msgFile, outputFolder, ".eml", ConvertMsgToEml, force);
     }
 
     /// <summary>
@@ -113,5 +97,16 @@ public static class EmailMessage {
             }
         }
         return new MsgConversionResult() { MsgFile = msgFile.FullName, EmlFile = emlFile.FullName, Status = false, Error = "MSG file does not exist" };
+    }
+
+    private static IEnumerable<TResult> ConvertFiles<TResult>(string[] inputFiles, string outputFolder, string targetExtension, Func<FileInfo, FileInfo, bool, TResult> converter, bool force) {
+        if (!Directory.Exists(outputFolder)) {
+            Directory.CreateDirectory(outputFolder);
+        }
+        foreach (var file in inputFiles) {
+            var fileName = Path.GetFileNameWithoutExtension(file);
+            var targetFile = Path.Combine(outputFolder, $"{fileName}{targetExtension}");
+            yield return converter(new FileInfo(file), new FileInfo(targetFile), force);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- centralize file conversion looping into a reusable helper
- call the helper from EML->MSG and MSG->EML converters
- test multi-file EML conversion and MSG-to-EML path

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -l "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_6897bd5115d4832e8811a561ba2ec09d