### PR TITLE
Fix nullability warnings in Receive helpers

### DIFF
--- a/Sources/Mailozaurr/Receive/ImapClientFolderCache.cs
+++ b/Sources/Mailozaurr/Receive/ImapClientFolderCache.cs
@@ -20,7 +20,7 @@ public static class ImapClientFolderCache {
     /// <returns>The opened folder.</returns>
     public static IMailFolder GetCachedFolder(this ImapClient client, string? folder, FolderAccess access) {
         var map = Cache.GetOrCreateValue(client);
-        var name = string.IsNullOrWhiteSpace(folder) ? client.Inbox.FullName : folder;
+        var name = string.IsNullOrWhiteSpace(folder) ? client.Inbox.FullName : folder!;
 
         if (!map.TryGetValue(name, out var mailFolder)) {
             if (name.Equals(client.Inbox.FullName, System.StringComparison.OrdinalIgnoreCase)) {

--- a/Sources/Mailozaurr/Receive/JunkCleaner.cs
+++ b/Sources/Mailozaurr/Receive/JunkCleaner.cs
@@ -17,6 +17,13 @@ public static class JunkCleaner {
     /// </summary>
     /// <param name="client">Connected IMAP client.</param>
     /// <param name="folder">Folder name or <c>null</c> for "Junk".</param>
+    /// <param name="skipFrom">Sender addresses to exclude.</param>
+    /// <param name="skipTo">Recipient addresses to exclude.</param>
+    /// <param name="skipSubjectContains">Subjects that, if contained, will exclude the message.</param>
+    /// <param name="skipMessageId">Message IDs to exclude.</param>
+    /// <param name="skipUid">Message UIDs to exclude.</param>
+    /// <param name="skipHasAttachment">When set, skip messages that contain attachments.</param>
+    /// <param name="skipAttachmentExtension">Attachment extensions that, if present, will cause skipping.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task ClearImapJunkAsync(
         ImapClient client,
@@ -65,6 +72,13 @@ public static class JunkCleaner {
     /// </summary>
     /// <param name="client">Connected IMAP client.</param>
     /// <param name="folder">Folder name or <c>null</c> for "Junk".</param>
+    /// <param name="skipFrom">Sender addresses to exclude.</param>
+    /// <param name="skipTo">Recipient addresses to exclude.</param>
+    /// <param name="skipSubjectContains">Subjects that, if contained, will exclude the message.</param>
+    /// <param name="skipMessageId">Message IDs to exclude.</param>
+    /// <param name="skipUid">Message UIDs to exclude.</param>
+    /// <param name="skipHasAttachment">When set, skip messages that contain attachments.</param>
+    /// <param name="skipAttachmentExtension">Attachment extensions that, if present, will cause skipping.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     public static async IAsyncEnumerable<ImapEmailMessage> GetImapJunkAsync(
         ImapClient client,

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -46,8 +46,8 @@ public static class MailboxSearcher {
                 if (q != null) search = search.And(q);
             }
         }
-        if (!string.IsNullOrWhiteSpace(queryString)) {
-            var parsed = ParseQuery(queryString);
+          if (!string.IsNullOrWhiteSpace(queryString)) {
+              var parsed = ParseQuery(queryString);
             if (!string.IsNullOrWhiteSpace(parsed.Subject)) search = search.And(SearchQuery.SubjectContains(parsed.Subject));
             if (!string.IsNullOrWhiteSpace(parsed.FromContains)) search = search.And(SearchQuery.FromContains(parsed.FromContains));
             if (!string.IsNullOrWhiteSpace(parsed.ToContains)) search = search.And(SearchQuery.ToContains(parsed.ToContains));
@@ -86,8 +86,8 @@ public static class MailboxSearcher {
         int maxResults = 0,
         CancellationToken cancellationToken = default,
         string? queryString = null) {
-        if (!string.IsNullOrWhiteSpace(queryString)) {
-            var parsed = ParseQuery(queryString);
+          if (!string.IsNullOrWhiteSpace(queryString)) {
+              var parsed = ParseQuery(queryString);
             if (string.IsNullOrWhiteSpace(subject)) subject = parsed.Subject;
             if (string.IsNullOrWhiteSpace(fromContains)) fromContains = parsed.FromContains;
             if (string.IsNullOrWhiteSpace(toContains)) toContains = parsed.ToContains;
@@ -101,8 +101,8 @@ public static class MailboxSearcher {
         for (int i = 0; i < client.Count; i++) {
             var message = await client.GetMessageAsync(i, cancellationToken).ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(subject) && (message.Subject == null || message.Subject.IndexOf(subject, StringComparison.OrdinalIgnoreCase) < 0)) continue;
-            if (!string.IsNullOrWhiteSpace(fromContains) && !AddressMatches(message.From, fromContains)) continue;
-            if (!string.IsNullOrWhiteSpace(toContains) && !AddressMatches(message.To, toContains)) continue;
+              if (!string.IsNullOrWhiteSpace(fromContains) && !AddressMatches(message.From, fromContains!)) continue;
+              if (!string.IsNullOrWhiteSpace(toContains) && !AddressMatches(message.To, toContains!)) continue;
             if (!string.IsNullOrWhiteSpace(bodyContains)) {
                 var textBody = message.TextBody ?? string.Empty;
                 var htmlBody = message.HtmlBody ?? string.Empty;
@@ -232,7 +232,7 @@ public static class MailboxSearcher {
             credential,
             userPrincipalName,
             new[] { "id" },
-            filter,
+            filter!,
             maxResults > 0 ? maxResults : (int?)null).ConfigureAwait(false);
         var mimeMessages = new List<MimeMessage>(msgs.Count);
         if (parallelDownloadLimit <= 1) {
@@ -277,7 +277,7 @@ public static class MailboxSearcher {
             foreach (var report in MimeKitUtils.GetNonDeliveryReports(message)) {
                 if (since.HasValue && report.Timestamp.DateTime < since.Value) continue;
                 if (before.HasValue && report.Timestamp.DateTime > before.Value) continue;
-                if (!string.IsNullOrWhiteSpace(recipientContains) && !RecipientMatches(report, recipientContains)) continue;
+                  if (!string.IsNullOrWhiteSpace(recipientContains) && !RecipientMatches(report, recipientContains!)) continue;
                 if (!string.IsNullOrWhiteSpace(messageId) && !string.Equals(report.OriginalMessageId, messageId, StringComparison.OrdinalIgnoreCase)) continue;
                 results.Add(report);
             }
@@ -285,13 +285,15 @@ public static class MailboxSearcher {
         return results;
     }
 
-    private static bool RecipientMatches(NonDeliveryReport report, string filter) {
-        if (!string.IsNullOrWhiteSpace(report.FinalRecipientAddress) &&
-            report.FinalRecipientAddress.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
-        if (!string.IsNullOrWhiteSpace(report.OriginalRecipientAddress) &&
-            report.OriginalRecipientAddress.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
-        return false;
-    }
+      private static bool RecipientMatches(NonDeliveryReport report, string filter) {
+          var final = report.FinalRecipientAddress;
+          if (final != null &&
+              final.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+          var original = report.OriginalRecipientAddress;
+          if (original != null &&
+              original.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+          return false;
+      }
 
     private static MimeKit.MessagePriority ConvertPriority(MessagePriority priority)
         => priority switch {
@@ -333,10 +335,10 @@ public static class MailboxSearcher {
         public List<SearchQuery> AdditionalQueries { get; } = new();
     }
 
-    internal static ParsedQuery ParseQuery(string query) {
-        var result = new ParsedQuery();
-        if (string.IsNullOrWhiteSpace(query)) return result;
-        foreach (var token in SplitTokens(query)) {
+      internal static ParsedQuery ParseQuery(string? query) {
+          var result = new ParsedQuery();
+          if (string.IsNullOrWhiteSpace(query)) return result;
+          foreach (var token in SplitTokens(query!)) {
             var parts = token.Split(new[] { ':' }, 2);
             if (parts.Length == 2) {
                 var key = parts[0];

--- a/Sources/Mailozaurr/Receive/MessageFetcher.cs
+++ b/Sources/Mailozaurr/Receive/MessageFetcher.cs
@@ -27,7 +27,9 @@ public static class MessageFetcher {
     /// <param name="before">Latest delivery date.</param>
     /// <param name="all">If set, ignores other filters.</param>
     /// <param name="delete">If set, messages are deleted after fetching.</param>
+    /// <param name="hasAttachment">When set, only messages with attachments are returned.</param>
     /// <param name="additionalQueries">Additional <see cref="SearchQuery"/> filters.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>Collection of matching messages.</returns>
     public static async IAsyncEnumerable<ImapEmailMessage> Fetch(
         ImapClient client,
@@ -116,6 +118,8 @@ public static class MessageFetcher {
     /// <param name="before">Latest delivery date.</param>
     /// <param name="all">If set, ignores other filters.</param>
     /// <param name="delete">If set, messages are deleted after fetching.</param>
+    /// <param name="hasAttachment">When set, only messages with attachments are returned.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>Collection of matching messages.</returns>
     public static async IAsyncEnumerable<Pop3EmailMessage> Fetch(
         Pop3Client client,
@@ -142,10 +146,10 @@ public static class MessageFetcher {
                 if (!string.IsNullOrWhiteSpace(subject) && (message.Subject == null || message.Subject.IndexOf(subject, StringComparison.OrdinalIgnoreCase) < 0)) {
                     continue;
                 }
-                if (!string.IsNullOrWhiteSpace(fromContains) && !AddressMatches(message.From, fromContains)) {
+                if (!string.IsNullOrWhiteSpace(fromContains) && !AddressMatches(message.From, fromContains!)) {
                     continue;
                 }
-                if (!string.IsNullOrWhiteSpace(toContains) && !AddressMatches(message.To, toContains)) {
+                if (!string.IsNullOrWhiteSpace(toContains) && !AddressMatches(message.To, toContains!)) {
                     continue;
                 }
                 var msgDate = message.Date.DateTime;


### PR DESCRIPTION
## Summary
- add missing XML docs for junk cleaning and message fetching APIs
- handle nullable parameters in mailbox searching and fetchers
- guard IMAP folder caching against null folder names

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a06abd8238832e8cf396bf44f71cab