### PR TITLE
Add custom header support to Gmail send methods

### DIFF
--- a/Examples/Example-GmailApi-13-SendWithHeaders.ps1
+++ b/Examples/Example-GmailApi-13-SendWithHeaders.ps1
@@ -1,0 +1,8 @@
+Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
+
+$cred = ConvertTo-OAuth2Credential -UserName 'user@gmail.com' -Token 'access_token'
+
+Send-GmailMessage -GmailAccount 'user@gmail.com' -Credential $cred \
+    -From 'user@gmail.com' -To 'recipient@example.com' \
+    -Subject 'Test API message with headers' -TextBody 'Hello from Gmail API' \
+    -Headers @{ 'X-Custom-Header' = 'Value' }

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -187,6 +187,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         smtp.Attachments = Attachment?.ToList();
         smtp.InlineAttachments = InlineAttachment?.ToList();
         smtp.Priority = Priority;
+        if (Headers != null) smtp.Headers = Headers.Cast<DictionaryEntry>().ToDictionary(d => d.Key?.ToString() ?? string.Empty, d => d.Value?.ToString() ?? string.Empty);
         smtp.CreateMessage(CancellationToken.None);
 
         var net = Credential!.GetNetworkCredential();

--- a/Sources/Mailozaurr.PowerShell/CmdletSendGmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendGmailMessage.cs
@@ -1,14 +1,16 @@
+using System.Collections;
 using System.Linq;
 using System.Management.Automation;
 using System.Threading.Tasks;
 using MimeKit;
+using Mailozaurr;
 
 namespace Mailozaurr.PowerShell;
 
 /// <summary>
 /// Sends an email using the Gmail API.
 /// </summary>
-[Cmdlet(VerbsCommunications.Send, "GmailMessage")]
+[Cmdlet(VerbsCommunications.Send, "GmailMessage", SupportsShouldProcess = true)]
 [OutputType(typeof(GmailMessage))]
 public sealed class CmdletSendGmailMessage : AsyncPSCmdlet {
     /// <summary>
@@ -61,6 +63,12 @@ public sealed class CmdletSendGmailMessage : AsyncPSCmdlet {
     public object[]? Attachment { get; set; }
 
     /// <summary>
+    /// Custom headers to include with the message.
+    /// </summary>
+    [Parameter]
+    public Hashtable? Headers { get; set; }
+
+    /// <summary>
     /// Executes the cmdlet logic asynchronously.
     /// </summary>
     protected override async Task ProcessRecordAsync() {
@@ -79,11 +87,19 @@ public sealed class CmdletSendGmailMessage : AsyncPSCmdlet {
             TextBody = TextBody is null ? string.Empty : string.Join(System.Environment.NewLine, TextBody),
             Attachments = Attachment?.ToList()
         };
+        if (Headers != null) {
+            smtp.Headers = Headers.Cast<DictionaryEntry>()
+                .ToDictionary(d => d.Key?.ToString() ?? string.Empty, d => d.Value?.ToString() ?? string.Empty);
+        }
         try {
             smtp.CreateMessage();
             var client = new GmailApiClient(oauth);
-            var result = await client.SendAsync(GmailAccount!, smtp.Message, CancelToken);
-            WriteObject(result);
+            if (ShouldProcess(GmailAccount!, "Sending email message via Gmail API")) {
+                var result = await client.SendAsync(GmailAccount!, smtp.Message, CancelToken);
+                WriteObject(result);
+            } else {
+                WriteObject(new SmtpResult(false, EmailAction.Send, smtp.SentTo, smtp.SentFrom, "GmailApi", 0, smtp.Stopwatch.Elapsed, string.Empty, "Email not sent (WhatIf)"));
+            }
         } finally {
             smtp.Dispose();
         }

--- a/Tests/Send-EmailMessage.GmailProvider.Tests.ps1
+++ b/Tests/Send-EmailMessage.GmailProvider.Tests.ps1
@@ -2,8 +2,8 @@ Describe 'Send-EmailMessage - Gmail provider' {
     It 'Enumeration includes Gmail' {
         [enum]::GetNames([Mailozaurr.EmailProvider]) | Should -Contain 'Gmail'
     }
-    It 'WhatIf returns result' -Skip {
+    It 'WhatIf returns result' {
         $cred = ConvertTo-OAuth2Credential -UserName 'user@gmail.com' -Token 'tok'
-        { Send-EmailMessage -EmailProvider Gmail -GmailAccount 'user@gmail.com' -From 'user@gmail.com' -To 'a@test.com' -Credential $cred -WhatIf } | Should -Not -Throw
+        { Send-EmailMessage -EmailProvider Gmail -GmailAccount 'user@gmail.com' -From 'user@gmail.com' -To 'a@test.com' -Subject 's' -Body 'b' -Credential $cred -WhatIf } | Should -Not -Throw
     }
 }

--- a/Tests/Send-EmailMessage.Headers.Tests.ps1
+++ b/Tests/Send-EmailMessage.Headers.Tests.ps1
@@ -3,4 +3,10 @@ Describe 'Send-EmailMessage - Headers' {
         $result = Send-EmailMessage -From 'a@b.com' -To 'c@d.com' -Subject 't' -Body 'b' -Server 'smtp.example.com' -Headers @{ 'X-Test'='123' } -WhatIf
         $result.Error | Should -Be 'Email not sent (WhatIf)'
     }
+
+    It 'Accepts custom headers with Gmail provider' {
+        $cred = ConvertTo-OAuth2Credential -UserName 'user@gmail.com' -Token 'tok'
+        $result = Send-EmailMessage -EmailProvider Gmail -GmailAccount 'user@gmail.com' -From 'user@gmail.com' -To 'recipient@example.com' -Subject 't' -Body 'b' -Credential $cred -Headers @{ 'X-Test'='123' } -WhatIf
+        $result.Error | Should -Be 'Email not sent (WhatIf)'
+    }
 }

--- a/Tests/Send-EmailMessage.Headers.Tests.ps1
+++ b/Tests/Send-EmailMessage.Headers.Tests.ps1
@@ -9,4 +9,29 @@ Describe 'Send-EmailMessage - Headers' {
         $result = Send-EmailMessage -EmailProvider Gmail -GmailAccount 'user@gmail.com' -From 'user@gmail.com' -To 'recipient@example.com' -Subject 't' -Body 'b' -Credential $cred -Headers @{ 'X-Test'='123' } -WhatIf
         $result.Error | Should -Be 'Email not sent (WhatIf)'
     }
+
+    It 'Accepts custom headers with Graph provider' {
+        $cred = ConvertTo-GraphCredential -ClientID 'client' -ClientSecret 'secret' -DirectoryID 'tenant'
+        $result = Send-EmailMessage -From 'user@example.com' -To 'recipient@example.com' -Subject 't' -Body 'b' -Graph -Credential $cred -Headers @{ 'X-Test'='123' } -WhatIf
+        $result.Error | Should -Be 'Email not sent (WhatIf)'
+    }
+
+    It 'Accepts custom headers with SendGrid provider' {
+        $cred = ConvertTo-SendGridCredential -ApiKey 'key'
+        $result = Send-EmailMessage -From 'user@example.com' -To 'recipient@example.com' -Subject 't' -Body 'b' -SendGrid -Credential $cred -Headers @{ 'X-Test'='123' } -WhatIf
+        $result.Error | Should -Be 'Email not sent (WhatIf)'
+    }
+
+    It 'Accepts custom headers with Mailgun provider' {
+        $cred = ConvertTo-MailgunCredential -ApiKey 'key'
+        $result = Send-EmailMessage -From 'user@example.com' -To 'recipient@example.com' -Subject 't' -Body 'b' -EmailProvider Mailgun -Credential $cred -Headers @{ 'X-Test'='123' } -WhatIf
+        $result.Error | Should -Be 'Email not sent (WhatIf)'
+    }
+
+    It 'Accepts custom headers with SES provider' {
+        $secure = ConvertTo-SecureString 'secret' -AsPlainText -Force
+        $cred = [PSCredential]::new('access', $secure)
+        $result = Send-EmailMessage -From 'user@example.com' -To 'recipient@example.com' -Subject 't' -Body 'b' -EmailProvider SES -Region 'us-east-1' -Credential $cred -Headers @{ 'X-Test'='123' } -WhatIf
+        $result.Error | Should -Be 'Email not sent (WhatIf)'
+    }
 }

--- a/Tests/Send-GmailMessage.Tests.ps1
+++ b/Tests/Send-GmailMessage.Tests.ps1
@@ -3,4 +3,10 @@ Describe 'Send-GmailMessage cmdlet' {
         $base = [Mailozaurr.PowerShell.CmdletSendGmailMessage].BaseType
         $base.FullName | Should -Be 'Mailozaurr.PowerShell.AsyncPSCmdlet'
     }
+
+    It 'Accepts custom headers parameter' {
+        $cred = ConvertTo-OAuth2Credential -UserName 'user@gmail.com' -Token 'tok'
+        $result = Send-GmailMessage -GmailAccount 'user@gmail.com' -Credential $cred -From 'user@gmail.com' -To 'recipient@example.com' -Subject 'h' -TextBody 'b' -Headers @{ 'X-Test' = '123' } -WhatIf
+        $result.Error | Should -Be 'Email not sent (WhatIf)'
+    }
 }


### PR DESCRIPTION
## Summary
- allow Send-EmailMessage Gmail provider to include custom headers
- enable Send-GmailMessage to accept custom headers and support WhatIf
- add example and tests for Gmail header usage

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./Mailozaurr.psd1 -Force; Invoke-Pester Tests/Send-GmailMessage.Tests.ps1,Tests/Send-EmailMessage.Headers.Tests.ps1,Tests/Send-EmailMessage.GmailProvider.Tests.ps1 -PassThru"`
- `pwsh -NoLogo -NoProfile -File ./Mailozaurr.Tests.ps1` *(fails: Unprotect-MimeMessage not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68a35dea1080832e80a9886018bc8d51