### PR TITLE
Add cancellation token to message preparation

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -3,6 +3,7 @@ using System.Management.Automation;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using System.Threading;
 using Mailozaurr;
 
 namespace Mailozaurr.PowerShell;
@@ -186,7 +187,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         smtp.Attachments = Attachment?.ToList();
         smtp.InlineAttachments = InlineAttachment?.ToList();
         smtp.Priority = Priority;
-        smtp.CreateMessage();
+        smtp.CreateMessage(CancellationToken.None);
 
         var net = Credential!.GetNetworkCredential();
         var oauth = new OAuthCredential {
@@ -383,7 +384,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             return;
         }
 
-        smtpClient.CreateMessage();
+        smtpClient.CreateMessage(CancellationToken.None);
 
         if (SignOrEncrypt != EmailActionEncryption.None) {
             if (SignOrEncrypt == EmailActionEncryption.PGPEncrypt && PublicKeyPath != null) {

--- a/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Threading;
 using MimeKit;
 using Xunit;
 
@@ -19,7 +20,7 @@ public class HtmlAutoEmbedImageTests {
         smtp.To = new object[] { "c@d.com" };
         smtp.Subject = "test";
         smtp.HtmlBody = $"<img src=\"{tmp}\">";
-        smtp.CreateMessage();
+        smtp.CreateMessage(CancellationToken.None);
         var body = (MultipartRelated)smtp.Message.Body;
         var inline = body.OfType<MimePart>().FirstOrDefault(p => p.ContentDisposition?.Disposition == ContentDisposition.Inline);
         File.Delete(tmp);
@@ -64,7 +65,7 @@ public class HtmlAutoEmbedImageTests {
             smtp.To = new object[] { "c@d.com" };
             smtp.Subject = "test";
             smtp.HtmlBody = "<img src=\"https://example.com/img.png\">";
-            smtp.CreateMessage();
+            smtp.CreateMessage(CancellationToken.None);
             var body = (MultipartRelated)smtp.Message.Body!;
             var inline = body.OfType<MimePart>().FirstOrDefault(p => p.ContentDisposition?.Disposition == ContentDisposition.Inline);
             Assert.NotNull(inline);

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using MimeKit.Utils;
 
 namespace Mailozaurr;
@@ -107,12 +108,13 @@ public partial class ClientSmtp : SmtpClient {
     /// <summary>
     /// Builds the <see cref="MimeMessage"/> based on the configured properties.
     /// </summary>
-    public void CreateMessage() {
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public void CreateMessage(CancellationToken cancellationToken = default) {
         InlineAttachments ??= new List<object>();
         var message = new MimeMessage();
         AddAddressesToMessage(message);
         SetMessagePriority(message);
-        BuildMessageBody(message);
+        BuildMessageBody(message, cancellationToken);
         message.Subject = Subject;
         AddHeaders(message);
         Message = message;
@@ -162,7 +164,7 @@ public partial class ClientSmtp : SmtpClient {
         }
     }
 
-    private void BuildMessageBody(MimeMessage message) {
+    private void BuildMessageBody(MimeMessage message, CancellationToken cancellationToken) {
         var bodyBuilder = new BodyBuilder();
         if (!string.IsNullOrWhiteSpace(HtmlBody)) {
             bodyBuilder.HtmlBody = HtmlBody;
@@ -229,7 +231,7 @@ public partial class ClientSmtp : SmtpClient {
             }
         }
         if (AutoEmbedRemoteImages && !string.IsNullOrWhiteSpace(bodyBuilder.HtmlBody)) {
-            var (html, images) = HtmlUtils.DownloadRemoteImagesAsync(bodyBuilder.HtmlBody).GetAwaiter().GetResult();
+            var (html, images) = HtmlUtils.DownloadRemoteImagesAsync(bodyBuilder.HtmlBody, cancellationToken).GetAwaiter().GetResult();
             bodyBuilder.HtmlBody = html;
             HtmlBody = html;
             foreach (var img in images) {

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -315,7 +315,7 @@ public class Smtp {
     /// <summary>
     /// Creates the MIME message using the current property values.
     /// </summary>
-    public void CreateMessage() {
+    public void CreateMessage(CancellationToken cancellationToken = default) {
         if (AutoEmbedImages) {
             var (html, paths) = HtmlUtils.ExtractLocalImagePaths(HtmlBody);
             HtmlBody = html;
@@ -328,7 +328,7 @@ public class Smtp {
                 }
             }
         }
-        Client.CreateMessage();
+        Client.CreateMessage(cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- allow cancelling SMTP message preparation via new `CancellationToken` parameter
- propagate the token to remote image downloads and PowerShell cmdlet calls
- adjust unit tests for the new overload

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh -NoLogo -NoProfile -File Mailozaurr.Tests.ps1` *(fails: 21 tests failed - CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_689829baca08832e9df656c8043cc110