### PR TITLE
Support token refresh in Gmail client

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -96,6 +96,29 @@ public class GmailApiClientTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task SendAsync_ExpiredToken_InvokesRefresh() {
+        var handler = new RecordingHandler(
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized) { Content = new System.Net.Http.StringContent("error") },
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("{\"id\":\"1\"}") });
+        int refreshes = 0;
+        System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>> refresher = _ => {
+            refreshes++;
+            return System.Threading.Tasks.Task.FromResult("new");
+        };
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "old", ExpiresOn = System.DateTimeOffset.MaxValue }, refresher);
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var httpClient = new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") };
+        httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "old");
+        field.SetValue(client, httpClient);
+        var message = new MimeKit.MimeMessage();
+        await Assert.ThrowsAsync<GmailAuthenticationException>(() => client.SendAsync("me", message));
+        Assert.Equal(1, refreshes);
+        await client.SendAsync("me", message);
+        Assert.Equal("Bearer old", handler.Requests[0].Headers.Authorization!.ToString());
+        Assert.Equal("Bearer new", handler.Requests[1].Headers.Authorization!.ToString());
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task ListAsync_PaginatesUntilTokenNull() {
         var page1 = "{\"messages\":[{\"id\":\"1\"}],\"nextPageToken\":\"tok\"}";
         var page2 = "{\"messages\":[{\"id\":\"2\"}]}";

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -18,20 +18,23 @@ namespace Mailozaurr;
 public sealed class GmailApiClient : IDisposable {
     private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
     private readonly HttpClient _client;
+    private readonly Func<CancellationToken, Task<string>>? _refreshToken;
     private bool _disposed;
 
     /// <summary>
     /// Initializes the client using the provided OAuth credential.
     /// </summary>
-    public GmailApiClient(OAuthCredential credential) {
+    public GmailApiClient(OAuthCredential credential, Func<CancellationToken, Task<string>>? refreshToken = null) {
         _client = new HttpClient {
             BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/")
         };
         _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential.AccessToken);
+        _refreshToken = refreshToken;
     }
 
-    internal GmailApiClient(HttpClient client) {
+    internal GmailApiClient(HttpClient client, Func<CancellationToken, Task<string>>? refreshToken = null) {
         _client = client;
+        _refreshToken = refreshToken;
     }
 
     /// <inheritdoc />
@@ -45,9 +48,13 @@ public sealed class GmailApiClient : IDisposable {
         GC.SuppressFinalize(this);
     }
 
-    private static async Task ThrowIfAuthErrorAsync(HttpResponseMessage response, CancellationToken cancellationToken) {
+    private async Task ThrowIfAuthErrorAsync(HttpResponseMessage response, CancellationToken cancellationToken) {
         if (response.StatusCode == HttpStatusCode.Unauthorized ||
             response.StatusCode == HttpStatusCode.Forbidden) {
+            if (_refreshToken != null) {
+                string token = await _refreshToken(cancellationToken);
+                _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
 #if NET5_0_OR_GREATER
             string content = await response.Content.ReadAsStringAsync(cancellationToken);
 #else


### PR DESCRIPTION
## Summary
- allow GmailApiClient to accept a refresh delegate for OAuth tokens
- refresh tokens when Gmail API returns auth errors
- test token refresh behavior with expired tokens

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net472`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_689e4557363c832eb33a26ccc6cdbb9c