### PR TITLE
Add missing Linq namespace

### DIFF
--- a/Sources/Mailozaurr/Validator.cs
+++ b/Sources/Mailozaurr/Validator.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using EmailValidation;
 


### PR DESCRIPTION
## Summary
- add System.Linq import to Validator

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release -f net472 /p:WarningLevel=0` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*
- `dotnet build Sources/Mailozaurr.sln -c Release -f net8.0 /p:WarningLevel=0`
- `dotnet build Sources/Mailozaurr.sln -c Release -f net9.0 /p:WarningLevel=0` *(fails: Assets file doesn't have a target for 'net9.0')*
- `dotnet test Sources/Mailozaurr.sln -c Release /p:WarningLevel=0`


------
https://chatgpt.com/codex/tasks/task_e_689e0af37fc4832eaa27d5da37e6814c