### PR TITLE
Validate MicrosoftGraphUtils credential inputs

### DIFF
--- a/Sources/Mailozaurr.Tests/ConvertFromGraphCredentialTests.cs
+++ b/Sources/Mailozaurr.Tests/ConvertFromGraphCredentialTests.cs
@@ -1,0 +1,36 @@
+using System;
+using Xunit;
+using Mailozaurr;
+
+namespace Mailozaurr.Tests;
+
+public class ConvertFromGraphCredentialTests
+{
+    [Fact]
+    public void ThrowsOnNullUsername()
+    {
+        Assert.Throws<ArgumentNullException>(() => MicrosoftGraphUtils.ConvertFromGraphCredential(null!, "secret"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ThrowsOnWhitespaceUsername(string username)
+    {
+        Assert.Throws<ArgumentException>(() => MicrosoftGraphUtils.ConvertFromGraphCredential(username, "secret"));
+    }
+
+    [Fact]
+    public void ThrowsOnNullPassword()
+    {
+        Assert.Throws<ArgumentNullException>(() => MicrosoftGraphUtils.ConvertFromGraphCredential("client@tenant", null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ThrowsOnWhitespacePassword(string password)
+    {
+        Assert.Throws<ArgumentException>(() => MicrosoftGraphUtils.ConvertFromGraphCredential("client@tenant", password));
+    }
+}

--- a/Sources/Mailozaurr.Tests/TestParallelization.cs
+++ b/Sources/Mailozaurr.Tests/TestParallelization.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -94,6 +94,22 @@ namespace Mailozaurr {
         /// Converts a credential string (username@directory) and secret to a GraphCredential object.
         /// </summary>
         public static GraphCredential ConvertFromGraphCredential(string username, string password) {
+            if (username == null) {
+                throw new ArgumentNullException(nameof(username));
+            }
+
+            if (string.IsNullOrWhiteSpace(username)) {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(username));
+            }
+
+            if (password == null) {
+                throw new ArgumentNullException(nameof(password));
+            }
+
+            if (string.IsNullOrWhiteSpace(password)) {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(password));
+            }
+
             username = username.Trim();
             var parts = username.Split('@');
             if (parts.Length != 2) {

--- a/Tests/ConvertFromGraphCredential.Tests.ps1
+++ b/Tests/ConvertFromGraphCredential.Tests.ps1
@@ -12,6 +12,18 @@ Describe 'MicrosoftGraphUtils.ConvertFromGraphCredential' {
         $cred.DirectoryId | Should -Be 'tenant'
         $cred.ClientSecret | Should -Be 'secret'
     }
+    It 'Throws when username is null' {
+        { [Mailozaurr.MicrosoftGraphUtils]::ConvertFromGraphCredential($null, 'secret') } | Should -Throw -ExceptionType System.ArgumentNullException
+    }
+    It 'Throws when username is whitespace' {
+        { [Mailozaurr.MicrosoftGraphUtils]::ConvertFromGraphCredential('   ', 'secret') } | Should -Throw -ExceptionType System.ArgumentException
+    }
+    It 'Throws when password is null' {
+        { [Mailozaurr.MicrosoftGraphUtils]::ConvertFromGraphCredential('client@tenant', $null) } | Should -Throw -ExceptionType System.ArgumentNullException
+    }
+    It 'Throws when password is whitespace' {
+        { [Mailozaurr.MicrosoftGraphUtils]::ConvertFromGraphCredential('client@tenant', '   ') } | Should -Throw -ExceptionType System.ArgumentException
+    }
     It 'Throws for invalid format' {
         { [Mailozaurr.MicrosoftGraphUtils]::ConvertFromGraphCredential('invalid', 'pwd') } | Should -Throw
     }


### PR DESCRIPTION
## Summary
- guard `ConvertFromGraphCredential` against null or whitespace usernames and passwords
- add unit tests for invalid credential inputs
- extend Pester coverage for missing username/password cases

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release --framework net8.0`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release --framework net472`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File Mailozaurr.Tests.ps1` *(fails: Cannot add type / missing assemblies, 25 tests failed)*


------
https://chatgpt.com/codex/tasks/task_e_689829d5b400832ea15c74125fdf3d08