### PR TITLE
Ensure IMAP folders close on errors

### DIFF
--- a/Sources/Mailozaurr.Tests/FolderOperationsTests.cs
+++ b/Sources/Mailozaurr.Tests/FolderOperationsTests.cs
@@ -35,4 +35,71 @@ public class FolderOperationsTests {
         source.Verify(f => f.CloseAsync(false, It.IsAny<CancellationToken>()), Times.Once());
         dest.Verify(f => f.CloseAsync(false, It.IsAny<CancellationToken>()), Times.Once());
     }
+
+    [Fact]
+    public async Task MoveFolderAsync_ClosesFolders_OnFailure() {
+        var source = new Mock<IMailFolder>();
+        var dest = new Mock<IMailFolder>();
+
+        source.SetupGet(f => f.FullName).Returns("source");
+        source.SetupGet(f => f.Name).Returns("source");
+        source.SetupGet(f => f.IsOpen).Returns(true);
+        source.Setup(f => f.Open(It.IsAny<FolderAccess>(), It.IsAny<CancellationToken>()));
+        source.Setup(f => f.RenameAsync(dest.Object, "source", It.IsAny<CancellationToken>())).ThrowsAsync(new ImapProtocolException("fail"));
+        source.Setup(f => f.CloseAsync(false, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask).Verifiable();
+
+        dest.SetupGet(f => f.FullName).Returns("dest");
+        dest.SetupGet(f => f.IsOpen).Returns(true);
+        dest.Setup(f => f.Open(It.IsAny<FolderAccess>(), It.IsAny<CancellationToken>()));
+        dest.Setup(f => f.CloseAsync(false, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask).Verifiable();
+
+        var client = new Mock<ImapClient> { CallBase = true };
+        client.Setup(c => c.Inbox).Returns(source.Object);
+        client.Setup(c => c.GetFolder(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(dest.Object);
+        client.Setup(c => c.PersonalNamespaces).Returns(new FolderNamespaceCollection());
+
+        await Assert.ThrowsAsync<ImapProtocolException>(() => FolderOperations.MoveFolderAsync(client.Object, "source", "dest"));
+
+        source.Verify(f => f.CloseAsync(false, It.IsAny<CancellationToken>()), Times.Once());
+        dest.Verify(f => f.CloseAsync(false, It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task RenameFolderAsync_ClosesFolder_OnFailure() {
+        var folder = new Mock<IMailFolder>();
+
+        folder.SetupGet(f => f.FullName).Returns("source");
+        folder.SetupGet(f => f.ParentFolder).Returns(Mock.Of<IMailFolder>());
+        folder.SetupGet(f => f.IsOpen).Returns(true);
+        folder.Setup(f => f.RenameAsync(It.IsAny<IMailFolder>(), "new", It.IsAny<CancellationToken>())).ThrowsAsync(new ImapProtocolException("fail"));
+        folder.Setup(f => f.CloseAsync(false, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask).Verifiable();
+
+        var client = new Mock<ImapClient> { CallBase = true };
+        client.Setup(c => c.Inbox).Returns(Mock.Of<IMailFolder>(f => f.FullName == "inbox"));
+        client.Setup(c => c.GetFolder("source", It.IsAny<CancellationToken>())).Returns(folder.Object);
+        client.Setup(c => c.PersonalNamespaces).Returns(new FolderNamespaceCollection());
+
+        await Assert.ThrowsAsync<ImapProtocolException>(() => FolderOperations.RenameFolderAsync(client.Object, "source", "new"));
+
+        folder.Verify(f => f.CloseAsync(false, It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task RemoveFolderAsync_ClosesFolder_OnFailure() {
+        var folder = new Mock<IMailFolder>();
+
+        folder.SetupGet(f => f.FullName).Returns("source");
+        folder.SetupGet(f => f.IsOpen).Returns(true);
+        folder.Setup(f => f.DeleteAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new ImapProtocolException("fail"));
+        folder.Setup(f => f.CloseAsync(false, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask).Verifiable();
+
+        var client = new Mock<ImapClient> { CallBase = true };
+        client.Setup(c => c.Inbox).Returns(Mock.Of<IMailFolder>(f => f.FullName == "inbox"));
+        client.Setup(c => c.GetFolder("source", It.IsAny<CancellationToken>())).Returns(folder.Object);
+        client.Setup(c => c.PersonalNamespaces).Returns(new FolderNamespaceCollection());
+
+        await Assert.ThrowsAsync<ImapProtocolException>(() => FolderOperations.RemoveFolderAsync(client.Object, "source"));
+
+        folder.Verify(f => f.CloseAsync(false, It.IsAny<CancellationToken>()), Times.Once());
+    }
 }

--- a/Sources/Mailozaurr/Receive/FolderOperations.cs
+++ b/Sources/Mailozaurr/Receive/FolderOperations.cs
@@ -33,12 +33,15 @@ public static class FolderOperations {
         } else {
             destParent = client.GetCachedFolder(destinationFolder, FolderAccess.ReadWrite);
         }
-        await source.RenameAsync(destParent, source.Name, cancellationToken).ConfigureAwait(false);
-        if (source.IsOpen)
-            await source.CloseAsync(false, cancellationToken).ConfigureAwait(false);
-        if (destParent.IsOpen)
-            await destParent.CloseAsync(false, cancellationToken).ConfigureAwait(false);
-        client.ClearFolderCache();
+        try {
+            await source.RenameAsync(destParent, source.Name, cancellationToken).ConfigureAwait(false);
+        } finally {
+            if (source.IsOpen)
+                await source.CloseAsync(false, cancellationToken).ConfigureAwait(false);
+            if (destParent.IsOpen)
+                await destParent.CloseAsync(false, cancellationToken).ConfigureAwait(false);
+            client.ClearFolderCache();
+        }
     }
 
     /// <summary>
@@ -55,8 +58,13 @@ public static class FolderOperations {
         string newName,
         CancellationToken cancellationToken = default) {
         var src = client.GetCachedFolder(folder, FolderAccess.ReadWrite);
-        await src.RenameAsync(src.ParentFolder, newName, cancellationToken).ConfigureAwait(false);
-        client.ClearFolderCache();
+        try {
+            await src.RenameAsync(src.ParentFolder, newName, cancellationToken).ConfigureAwait(false);
+        } finally {
+            if (src.IsOpen)
+                await src.CloseAsync(false, cancellationToken).ConfigureAwait(false);
+            client.ClearFolderCache();
+        }
     }
 
     /// <summary>
@@ -73,13 +81,21 @@ public static class FolderOperations {
         bool recursive = false,
         CancellationToken cancellationToken = default) {
         var src = client.GetCachedFolder(folder, FolderAccess.ReadWrite);
-        if (recursive) {
-            foreach (var sub in await src.GetSubfoldersAsync(false, cancellationToken).ConfigureAwait(false)) {
-                await RemoveFolderAsync(client, sub.FullName, true, cancellationToken).ConfigureAwait(false);
+        try {
+            if (recursive) {
+                foreach (var sub in await src.GetSubfoldersAsync(false, cancellationToken).ConfigureAwait(false))
+                    await RemoveFolderAsync(client, sub.FullName, true, cancellationToken).ConfigureAwait(false);
+
+                if (src.IsOpen)
+                    await src.CloseAsync(false, cancellationToken).ConfigureAwait(false);
+                src = client.GetCachedFolder(folder, FolderAccess.ReadWrite);
             }
-            src = client.GetCachedFolder(folder, FolderAccess.ReadWrite);
+
+            await src.DeleteAsync(cancellationToken).ConfigureAwait(false);
+        } finally {
+            if (src.IsOpen)
+                await src.CloseAsync(false, cancellationToken).ConfigureAwait(false);
+            client.ClearFolderCache();
         }
-        await src.DeleteAsync(cancellationToken).ConfigureAwait(false);
-        client.ClearFolderCache();
     }
 }


### PR DESCRIPTION
## Summary
- protect IMAP folder operations with try/finally blocks to always close folders and clear the cache
- add unit tests proving folders close even when move, rename, or delete fails

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689e0b15fab4832eba8c4b44ee22351e