### PR TITLE
Fix nullable warnings in PowerShell cmdlets and tests

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
@@ -53,7 +53,7 @@ public sealed class CmdletConnectOAuthGoogle : AsyncPSCmdlet {
         OAuthCredential? cred = null;
         try {
             cred = await Mailozaurr.OAuthHelpers
-                .AcquireGoogleTokenCachedAsync(GmailAccount, ClientID, ClientSecret, Scope);
+                .AcquireGoogleTokenCachedAsync(GmailAccount!, ClientID!, ClientSecret!, Scope!);
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(ex, "OAuthGoogleAuthFailed", ErrorCategory.AuthenticationError, null));
             return;

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthO365.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthO365.cs
@@ -64,7 +64,7 @@ public class CmdletConnectOAuthO365 : PSCmdlet {
     protected override void ProcessRecord() {
         Mailozaurr.OAuthCredential? cred = null;
         try {
-            cred = Task.Run(() => Mailozaurr.OAuthHelpers.AcquireO365TokenCachedAsync(Login, ClientID, TenantID, RedirectUri, Scopes)).GetAwaiter().GetResult();
+            cred = Task.Run(() => Mailozaurr.OAuthHelpers.AcquireO365TokenCachedAsync(Login, ClientID!, TenantID!, RedirectUri!, Scopes!)).GetAwaiter().GetResult();
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(ex, "OAuthO365AuthFailed", ErrorCategory.AuthenticationError, null));
             return;

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertFromEmlToMsg.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertFromEmlToMsg.cs
@@ -56,13 +56,16 @@ public sealed class CmdletConvertFromEmlToMsg : AsyncPSCmdlet {
     /// Converts the specified EML files to MSG format and writes the results to the output folder.
     /// </summary>
     protected override Task ProcessRecordAsync() {
-        var outputMessage = EmailMessage.ConvertEmlToMsg(InputPath, OutputFolder, Force);
+        var outputMessage = EmailMessage.ConvertEmlToMsg(InputPath!, OutputFolder!, Force);
         foreach (var obj in outputMessage) {
             WriteObject(obj);
         }
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Releases logging resources.
+    /// </summary>
     protected override Task EndProcessingAsync() {
         _listener?.Dispose();
         _listener = null;

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertFromMsgToEml.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertFromMsgToEml.cs
@@ -51,13 +51,16 @@ public sealed class CmdletConvertFromMsgToEml : AsyncPSCmdlet {
     /// Converts the specified MSG files to EML format.
     /// </summary>
     protected override Task ProcessRecordAsync() {
-        var outputMessage = EmailMessage.ConvertMsgToEml(InputPath, OutputFolder, Force);
+        var outputMessage = EmailMessage.ConvertMsgToEml(InputPath!, OutputFolder!, Force);
         foreach (var obj in outputMessage) {
             WriteObject(obj);
         }
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Cleans up logging resources.
+    /// </summary>
     protected override Task EndProcessingAsync() {
         _listener?.Dispose();
         _listener = null;

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
@@ -234,13 +234,13 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
         var filters = new List<string>();
         if (!All.IsPresent) {
             if (!string.IsNullOrWhiteSpace(Subject)) {
-                filters.Add($"contains(subject,'{Subject.Replace("'", "''")}')");
+                filters.Add($"contains(subject,'{Subject!.Replace("'", "''")}')");
             }
             if (!string.IsNullOrWhiteSpace(FromContains)) {
-                filters.Add($"contains(from/emailAddress/address,'{FromContains.Replace("'", "''")}')");
+                filters.Add($"contains(from/emailAddress/address,'{FromContains!.Replace("'", "''")}')");
             }
             if (!string.IsNullOrWhiteSpace(ToContains)) {
-                filters.Add($"toRecipients/any(r:contains(r/emailAddress/address,'{ToContains.Replace("'", "''")}'))");
+                filters.Add($"toRecipients/any(r:contains(r/emailAddress/address,'{ToContains!.Replace("'", "''")}'))");
             }
             if (Since.HasValue) {
                 filters.Add($"receivedDateTime ge {Since.Value.ToUniversalTime():yyyy-MM-ddTHH:mm:ssZ}");
@@ -254,7 +254,7 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
         }
         var filter = string.Join(" and ", filters);
         if (!string.IsNullOrWhiteSpace(rawFilter)) {
-            filter = string.IsNullOrWhiteSpace(filter) ? rawFilter : $"{filter} and {rawFilter}";
+            filter = string.IsNullOrWhiteSpace(filter) ? rawFilter! : $"{filter} and {rawFilter}";
         }
         return filter;
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetGraphInboxRule.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetGraphInboxRule.cs
@@ -106,7 +106,7 @@ public sealed class CmdletGetGraphInboxRule : AsyncPSCmdlet {
     }
 
     private Task ProcessMgGraph() {
-        var qp = string.IsNullOrWhiteSpace(Filter) ? null : new Dictionary<string, object> { ["$filter"] = Filter };
+        var qp = string.IsNullOrWhiteSpace(Filter) ? null : new Dictionary<string, object> { ["$filter"] = Filter! };
         var uri = MicrosoftGraphUtils.JoinUriQuery(
             GraphEndpoint.V1,
             $"/users/{UserPrincipalName}/mailFolders/inbox/messageRules",

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphEventBuilder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphEventBuilder.cs
@@ -66,13 +66,13 @@ public sealed class CmdletNewGraphEventBuilder : PSCmdlet
     {
         var builder = new GraphEventBuilder();
         if (!string.IsNullOrEmpty(Subject))
-            builder.Subject(Subject);
+            builder.Subject(Subject!);
         if (Start.HasValue)
             builder.Start(Start.Value, StartTimeZone);
         if (End.HasValue)
             builder.End(End.Value, EndTimeZone);
         if (!string.IsNullOrEmpty(Body))
-            builder.Body(Body, BodyType);
+            builder.Body(Body!, BodyType);
         if (Attendees != null)
         {
             foreach (var addr in Attendees)

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRule.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRule.cs
@@ -90,7 +90,7 @@ public sealed class CmdletNewGraphInboxRule : AsyncPSCmdlet {
     /// Stops processing additional rules when this rule matches.
     /// </summary>
     [Parameter(ParameterSetName = "Params")]
-    public SwitchParameter StopProcessing { get; set; }
+    public new SwitchParameter StopProcessing { get; set; }
 
     /// <summary>
     /// Sender addresses that trigger the rule.

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleBuilder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleBuilder.cs
@@ -57,7 +57,7 @@ public sealed class CmdletNewGraphInboxRuleBuilder : PSCmdlet
     /// Stops processing further rules when this rule matches.
     /// </summary>
     [Parameter]
-    public SwitchParameter StopProcessing { get; set; }
+    public new SwitchParameter StopProcessing { get; set; }
 
     /// <summary>
     /// Sender address patterns to match.
@@ -108,11 +108,11 @@ public sealed class CmdletNewGraphInboxRuleBuilder : PSCmdlet
         if (BodyContains != null)
             builder.BodyContains(BodyContains!);
         if (!string.IsNullOrEmpty(Importance))
-            builder.Importance(Importance);
+            builder.Importance(Importance!);
         if (!string.IsNullOrEmpty(MoveToFolder))
-            builder.MoveToFolder(MoveToFolder);
+            builder.MoveToFolder(MoveToFolder!);
         if (!string.IsNullOrEmpty(CopyToFolder))
-            builder.CopyToFolder(CopyToFolder);
+            builder.CopyToFolder(CopyToFolder!);
         if (Delete.IsPresent)
             builder.Delete();
         if (ForwardTo != null)

--- a/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleObject.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewGraphInboxRuleObject.cs
@@ -64,7 +64,7 @@ public sealed class CmdletNewGraphInboxRuleObject : PSCmdlet
     /// Stops processing additional rules when this rule matches.
     /// </summary>
     [Parameter(ParameterSetName = "Params")]
-    public SwitchParameter StopProcessing { get; set; }
+    public new SwitchParameter StopProcessing { get; set; }
 
     /// <summary>
     /// Sender address patterns to match.

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMailboxPermission.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveGraphMailboxPermission.cs
@@ -108,6 +108,7 @@ public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
 
         if (ParameterSetName == "Object") {
             foreach (var perm in MailboxPermission!) {
+                if (perm is null) continue;
                 if (perm.UserPrincipalName == null)
                     perm.UserPrincipalName = UserPrincipalName;
                 await ProcessGraphAsync(conn.Credential, perm);
@@ -120,8 +121,11 @@ public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
             return;
         }
 
-        foreach (var id in PermissionId!)
-            await ProcessGraphAsync(conn.Credential, id);
+        foreach (var id in PermissionId!) {
+            if (id is not null) {
+                await ProcessGraphAsync(conn.Credential, id);
+            }
+        }
         return;
     }
 
@@ -132,7 +136,7 @@ public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
         foreach (var row in rows.OfType<PSObject>()) {
             var id = row.Properties["PermissionId"].Value?.ToString();
             if (!string.IsNullOrWhiteSpace(id))
-                await ProcessGraphAsync(cred, id);
+                await ProcessGraphAsync(cred, id!);
         }
     }
 
@@ -188,13 +192,13 @@ public class CmdletRemoveGraphMailboxPermission : AsyncPSCmdlet {
             foreach (var row in rows.OfType<PSObject>()) {
                 var id = row.Properties["PermissionId"].Value?.ToString();
                 if (!string.IsNullOrWhiteSpace(id))
-                    InvokeMgGraph(id);
+                    InvokeMgGraph(id!);
             }
         } else if (MailboxPermission != null) {
             foreach (var perm in MailboxPermission) {
                 if (perm.Id != null) {
                     if (!ShouldProcess(perm.Id, "Removing mailbox permission")) continue;
-                    InvokeMgGraph(perm.Id);
+                    InvokeMgGraph(perm.Id!);
                 }
             }
         } else if (PermissionId != null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveGmailMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveGmailMessageAttachment.cs
@@ -51,7 +51,7 @@ public sealed class CmdletSaveGmailMessageAttachment : AsyncPSCmdlet {
         Directory.CreateDirectory(Path!);
         foreach (var att in list) {
             var bytes = await client.DownloadAttachmentAsync(GmailAccount!, Id!, att.Id!, CancelToken);
-            var filePath = System.IO.Path.Combine(Path!, att.FileName ?? att.Id);
+            var filePath = System.IO.Path.Combine(Path!, att.FileName ?? att.Id!);
             File.WriteAllBytes(filePath, bytes);
         }
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveGraphMessage.cs
@@ -34,11 +34,14 @@ public class CmdletSaveGraphMessage : PSCmdlet {
     /// Saves the specified mail messages to disk at the given path.
     /// </summary>
     protected override void ProcessRecord() {
+        if (Message is null || Path is null) {
+            return;
+        }
         foreach (var m in Message) {
             if (m.BaseObject is EmailGraphMessage gm) {
-                MicrosoftGraphUtils.SaveMailMessages(new[] { gm }, Path);
+                MicrosoftGraphUtils.SaveMailMessages(new[] { gm }, Path!);
             } else if (m.BaseObject is MimeKit.MimeMessage mm) {
-                var resolved = System.IO.Path.GetFullPath(Path);
+                var resolved = System.IO.Path.GetFullPath(Path!);
                 if (!System.IO.Directory.Exists(resolved)) System.IO.Directory.CreateDirectory(resolved);
                 var file = System.IO.Path.Combine(resolved, System.IO.Path.ChangeExtension(System.IO.Path.GetRandomFileName(), "eml"));
                 mm.WriteTo(file);

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveGraphMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveGraphMessageAttachment.cs
@@ -26,7 +26,7 @@ public class CmdletSaveGraphMessageAttachment : PSCmdlet {
     /// Processes the cmdlet invocation.
     /// </summary>
     protected override void ProcessRecord() {
-        if (Attachment?.Length > 0) {
+        if (Attachment?.Length > 0 && Path is not null) {
             MicrosoftGraphUtils.SaveAttachments(Attachment, Path);
         }
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveIMAPMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveIMAPMessageAttachment.cs
@@ -48,7 +48,9 @@ public sealed class CmdletSaveIMAPMessageAttachment : AsyncPSCmdlet {
             var mailFolder = conn.Data.GetCachedFolder(Folder ?? conn.Folder?.FullName, FolderAccess.ReadOnly);
             conn.Folders[mailFolder.FullName] = (ImapFolder)mailFolder;
             var message = mailFolder.GetMessage(uid);
-            MimeKitUtils.SaveAttachments(message.Attachments, Path);
+            if (Path is not null) {
+                MimeKitUtils.SaveAttachments(message.Attachments, Path);
+            }
         } else {
             ThrowTerminatingError(new ErrorRecord(
                 new InvalidOperationException("Save-IMAPMessageAttachment - IMAP client not provided or not connected."),

--- a/Sources/Mailozaurr.PowerShell/CmdletSavePOP3MessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSavePOP3MessageAttachment.cs
@@ -38,7 +38,9 @@ public sealed class CmdletSavePOP3MessageAttachment : AsyncPSCmdlet {
         if (conn != null && conn.Data != null) {
             if (Index < conn.Data.Count) {
                 var message = conn.Data.GetMessage(Index);
-                MimeKitUtils.SaveAttachments(message.Attachments, Path);
+                if (Path is not null) {
+                    MimeKitUtils.SaveAttachments(message.Attachments, Path);
+                }
             } else {
                 WriteWarning($"Save-POP3MessageAttachment - Index is out of range. Use index less than {conn.Data.Count}.");
             }

--- a/Sources/Mailozaurr.PowerShell/CmdletTestEmailAddress.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletTestEmailAddress.cs
@@ -46,7 +46,7 @@ public sealed class CmdletTestEmailAddress : AsyncPSCmdlet {
     [Parameter(Mandatory = false, Position = 2)]
     public SwitchParameter AllowTopLevelDomains { get; set; }
 
-    private InternalLogger _logger;
+    private InternalLogger _logger = null!;
     private InternalLoggerPowerShell? _listener;
 
     /// <summary>
@@ -62,13 +62,20 @@ public sealed class CmdletTestEmailAddress : AsyncPSCmdlet {
     /// <summary>
     /// Processes each email address and checks if it is valid. Writes results to the output pipeline.
     /// </summary>
-    protected override async Task ProcessRecordAsync() {
+    protected override Task ProcessRecordAsync() {
+        if (EmailAddress is null) {
+            return Task.CompletedTask;
+        }
         foreach (var email in EmailAddress) {
             _logger.WriteVerbose("Processing email: {0}", email);
             WriteObject(Validator.ValidateEmail(email, AllowInternational, AllowTopLevelDomains));
         }
+        return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Cleans up resources used by the cmdlet.
+    /// </summary>
     protected override Task EndProcessingAsync() {
         _listener?.Dispose();
         _listener = null;

--- a/Sources/Mailozaurr.PowerShell/CmdletWaitGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWaitGraphMessage.cs
@@ -115,7 +115,7 @@ public sealed class CmdletWaitGraphMessage : AsyncPSCmdlet, IDisposable {
     }
 
     /// <inheritdoc />
-    public void Dispose() {
+    public new void Dispose() {
         if (_listener != null) {
             _listener.MessageArrived -= OnMessageArrived;
             _listener.Dispose();

--- a/Sources/Mailozaurr.PowerShell/CmdletWaitIMAPMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWaitIMAPMessage.cs
@@ -138,7 +138,7 @@ public sealed class CmdletWaitIMAPMessage : AsyncPSCmdlet, System.IDisposable {
     }
 
     /// <inheritdoc />
-    public void Dispose() {
+    public new void Dispose() {
         if (_listener != null) {
             _listener.MessageArrived -= OnMessageArrived;
             _listener.Dispose();

--- a/Sources/Mailozaurr.PowerShell/CmdletWaitPOP3Message.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletWaitPOP3Message.cs
@@ -106,7 +106,7 @@ public sealed class CmdletWaitPOP3Message : AsyncPSCmdlet, IDisposable {
     }
 
     /// <inheritdoc />
-    public void Dispose() {
+    public new void Dispose() {
         if (_listener != null) {
             _listener.MessageArrived -= OnMessageArrived;
             _listener.Dispose();

--- a/Sources/Mailozaurr.PowerShell/CredentialHelpers.cs
+++ b/Sources/Mailozaurr.PowerShell/CredentialHelpers.cs
@@ -19,9 +19,9 @@ public static class CredentialHelpers {
         try {
             return new NetworkCredential("", s).SecurePassword;
         } catch (ArgumentException ex) {
-            LoggingMessages.Logger.WriteWarning($"Failed to convert to SecureString: {ex.Message}");
+            LoggingMessages.Logger?.WriteWarning($"Failed to convert to SecureString: {ex.Message}");
             var ss = new SecureString();
-            foreach (char c in s) ss.AppendChar(c);
+            foreach (char c in s!) ss.AppendChar(c);
             ss.MakeReadOnly();
             return ss;
         }

--- a/Sources/Mailozaurr.PowerShell/Definitions/EmlConversionResult.cs
+++ b/Sources/Mailozaurr.PowerShell/Definitions/EmlConversionResult.cs
@@ -7,11 +7,11 @@ public class EmlConversionResult {
     /// <summary>
     /// Eml file path to file that was converted
     /// </summary>
-    public string EmlFile { get; set; }
+    public string EmlFile { get; set; } = string.Empty;
     /// <summary>
     /// Msg file path to file that was created
     /// </summary>
-    public string MsgFile { get; set; }
+    public string MsgFile { get; set; } = string.Empty;
     /// <summary>
     /// Status of the conversion
     /// </summary>
@@ -19,5 +19,5 @@ public class EmlConversionResult {
     /// <summary>
     /// Error message if conversion failed
     /// </summary>
-    public string Error { get; set; }
+    public string? Error { get; set; }
 }

--- a/Sources/Mailozaurr.PowerShell/Definitions/GraphConnectionInfo.cs
+++ b/Sources/Mailozaurr.PowerShell/Definitions/GraphConnectionInfo.cs
@@ -7,7 +7,7 @@ namespace Mailozaurr.PowerShell;
 /// </summary>
 public class GraphConnectionInfo : ConnectionInfoBase {
     /// <summary>Graph credentials.</summary>
-    public GraphCredential Credential { get; set; }
+    public GraphCredential Credential { get; set; } = null!;
 
     /// <summary>
     /// OAuth credential obtained using device code or on-behalf-of flow.

--- a/Sources/Mailozaurr.PowerShell/Definitions/MsgConversionResult.cs
+++ b/Sources/Mailozaurr.PowerShell/Definitions/MsgConversionResult.cs
@@ -7,11 +7,11 @@ public class MsgConversionResult {
     /// <summary>
     /// Msg file path to file that was converted
     /// </summary>
-    public string MsgFile { get; set; }
+    public string MsgFile { get; set; } = string.Empty;
     /// <summary>
     /// Eml file path to file that was created
     /// </summary>
-    public string EmlFile { get; set; }
+    public string EmlFile { get; set; } = string.Empty;
     /// <summary>
     /// Status of the conversion
     /// </summary>
@@ -19,5 +19,5 @@ public class MsgConversionResult {
     /// <summary>
     /// Error message if conversion failed
     /// </summary>
-    public string Error { get; set; }
+    public string? Error { get; set; }
 }

--- a/Sources/Mailozaurr.PowerShell/OnImportAndRemove.cs
+++ b/Sources/Mailozaurr.PowerShell/OnImportAndRemove.cs
@@ -47,10 +47,14 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
     /// <returns></returns>
     private static Assembly? MyResolveEventHandler(object? sender, ResolveEventArgs args) {
         var libDirectory = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location);
-        var directoriesToSearch = new List<string> { libDirectory };
+        var directoriesToSearch = new List<string>();
 
-        if (Directory.Exists(libDirectory)) {
-            directoriesToSearch.AddRange(Directory.GetDirectories(libDirectory, "*", SearchOption.AllDirectories));
+        if (libDirectory is not null) {
+            directoriesToSearch.Add(libDirectory);
+
+            if (Directory.Exists(libDirectory)) {
+                directoriesToSearch.AddRange(Directory.GetDirectories(libDirectory, "*", SearchOption.AllDirectories));
+            }
         }
 
         var requestedAssemblyName = new AssemblyName(args.Name).Name + ".dll";

--- a/Sources/Mailozaurr.Tests/FetchExamplesTests.cs
+++ b/Sources/Mailozaurr.Tests/FetchExamplesTests.cs
@@ -20,7 +20,7 @@ namespace Mailozaurr.Tests {
                 return Task.CompletedTask;
             }
 
-            public Task<IList<int>> SearchAsync(object query)
+            public Task<IList<int>> SearchAsync(object? query)
                 => Task.FromResult<IList<int>>(new List<int> { 1, 2 });
 
             public Task<MimeMessage> GetMessageAsync(int id)

--- a/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
@@ -66,7 +66,9 @@ public class GraphBatchAndRetryTests {
             var req = doc.RootElement.GetProperty("requests")[0];
             Assert.Equal("1", req.GetProperty("id").GetString());
             Assert.Equal("POST", req.GetProperty("method").GetString());
-            Assert.Equal($"users/{graph.MessageContainer.Message.From.Email.Address}/sendMail", req.GetProperty("url").GetString());
+            var msg = graph.MessageContainer?.Message;
+            Assert.NotNull(msg);
+            Assert.Equal($"users/{msg!.From!.Email!.Address!}/sendMail", req.GetProperty("url").GetString());
             Assert.Equal("application/json", req.GetProperty("headers").GetProperty("Content-Type").GetString());
             Assert.Equal("sub", req.GetProperty("body").GetProperty("message").GetProperty("subject").GetString());
         } finally {

--- a/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
@@ -12,7 +12,7 @@ namespace Mailozaurr.Tests;
 public class GraphUploadRangeTests
 {
     [Fact]
-    public async Task PrepareByteArrayContentForUpload_ComputesRangesCorrectly()
+    public void PrepareByteArrayContentForUpload_ComputesRangesCorrectly()
     {
         string tmp = Path.GetTempFileName();
         File.WriteAllBytes(tmp, Enumerable.Range(0, 25).Select(b => (byte)b).ToArray());

--- a/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
@@ -42,7 +42,9 @@ public class HtmlAutoEmbedImageTests {
         };
         graph.CreateMessage();
         File.Delete(tmp);
-        var attachment = Assert.Single(graph.MessageContainer.Message.Attachments);
+        var message = graph.MessageContainer?.Message;
+        Assert.NotNull(message);
+        var attachment = Assert.Single(message!.Attachments!);
         Assert.True(attachment.IsInline);
         Assert.Contains("cid:" + attachment.ContentId, graph.HTML);
     }

--- a/Sources/Mailozaurr.Tests/NonDeliveryReportServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportServiceTests.cs
@@ -19,7 +19,7 @@ public class NonDeliveryReportServiceTests {
 
         public Task<SentMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
             store.TryGetValue(messageId, out SentMessageRecord? record);
-            return Task.FromResult(record);
+            return Task.FromResult<SentMessageRecord?>(record);
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure nullable-safe filter building in Get-EmailGraphMessage
- harden Test-EmailAddress and conversion cmdlets against null values
- update tests to remove nullability and async warnings

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Release`
- `dotnet build Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a396e93bb4832ebdede374638a2004