### PR TITLE
Use interlocked count for SMTP connection pool

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpConnectionPoolConcurrencyTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConnectionPoolConcurrencyTests.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpConnectionPoolConcurrencyTests {
+    private class FakeClient : ClientSmtp {
+        private bool _connected = true;
+        public override bool IsConnected => _connected;
+        public void SetConnected(bool value) => _connected = value;
+    }
+
+    [Fact]
+    public void ReturnClient_ConcurrentCallsRespectMaxPoolSize() {
+        SmtpConnectionPool.PoolingEnabled = true;
+        SmtpConnectionPool.ClearConnectionPool();
+        SmtpConnectionPool.MaxPoolSize = 2;
+
+        var clients = Enumerable.Range(0, 20).Select(_ => new FakeClient()).ToArray();
+        Parallel.ForEach(clients, c => SmtpConnectionPool.ReturnClient("h", 25, c));
+
+        var rented = 0;
+        ClientSmtp? client;
+        while ((client = SmtpConnectionPool.TryRentClient("h", 25)) != null) {
+            rented++;
+            client.Dispose();
+        }
+
+        Assert.Equal(SmtpConnectionPool.MaxPoolSize, rented);
+
+        SmtpConnectionPool.ClearConnectionPool();
+        SmtpConnectionPool.PoolingEnabled = false;
+    }
+
+    [Fact]
+    public void TryRentClient_ConcurrentCallsEmptyPool() {
+        SmtpConnectionPool.PoolingEnabled = true;
+        SmtpConnectionPool.ClearConnectionPool();
+        SmtpConnectionPool.MaxPoolSize = 5;
+
+        foreach (var _ in Enumerable.Range(0, SmtpConnectionPool.MaxPoolSize)) {
+            SmtpConnectionPool.ReturnClient("h", 25, new FakeClient());
+        }
+
+        var rented = 0;
+        Parallel.For(0, SmtpConnectionPool.MaxPoolSize, _ => {
+            var client = SmtpConnectionPool.TryRentClient("h", 25);
+            if (client != null) {
+                Interlocked.Increment(ref rented);
+                client.Dispose();
+            }
+        });
+
+        Assert.Equal(SmtpConnectionPool.MaxPoolSize, rented);
+        Assert.Null(SmtpConnectionPool.TryRentClient("h", 25));
+
+        SmtpConnectionPool.ClearConnectionPool();
+        SmtpConnectionPool.PoolingEnabled = false;
+    }
+}

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
@@ -1,12 +1,18 @@
 namespace Mailozaurr;
 
 using System.Collections.Concurrent;
+using System.Threading;
 
 /// <summary>
 /// Manages SMTP connection pooling.
 /// </summary>
 public static class SmtpConnectionPool {
-    private static readonly ConcurrentDictionary<string, ConcurrentBag<ClientSmtp>> _connectionPool = new();
+    private sealed class PoolEntry {
+        public readonly ConcurrentBag<ClientSmtp> Bag = new();
+        public int Count;
+    }
+
+    private static readonly ConcurrentDictionary<string, PoolEntry> _connectionPool = new();
 
     /// <summary>Maximum number of pooled connections per server/port.</summary>
     public static int MaxPoolSize { get; set; } = 2;
@@ -20,8 +26,9 @@ public static class SmtpConnectionPool {
         }
 
         var key = $"{server}:{port}";
-        if (_connectionPool.TryGetValue(key, out var bag)) {
-            while (bag.TryTake(out var pooled)) {
+        if (_connectionPool.TryGetValue(key, out var entry)) {
+            while (entry.Bag.TryTake(out var pooled)) {
+                Interlocked.Decrement(ref entry.Count);
                 if (pooled.IsConnected) {
                     return pooled;
                 }
@@ -45,18 +52,21 @@ public static class SmtpConnectionPool {
         }
 
         var key = $"{server}:{port}";
-        var bag = _connectionPool.GetOrAdd(key, _ => new ConcurrentBag<ClientSmtp>());
-        if (bag.Count >= MaxPoolSize) {
+        var entry = _connectionPool.GetOrAdd(key, _ => new PoolEntry());
+        var current = Interlocked.Increment(ref entry.Count);
+        if (current > MaxPoolSize) {
+            Interlocked.Decrement(ref entry.Count);
             client.Dispose();
         } else {
-            bag.Add(client);
+            entry.Bag.Add(client);
         }
     }
 
     /// <summary>Disposes all SMTP clients stored in the connection pool.</summary>
     public static void ClearConnectionPool() {
-        foreach (var bag in _connectionPool.Values) {
-            while (bag.TryTake(out var client)) {
+        foreach (var entry in _connectionPool.Values) {
+            while (entry.Bag.TryTake(out var client)) {
+                Interlocked.Decrement(ref entry.Count);
                 if (!client.IsConnected) {
                     client.Dispose();
                     continue;


### PR DESCRIPTION
## Summary
- track pooled SMTP clients with an interlocked counter instead of bag.Count
- add concurrency tests covering pooled returns and rentals

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `pwsh -NoLogo -File ./Mailozaurr.Tests.ps1` *(fails: Unprotect-MimeMessage cmdlet not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0b0e9860832e827a15d17049bf98