### PR TITLE
Add SES templated email support

### DIFF
--- a/Sources/Mailozaurr.Examples/SendTemplatedEmailSes.cs
+++ b/Sources/Mailozaurr.Examples/SendTemplatedEmailSes.cs
@@ -1,0 +1,36 @@
+using Mailozaurr;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Example sending a templated email using <see cref="SesClient"/>.
+/// </summary>
+public static class SendTemplatedEmailSes {
+    /// <summary>Runs the example.</summary>
+    public static async Task RunAsync() {
+        // === CONFIGURATION ===
+        string accessKey = "your-access-key";
+        string secretKey = "your-secret-key";
+        string sender = "sender@example.com";
+        string recipient = "recipient@example.com";
+
+        // === EXAMPLE ===
+        try {
+            using var ses = new SesClient();
+            ses.Credentials = new NetworkCredential(accessKey, secretKey);
+            ses.From = sender;
+            ses.To = new List<object> { recipient };
+            ses.TemplateName = "MyTemplate";
+            ses.TemplateData = new Dictionary<string, string> { ["Name"] = "John" };
+            using var cts = new CancellationTokenSource();
+            var result = await ses.SendTemplatedEmailAsync(cts.Token);
+            Console.WriteLine(result.Status ? "SES: Email sent!" : $"SES: Failed: {result.Error}");
+        } catch (Exception ex) {
+            Console.WriteLine($"SES Example Error: {ex.Message}");
+        }
+    }
+}
+

--- a/Sources/Mailozaurr.Tests/SesClientSendTemplatedEmailAsyncTests.cs
+++ b/Sources/Mailozaurr.Tests/SesClientSendTemplatedEmailAsyncTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SesClientSendTemplatedEmailAsyncTests {
+    private static byte[] HmacSha256(byte[] key, string data) {
+        using HMACSHA256 hmac = new(key);
+        return hmac.ComputeHash(Encoding.UTF8.GetBytes(data));
+    }
+
+    private static string Sha256Hex(string data) {
+        using SHA256 sha = SHA256.Create();
+        byte[] hash = sha.ComputeHash(Encoding.UTF8.GetBytes(data));
+        return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+    }
+
+    private static string ExpectedAuthorization(string accessKey, string secretKey, string region, string amzDate, string body) {
+        string service = "ses";
+        string dateStamp = amzDate.Substring(0, 8);
+        string canonicalHeaders = $"content-type:application/x-www-form-urlencoded\nhost:email.{region}.amazonaws.com\nx-amz-date:{amzDate}\n";
+        string signedHeaders = "content-type;host;x-amz-date";
+        string payloadHash = Sha256Hex(body);
+        string canonicalRequest = $"POST\n/\n\n{canonicalHeaders}\n{signedHeaders}\n{payloadHash}";
+        string credentialScope = $"{dateStamp}/{region}/{service}/aws4_request";
+        string stringToSign = $"AWS4-HMAC-SHA256\n{amzDate}\n{credentialScope}\n{Sha256Hex(canonicalRequest)}";
+        byte[] kDate = HmacSha256(Encoding.UTF8.GetBytes("AWS4" + secretKey), dateStamp);
+        byte[] kRegion = HmacSha256(kDate, region);
+        byte[] kService = HmacSha256(kRegion, service);
+        byte[] kSigning = HmacSha256(kService, "aws4_request");
+        byte[] sigBytes = HmacSha256(kSigning, stringToSign);
+        string signature = BitConverter.ToString(sigBytes).Replace("-", string.Empty).ToLowerInvariant();
+        return $"AWS4-HMAC-SHA256 Credential={accessKey}/{credentialScope}, SignedHeaders={signedHeaders}, Signature={signature}";
+    }
+
+    private static SesClient CreateClient(HttpMessageHandler handler) {
+        return new SesClient(handler) {
+            Credentials = new NetworkCredential("AKID", "SECRET"),
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            TemplateName = "MyTemplate",
+            TemplateData = new Dictionary<string, string> { ["Name"] = "John" },
+            RetryDelayMilliseconds = 0,
+            Region = "us-east-1"
+        };
+    }
+
+    [Fact]
+    public async Task SendTemplatedEmailAsync_ComputesSignature() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+        using var client = CreateClient(handler);
+        client.WebhookUrl = null;
+
+        var result = await client.SendTemplatedEmailAsync();
+
+        Assert.True(result.Status);
+        var request = Assert.Single(handler.Requests);
+        string amzDate = request.Headers.GetValues("x-amz-date").Single();
+        string auth = request.Headers.GetValues("Authorization").Single();
+        string body = await request.Content!.ReadAsStringAsync();
+        string expected = ExpectedAuthorization("AKID", "SECRET", "us-east-1", amzDate, body);
+        Assert.Equal(expected, auth);
+        Assert.Contains("Template=MyTemplate", body);
+        string expectedJson = JsonSerializer.Serialize(client.TemplateData);
+        Assert.Contains("TemplateData=" + Uri.EscapeDataString(expectedJson), body);
+    }
+
+    [Fact]
+    public async Task SendTemplatedEmailAsync_EncodesMultipleParameters() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+        using var client = new SesClient(handler) {
+            Credentials = new NetworkCredential("AKID", "SECRET"),
+            From = "sender@example.com",
+            To = new List<object> { "to1@example.com", "to2@example.com" },
+            TemplateName = "MyTemplate",
+            TemplateData = new Dictionary<string, string> { ["Name"] = "John", ["Code"] = "123" },
+            RetryDelayMilliseconds = 0,
+            Region = "us-east-1"
+        };
+        client.WebhookUrl = null;
+
+        await client.SendTemplatedEmailAsync();
+
+        var request = Assert.Single(handler.Requests);
+        string body = await request.Content!.ReadAsStringAsync();
+        Assert.Contains("Destination.ToAddresses.member.1=to1%40example.com", body);
+        Assert.Contains("Destination.ToAddresses.member.2=to2%40example.com", body);
+        string expectedJson = JsonSerializer.Serialize(client.TemplateData);
+        Assert.Contains("TemplateData=" + Uri.EscapeDataString(expectedJson), body);
+    }
+}
+

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -1,6 +1,7 @@
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 
 namespace Mailozaurr;
 
@@ -42,6 +43,11 @@ public class SesClient : IDisposable {
     public string[]? Attachment { get; set; }
     /// <summary>Paths to inline attachments to include.</summary>
     public string[]? InlineAttachment { get; set; }
+
+    /// <summary>Name of the SES template to use.</summary>
+    public string? TemplateName { get; set; }
+    /// <summary>Template data variables.</summary>
+    public Dictionary<string, string>? TemplateData { get; set; }
 
     /// <summary>Custom headers to include with the message.</summary>
     public Dictionary<string, string>? Headers { get; set; }
@@ -162,23 +168,10 @@ public class SesClient : IDisposable {
         return request;
     }
 
-    /// <summary>
-    /// Sends the email using Amazon SES.
-    /// </summary>
-    public Task<SmtpResult> SendEmailAsync() => SendEmailAsync(CancellationToken.None);
-
-    /// <summary>
-    /// Sends the email using Amazon SES.
-    /// </summary>
-    public async Task<SmtpResult> SendEmailAsync(CancellationToken cancellationToken)
+    private async Task<SmtpResult> SendSesRequestAsync(string body, CancellationToken cancellationToken)
     {
         int attempts = 0;
         Exception? lastException = null;
-        MimeMessage message = BuildMessage();
-        using MemoryStream stream = new();
-        await message.WriteToAsync(stream, cancellationToken);
-        string raw = Convert.ToBase64String(stream.ToArray());
-        string body = $"Action=SendRawEmail&RawMessage.Data={Uri.EscapeDataString(raw)}&Version=2010-12-01";
         do
         {
             try
@@ -229,6 +222,55 @@ public class SesClient : IDisposable {
         SmtpResult final = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message);
         await Helpers.PostWebhookAsync(WebhookUrl, final, cancellationToken, _client);
         return final;
+    }
+
+    /// <summary>
+    /// Sends the email using Amazon SES.
+    /// </summary>
+    public Task<SmtpResult> SendEmailAsync() => SendEmailAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Sends the email using Amazon SES.
+    /// </summary>
+    public async Task<SmtpResult> SendEmailAsync(CancellationToken cancellationToken)
+    {
+        MimeMessage message = BuildMessage();
+        using MemoryStream stream = new();
+        await message.WriteToAsync(stream, cancellationToken);
+        string raw = Convert.ToBase64String(stream.ToArray());
+        string body = $"Action=SendRawEmail&RawMessage.Data={Uri.EscapeDataString(raw)}&Version=2010-12-01";
+        return await SendSesRequestAsync(body, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a templated email using Amazon SES.
+    /// </summary>
+    public Task<SmtpResult> SendTemplatedEmailAsync() => SendTemplatedEmailAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Sends a templated email using Amazon SES.
+    /// </summary>
+    public async Task<SmtpResult> SendTemplatedEmailAsync(CancellationToken cancellationToken)
+    {
+        StringBuilder sb = new("Action=SendTemplatedEmail&Version=2010-12-01");
+        if (!string.IsNullOrEmpty(TemplateName)) sb.Append("&Template=").Append(Uri.EscapeDataString(TemplateName));
+        sb.Append("&Source=").Append(Uri.EscapeDataString(SentFrom));
+        if (To != null)
+        {
+            for (int i = 0; i < To.Count; i++) sb.Append("&Destination.ToAddresses.member.").Append(i + 1).Append("=").Append(Uri.EscapeDataString(Helpers.GetEmailAddress(To[i])));
+        }
+        if (Cc != null)
+        {
+            for (int i = 0; i < Cc.Count; i++) sb.Append("&Destination.CcAddresses.member.").Append(i + 1).Append("=").Append(Uri.EscapeDataString(Helpers.GetEmailAddress(Cc[i])));
+        }
+        if (Bcc != null)
+        {
+            for (int i = 0; i < Bcc.Count; i++) sb.Append("&Destination.BccAddresses.member.").Append(i + 1).Append("=").Append(Uri.EscapeDataString(Helpers.GetEmailAddress(Bcc[i])));
+        }
+        if (ReplyTo != null) sb.Append("&ReplyToAddresses.member.1=").Append(Uri.EscapeDataString(Helpers.GetEmailAddress(ReplyTo)));
+        string json = TemplateData != null ? JsonSerializer.Serialize(TemplateData) : "{}";
+        sb.Append("&TemplateData=").Append(Uri.EscapeDataString(json));
+        return await SendSesRequestAsync(sb.ToString(), cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add SendTemplatedEmailAsync to SES client with request signing
- add example for templated SES emails
- test templated email signature and parameter encoding

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689e0b57bfd8832e8daf15451ad728cc