### PR TITLE
Fix nullable warnings in mail utilities

### DIFF
--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -399,18 +399,29 @@ namespace Mailozaurr {
                 var query = new StringBuilder();
                 bool first = true;
                 foreach (var kvp in queryParameters) {
-                    if (kvp.Value == null) continue;
-                    if (!first) query.Append('&');
+                    if (kvp.Value == null) {
+                        continue;
+                    }
+
+                    if (!first) {
+                        query.Append('&');
+                    }
+
                     query.Append(Uri.EscapeDataString(kvp.Key));
                     query.Append('=');
-                    query.Append(Uri.EscapeDataString(kvp.Value.ToString()));
+                    var valueString = kvp.Value.ToString() ?? string.Empty;
+                    query.Append(Uri.EscapeDataString(valueString));
                     first = false;
                 }
                 uriBuilder.Query = query.ToString();
             }
             var result = uriBuilder.Uri.AbsoluteUri;
             if (escapeUriString) {
-                result = Uri.EscapeUriString(result);
+                if (Uri.TryCreate(result, UriKind.Absolute, out var uri)) {
+                    result = uri.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped);
+                } else {
+                    result = Uri.EscapeDataString(result);
+                }
             }
             return result;
         }

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -162,25 +162,34 @@ public class SendGridClient {
     /// <param name="emailAddress">The object to convert.</param>
     /// <returns>A SendGridEmailAddress object, or null if the provided object is null or an empty string.</returns>
     private SendGridEmailAddress? ConvertToEmailObject(object? emailAddress) {
-        if (emailAddress == null || string.IsNullOrWhiteSpace(emailAddress.ToString())) {
+        if (emailAddress == null) {
             return null;
-        } else if (emailAddress is string emailString) {
+        }
+
+        var emailAsString = Convert.ToString(emailAddress);
+        if (string.IsNullOrWhiteSpace(emailAsString)) {
+            return null;
+        }
+
+        if (emailAddress is string emailString) {
             return new SendGridEmailAddress { Email = emailString };
-        } else if (emailAddress is IDictionary<string, object> emailDict) {
+        }
+
+        if (emailAddress is IDictionary<string, object> emailDict) {
             if (!emailDict.ContainsKey("Email")) {
                 throw new ArgumentException("Dictionary is missing required key 'Email'.", nameof(emailAddress));
             }
 
-            var emailValue = emailDict["Email"] as string;
+            var emailValue = Convert.ToString(emailDict["Email"]);
             if (string.IsNullOrWhiteSpace(emailValue)) {
                 return null;
             }
 
-            var nameValue = emailDict.ContainsKey("Name") ? emailDict["Name"] as string : null;
-            return new SendGridEmailAddress { Email = emailValue!, Name = nameValue };
-        } else {
-            throw new ArgumentException($"email object type {emailAddress.GetType().Name} requires addition");
+            var nameValue = emailDict.ContainsKey("Name") ? Convert.ToString(emailDict["Name"]) : null;
+            return new SendGridEmailAddress { Email = emailValue, Name = nameValue };
         }
+
+        throw new ArgumentException($"email object type {emailAddress.GetType().Name} requires addition");
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/SentMessages/SendLogResolver.cs
+++ b/Sources/Mailozaurr/SentMessages/SendLogResolver.cs
@@ -12,7 +12,8 @@ public sealed class SendLogResolver {
     /// Initializes a new instance of the <see cref="SendLogResolver"/> class.
     /// </summary>
     /// <param name="repository">Repository used to look up sent messages.</param>
-    public SendLogResolver(ISentMessageRepository repository) => this.repository = repository;
+    public SendLogResolver(ISentMessageRepository repository) =>
+        this.repository = repository ?? throw new ArgumentNullException(nameof(repository));
 
     /// <summary>
     /// Attempts to resolve a sent message record from a non-delivery report.

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -324,7 +324,11 @@ public partial class ClientSmtp : SmtpClient {
 
     private IEnumerable<MailboxAddress> ConvertDictionaryToMailboxAddresses(IDictionary dict) {
         if (dict.Contains("Name") && dict.Contains("Email")) {
-            yield return new MailboxAddress(dict["Name"]?.ToString(), dict["Email"]?.ToString());
+            var name = Convert.ToString(dict["Name"]) ?? string.Empty;
+            var email = Convert.ToString(dict["Email"]);
+            if (!string.IsNullOrWhiteSpace(email)) {
+                yield return new MailboxAddress(name, email);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- guard against null values when constructing query strings and escaping URIs in MicrosoftGraphUtils
- tighten null checks in SendGridClient email conversion logic
- validate repository dependency and mailbox dictionaries to avoid null dereferences

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj --no-incremental`

------
https://chatgpt.com/codex/tasks/task_e_68a4118eda90832e9e5fc2503b9f0b11