### PR TITLE
Dispose HttpClient in GmailApiClient

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -13,6 +13,19 @@ public class GmailApiClientTests {
             return Task.FromResult(_response);
         }
     }
+
+    private sealed class DisposingHandler : HttpMessageHandler {
+        public bool Disposed { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+
+        protected override void Dispose(bool disposing) {
+            if (disposing) {
+                Disposed = true;
+            }
+            base.Dispose(disposing);
+        }
+    }
     [Fact]
     public void Constructor_SetsAuthorizationHeader() {
         var cred = new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue };
@@ -163,5 +176,17 @@ public class GmailApiClientTests {
         var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
         field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
         await Assert.ThrowsAsync<System.IO.InvalidDataException>(() => client.GetAsync("me", "id"));
+    }
+
+    [Fact]
+    public void Dispose_DisposesHttpClient() {
+        var cred = new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue };
+        var client = new GmailApiClient(cred);
+        var handler = new DisposingHandler();
+        var httpClient = new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") };
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, httpClient);
+        client.Dispose();
+        Assert.True(handler.Disposed);
     }
 }

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -15,9 +15,10 @@ namespace Mailozaurr;
 /// <summary>
 /// Lightweight client for sending and retrieving messages using Gmail REST API.
 /// </summary>
-public sealed class GmailApiClient {
+public sealed class GmailApiClient : IDisposable {
     private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
     private readonly HttpClient _client;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes the client using the provided OAuth credential.
@@ -31,6 +32,17 @@ public sealed class GmailApiClient {
 
     internal GmailApiClient(HttpClient client) {
         _client = client;
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        if (_disposed) {
+            return;
+        }
+
+        _client.Dispose();
+        _disposed = true;
+        GC.SuppressFinalize(this);
     }
 
     private static async Task ThrowIfAuthErrorAsync(HttpResponseMessage response, CancellationToken cancellationToken) {


### PR DESCRIPTION
## Summary
- implement `IDisposable` on `GmailApiClient`
- ensure internal `HttpClient` is disposed and finalization is suppressed
- add unit test verifying client disposal

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet build Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689e0afe8c90832e8a7cfdbc34e475bb