### PR TITLE
Fix nullable warnings in core mail components

### DIFF
--- a/Sources/Mailozaurr/Definitions/MsgConversionResult.cs
+++ b/Sources/Mailozaurr/Definitions/MsgConversionResult.cs
@@ -4,18 +4,18 @@ namespace Mailozaurr;
 /// Result information returned when converting a MSG file to EML.
 /// </summary>
 /// <remarks>
-/// Used by <see cref="EmailMessage.ConvertMsgToEml"/> to expose
+/// Used by <see cref="EmailMessage.ConvertMsgToEml(string[], string, bool)"/> to expose
 /// the source and target paths along with status information.
 /// </remarks>
 public class MsgConversionResult {
     /// <summary>
     /// Msg file path to file that was converted
     /// </summary>
-    public string MsgFile { get; set; }
+    public string MsgFile { get; set; } = string.Empty;
     /// <summary>
     /// Eml file path to file that was created
     /// </summary>
-    public string EmlFile { get; set; }
+    public string EmlFile { get; set; } = string.Empty;
     /// <summary>
     /// Status of the conversion
     /// </summary>
@@ -23,5 +23,5 @@ public class MsgConversionResult {
     /// <summary>
     /// Error message if conversion failed
     /// </summary>
-    public string Error { get; set; }
+    public string? Error { get; set; }
 }

--- a/Sources/Mailozaurr/EmailGraphMessage.cs
+++ b/Sources/Mailozaurr/EmailGraphMessage.cs
@@ -11,26 +11,26 @@ public class EmailGraphMessage {
     /// <summary>
     /// Gets or sets the unique identifier of the message.
     /// </summary>
-    public string Id { get; set; }
+    public string Id { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the subject line of the message.
     /// </summary>
-    public string Subject { get; set; }
+    public string Subject { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the preview text of the message body.
     /// </summary>
-    public string BodyPreview { get; set; }
+    public string BodyPreview { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the full body content of the message.
     /// </summary>
-    public object Body { get; set; }
+    public object? Body { get; set; }
 
     /// <summary>
     /// Gets or sets the change key used for concurrency checks.
     /// </summary>
-    public string ChangeKey { get; set; }
+    public string ChangeKey { get; set; } = string.Empty;
     // Add more properties as needed
 }

--- a/Sources/Mailozaurr/Logging/InternalLogger.cs
+++ b/Sources/Mailozaurr/Logging/InternalLogger.cs
@@ -13,32 +13,32 @@ public class InternalLogger {
     /// <summary>
     /// Occurs when a verbose message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnVerboseMessage;
+    public event EventHandler<LogEventArgs>? OnVerboseMessage;
 
     /// <summary>
     /// Occurs when a warning message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnWarningMessage;
+    public event EventHandler<LogEventArgs>? OnWarningMessage;
 
     /// <summary>
     /// Occurs when an error message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnErrorMessage;
+    public event EventHandler<LogEventArgs>? OnErrorMessage;
 
     /// <summary>
     /// Occurs when a debug message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnDebugMessage;
+    public event EventHandler<LogEventArgs>? OnDebugMessage;
 
     /// <summary>
     /// Occurs when a progress message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnProgressMessage;
+    public event EventHandler<LogEventArgs>? OnProgressMessage;
 
     /// <summary>
     /// Occurs when an information message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnInformationMessage;
+    public event EventHandler<LogEventArgs>? OnInformationMessage;
 
     /// <summary>
     /// Gets or sets a value indicating whether verbose messages should be logged.

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -11,9 +11,12 @@ namespace Mailozaurr;
 /// Provides convenience methods for constructing requests and
 /// uploading attachments without having to manually craft HTTP calls.
 /// </remarks>
-public class Graph : IDisposable {
-    private readonly HttpClient _client;
-    public const int MaxChunkSize = 4 * 1024 * 1024;
+    public class Graph : IDisposable {
+        private readonly HttpClient _client;
+        /// <summary>
+        /// Maximum size of an attachment chunk when uploading large files (4 MB).
+        /// </summary>
+        public const int MaxChunkSize = 4 * 1024 * 1024;
     private int _chunkSize = MaxChunkSize;
     /// <summary>
     /// Serialized JSON representation of the current Graph message.
@@ -23,7 +26,7 @@ public class Graph : IDisposable {
     /// <summary>
     /// Container object used when building a Graph message.
     /// </summary>
-    public GraphMessageContainer MessageContainer;
+    public GraphMessageContainer MessageContainer = new();
 
     /// <summary>Measures elapsed time spent during send operations.</summary>
     public readonly Stopwatch Stopwatch;
@@ -80,17 +83,17 @@ public class Graph : IDisposable {
     /// <summary>
     /// Gets or sets the subject of the email.
     /// </summary>
-    public string Subject { get; set; }
+    public string Subject { get; set; } = string.Empty;
 
     /// <summary>
     /// HTML content of the email.
     /// </summary>
-    public string HTML { get; set; }
+    public string HTML { get; set; } = string.Empty;
 
     /// <summary>
     /// Content type of the email.
     /// </summary>
-    public string ContentType { get; set; }
+    public string ContentType { get; set; } = string.Empty;
 
     /// <summary>
     /// Value indicating whether the message should not be saved to the Sent Items folder.
@@ -100,22 +103,22 @@ public class Graph : IDisposable {
     /// <summary>
     /// Access token for the Graph API.
     /// </summary>
-    public string AccessToken { get; set; }
+    public string AccessToken { get; set; } = string.Empty;
 
     /// <summary>
     /// Application ID for the Graph API.
     /// </summary>
-    private string ApplicationID { get; set; }
+    private string ApplicationID { get; set; } = string.Empty;
 
     /// <summary>
     /// Application key for the Graph API.
     /// </summary>
-    private string ApplicationKey { get; set; }
+    private string ApplicationKey { get; set; } = string.Empty;
 
     /// <summary>
     /// Tenant domain for the Graph API.
     /// </summary>
-    private string TenantDomain { get; set; }
+    private string TenantDomain { get; set; } = string.Empty;
 
     /// <summary>
     /// Action to take when an error occurs based on the ErrorAction preference.
@@ -176,7 +179,7 @@ public class Graph : IDisposable {
     /// <summary>
     /// The type of token that was issued.
     /// </summary>
-    public string TokenType { get; set; }
+    public string TokenType { get; set; } = string.Empty;
 
     /// <summary>
     /// The email address that the message was sent from.
@@ -399,8 +402,8 @@ public class Graph : IDisposable {
                 }
 
                 var authorization = JsonSerializer.Deserialize<GraphAuthorization>(content);
-                AccessToken = authorization.AccessToken;
-                TokenType = authorization.TokenType;
+                AccessToken = authorization?.AccessToken ?? string.Empty;
+                TokenType = authorization?.TokenType ?? string.Empty;
                 return new SmtpResult(true, EmailAction.Connect, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", "");
             } finally {
                 MicrosoftGraphUtils.ConcurrencySemaphore.Release();
@@ -428,7 +431,7 @@ public class Graph : IDisposable {
         // Create the request URI outside the loop.
         var requestUri = MicrosoftGraphUtils.BuildGraphUri(
             GraphEndpoint.V1,
-            $"/users/{MessageContainer.Message.From.Email.Address}/sendMail");
+            $"/users/{MessageContainer.Message.From!.Email.Address}/sendMail");
 
         int attempts = 0;
         Exception? lastException = null;
@@ -544,16 +547,17 @@ public class Graph : IDisposable {
         return finalResult;
     }
 
-    /// <summary>
-    /// Sends a previously created draft message.
-    /// </summary>
-    /// <param name="draftMessage">The draft message to send.</param>
-    /// <returns>The result of the send operation.</returns>
-    public async Task<SmtpResult> SendDraftMessage(GraphMessage draftMessage, CancellationToken cancellationToken = default) {
+        /// <summary>
+        /// Sends a previously created draft message.
+        /// </summary>
+        /// <param name="draftMessage">The draft message to send.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The result of the send operation.</returns>
+        public async Task<SmtpResult> SendDraftMessage(GraphMessage draftMessage, CancellationToken cancellationToken = default) {
         // Send the draft message
         var sendRequestUri = MicrosoftGraphUtils.BuildGraphUri(
             GraphEndpoint.V1,
-            $"/users/{MessageContainer.Message.From.Email.Address}/messages/{draftMessage.Id}/send");
+            $"/users/{MessageContainer.Message.From!.Email.Address}/messages/{draftMessage.Id!}/send");
         using var sendRequest = new HttpRequestMessage(HttpMethod.Post, sendRequestUri);
 
         // Add the authorization header
@@ -602,7 +606,7 @@ public class Graph : IDisposable {
         var request = new GraphBatchRequest {
             Id = "1",
             Method = GraphHttpMethod.POST,
-            Url = $"/users/{MessageContainer.Message.From.Email.Address}/sendMail",
+            Url = $"/users/{MessageContainer.Message.From!.Email.Address}/sendMail",
             Headers = new Dictionary<string, string> { ["Content-Type"] = "application/json" },
             Body = bodyObj
         };
@@ -640,7 +644,7 @@ public class Graph : IDisposable {
 
         var draftRequestUri = MicrosoftGraphUtils.BuildGraphUri(
             GraphEndpoint.V1,
-            $"/users/{MessageContainer.Message.From.Email.Address}/mailfolders/drafts/messages");
+            $"/users/{MessageContainer.Message.From!.Email.Address}/mailfolders/drafts/messages");
         var draftRequest = new HttpRequestMessage(HttpMethod.Post, draftRequestUri) {
             Content = new StringContent(messageJson, Encoding.UTF8, "application/json")
         };
@@ -708,12 +712,13 @@ public class Graph : IDisposable {
     }
 
 
-    /// <summary>
-    /// Creates the metadata and content placeholders required for uploading a file attachment.
-    /// </summary>
-    /// <param name="attachmentPath">Path to the attachment file.</param>
-    /// <returns>The placeholder representing the attachment.</returns>
-    public Task<GraphAttachmentPlaceHolder> CreateGraphAttachment(string attachmentPath, CancellationToken cancellationToken = default) {
+        /// <summary>
+        /// Creates the metadata and content placeholders required for uploading a file attachment.
+        /// </summary>
+        /// <param name="attachmentPath">Path to the attachment file.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The placeholder representing the attachment.</returns>
+        public Task<GraphAttachmentPlaceHolder> CreateGraphAttachment(string attachmentPath, CancellationToken cancellationToken = default) {
         var fileName = Path.GetFileName(attachmentPath);
         var fileSize = new FileInfo(attachmentPath).Length;
 
@@ -735,13 +740,14 @@ public class Graph : IDisposable {
         return Task.FromResult(placeholder);
     }
 
-    /// <summary>
-    /// Creates an upload session for a large attachment.
-    /// </summary>
-    /// <param name="draftMessage">The draft message the attachment belongs to.</param>
-    /// <param name="attachmentItemJson">The serialized attachment item.</param>
-    /// <returns>The upload session URL.</returns>
-    public async Task<string> CreateUploadSession(GraphMessage draftMessage, string attachmentItemJson, CancellationToken cancellationToken = default) {
+        /// <summary>
+        /// Creates an upload session for a large attachment.
+        /// </summary>
+        /// <param name="draftMessage">The draft message the attachment belongs to.</param>
+        /// <param name="attachmentItemJson">The serialized attachment item.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The upload session URL.</returns>
+        public async Task<string> CreateUploadSession(GraphMessage draftMessage, string attachmentItemJson, CancellationToken cancellationToken = default) {
         var uploadSessionUrl = MicrosoftGraphUtils.BuildGraphUri(
             GraphEndpoint.V1,
             $"/users('{SentFrom}')/messages/{draftMessage.Id}/attachments/createUploadSession");
@@ -779,13 +785,14 @@ public class Graph : IDisposable {
         return uploadSessionResult.UploadUrl;
     }
 
-    /// <summary>
-    /// Splits <paramref name="filePath"/> into chunks no larger than <see cref="MaxChunkSize"/>.
-    /// </summary>
-    /// <param name="filePath"></param>
-    /// <param name="chunkSize"></param>
-    /// <returns></returns>
-    private List<StreamContent> PrepareByteArrayContentForUpload(string filePath, int chunkSize = MaxChunkSize, CancellationToken cancellationToken = default) {
+        /// <summary>
+        /// Splits <paramref name="filePath"/> into chunks no larger than <see cref="MaxChunkSize"/>.
+        /// </summary>
+        /// <param name="filePath">Path to the file to split.</param>
+        /// <param name="chunkSize">Desired size of each chunk in bytes.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>List of stream contents representing file chunks.</returns>
+        private List<StreamContent> PrepareByteArrayContentForUpload(string filePath, int chunkSize = MaxChunkSize, CancellationToken cancellationToken = default) {
         chunkSize = Math.Min(chunkSize, MaxChunkSize);
         var fileContents = new List<StreamContent>();
         var fileSize = new FileInfo(filePath).Length;
@@ -812,11 +819,12 @@ public class Graph : IDisposable {
         return fileContents;
     }
 
-    /// <summary>
-    /// Uploads all attachments for the specified draft message.
-    /// </summary>
-    /// <param name="draftMessage">The draft message to attach the files to.</param>
-    public async Task UploadAttachmentsAsync(GraphMessage draftMessage, CancellationToken cancellationToken = default) {
+        /// <summary>
+        /// Uploads all attachments for the specified draft message.
+        /// </summary>
+        /// <param name="draftMessage">The draft message to attach the files to.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        public async Task UploadAttachmentsAsync(GraphMessage draftMessage, CancellationToken cancellationToken = default) {
         if (Attachments != null && Attachments.Length > 0) {
             foreach (var attachmentPath in Attachments) {
                 if (attachmentPath is string path) {
@@ -828,10 +836,11 @@ public class Graph : IDisposable {
         }
     }
 
-    /// <summary>
-    /// Prepares attachments for upload by creating placeholders.
-    /// </summary>
-    public async Task PrepareAttachments(CancellationToken cancellationToken = default) {
+        /// <summary>
+        /// Prepares attachments for upload by creating placeholders.
+        /// </summary>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        public async Task PrepareAttachments(CancellationToken cancellationToken = default) {
         if (Attachments != null && Attachments.Length > 0) {
             foreach (var attachmentPath in Attachments) {
                 if (attachmentPath is string path) {
@@ -842,23 +851,25 @@ public class Graph : IDisposable {
         }
     }
 
-    /// <summary>
-    /// Uploads all chunks of a file to the provided upload session URL.
-    /// </summary>
-    /// <param name="uploadUrl">The upload session URL.</param>
-    /// <param name="fileChunks">The file chunks to upload.</param>
-    public async Task SendFileChunks(string uploadUrl, IEnumerable<StreamContent> fileChunks, CancellationToken cancellationToken = default) {
+        /// <summary>
+        /// Uploads all chunks of a file to the provided upload session URL.
+        /// </summary>
+        /// <param name="uploadUrl">The upload session URL.</param>
+        /// <param name="fileChunks">The file chunks to upload.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        public async Task SendFileChunks(string uploadUrl, IEnumerable<StreamContent> fileChunks, CancellationToken cancellationToken = default) {
         foreach (var chunk in fileChunks) {
             await SendAttachmentChunk(uploadUrl, chunk, cancellationToken);
         }
     }
 
-    /// <summary>
-    /// Uploads a single attachment chunk to the Graph API.
-    /// </summary>
-    /// <param name="uploadUrl">The upload session URL.</param>
-    /// <param name="byteArrayContent">The chunk to send.</param>
-    public async Task SendAttachmentChunk(string uploadUrl, StreamContent byteArrayContent, CancellationToken cancellationToken = default) {
+        /// <summary>
+        /// Uploads a single attachment chunk to the Graph API.
+        /// </summary>
+        /// <param name="uploadUrl">The upload session URL.</param>
+        /// <param name="byteArrayContent">The chunk to send.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        public async Task SendAttachmentChunk(string uploadUrl, StreamContent byteArrayContent, CancellationToken cancellationToken = default) {
         using var requestMessage = new HttpRequestMessage(HttpMethod.Put, uploadUrl) {
             Content = byteArrayContent
         };

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMessage.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMessage.cs
@@ -13,12 +13,12 @@ public class GraphMessage {
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string? Id { get; set; }
     /// <summary>
     /// Gets or sets the sender address.
     /// </summary>
     [JsonPropertyName("from")]
-    public GraphEmailAddress From { get; set; }
+    public GraphEmailAddress? From { get; set; }
 
     /// <summary>
     /// Gets or sets the primary recipients of the message.
@@ -52,13 +52,13 @@ public class GraphMessage {
     /// Gets or sets the subject line of the message.
     /// </summary>
     [JsonPropertyName("subject")]
-    public string Subject { get; set; }
+    public string? Subject { get; set; }
 
     /// <summary>
     /// Gets or sets the message body.
     /// </summary>
     [JsonPropertyName("body")]
-    public GraphContent Body { get; set; }
+    public GraphContent? Body { get; set; }
 
     /// <summary>
     /// Gets or sets the importance of the message.

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -127,7 +127,7 @@ namespace Mailozaurr {
                 var auth = await OAuthHelpers.AcquireGraphCertificateTokenAsync(
                     credential.ClientId,
                     tenantDomain,
-                    credential.CertificatePath,
+                    credential.CertificatePath!,
                     credential.CertificatePassword ?? string.Empty,
                     scopes);
                 TokenCache[key] = auth;
@@ -148,7 +148,7 @@ namespace Mailozaurr {
                 var auth = await OAuthHelpers.AcquireGraphCertificatePemTokenAsync(
                     credential.ClientId,
                     tenantDomain,
-                    credential.CertificatePemPath,
+                    credential.CertificatePemPath!,
                     scopes);
                 return $"{auth.TokenType} {auth.AccessToken}";
             }
@@ -157,9 +157,11 @@ namespace Mailozaurr {
             {
                 { "grant_type", "client_credentials" },
                 { "resource", resource },
-                { "client_id", credential.ClientId },
-                { "client_secret", credential.ClientSecret }
+                { "client_id", credential.ClientId }
             };
+            if (!string.IsNullOrEmpty(credential.ClientSecret)) {
+                body.Add("client_secret", credential.ClientSecret!);
+            }
             var content = new FormUrlEncodedContent(body);
             var url = $"https://login.microsoftonline.com/{tenantDomain}/oauth2/token";
             await ConcurrencySemaphore.WaitAsync();
@@ -193,10 +195,10 @@ namespace Mailozaurr {
                         expiresOn = DateTimeOffset.FromUnixTimeSeconds(expSeconds);
                     }
                 }
-                TokenCache[key] = new GraphAuthorization { AccessToken = accessToken, TokenType = tokenType, ExpiresOn = expiresOn };
+                TokenCache[key] = new GraphAuthorization { AccessToken = accessToken ?? string.Empty, TokenType = tokenType ?? string.Empty, ExpiresOn = expiresOn };
                 await OAuthTokenCache.SetAsync($"graph:{key}", new OAuthCredential {
                     UserName = credential.ClientId,
-                    AccessToken = accessToken,
+                    AccessToken = accessToken ?? string.Empty,
                     ExpiresOn = expiresOn
                 });
                 return $"{tokenType} {accessToken}";
@@ -273,8 +275,8 @@ namespace Mailozaurr {
         public static async Task<JsonDocument> InvokeGraphApiAsync(
             string method,
             string uri,
-            IDictionary<string, string> headers = null,
-            string body = null) {
+            IDictionary<string, string>? headers = null,
+            string? body = null) {
             var request = new HttpRequestMessage(new HttpMethod(method), uri);
             if (headers != null) {
                 foreach (var kvp in headers) {
@@ -324,12 +326,12 @@ namespace Mailozaurr {
             if (doc.RootElement.TryGetProperty("responses", out var responses) && responses.ValueKind == JsonValueKind.Array) {
                 foreach (var item in responses.EnumerateArray()) {
                     var result = new GraphBatchResult();
-                    if (item.TryGetProperty("id", out var idEl) && idEl.ValueKind == JsonValueKind.String) result.Id = idEl.GetString();
+                    if (item.TryGetProperty("id", out var idEl) && idEl.ValueKind == JsonValueKind.String) result.Id = idEl.GetString() ?? string.Empty;
                     if (item.TryGetProperty("status", out var statusEl) && statusEl.TryGetInt32(out var status)) result.Status = status;
                     if (item.TryGetProperty("headers", out var headersEl) && headersEl.ValueKind == JsonValueKind.Object) {
                         var h = new Dictionary<string, string>();
                         foreach (var prop in headersEl.EnumerateObject()) {
-                            if (prop.Value.ValueKind == JsonValueKind.String) h[prop.Name] = prop.Value.GetString();
+                            if (prop.Value.ValueKind == JsonValueKind.String) h[prop.Name] = prop.Value.GetString() ?? string.Empty;
                         }
                         result.Headers = h;
                     }
@@ -345,7 +347,7 @@ namespace Mailozaurr {
         /// <summary>
         /// Removes empty values from a dictionary recursively (null, empty string, empty array, empty dictionary).
         /// </summary>
-        public static void RemoveEmptyValues(IDictionary<string, object> dict, HashSet<string> exclude = null, bool recursive = true, int rerun = 0) {
+        public static void RemoveEmptyValues(IDictionary<string, object> dict, HashSet<string>? exclude = null, bool recursive = true, int rerun = 0) {
             exclude ??= new HashSet<string>();
             var keys = dict.Keys.ToList();
             foreach (var key in keys) {
@@ -385,9 +387,12 @@ namespace Mailozaurr {
         /// Joins a base URI, optional relative URI, and query parameters into a full URI string.
         /// </summary>
         public static string JoinUriQuery(string baseUri, string? relativeOrAbsoluteUri = null, IDictionary<string, object>? queryParameters = null, bool escapeUriString = false) {
+            if (baseUri == null) {
+                throw new ArgumentNullException(nameof(baseUri));
+            }
             string url = baseUri.TrimEnd('/');
             if (!string.IsNullOrWhiteSpace(relativeOrAbsoluteUri)) {
-                url += "/" + relativeOrAbsoluteUri.TrimStart('/');
+                url += "/" + relativeOrAbsoluteUri!.TrimStart('/');
             }
             var uriBuilder = new UriBuilder(url);
             if (queryParameters != null && queryParameters.Count > 0) {
@@ -410,17 +415,17 @@ namespace Mailozaurr {
             return result;
         }
 
-        private static object ConvertJsonElementToNativeObject(JsonElement element) {
+        private static object? ConvertJsonElementToNativeObject(JsonElement element) {
             switch (element.ValueKind) {
                 case JsonValueKind.Object:
                     var dict = new Dictionary<string, object>();
                     foreach (var prop in element.EnumerateObject())
-                        dict[prop.Name] = ConvertJsonElementToNativeObject(prop.Value);
+                        dict[prop.Name] = ConvertJsonElementToNativeObject(prop.Value)!;
                     return dict;
                 case JsonValueKind.Array:
                     var list = new List<object>();
                     foreach (var item in element.EnumerateArray())
-                        list.Add(ConvertJsonElementToNativeObject(item));
+                        list.Add(ConvertJsonElementToNativeObject(item)!);
                     return list.ToArray();
                 case JsonValueKind.String:
                     return element.GetString();
@@ -440,12 +445,12 @@ namespace Mailozaurr {
         /// <summary>
         /// Retrieves mail messages for the specified user.
         /// </summary>
-        public static async Task<List<Dictionary<string, object>>> GetMailMessagesAsync(GraphCredential credential, string userPrincipalName, IEnumerable<string> properties = null, string filter = null, int? limit = null) {
+        public static async Task<List<Dictionary<string, object>>> GetMailMessagesAsync(GraphCredential credential, string userPrincipalName, IEnumerable<string>? properties = null, string? filter = null, int? limit = null) {
             var headers = new Dictionary<string, string>();
             var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
-            headers["Authorization"] = token;
+            headers["Authorization"] = token ?? string.Empty;
             var queryParams = new Dictionary<string, object>();
-            if (!string.IsNullOrWhiteSpace(filter)) queryParams["$filter"] = filter;
+            if (!string.IsNullOrWhiteSpace(filter)) queryParams["$filter"] = filter!;
             if (properties != null && properties.Any()) queryParams["$select"] = string.Join(",", properties);
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/messages", queryParams);
             var doc = await InvokeGraphApiAsync("GET", uri, headers);
@@ -453,8 +458,10 @@ namespace Mailozaurr {
             if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                 foreach (var item in valueElement.EnumerateArray()) {
                     var native = ConvertJsonElementToNativeObject(item) as Dictionary<string, object>;
-                    messages.Add(native);
-                    if (limit.HasValue && messages.Count >= limit.Value) break;
+                    if (native != null) {
+                        messages.Add(native);
+                        if (limit.HasValue && messages.Count >= limit.Value) break;
+                    }
                 }
             }
             return messages;
@@ -463,7 +470,7 @@ namespace Mailozaurr {
         /// <summary>
         /// Retrieves attachments for a specific message.
         /// </summary>
-        public static async Task<List<Attachment>> GetMailMessageAttachmentsAsync(GraphCredential credential, string userPrincipalName, string messageId, IEnumerable<string> properties = null) {
+        public static async Task<List<Attachment>> GetMailMessageAttachmentsAsync(GraphCredential credential, string userPrincipalName, string messageId, IEnumerable<string>? properties = null) {
             var headers = new Dictionary<string, string>();
             var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
             headers["Authorization"] = token;
@@ -475,7 +482,9 @@ namespace Mailozaurr {
             if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                 foreach (var item in valueElement.EnumerateArray()) {
                     var att = JsonSerializer.Deserialize<Attachment>(item.GetRawText());
-                    attachments.Add(att);
+                    if (att != null) {
+                        attachments.Add(att);
+                    }
                 }
             }
             return attachments;
@@ -720,7 +729,7 @@ namespace Mailozaurr {
             foreach (var msg in messages) {
                 var id = msg["id"] as string;
                 if (string.IsNullOrWhiteSpace(id)) continue;
-                await DeleteMailMessageAsync(credential, userPrincipalName, id);
+                await DeleteMailMessageAsync(credential, userPrincipalName, id!);
             }
         }
 
@@ -745,7 +754,7 @@ namespace Mailozaurr {
             var skipIdsSet = skipIds != null ? new HashSet<string>(skipIds, StringComparer.OrdinalIgnoreCase) : null;
             foreach (var msg in messages) {
                 var id = msg.TryGetValue("id", out var idObj) ? idObj as string : null;
-                if (!string.IsNullOrWhiteSpace(id) && skipIdsSet != null && skipIdsSet.Contains(id)) {
+                if (!string.IsNullOrWhiteSpace(id) && skipIdsSet != null && skipIdsSet.Contains(id!)) {
                     continue;
                 }
 
@@ -815,7 +824,7 @@ namespace Mailozaurr {
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/junkemail/messages", query);
             var messages = new List<Dictionary<string, object>>();
             while (!string.IsNullOrWhiteSpace(uri)) {
-                var doc = await InvokeGraphApiAsync("GET", uri, headers);
+                var doc = await InvokeGraphApiAsync("GET", uri!, headers);
                 if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                     foreach (var item in valueElement.EnumerateArray()) {
                         var native = ConvertJsonElementToNativeObject(item) as Dictionary<string, object>;
@@ -974,12 +983,12 @@ namespace Mailozaurr {
             int folderCount = 0;
             var foldersStats = new List<GraphMailboxFolderStatistics>();
             while (!string.IsNullOrWhiteSpace(folderUri)) {
-                var doc = await InvokeGraphApiAsync("GET", folderUri, headers);
+                var doc = await InvokeGraphApiAsync("GET", folderUri!, headers);
                 if (doc.RootElement.TryGetProperty("value", out var folders) && folders.ValueKind == JsonValueKind.Array) {
                     foreach (var item in folders.EnumerateArray()) {
                         var stat = new GraphMailboxFolderStatistics {
-                            Id = item.GetProperty("id").GetString(),
-                            DisplayName = item.GetProperty("displayName").GetString(),
+                            Id = item.GetProperty("id").GetString() ?? string.Empty,
+                            DisplayName = item.GetProperty("displayName").GetString() ?? string.Empty,
                             WellKnownName = item.TryGetProperty("wellKnownName", out var wn) ? wn.GetString() : null,
                             TotalItemCount = item.TryGetProperty("totalItemCount", out var tic) && tic.TryGetInt32(out var c) ? c : 0,
                             UnreadItemCount = item.TryGetProperty("unreadItemCount", out var uic) && uic.TryGetInt32(out var u) ? u : 0,
@@ -1004,7 +1013,7 @@ namespace Mailozaurr {
             };
             var msgUri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/messages", msgQuery);
             while (!string.IsNullOrWhiteSpace(msgUri)) {
-                var doc = await InvokeGraphApiAsync("GET", msgUri, headers);
+                var doc = await InvokeGraphApiAsync("GET", msgUri!, headers);
                 if (doc.RootElement.TryGetProperty("value", out var msgs) && msgs.ValueKind == JsonValueKind.Array) {
                     foreach (var msg in msgs.EnumerateArray()) {
                         if (!msg.TryGetProperty("id", out var idEl) || idEl.ValueKind != JsonValueKind.String) {
@@ -1051,6 +1060,7 @@ namespace Mailozaurr {
         /// </summary>
         /// <param name="credential">Credential used to authenticate to Microsoft Graph.</param>
         /// <param name="userPrincipalName">User principal name owning the mailbox.</param>
+        /// <param name="filter">Optional OData filter to apply to the query.</param>
         /// <returns>List of inbox rules represented as dictionaries.</returns>
         public static async Task<List<GraphInboxRule>> GetRulesAsync(
             GraphCredential credential,
@@ -1060,7 +1070,7 @@ namespace Mailozaurr {
             var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
             headers["Authorization"] = token;
             Dictionary<string, object>? qp = null;
-            if (!string.IsNullOrWhiteSpace(filter)) qp = new Dictionary<string, object> { ["$filter"] = filter };
+            if (!string.IsNullOrWhiteSpace(filter)) qp = new Dictionary<string, object> { ["$filter"] = filter! };
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/inbox/messageRules", qp);
             var doc = await InvokeGraphApiAsync("GET", uri, headers);
             var rules = new List<GraphInboxRule>();
@@ -1149,7 +1159,7 @@ namespace Mailozaurr {
             var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
             headers["Authorization"] = token;
             var qp = new Dictionary<string, object>();
-            if (!string.IsNullOrWhiteSpace(filter)) qp["$filter"] = filter;
+            if (!string.IsNullOrWhiteSpace(filter)) qp["$filter"] = filter!;
             if (properties != null && properties.Any()) qp["$select"] = string.Join(",", properties);
             var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/events", qp);
             var doc = await InvokeGraphApiAsync("GET", uri, headers);

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -13,7 +13,7 @@ public class SendGridClient {
     /// <summary>
     /// Gets the JSON representation of the message to be sent.
     /// </summary>
-    private string MessageJson { get; set; }
+    private string MessageJson { get; set; } = string.Empty;
 
     /// <summary>
     /// The HttpClient used to send HTTP requests.
@@ -28,22 +28,22 @@ public class SendGridClient {
     /// <summary>
     /// Gets or sets the sender of the email.
     /// </summary>
-    public object From { get; set; }
+    public object? From { get; set; }
 
     /// <summary>
     /// Gets or sets the list of primary recipients of the email.
     /// </summary>
-    public List<object> To { get; set; }
+    public List<object>? To { get; set; }
 
     /// <summary>
     /// Gets or sets the list of carbon copy (CC) recipients of the email.
     /// </summary>
-    public List<object> Cc { get; set; }
+    public List<object>? Cc { get; set; }
 
     /// <summary>
     /// Gets or sets the list of blind carbon copy (BCC) recipients of the email.
     /// </summary>
-    public List<object> Bcc { get; set; }
+    public List<object>? Bcc { get; set; }
 
     /// <summary>
     /// Gets or sets the reply-to address for the email.
@@ -66,12 +66,12 @@ public class SendGridClient {
     /// <summary>
     /// Gets or sets the plain text content of the email.
     /// </summary>
-    public string Text { get; set; }
+    public string Text { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the HTML content of the email.
     /// </summary>
-    public string Html { get; set; }
+    public string Html { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the priority of the email.
@@ -86,7 +86,7 @@ public class SendGridClient {
     /// <summary>
     /// Gets or sets the credentials used for authentication with the SendGrid API.
     /// </summary>
-    public ICredentials Credentials { get; set; }
+    public ICredentials? Credentials { get; set; }
 
     /// <summary>
     /// Gets or sets the action to take when an error occurs.
@@ -126,13 +126,13 @@ public class SendGridClient {
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var addresses = new List<string>();
             if (To != null) {
-                addresses.AddRange(To.Select(ConvertToEmailObject).Where(x => x != null && seen.Add(x.Email)).Select(x => x.Email));
+                addresses.AddRange(To.Select(ConvertToEmailObject).Where(x => x != null && seen.Add(x.Email)).Select(x => x!.Email));
             }
             if (Cc != null) {
-                addresses.AddRange(Cc.Select(ConvertToEmailObject).Where(x => x != null && seen.Add(x.Email)).Select(x => x.Email));
+                addresses.AddRange(Cc.Select(ConvertToEmailObject).Where(x => x != null && seen.Add(x.Email)).Select(x => x!.Email));
             }
             if (Bcc != null) {
-                addresses.AddRange(Bcc.Select(ConvertToEmailObject).Where(x => x != null && seen.Add(x.Email)).Select(x => x.Email));
+                addresses.AddRange(Bcc.Select(ConvertToEmailObject).Where(x => x != null && seen.Add(x.Email)).Select(x => x!.Email));
             }
             return string.Join(",", addresses);
         }
@@ -141,7 +141,7 @@ public class SendGridClient {
     /// <summary>
     /// Gets the email address of the sender of the email.
     /// </summary>
-    public string SentFrom => Helpers.GetEmailAddress(From);
+    public string SentFrom => From != null ? Helpers.GetEmailAddress(From) : string.Empty;
 
     /// <summary>
     /// Gets or sets the log collector for this client.
@@ -177,7 +177,7 @@ public class SendGridClient {
             }
 
             var nameValue = emailDict.ContainsKey("Name") ? emailDict["Name"] as string : null;
-            return new SendGridEmailAddress { Email = emailValue, Name = nameValue };
+            return new SendGridEmailAddress { Email = emailValue!, Name = nameValue };
         } else {
             throw new ArgumentException($"email object type {emailAddress.GetType().Name} requires addition");
         }
@@ -242,14 +242,17 @@ public class SendGridClient {
                     To = To?.Where(t => t != null)
                         .Select(ConvertToEmailObject)
                         .Where(x => x != null && seen.Add(x.Email))
+                        .Select(x => x!)
                         .ToList(),
                     Cc = Cc?.Where(c => c != null)
                         .Select(ConvertToEmailObject)
                         .Where(x => x != null && seen.Add(x.Email))
+                        .Select(x => x!)
                         .ToList(),
                     Bcc = Bcc?.Where(b => b != null)
                         .Select(ConvertToEmailObject)
                         .Where(x => x != null && seen.Add(x.Email))
+                        .Select(x => x!)
                         .ToList()
                 }
             }
@@ -262,9 +265,11 @@ public class SendGridClient {
             }.Where(c => c.Value != null).ToList();
 
 
+        var fromAddress = ConvertToEmailObject(From) ?? throw new InvalidOperationException("From address is required.");
+
         var message = new SendGridMessage {
             Personalizations = personalizations,
-            From = ConvertToEmailObject(From),
+            From = fromAddress,
             Subject = Subject,
             Content = content,
             ReplyTo = ConvertToEmailObject(ReplyTo),

--- a/Sources/Mailozaurr/SentMessages/SendLogResolver.cs
+++ b/Sources/Mailozaurr/SentMessages/SendLogResolver.cs
@@ -2,16 +2,30 @@ using Mailozaurr.NonDeliveryReports;
 
 namespace Mailozaurr;
 
+/// <summary>
+/// Resolves log entries for previously sent messages based on non-delivery reports.
+/// </summary>
 public sealed class SendLogResolver {
     private readonly ISentMessageRepository repository;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SendLogResolver"/> class.
+    /// </summary>
+    /// <param name="repository">Repository used to look up sent messages.</param>
     public SendLogResolver(ISentMessageRepository repository) => this.repository = repository;
 
+    /// <summary>
+    /// Attempts to resolve a sent message record from a non-delivery report.
+    /// </summary>
+    /// <param name="report">Non-delivery report to analyze.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The matching <see cref="SentMessageRecord"/>, or <c>null</c> if not found.</returns>
     public async Task<SentMessageRecord?> ResolveAsync(NonDeliveryReport report, CancellationToken cancellationToken = default) {
-        if (string.IsNullOrWhiteSpace(report?.OriginalMessageId)) {
+        if (string.IsNullOrWhiteSpace(report.OriginalMessageId)) {
             return null;
         }
-        var record = await repository.GetByMessageIdAsync(report.OriginalMessageId!, cancellationToken);
+        var messageId = report.OriginalMessageId!;
+        var record = await repository.GetByMessageIdAsync(messageId, cancellationToken);
         if (record != null) {
             var recipient = report.FinalRecipientAddress ?? report.OriginalRecipientAddress;
             if (!string.IsNullOrWhiteSpace(recipient)) {

--- a/Sources/Mailozaurr/SentMessages/SentMessageRecord.cs
+++ b/Sources/Mailozaurr/SentMessages/SentMessageRecord.cs
@@ -1,8 +1,18 @@
 namespace Mailozaurr;
 
+/// <summary>
+/// Represents a record of a message that has been sent.
+/// </summary>
 public sealed class SentMessageRecord {
+    /// <summary>Identifier of the message.</summary>
     public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>Comma-separated list of recipients.</summary>
     public string Recipients { get; set; } = string.Empty;
+
+    /// <summary>Subject line of the message.</summary>
     public string Subject { get; set; } = string.Empty;
+
+    /// <summary>Time at which the message was sent.</summary>
     public DateTimeOffset Timestamp { get; set; }
 }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -18,7 +18,7 @@ public partial class ClientSmtp : SmtpClient {
     /// <summary>Inline attachments to embed in the message.</summary>
     public List<object>? InlineAttachments { get; set; } = new List<object>();
     /// <summary>The sender address.</summary>
-    public object From { get; set; }
+    public object? From { get; set; }
     /// <summary>Primary recipients.</summary>
     public IEnumerable<object>? To { get; set; } = new List<object>();
     /// <summary>Carbon copy recipients.</summary>
@@ -28,7 +28,7 @@ public partial class ClientSmtp : SmtpClient {
     /// <summary>Reply-to address.</summary>
     public object? ReplyTo { get; set; }
     /// <summary>The underlying MIME message.</summary>
-    public MimeMessage Message { get; set; }
+    public MimeMessage Message { get; set; } = new MimeMessage();
     /// <summary>Priority of the message.</summary>
     public MessagePriority Priority { get; set; }
     /// <summary>Delivery notification options.</summary>
@@ -58,7 +58,9 @@ public partial class ClientSmtp : SmtpClient {
     /// <summary>The address(es) the message is sent from.</summary>
     public string SentFrom {
         get {
-            var addresses = ConvertToMailboxAddress(From).Select(x => x.Address);
+            var addresses = From != null
+                ? ConvertToMailboxAddress(From).Select(x => x.Address)
+                : Enumerable.Empty<string>();
             return string.Join(",", addresses);
         }
     }
@@ -121,7 +123,7 @@ public partial class ClientSmtp : SmtpClient {
     }
 
     private void AddAddressesToMessage(MimeMessage message) {
-        var fromAddresses = ConvertToMailboxAddress(From).ToList();
+        var fromAddresses = From != null ? ConvertToMailboxAddress(From).ToList() : new List<MailboxAddress>();
         if (fromAddresses.Any()) {
             LoggingMessages.Logger.WriteVerbose("Adding from address to message: {0}", fromAddresses.First());
             message.From.Add(fromAddresses.First());


### PR DESCRIPTION
## Summary
- add nullability annotations and defaults across SendGrid and SMTP clients
- document Graph helpers and resolve nullable warnings
- improve logging and sent message records with XML docs

## Testing
- `dotnet build Mailozaurr/Mailozaurr.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68a3911cf918832eaf47a849cc64298e