### PR TITLE
fix: clean up Watch-SmtpConnectionPool cmdlet

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletWatchSmtpConnectionPool.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWatchSmtpConnectionPool.cs
@@ -16,25 +16,21 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 [Cmdlet("Watch", "SmtpConnectionPool")]
 [OutputType(typeof(Action<int>))]
-public sealed class CmdletWatchSmtpConnectionPool : PSCmdlet {
+public sealed class CmdletWatchSmtpConnectionPool : PSCmdlet
+{
     /// <summary>Script block executed for each snapshot.</summary>
     [Parameter(Mandatory = true)]
     public ScriptBlock Action { get; set; } = null!;
 
     /// <summary>Registers the handler and writes it to the pipeline.</summary>
-    protected override void ProcessRecord() {
+    protected override void ProcessRecord()
+    {
         Action<int> handler = _ => Action.Invoke(SmtpConnectionPool.GetSnapshot());
         SmtpConnectionPool.PoolSizeChanged += handler;
         Action.Invoke(SmtpConnectionPool.GetSnapshot());
         WriteObject(handler);
     }
 }
-
-            eventName: nameof(SmtpConnectionPool.PoolSizeChanged),
-            sourceIdentifier: null,
-            data: null,
-            action: Action,
-            supportEvent: true);
 
         Action.Invoke(SmtpConnectionPool.GetSnapshot());
         WriteObject(subscriber);


### PR DESCRIPTION
## Summary
- remove leftover code from Watch-SmtpConnectionPool cmdlet

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Script Tests/Watch-SmtpConnectionPool.Tests.ps1 -PassThru"`
- `pwsh -NoLogo -NoProfile -Command "./Mailozaurr.Tests.ps1"` *(fails: 25 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a027009144832e921aada71704701b