### PR TITLE
refactor: streamline packages and usings

### DIFF
--- a/Sources/Mailozaurr.PowerShell/GlobalUsings.cs
+++ b/Sources/Mailozaurr.PowerShell/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using Mailozaurr;
+global using System.Management.Automation;
+global using System.Collections;
+global using System.Net;

--- a/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
+++ b/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
@@ -8,12 +8,13 @@
         <AssemblyName>Mailozaurr.PowerShell</AssemblyName>
         <Nullable>enable</Nullable>
         <Copyright>(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
-        <LangVersion>latest</LangVersion>
-        <RepositoryUrl>https://github.com/EvotecIT/Mailozaurr</RepositoryUrl>
-        <PackageTags>
-            Windows;MacOS;Linux;Mail;Email;MX;SPF;DMARC;DKIM;GraphApi;SendGrid;Graph;IMAP;POP3</PackageTags>
-        <PackageIconUrl>https://evotec.xyz/wp-content/uploads/2020/07/MailoZaurr.png</PackageIconUrl>
-    </PropertyGroup>
+         <LangVersion>latest</LangVersion>
+         <ImplicitUsings>enable</ImplicitUsings>
+         <RepositoryUrl>https://github.com/EvotecIT/Mailozaurr</RepositoryUrl>
+         <PackageTags>
+             Windows;MacOS;Linux;Mail;Email;MX;SPF;DMARC;DKIM;GraphApi;SendGrid;Graph;IMAP;POP3</PackageTags>
+         <PackageIconUrl>https://evotec.xyz/wp-content/uploads/2020/07/MailoZaurr.png</PackageIconUrl>
+     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Mailozaurr\Mailozaurr.csproj" />
@@ -34,21 +35,6 @@
         <Delete Files="$(OutDir)System.Management.dll" />
     </Target>
 
-    <ItemGroup>
-        <Using Include="Mailozaurr" />
-        <Using Include="System.Collections" />
-        <Using Include="System.Management.Automation" />
-        <Using Include="System.Threading.Tasks" />
-        <Using Include="System.Collections.Concurrent" />
-        <Using Include="System.Threading" />
-        <Using Include="System" />
-        <Using Include="System.Collections.Generic" />
-        <Using Include="System.Linq" />
-        <Using Include="System.Text" />
-        <Using Include="System.IO" />
-        <Using Include="System.Net" />
-        <Using Include="System.Diagnostics" />
-    </ItemGroup>
 
     <PropertyGroup>
         <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->

--- a/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
+++ b/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
@@ -20,9 +20,6 @@
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     </ItemGroup>
 
-    <ItemGroup>
-        <Using Include="Xunit" />
-    </ItemGroup>
 
   <ItemGroup>
         <ProjectReference Include="..\Mailozaurr\Mailozaurr.csproj" />

--- a/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
@@ -2,6 +2,7 @@ using Mailozaurr.NonDeliveryReports;
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using Xunit;
 
 namespace Mailozaurr.Tests;
 

--- a/Sources/Mailozaurr/GlobalUsings.cs
+++ b/Sources/Mailozaurr/GlobalUsings.cs
@@ -1,0 +1,16 @@
+global using MailKit;
+global using MailKit.Net.Smtp;
+global using MailKit.Security;
+global using MailKit.Net.Pop3;
+global using MailKit.Net.Imap;
+global using MailKit.Net;
+global using MimeKit;
+global using MimeKit.Cryptography;
+global using System.Collections;
+global using System.Collections.Generic;
+global using System.Diagnostics;
+global using System.Net;
+global using System.Net.Http;
+global using System.Text;
+global using System.Text.Json;
+global using System.Text.Json.Serialization;

--- a/Sources/Mailozaurr/Mailozaurr.csproj
+++ b/Sources/Mailozaurr/Mailozaurr.csproj
@@ -31,34 +31,10 @@
         <PackageReference Include="MsgKit" Version="2.8.3" />
         <PackageReference Include="Microsoft.Identity.Client" Version="4.66.1" />
         <PackageReference Include="NSspi" Version="0.3.1" />
-        <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
-        <PackageReference Include="System.Data.SQLite" Version="1.0.119" />
+        <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
         <PackageReference Include="MsgReader" Version="5.7.3" />
-        <PackageReference Include="System.Text.Json" Version="8.0.5" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netstandard2.0'" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
-    </ItemGroup>
-
-
-    <ItemGroup>
-        <Using Include="MailKit" />
-        <Using Include="MailKit.Net.Smtp" />
-        <Using Include="MailKit.Security" />
-        <Using Include="MailKit.Net.Pop3" />
-        <Using Include="MailKit.Net.Imap" />
-        <Using Include="MailKit.Net" />
-        <Using Include="MimeKit" />
-        <Using Include="MimeKit.Cryptography" />
-        <Using Include="System" />
-        <Using Include="System.Net" />
-        <Using Include="System.Net.Http" />
-        <Using Include="System.Text" />
-        <Using Include="System.Text.Json" />
-        <Using Include="System.Text.Json.Serialization" />
-        <Using Include="System.Collections" />
-        <Using Include="System.Collections.Generic" />
-        <Using Include="System.IO" />
-        <Using Include="System.Linq" />
-        <Using Include="System.Diagnostics" />
     </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- rely on implicit usings with new global using files
- drop unused System.Data.SQLite and add conditional framework packages
- enable implicit usings in PowerShell project and prune project usings

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj`
- `dotnet build Sources/Mailozaurr.Examples/Mailozaurr.Examples.csproj`
- `dotnet build Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a06a934eb4832ea1590334181be37d