### PR TITLE
Add body search support to mailbox searchers

### DIFF
--- a/Examples/Example-SearchMessageBody.ps1
+++ b/Examples/Example-SearchMessageBody.ps1
@@ -1,0 +1,13 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+# Search IMAP mailbox body
+$imap = Connect-IMAP -Server 'imap.example.com' -Credential (Get-Credential)
+$imapMsgs = Search-IMAPMailbox -Client $imap -BodyContains 'invoice'
+$imapMsgs | ForEach-Object { Write-Host "IMAP found $($_.Message.Subject)" }
+Disconnect-IMAP -Client $imap
+
+# Search POP3 mailbox body
+$pop = Connect-POP3 -Server 'pop.example.com' -Credential (Get-Credential)
+$popMsgs = Search-POP3Mailbox -Client $pop -BodyContains 'invoice'
+$popMsgs | ForEach-Object { Write-Host "POP3 found $($_.Message.Subject)" }
+Disconnect-POP3 -Client $pop

--- a/Sources/Mailozaurr.Examples/SearchBodyContainsExample.cs
+++ b/Sources/Mailozaurr.Examples/SearchBodyContainsExample.cs
@@ -1,0 +1,31 @@
+using MailKit.Net.Imap;
+using MailKit.Net.Pop3;
+using MailKit.Security;
+using System;
+using System.Threading.Tasks;
+using Mailozaurr;
+
+/// <summary>
+/// Example demonstrating how to search message bodies.
+/// </summary>
+public static class SearchBodyContainsExample {
+    /// <summary>Runs the example.</summary>
+    public static async Task RunAsync() {
+        string user = "user@example.com";
+        string pass = "Pa55w0rd";
+
+        using var imap = new ImapClient();
+        await imap.ConnectAsync("imap.example.com", 993, SecureSocketOptions.SslOnConnect);
+        await imap.AuthenticateAsync(user, pass);
+        var imapMessages = await MailboxSearcher.SearchImapAsync(imap, bodyContains: "invoice");
+        foreach (var m in imapMessages) Console.WriteLine($"IMAP: {m.Message.Subject}");
+        await imap.DisconnectAsync(true);
+
+        using var pop = new Pop3Client();
+        await pop.ConnectAsync("pop.example.com", 995, SecureSocketOptions.SslOnConnect);
+        await pop.AuthenticateAsync(user, pass);
+        var popMessages = await MailboxSearcher.SearchPop3Async(pop, bodyContains: "invoice");
+        foreach (var m in popMessages) Console.WriteLine($"POP3: {m.Message.Subject}");
+        await pop.DisconnectAsync(true);
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchIMAPMailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchIMAPMailbox.cs
@@ -56,6 +56,12 @@ public sealed class CmdletSearchIMAPMailbox : AsyncPSCmdlet {
     public string? ToContains { get; set; }
 
     /// <summary>
+    /// Filters messages where the body contains this text.
+    /// </summary>
+    [Parameter]
+    public string? BodyContains { get; set; }
+
+    /// <summary>
     /// Filters messages by priority.
     /// </summary>
     [Parameter]
@@ -99,6 +105,7 @@ public sealed class CmdletSearchIMAPMailbox : AsyncPSCmdlet {
                 Subject,
                 FromContains,
                 ToContains,
+                BodyContains,
                 Priority,
                 Since,
                 Before,

--- a/Sources/Mailozaurr.PowerShell/CmdletSearchPOP3Mailbox.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSearchPOP3Mailbox.cs
@@ -37,6 +37,12 @@ public sealed class CmdletSearchPOP3Mailbox : AsyncPSCmdlet {
     public string? ToContains { get; set; }
 
     /// <summary>
+    /// Filters messages where the body contains this string.
+    /// </summary>
+    [Parameter]
+    public string? BodyContains { get; set; }
+
+    /// <summary>
     /// Filters messages by priority.
     /// </summary>
     [Parameter]
@@ -89,6 +95,7 @@ public sealed class CmdletSearchPOP3Mailbox : AsyncPSCmdlet {
                 Subject,
                 FromContains,
                 ToContains,
+                BodyContains,
                 Priority,
                 Since,
                 Before,

--- a/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
+++ b/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
@@ -1,0 +1,32 @@
+using MailKit;
+using MailKit.Net.Pop3;
+using MimeKit;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class MailboxSearcherBodyTests {
+    [Fact]
+    public async Task SearchPop3Async_BodyContains_FiltersMessages() {
+        var msg1 = new MimeMessage();
+        msg1.Body = new TextPart("plain") { Text = "hello world" };
+        var msg2 = new MimeMessage();
+        msg2.Body = new TextPart("plain") { Text = "other" };
+        var client = new FakePop3Client(new[] { msg1, msg2 });
+        var result = await MailboxSearcher.SearchPop3Async(client, bodyContains: "hello");
+        Assert.Single(result);
+    }
+
+    private sealed class FakePop3Client : Pop3Client {
+        private readonly List<MimeMessage> _messages;
+        public FakePop3Client(IEnumerable<MimeMessage> messages) => _messages = new List<MimeMessage>(messages);
+        public override bool IsConnected => true;
+        public override bool IsAuthenticated => true;
+        public override int Count => _messages.Count;
+        public override Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken = default, ITransferProgress? progress = null)
+            => Task.FromResult(_messages[index]);
+    }
+}

--- a/Sources/Mailozaurr.Tests/QueryLanguageParserTests.cs
+++ b/Sources/Mailozaurr.Tests/QueryLanguageParserTests.cs
@@ -29,4 +29,10 @@ public class QueryLanguageParserTests {
         Assert.Equal("Report", result.Subject);
         Assert.True(result.HasAttachment);
     }
+
+    [Fact]
+    public void ParseQuery_ParsesBodyContains() {
+        var result = MailboxSearcher.ParseQuery("body:invoice");
+        Assert.Equal("invoice", result.BodyContains);
+    }
 }

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -24,6 +24,7 @@ public static class MailboxSearcher {
         string? subject = null,
         string? fromContains = null,
         string? toContains = null,
+        string? bodyContains = null,
         MessagePriority? priority = null,
         DateTime? since = null,
         DateTime? before = null,
@@ -37,6 +38,7 @@ public static class MailboxSearcher {
         if (!string.IsNullOrWhiteSpace(subject)) search = search.And(SearchQuery.SubjectContains(subject));
         if (!string.IsNullOrWhiteSpace(fromContains)) search = search.And(SearchQuery.FromContains(fromContains));
         if (!string.IsNullOrWhiteSpace(toContains)) search = search.And(SearchQuery.ToContains(toContains));
+        if (!string.IsNullOrWhiteSpace(bodyContains)) search = search.And(SearchQuery.BodyContains(bodyContains));
         if (since.HasValue) search = search.And(SearchQuery.DeliveredAfter(since.Value));
         if (before.HasValue) search = search.And(SearchQuery.DeliveredBefore(before.Value));
         if (additionalQueries != null) {
@@ -49,6 +51,7 @@ public static class MailboxSearcher {
             if (!string.IsNullOrWhiteSpace(parsed.Subject)) search = search.And(SearchQuery.SubjectContains(parsed.Subject));
             if (!string.IsNullOrWhiteSpace(parsed.FromContains)) search = search.And(SearchQuery.FromContains(parsed.FromContains));
             if (!string.IsNullOrWhiteSpace(parsed.ToContains)) search = search.And(SearchQuery.ToContains(parsed.ToContains));
+            if (!string.IsNullOrWhiteSpace(parsed.BodyContains)) search = search.And(SearchQuery.BodyContains(parsed.BodyContains));
             if (parsed.Since.HasValue) search = search.And(SearchQuery.DeliveredAfter(parsed.Since.Value));
             if (parsed.Before.HasValue) search = search.And(SearchQuery.DeliveredBefore(parsed.Before.Value));
             foreach (var q in parsed.AdditionalQueries) search = search.And(q);
@@ -75,6 +78,7 @@ public static class MailboxSearcher {
         string? subject = null,
         string? fromContains = null,
         string? toContains = null,
+        string? bodyContains = null,
         MessagePriority? priority = null,
         DateTime? since = null,
         DateTime? before = null,
@@ -87,6 +91,7 @@ public static class MailboxSearcher {
             if (string.IsNullOrWhiteSpace(subject)) subject = parsed.Subject;
             if (string.IsNullOrWhiteSpace(fromContains)) fromContains = parsed.FromContains;
             if (string.IsNullOrWhiteSpace(toContains)) toContains = parsed.ToContains;
+            if (string.IsNullOrWhiteSpace(bodyContains)) bodyContains = parsed.BodyContains;
             if (!since.HasValue) since = parsed.Since;
             if (!before.HasValue) before = parsed.Before;
             if (!priority.HasValue) priority = parsed.Priority;
@@ -98,6 +103,12 @@ public static class MailboxSearcher {
             if (!string.IsNullOrWhiteSpace(subject) && (message.Subject == null || message.Subject.IndexOf(subject, StringComparison.OrdinalIgnoreCase) < 0)) continue;
             if (!string.IsNullOrWhiteSpace(fromContains) && !AddressMatches(message.From, fromContains)) continue;
             if (!string.IsNullOrWhiteSpace(toContains) && !AddressMatches(message.To, toContains)) continue;
+            if (!string.IsNullOrWhiteSpace(bodyContains)) {
+                var textBody = message.TextBody ?? string.Empty;
+                var htmlBody = message.HtmlBody ?? string.Empty;
+                if (textBody.IndexOf(bodyContains, StringComparison.OrdinalIgnoreCase) < 0 &&
+                    htmlBody.IndexOf(bodyContains, StringComparison.OrdinalIgnoreCase) < 0) continue;
+            }
             var msgDate = message.Date.DateTime;
             if (since.HasValue && msgDate < since.Value) continue;
             if (before.HasValue && msgDate > before.Value) continue;
@@ -314,6 +325,7 @@ public static class MailboxSearcher {
         public string? Subject { get; set; }
         public string? FromContains { get; set; }
         public string? ToContains { get; set; }
+        public string? BodyContains { get; set; }
         public MessagePriority? Priority { get; set; }
         public DateTime? Since { get; set; }
         public DateTime? Before { get; set; }
@@ -344,7 +356,7 @@ public static class MailboxSearcher {
                 } else if (string.Equals(key, "has", StringComparison.OrdinalIgnoreCase)) {
                     if (value.Equals("attachment", StringComparison.OrdinalIgnoreCase) || value.Equals("attachments", StringComparison.OrdinalIgnoreCase)) result.HasAttachment = true;
                 } else if (string.Equals(key, "body", StringComparison.OrdinalIgnoreCase)) {
-                    result.AdditionalQueries.Add(SearchQuery.BodyContains(value));
+                    result.BodyContains = value;
                 } else {
                     result.AdditionalQueries.Add(SearchQuery.MessageContains(token));
                 }

--- a/Tests/Search-IMAPMailbox.Tests.ps1
+++ b/Tests/Search-IMAPMailbox.Tests.ps1
@@ -3,4 +3,9 @@ Describe 'Search-IMAPMailbox' {
         $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
         { Search-IMAPMailbox -Client $info } | Should -Throw
     }
+
+    It 'Supports BodyContains parameter' {
+        $info = [Mailozaurr.PowerShell.ImapConnectionInfo]::new()
+        { Search-IMAPMailbox -Client $info -BodyContains 'test' } | Should -Throw
+    }
 }

--- a/Tests/Search-POP3Mailbox.Tests.ps1
+++ b/Tests/Search-POP3Mailbox.Tests.ps1
@@ -3,4 +3,9 @@ Describe 'Search-POP3Mailbox' {
         $info = [Mailozaurr.PowerShell.PopConnectionInfo]::new()
         { Search-POP3Mailbox -Client $info } | Should -Throw
     }
+
+    It 'Supports BodyContains parameter' {
+        $info = [Mailozaurr.PowerShell.PopConnectionInfo]::new()
+        { Search-POP3Mailbox -Client $info -BodyContains 'test' } | Should -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- allow IMAP and POP3 search helpers to filter by message body
- parse body: tokens in query language
- cover POP3 body filtering and document usage examples

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net472`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0`
- `pwsh -NoLogo -Command "./Mailozaurr.Tests.ps1"` *(fails: Unprotect-MimeMessage cmdlet not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e454e2db4832ea34fd9159954fc18