### PR TITLE
Add XML documentation for non-delivery report services

### DIFF
--- a/Sources/Mailozaurr/NonDeliveryReports/DsnStatus.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/DsnStatus.cs
@@ -33,7 +33,7 @@ public sealed class DsnStatus {
         if (string.IsNullOrWhiteSpace(value)) {
             return false;
         }
-        var parts = value.Trim().Split('.');
+        var parts = value!.Trim().Split('.');
         if (parts.Length != 3 || !int.TryParse(parts[0], out var cls) || !int.TryParse(parts[1], out var subj) || !int.TryParse(parts[2], out var detail)) {
             return false;
         }

--- a/Sources/Mailozaurr/NonDeliveryReports/GraphNonDeliveryReportService.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/GraphNonDeliveryReportService.cs
@@ -5,15 +5,25 @@ using System.Threading.Tasks;
 
 namespace Mailozaurr.NonDeliveryReports;
 
+/// <summary>
+/// Retrieves non-delivery reports using the Microsoft Graph API.
+/// </summary>
 public sealed class GraphNonDeliveryReportService : NonDeliveryReportServiceBase {
     private readonly GraphCredential credential;
     private readonly string userPrincipalName;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GraphNonDeliveryReportService"/> class.
+    /// </summary>
+    /// <param name="credential">Graph authentication credential.</param>
+    /// <param name="userPrincipalName">User principal name to search the mailbox for.</param>
+    /// <param name="resolver">Resolver used to match reports with sent messages.</param>
     public GraphNonDeliveryReportService(GraphCredential credential, string userPrincipalName, SendLogResolver resolver) : base(resolver) {
         this.credential = credential;
         this.userPrincipalName = userPrincipalName;
     }
 
+    /// <inheritdoc />
     protected override Task<IList<NonDeliveryReport>> SearchInternalAsync(
         DateTime? since,
         DateTime? before,

--- a/Sources/Mailozaurr/NonDeliveryReports/ImapNonDeliveryReportService.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/ImapNonDeliveryReportService.cs
@@ -6,15 +6,25 @@ using MailKit.Net.Imap;
 
 namespace Mailozaurr.NonDeliveryReports;
 
+/// <summary>
+/// Retrieves non-delivery reports from an IMAP mailbox.
+/// </summary>
 public sealed class ImapNonDeliveryReportService : NonDeliveryReportServiceBase {
     private readonly ImapClient client;
     private readonly string? folder;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImapNonDeliveryReportService"/> class.
+    /// </summary>
+    /// <param name="client">IMAP client used to access the mailbox.</param>
+    /// <param name="resolver">Resolver used to match reports with sent messages.</param>
+    /// <param name="folder">Optional folder name to search within.</param>
     public ImapNonDeliveryReportService(ImapClient client, SendLogResolver resolver, string? folder = null) : base(resolver) {
         this.client = client;
         this.folder = folder;
     }
 
+    /// <inheritdoc />
     protected override Task<IList<NonDeliveryReport>> SearchInternalAsync(
         DateTime? since,
         DateTime? before,

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
@@ -84,7 +84,7 @@ public sealed class NonDeliveryReport {
         if (string.IsNullOrWhiteSpace(header)) {
             return null;
         }
-        var idx = header.IndexOf(';');
+        var idx = header!.IndexOf(';');
         return idx >= 0 ? header.Substring(idx + 1).Trim() : header.Trim();
     }
 

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportResult.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportResult.cs
@@ -2,13 +2,23 @@ using Mailozaurr;
 
 namespace Mailozaurr.NonDeliveryReports;
 
+/// <summary>
+/// Represents a non-delivery report paired with an optional sent message record.
+/// </summary>
 public sealed class NonDeliveryReportResult {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NonDeliveryReportResult"/> class.
+    /// </summary>
+    /// <param name="report">Parsed non-delivery report details.</param>
+    /// <param name="sentMessage">Associated sent message record, if available.</param>
     public NonDeliveryReportResult(NonDeliveryReport report, SentMessageRecord? sentMessage) {
         Report = report;
         SentMessage = sentMessage;
     }
 
+    /// <summary>Parsed non-delivery report details.</summary>
     public NonDeliveryReport Report { get; }
 
+    /// <summary>Sent message record corresponding to the report if resolved; otherwise <c>null</c>.</summary>
     public SentMessageRecord? SentMessage { get; }
 }

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportServiceBase.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportServiceBase.cs
@@ -5,12 +5,29 @@ using System.Threading.Tasks;
 
 namespace Mailozaurr.NonDeliveryReports;
 
+/// <summary>
+/// Provides common functionality for non-delivery report services.
+/// </summary>
 public abstract class NonDeliveryReportServiceBase : INonDeliveryReportService {
     private readonly SendLogResolver resolver;
     private readonly SemaphoreSlim gate = new(1, 1);
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NonDeliveryReportServiceBase"/> class.
+    /// </summary>
+    /// <param name="resolver">Resolver used to match reports with sent messages.</param>
     protected NonDeliveryReportServiceBase(SendLogResolver resolver) => this.resolver = resolver;
 
+    /// <summary>
+    /// Searches for non-delivery reports using implementation specific logic.
+    /// </summary>
+    /// <param name="since">Only reports after this date are considered.</param>
+    /// <param name="before">Only reports before this date are considered.</param>
+    /// <param name="recipientContains">Filters reports by recipient substring.</param>
+    /// <param name="messageId">Filters reports by message identifier.</param>
+    /// <param name="maxResults">Maximum number of reports to return.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>List of found reports paired with optional sent message records.</returns>
     public async Task<IList<NonDeliveryReportResult>> SearchAsync(
         DateTime? since = null,
         DateTime? before = null,
@@ -34,6 +51,16 @@ public abstract class NonDeliveryReportServiceBase : INonDeliveryReportService {
         return results;
     }
 
+    /// <summary>
+    /// Performs the actual search for non-delivery reports.
+    /// </summary>
+    /// <param name="since">Only reports after this date are considered.</param>
+    /// <param name="before">Only reports before this date are considered.</param>
+    /// <param name="recipientContains">Filters reports by recipient substring.</param>
+    /// <param name="messageId">Filters reports by message identifier.</param>
+    /// <param name="maxResults">Maximum number of reports to return.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>Collection of parsed non-delivery reports.</returns>
     protected abstract Task<IList<NonDeliveryReport>> SearchInternalAsync(
         DateTime? since,
         DateTime? before,

--- a/Sources/Mailozaurr/NonDeliveryReports/Pop3NonDeliveryReportService.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/Pop3NonDeliveryReportService.cs
@@ -6,11 +6,20 @@ using MailKit.Net.Pop3;
 
 namespace Mailozaurr.NonDeliveryReports;
 
+/// <summary>
+/// Retrieves non-delivery reports using the POP3 protocol.
+/// </summary>
 public sealed class Pop3NonDeliveryReportService : NonDeliveryReportServiceBase {
     private readonly Pop3Client client;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Pop3NonDeliveryReportService"/> class.
+    /// </summary>
+    /// <param name="client">POP3 client used to access the mailbox.</param>
+    /// <param name="resolver">Resolver used to match reports with sent messages.</param>
     public Pop3NonDeliveryReportService(Pop3Client client, SendLogResolver resolver) : base(resolver) => this.client = client;
 
+    /// <inheritdoc />
     protected override Task<IList<NonDeliveryReport>> SearchInternalAsync(
         DateTime? since,
         DateTime? before,


### PR DESCRIPTION
## Summary
- document non-delivery report service types and results
- fix nullability warnings in non-delivery report parsing

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a06aa93450832e88f06ccac670c41d