### PR TITLE
feat: support in-memory pgp import

### DIFF
--- a/Examples/Example-SendEmail-TemporaryPgpInMemory.ps1
+++ b/Examples/Example-SendEmail-TemporaryPgpInMemory.ps1
@@ -1,0 +1,27 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+# Generate temporary keys
+$pair = [Mailozaurr.TemporaryPgpKeyPair]::Create('sender@example.com')
+$public = $pair.ExportPublicKey()
+$private = $pair.ExportPrivateKey()
+
+# Create context and import keys entirely from memory
+$ctx = [Mailozaurr.EphemeralOpenPgpContext]::new($pair.PassPhrase)
+$ctx.ImportKeys($public)
+$ctx.ImportKeys($private)
+
+# Build a message and encrypt it using the imported keys
+$smtp = [Mailozaurr.Smtp]::new()
+$smtp.From = 'sender@example.com'
+$smtp.To   = @('sender@example.com')
+$smtp.Subject = 'Temporary in-memory PGP'
+$smtp.TextBody = 'Secret text'
+$smtp.CreateMessage()
+$keys = $ctx.GetPublicKeys($smtp.Message.To)
+$smtp.Message.Body = [MimeKit.Cryptography.MultipartEncrypted]::Encrypt($ctx, $keys, $smtp.Message.Body)
+
+# Decrypt the message using the same in-memory context
+$encrypted = [MimeKit.Cryptography.MultipartEncrypted]$smtp.Message.Body
+$decrypted = $encrypted.Decrypt($ctx)
+$reader = [System.IO.StreamReader]::new($decrypted.Content.Open())
+Write-Host "Decrypted body: $($reader.ReadToEnd())"

--- a/Sources/Mailozaurr.Tests/EphemeralOpenPgpContextTests.cs
+++ b/Sources/Mailozaurr.Tests/EphemeralOpenPgpContextTests.cs
@@ -3,7 +3,11 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
+using Mailozaurr;
+using MimeKit;
+using MimeKit.Cryptography;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -46,5 +50,32 @@ public class EphemeralOpenPgpContextTests
 
         var ex = Record.Exception(() => ctx.Dispose());
         Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ImportKeys_FromStreamAndString_AllowsEncryptionAndDecryption()
+    {
+        using var pair = TemporaryPgpKeyPair.Create("a@b.com", "pass");
+        var publicKey = pair.ExportPublicKey();
+        var privateKey = pair.ExportPrivateKey();
+
+        using var ctx = new EphemeralOpenPgpContext(pair.PassPhrase);
+        ctx.ImportKeys(publicKey);
+        using var privStream = new MemoryStream(Encoding.UTF8.GetBytes(privateKey));
+        ctx.ImportKeys(privStream);
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("a@b.com"));
+        message.To.Add(MailboxAddress.Parse("a@b.com"));
+        message.Subject = "test";
+        var body = new TextPart("plain") { Text = "secret" };
+        var recipients = message.To.Mailboxes;
+        var encKeys = ctx.GetPublicKeys(recipients);
+        message.Body = MultipartEncrypted.Encrypt(ctx, encKeys, body);
+
+        var encrypted = (MultipartEncrypted)message.Body;
+        var decrypted = encrypted.Decrypt(ctx);
+        var text = ((TextPart)decrypted).Text;
+        Assert.Equal("secret", text);
     }
 }

--- a/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
+++ b/Sources/Mailozaurr/Cryptography/EphemeralOpenPgpContext.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Text;
+using Org.BouncyCastle.Bcpg;
 using Org.BouncyCastle.Bcpg.OpenPgp;
 using MimeKit.Cryptography;
 
@@ -54,6 +56,44 @@ public class EphemeralOpenPgpContext : GnuPGContext, IDisposable {
     /// <returns>The passphrase to use.</returns>
     protected override string GetPasswordForKey(PgpSecretKey key) {
         return _password ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Imports PGP key material from a stream. The method automatically detects
+    /// whether the stream contains a public or a private key and imports it
+    /// into the context.
+    /// </summary>
+    /// <param name="stream">The stream containing ASCII-armored key data.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="stream"/> is <c>null</c>.</exception>
+    public void ImportKeys(Stream stream) {
+        if (stream == null)
+            throw new ArgumentNullException(nameof(stream));
+
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        ms.Position = 0;
+
+        try {
+            base.Import(new PgpSecretKeyRingBundle(new ArmoredInputStream(ms)));
+            return;
+        } catch {
+            ms.Position = 0;
+            base.Import(ms);
+        }
+    }
+
+    /// <summary>
+    /// Imports PGP key material from a raw string.
+    /// </summary>
+    /// <param name="keyData">ASCII-armored key data.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="keyData"/> is <c>null</c>.</exception>
+    public void ImportKeys(string keyData) {
+        if (keyData == null)
+            throw new ArgumentNullException(nameof(keyData));
+
+        var bytes = Encoding.UTF8.GetBytes(keyData);
+        using var ms = new MemoryStream(bytes);
+        ImportKeys(ms);
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/Cryptography/TemporaryPgpKeyPair.cs
+++ b/Sources/Mailozaurr/Cryptography/TemporaryPgpKeyPair.cs
@@ -24,6 +24,11 @@ public sealed class TemporaryPgpKeyPair : IDisposable
     /// <summary>Passphrase used for the private key.</summary>
     public string PassPhrase { get; }
 
+    /// <summary>Gets the ASCII-armored public key.</summary>
+    public string ExportPublicKey() => File.ReadAllText(PublicKeyPath);
+    /// <summary>Gets the ASCII-armored private key.</summary>
+    public string ExportPrivateKey() => File.ReadAllText(PrivateKeyPath);
+
     private readonly string _tempDirectory;
     private readonly bool _removeDirectory;
     private readonly bool _deleteOnDispose;

--- a/Tests/EphemeralOpenPgpContext.InMemory.Tests.ps1
+++ b/Tests/EphemeralOpenPgpContext.InMemory.Tests.ps1
@@ -1,0 +1,25 @@
+Describe 'EphemeralOpenPgpContext - in-memory import' {
+    It 'Encrypts and decrypts using string keys' {
+        $pair = [Mailozaurr.TemporaryPgpKeyPair]::Create('a@b.com')
+        $ctx = [Mailozaurr.EphemeralOpenPgpContext]::new($pair.PassPhrase)
+        $ctx.ImportKeys($pair.ExportPublicKey())
+        $ctx.ImportKeys($pair.ExportPrivateKey())
+
+        $smtp = [Mailozaurr.Smtp]::new()
+        $smtp.From = 'a@b.com'
+        $smtp.To = @('a@b.com')
+        $smtp.Subject = 'test'
+        $smtp.TextBody = 'secret'
+        $smtp.CreateMessage()
+        $keys = $ctx.GetPublicKeys($smtp.Message.To)
+        $smtp.Message.Body = [MimeKit.Cryptography.MultipartEncrypted]::Encrypt($ctx, $keys, $smtp.Message.Body)
+
+        $encrypted = [MimeKit.Cryptography.MultipartEncrypted]$smtp.Message.Body
+        $decrypted = $encrypted.Decrypt($ctx)
+        $reader = New-Object System.IO.StreamReader($decrypted.Content.Open())
+        $reader.ReadToEnd() | Should -Be 'secret'
+
+        $ctx.Dispose()
+        $pair.Dispose()
+    }
+}


### PR DESCRIPTION
## Summary
- allow `EphemeralOpenPgpContext` to import PGP keys from streams or raw strings
- expose public/private key export helpers in `TemporaryPgpKeyPair`
- document and test in-memory PGP usage

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `pwsh -File Mailozaurr.Tests.ps1` *(fails: The term 'Unprotect-MimeMessage' is not recognized as a name of a cmdlet)*

------
https://chatgpt.com/codex/tasks/task_e_689e0b6a4a00832ea3e6e19163795176