### PR TITLE
Use precompiled regex for local image paths

### DIFF
--- a/Sources/Mailozaurr.Tests/HtmlUtilsTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlUtilsTests.cs
@@ -1,8 +1,10 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -23,6 +25,42 @@ public class HtmlUtilsTests
         Assert.Contains($"<p>{tmp}</p>", result);
         var path = Assert.Single(paths);
         Assert.Equal(tmp, path);
+
+        File.Delete(tmp);
+    }
+
+    [Fact]
+    public void ExtractLocalImagePaths_PrecompiledRegex_MatchesInlineImplementation()
+    {
+        var tmp = Path.GetTempFileName();
+        File.WriteAllText(tmp, "data");
+        var html = $"<IMG SRC=\"{tmp}\"><p>{tmp}</p>";
+
+        var expectedPaths = new List<string>();
+        const string pattern = @"(?<=<img[^>]+src=['""])([^'""]+)(?=['""])";
+        var expectedHtml = Regex.Replace(html, pattern, match =>
+        {
+            var path = match.Value;
+            if (string.IsNullOrWhiteSpace(path)) return path;
+            if (path.StartsWith("http", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith("cid:", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            {
+                return path;
+            }
+            if (File.Exists(path))
+            {
+                var fileName = Path.GetFileName(path);
+                expectedPaths.Add(path);
+                return $"cid:{fileName}";
+            }
+            return path;
+        }, RegexOptions.IgnoreCase);
+
+        var (actualHtml, actualPaths) = HtmlUtils.ExtractLocalImagePaths(html);
+
+        Assert.Equal(expectedHtml, actualHtml);
+        Assert.Equal(expectedPaths, actualPaths);
 
         File.Delete(tmp);
     }

--- a/Sources/Mailozaurr/Helpers/HtmlUtils.cs
+++ b/Sources/Mailozaurr/Helpers/HtmlUtils.cs
@@ -14,6 +14,8 @@ namespace Mailozaurr;
 public static class HtmlUtils {
     internal static HttpClient HttpClient { get; } = new HttpClient();
 
+    private static readonly Regex ImageSrcRegex = new("(?<=<img[^>]+src=[\"'])([^\"']+)(?=[\"'])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     static HtmlUtils() {
         AppDomain.CurrentDomain.ProcessExit += (_, _) => HttpClient.Dispose();
     }
@@ -40,8 +42,7 @@ public static class HtmlUtils {
         var paths = new List<string>();
         if (string.IsNullOrWhiteSpace(html)) return (html, paths);
 
-        string pattern = "(?<=<img[^>]+src=[\"'])([^\"']+)(?=[\"'])";
-        html = Regex.Replace(html, pattern, match => {
+        html = ImageSrcRegex.Replace(html, match => {
             var path = match.Value;
             if (string.IsNullOrWhiteSpace(path)) return path;
             if (path.StartsWith("http", StringComparison.OrdinalIgnoreCase) ||
@@ -55,7 +56,7 @@ public static class HtmlUtils {
                 return $"cid:{fileName}";
             }
             return path;
-        }, RegexOptions.IgnoreCase);
+        });
         return (html, paths);
     }
 


### PR DESCRIPTION
## Summary
- precompile regex for local image src extraction
- ensure HTML extraction matches previous behavior

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_689829c98c2c832e866b8d594d14dbe6