### PR TITLE
Extract LoginState enum to standalone file

### DIFF
--- a/Sources/Mailozaurr/Authentication/LoginState.cs
+++ b/Sources/Mailozaurr/Authentication/LoginState.cs
@@ -1,0 +1,11 @@
+namespace Mailozaurr {
+
+    internal enum LoginState {
+
+        Initial,
+
+        Challenge
+
+    }
+
+}

--- a/Sources/Mailozaurr/Authentication/SaslMechanismNtlmIntegrated.cs
+++ b/Sources/Mailozaurr/Authentication/SaslMechanismNtlmIntegrated.cs
@@ -13,11 +13,6 @@ namespace Mailozaurr {
     /// </remarks>
     /// <inheritdoc cref="SaslMechanism"/>
     public class SaslMechanismNtlmIntegrated : SaslMechanism {
-        enum LoginState {
-            Initial,
-            Challenge
-        }
-
         LoginState state;
         ClientContext sspiContext;
 


### PR DESCRIPTION
## Summary
- move `LoginState` enum into its own `LoginState.cs` file
- update `SaslMechanismNtlmIntegrated` to use shared `LoginState`

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a057692504832eb8399ba07f50d8e9