### PR TITLE
chore: extract GraphEndpoint enum

### DIFF
--- a/Sources/Mailozaurr/Enums/GraphEndpoint.cs
+++ b/Sources/Mailozaurr/Enums/GraphEndpoint.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Known Microsoft Graph API endpoints.
+/// </summary>
+/// <remarks>
+/// These values are used when constructing Graph URLs for
+/// requests to either the stable or beta API surface.
+/// </remarks>
+public enum GraphEndpoint {
+    /// <summary>Represents the v1.0 endpoint.</summary>
+    V1,
+    /// <summary>Represents the beta endpoint.</summary>
+    Beta
+}

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -16,20 +16,6 @@ using MimeKit;
 namespace Mailozaurr {
 
     /// <summary>
-    /// Known Microsoft Graph API endpoints.
-    /// </summary>
-    /// <remarks>
-    /// These values are used when constructing Graph URLs for
-    /// requests to either the stable or beta API surface.
-    /// </remarks>
-    public enum GraphEndpoint {
-        /// <summary>Represents the v1.0 endpoint.</summary>
-        V1,
-        /// <summary>Represents the beta endpoint.</summary>
-        Beta
-    }
-
-    /// <summary>
     /// Utility helpers for working with the Microsoft Graph API.
     /// </summary>
     public static class MicrosoftGraphUtils {


### PR DESCRIPTION
## Summary
- move GraphEndpoint enum into dedicated Enums folder
- simplify MicrosoftGraphUtils by referencing extracted enum

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -f net472 -p:NoWarn=1573%3B1591`
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -f netstandard2.0 -p:NoWarn=1573%3B1591`
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -f net8.0 -p:NoWarn=1573%3B1591`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -p:NoWarn=1998%3B1573%3B1591`


------
https://chatgpt.com/codex/tasks/task_e_68a0575a2bd4832e9f607b4132c4f44a