### PR TITLE
Add Gmail thread operations

### DIFF
--- a/Examples/Example-GmailApi-11-ListThreads.ps1
+++ b/Examples/Example-GmailApi-11-ListThreads.ps1
@@ -1,0 +1,7 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$cred = ConvertTo-OAuth2Credential -UserName 'user@gmail.com' -Token 'access_token'
+
+# List last 5 threads with alerts
+Get-GmailThread -GmailAccount 'user@gmail.com' -Credential $cred `
+    -Query 'from:alerts@example.com' -MaxResults 5

--- a/Examples/Example-GmailApi-12-GetThread.ps1
+++ b/Examples/Example-GmailApi-12-GetThread.ps1
@@ -1,0 +1,7 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$cred = ConvertTo-OAuth2Credential -UserName 'user@gmail.com' -Token 'access_token'
+
+# Retrieve a thread and output snippets
+$thread = Get-GmailThread -GmailAccount 'user@gmail.com' -Credential $cred -Id 'threadId'
+$thread.Messages | ForEach-Object { $_.Snippet }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetGmailThread.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetGmailThread.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// Retrieves Gmail threads using the Gmail API.
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "GmailThread")]
+[OutputType(typeof(GmailThread))]
+[OutputType(typeof(GmailThreadInfo), ParameterSetName = new[] { "List" })]
+public sealed class CmdletGetGmailThread : AsyncPSCmdlet {
+    /// <summary>
+    /// Gmail account address to operate on.
+    /// </summary>
+    [Parameter(Mandatory = true)]
+    public string? GmailAccount { get; set; }
+
+    /// <summary>
+    /// OAuth credential used to authenticate to Gmail.
+    /// </summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNull]
+    public PSCredential? Credential { get; set; }
+
+    /// <summary>
+    /// Search query used when listing threads.
+    /// </summary>
+    [Parameter(ParameterSetName = "List")]
+    public string? Query { get; set; }
+
+    /// <summary>
+    /// Maximum number of threads to return when listing.
+    /// </summary>
+    [Parameter(ParameterSetName = "List")]
+    public int? MaxResults { get; set; }
+
+    /// <summary>
+    /// Identifier of a specific Gmail thread.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "Id")]
+    public string? Id { get; set; }
+
+    /// <summary>
+    /// Retrieves Gmail threads based on the specified parameters.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    protected override async Task ProcessRecordAsync() {
+        var net = Credential!.GetNetworkCredential();
+        var oauth = new OAuthCredential {
+            UserName = net.UserName,
+            AccessToken = net.Password,
+            ExpiresOn = System.DateTimeOffset.MaxValue
+        };
+        var client = new GmailApiClient(oauth);
+        if (ParameterSetName == "Id") {
+            var thread = await client.GetThreadAsync(GmailAccount!, Id!, CancelToken);
+            WriteObject(thread);
+            return;
+        }
+        IList<GmailThreadInfo> list = await client.ListThreadsAsync(GmailAccount!, Query, MaxResults, CancelToken);
+        foreach (var t in list) {
+            WriteObject(t);
+        }
+    }
+}
+

--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -164,4 +164,67 @@ public class GmailApiClientTests {
         field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
         await Assert.ThrowsAsync<System.IO.InvalidDataException>(() => client.GetAsync("me", "id"));
     }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ListThreadsAsync_PaginatesUntilTokenNull() {
+        var page1 = "{\"threads\":[{\"id\":\"1\"}],\"nextPageToken\":\"tok\"}";
+        var page2 = "{\"threads\":[{\"id\":\"2\"}]}";
+        var handler = new RecordingHandler(
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(page1) },
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(page2) });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        var list = await client.ListThreadsAsync("me");
+        Assert.Equal(2, list.Count);
+        Assert.Equal("1", list[0].Id);
+        Assert.Equal("2", list[1].Id);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?pageToken=tok", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetThreadAsync_ReturnsThread() {
+        var json = "{\"id\":\"t1\",\"messages\":[{\"id\":\"m1\"}]}";
+        var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(json) });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        var thread = await client.GetThreadAsync("me", "t1");
+        Assert.Equal("t1", thread.Id);
+        Assert.Single(thread.Messages!);
+        Assert.Equal("m1", thread.Messages![0].Id);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ListThreadsAsync_CanBeCancelled() {
+        var handler = new CancelAwareHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("{}") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        using var cts = new System.Threading.CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<System.OperationCanceledException>(() => client.ListThreadsAsync("me", cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetThreadAsync_CanBeCancelled() {
+        var handler = new CancelAwareHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("{}") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        using var cts = new System.Threading.CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<System.OperationCanceledException>(() => client.GetThreadAsync("me", "id", cts.Token));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetThreadAsync_NullResponse_Throws() {
+        var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("null") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        await Assert.ThrowsAsync<System.IO.InvalidDataException>(() => client.GetThreadAsync("me", "id"));
+    }
 }

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -134,6 +134,58 @@ public sealed class GmailApiClient {
     }
 
     /// <summary>
+    /// Lists threads matching the supplied query.
+    /// </summary>
+    public async Task<IList<GmailThreadInfo>> ListThreadsAsync(string userId, string? query = null, int? maxResults = null, CancellationToken cancellationToken = default) {
+        var threads = new List<GmailThreadInfo>();
+        string? pageToken = null;
+        do {
+            var url = new StringBuilder($"users/{userId}/threads");
+            var qs = new List<string>();
+            if (!string.IsNullOrWhiteSpace(query)) qs.Add($"q={Uri.EscapeDataString(query)}");
+            if (maxResults.HasValue) qs.Add($"maxResults={maxResults.Value}");
+            if (!string.IsNullOrEmpty(pageToken)) qs.Add($"pageToken={pageToken}");
+            if (qs.Count > 0) {
+                url.Append('?').Append(string.Join("&", qs));
+            }
+            using var response = await _client.GetAsync(url.ToString(), cancellationToken);
+            await ThrowIfAuthErrorAsync(response, cancellationToken);
+            response.EnsureSuccessStatusCode();
+#if NET5_0_OR_GREATER
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
+            var json = await response.Content.ReadAsStringAsync();
+#endif
+            var list = JsonSerializer.Deserialize<GmailThreadListResponse>(json, s_jsonOptions);
+            if (list?.Threads != null) {
+                threads.AddRange(list.Threads);
+            }
+            pageToken = list?.NextPageToken;
+        } while (!string.IsNullOrEmpty(pageToken));
+
+        return threads;
+    }
+
+    /// <summary>
+    /// Retrieves a single thread by id.
+    /// </summary>
+    public async Task<GmailThread> GetThreadAsync(string userId, string id, CancellationToken cancellationToken = default) {
+        using var response = await _client.GetAsync($"users/{userId}/threads/{id}", cancellationToken);
+        await ThrowIfAuthErrorAsync(response, cancellationToken);
+        response.EnsureSuccessStatusCode();
+#if NET5_0_OR_GREATER
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
+        var json = await response.Content.ReadAsStringAsync();
+#endif
+        var thread = JsonSerializer.Deserialize<GmailThread>(json, s_jsonOptions);
+        if (thread is null) {
+            throw new InvalidDataException("Gmail API returned an invalid thread response.");
+        }
+        return thread;
+    }
+
+    /// <summary>
     /// Lists attachment metadata for a message.
     /// </summary>
     public async Task<IList<GmailAttachmentInfo>> ListAttachmentsAsync(string userId, string id, CancellationToken cancellationToken = default) {
@@ -211,6 +263,13 @@ public sealed class GmailApiClient {
     private sealed class GmailListResponse {
         /// <summary>Messages returned by the API.</summary>
         public List<GmailMessage>? Messages { get; set; }
+        /// <summary>Token for the next page of results.</summary>
+        public string? NextPageToken { get; set; }
+    }
+
+    private sealed class GmailThreadListResponse {
+        /// <summary>Threads returned by the API.</summary>
+        public List<GmailThreadInfo>? Threads { get; set; }
         /// <summary>Token for the next page of results.</summary>
         public string? NextPageToken { get; set; }
     }

--- a/Sources/Mailozaurr/Gmail/GmailThread.cs
+++ b/Sources/Mailozaurr/Gmail/GmailThread.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents a thread returned by Gmail REST API.
+/// </summary>
+public sealed class GmailThread {
+    /// <summary>Unique thread identifier.</summary>
+    public string? Id { get; set; }
+
+    /// <summary>Thread history identifier.</summary>
+    public string? HistoryId { get; set; }
+
+    /// <summary>Thread snippet.</summary>
+    public string? Snippet { get; set; }
+
+    /// <summary>Messages contained in this thread.</summary>
+    public IList<GmailMessage>? Messages { get; set; }
+}

--- a/Sources/Mailozaurr/Gmail/GmailThreadInfo.cs
+++ b/Sources/Mailozaurr/Gmail/GmailThreadInfo.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents a thread item returned by Gmail REST API.
+/// </summary>
+public sealed class GmailThreadInfo {
+    /// <summary>Unique thread identifier.</summary>
+    public string? Id { get; set; }
+
+    /// <summary>Thread history identifier.</summary>
+    public string? HistoryId { get; set; }
+
+    /// <summary>Thread snippet.</summary>
+    public string? Snippet { get; set; }
+}

--- a/Tests/Get-GmailThread.Tests.ps1
+++ b/Tests/Get-GmailThread.Tests.ps1
@@ -1,0 +1,7 @@
+Describe 'Get-GmailThread cmdlet' {
+    It 'Cmdlet derives from AsyncPSCmdlet' {
+        $base = [Mailozaurr.PowerShell.CmdletGetGmailThread].BaseType
+        $base.FullName | Should -Be 'Mailozaurr.PowerShell.AsyncPSCmdlet'
+    }
+}
+


### PR DESCRIPTION
## Summary
- add models for Gmail threads
- support listing and retrieving threads in `GmailApiClient`
- expose thread APIs via `Get-GmailThread` cmdlet
- demonstrate thread usage in PowerShell examples and tests

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh -NoLogo -NoProfile -File ./Mailozaurr.Tests.ps1` *(fails: Unprotect-MimeMessage command not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_689e0b208c94832e8048e68d7e3b2171