### PR TITLE
Initialize non-nullable members

### DIFF
--- a/Sources/Mailozaurr/Logging/LogEntry.cs
+++ b/Sources/Mailozaurr/Logging/LogEntry.cs
@@ -10,7 +10,7 @@ namespace Mailozaurr;
 /// </remarks>
 public class LogEntry {
     /// <summary>The log message.</summary>
-    public string Message { get; set; }
+    public string Message { get; set; } = string.Empty;
     /// <summary>The type of log (warning, error, etc.).</summary>
     public LogType Type { get; set; }
 }

--- a/Sources/Mailozaurr/Logging/LogEventArgs.cs
+++ b/Sources/Mailozaurr/Logging/LogEventArgs.cs
@@ -18,19 +18,19 @@ public class LogEventArgs : EventArgs {
     public int? ProgressCurrentSteps { get; set; }
 
     /// <summary>Progress current operation.</summary>
-    public string ProgressCurrentOperation { get; set; }
+    public string ProgressCurrentOperation { get; set; } = string.Empty;
 
     /// <summary>Progress activity.</summary>
-    public string ProgressActivity { get; set; }
+    public string ProgressActivity { get; set; } = string.Empty;
 
     /// <summary>Message to be written including arguments substitution.</summary>
-    public string FullMessage { get; set; }
+    public string FullMessage { get; set; } = string.Empty;
 
     /// <summary>Message to be written.</summary>
-    public string Message { get; set; }
+    public string Message { get; set; } = string.Empty;
 
     /// <summary>Gets or sets the arguments.</summary>
-    public object[] Args { get; set; }
+    public object[] Args { get; set; } = Array.Empty<object>();
 
     /// <summary>Initializes a new instance of the <see cref="LogEventArgs"/> class.</summary>
     public LogEventArgs(string message, object[] args) {

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -36,7 +36,7 @@ public class MailgunClient : IDisposable {
 
     /// <summary>Credentials used to authenticate to the API.</summary>
     /// <remarks>Must be <see cref="NetworkCredential"/>.</remarks>
-    public ICredentials Credentials { get; set; }
+    public ICredentials Credentials { get; set; } = null!;
     /// <summary>Determines how errors are handled.</summary>
     public ActionPreference? ErrorAction { get; set; }
 
@@ -47,7 +47,7 @@ public class MailgunClient : IDisposable {
     /// <summary>Blind carbon copy recipients.</summary>
     public List<object> Bcc { get; set; } = new();
     /// <summary>The sender address.</summary>
-    public object From { get; set; }
+    public object From { get; set; } = null!;
     /// <summary>Reply-to address.</summary>
     public object? ReplyTo { get; set; }
     /// <summary>Message subject.</summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorDetail.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorDetail.cs
@@ -12,17 +12,17 @@ public class GraphApiErrorDetail {
     /// Gets or sets the error code returned by the API.
     /// </summary>
     [JsonPropertyName("code")]
-    public string Code { get; set; }
+    public string Code { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the human readable error message.
     /// </summary>
     [JsonPropertyName("message")]
-    public string Message { get; set; }
+    public string Message { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets additional error details.
     /// </summary>
     [JsonPropertyName("innerError")]
-    public GraphApiInnerError InnerError { get; set; }
+    public GraphApiInnerError InnerError { get; set; } = new();
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiInnerError.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiInnerError.cs
@@ -12,13 +12,13 @@ public class GraphApiInnerError {
     /// Gets or sets the request identifier associated with the error.
     /// </summary>
     [JsonPropertyName("request-id")]
-    public string RequestId { get; set; }
+    public string RequestId { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the client request identifier associated with the error.
     /// </summary>
     [JsonPropertyName("client-request-id")]
-    public string ClientRequestId { get; set; }
+    public string ClientRequestId { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the timestamp of when the error occurred.

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachment.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachment.cs
@@ -18,13 +18,13 @@ public class GraphAttachment {
     /// Gets or sets the attachment file name.
     /// </summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the file content encoded as a Base64 string.
     /// </summary>
     [JsonPropertyName("contentBytes")]
-    public string ContentBytes { get; set; }
+    public string ContentBytes { get; set; } = string.Empty;
 
     /// <summary>
     /// Indicates whether this attachment should be rendered inline in the

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentPlaceHolder.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentPlaceHolder.cs
@@ -9,13 +9,13 @@ namespace Mailozaurr;
 /// </remarks>
 public class GraphAttachmentPlaceHolder {
     /// <summary>Serialized attachment metadata.</summary>
-    public string Json { get; set; }
+    public string Json { get; set; } = string.Empty;
     /// <summary>Chunks of the file content.</summary>
-    public List<StreamContent> Content { get; set; }
+    public List<StreamContent> Content { get; set; } = [];
     /// <summary>Path to the file.</summary>
-    public string FilePath { get; set; }
+    public string FilePath { get; set; } = string.Empty;
     /// <summary>Size of the file in bytes.</summary>
     public long FileSize { get; set; }
     /// <summary>Name of the file.</summary>
-    public string FileName { get; set; }
+    public string FileName { get; set; } = string.Empty;
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphEmail.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphEmail.cs
@@ -8,5 +8,5 @@ public class GraphEmail {
     /// Gets or sets the email address value.
     /// </summary>
     [JsonPropertyName("address")]
-    public string Address { get; set; }
+    public string Address { get; set; } = string.Empty;
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphEmailAddress.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphEmailAddress.cs
@@ -11,5 +11,5 @@ public class GraphEmailAddress {
     /// Gets or sets the email details.
     /// </summary>
     [JsonPropertyName("emailAddress")]
-    public GraphEmail Email { get; set; }
+    public GraphEmail Email { get; set; } = new();
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphErrors.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphErrors.cs
@@ -12,5 +12,5 @@ public class GraphApiError {
     /// Gets or sets the error details returned by the API.
     /// </summary>
     [JsonPropertyName("error")]
-    public GraphApiErrorDetail Error { get; set; }
+    public GraphApiErrorDetail Error { get; set; } = new();
 }

--- a/Sources/Mailozaurr/SendGrid/SendGridEmailAddress.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridEmailAddress.cs
@@ -10,7 +10,7 @@ namespace Mailozaurr;
 public class SendGridEmailAddress {
     /// <summary>Gets or sets the email address.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string Email { get; set; }
+    public string Email { get; set; } = string.Empty;
 
     /// <summary>Gets or sets the name associated with the email address.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/Sources/Mailozaurr/SendGrid/SendGridMessage.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridMessage.cs
@@ -11,12 +11,12 @@ public class SendGridMessage {
     /// <summary>
     /// Gets or sets the list of personalizations for the message.
     /// </summary>
-    public List<SendGridPersonalization> Personalizations { get; set; }
+    public List<SendGridPersonalization> Personalizations { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the sender of the message.
     /// </summary>
-    public SendGridEmailAddress From { get; set; }
+    public SendGridEmailAddress From { get; set; } = null!;
 
     /// <summary>
     /// Gets or sets the subject of the message.
@@ -27,7 +27,7 @@ public class SendGridMessage {
     /// <summary>
     /// Gets or sets the content of the message.
     /// </summary>
-    public List<SendGridContent> Content { get; set; }
+    public List<SendGridContent> Content { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the reply-to address for the message.


### PR DESCRIPTION
## Summary
- default initialize SendGrid message components
- ensure logging event args and entries have safe defaults
- populate Graph and Mailgun models to avoid CS8618 warnings

## Testing
- `dotnet build Sources/Mailozaurr.sln -v m`
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_689ee386ebe4832e8efdcbaaf1e5432a