### PR TITLE
Improve nullability and documentation in core types

### DIFF
--- a/Sources/Mailozaurr/Cryptography/TemporaryPgpKeyPair.cs
+++ b/Sources/Mailozaurr/Cryptography/TemporaryPgpKeyPair.cs
@@ -44,6 +44,8 @@ public sealed class TemporaryPgpKeyPair : IDisposable
     /// <param name="identity">Identity for the key pair.</param>
     /// <param name="passPhrase">Passphrase protecting the private key.</param>
     /// <param name="keySize">RSA key size.</param>
+    /// <param name="outputDirectory">Directory where the keys should be written.</param>
+    /// <param name="deleteOnDispose">Whether generated files should be removed on disposal.</param>
     /// <returns>Instance representing the created key pair.</returns>
     public static TemporaryPgpKeyPair Create(string identity = "Mailozaurr Test", string passPhrase = "", int keySize = 2048, string? outputDirectory = null, bool deleteOnDispose = true)
     {

--- a/Sources/Mailozaurr/Cryptography/TemporarySmimeCertificate.cs
+++ b/Sources/Mailozaurr/Cryptography/TemporarySmimeCertificate.cs
@@ -24,6 +24,7 @@ public static class TemporarySmimeCertificate {
     /// </summary>
     /// <param name="subjectName">Subject name of the certificate.</param>
     /// <param name="validDays">Number of days the certificate is valid.</param>
+    /// <param name="outputPath">Optional path where the certificate file will be written.</param>
     /// <returns>A new <see cref="X509Certificate2"/> instance.</returns>
     public static X509Certificate2 CreateSelfSigned(string subjectName = "CN=Mailozaurr Test", int validDays = 1, string? outputPath = null) {
 #if NETSTANDARD2_0

--- a/Sources/Mailozaurr/Definitions/EmlConversionResult.cs
+++ b/Sources/Mailozaurr/Definitions/EmlConversionResult.cs
@@ -4,24 +4,27 @@
 /// Result information returned when converting an EML file to MSG.
 /// </summary>
 /// <remarks>
-/// Used by <see cref="EmailMessage.ConvertEmlToMsg"/> to report
+/// Used by <see cref="EmailMessage.ConvertEmlToMsg(string[], string, bool)"/> to report
 /// the path of the generated message and whether the operation succeeded.
 /// </remarks>
 public class EmlConversionResult {
     /// <summary>
     /// Eml file path to file that was converted
     /// </summary>
-    public string EmlFile { get; set; }
+    public string EmlFile { get; set; } = string.Empty;
+
     /// <summary>
     /// Msg file path to file that was created
     /// </summary>
-    public string MsgFile { get; set; }
+    public string MsgFile { get; set; } = string.Empty;
+
     /// <summary>
     /// Status of the conversion
     /// </summary>
     public bool Status { get; set; }
+
     /// <summary>
     /// Error message if conversion failed
     /// </summary>
-    public string Error { get; set; }
+    public string Error { get; set; } = string.Empty;
 }

--- a/Sources/Mailozaurr/GraphEmailMessage.cs
+++ b/Sources/Mailozaurr/GraphEmailMessage.cs
@@ -12,6 +12,7 @@ public class GraphEmailMessage {
     /// </summary>
     /// <param name="id">Unique identifier of the message.</param>
     /// <param name="message">The MIME message.</param>
+    /// <param name="nonDeliveryReports">Optional pre-parsed non delivery reports.</param>
     public GraphEmailMessage(string id, MimeMessage message, IList<NonDeliveryReport>? nonDeliveryReports = null) {
         Id = id;
         Message = message;
@@ -32,5 +33,5 @@ public class GraphEmailMessage {
     public IList<NonDeliveryReport> NonDeliveryReports { get; }
 
     /// <inheritdoc />
-    public override string ToString() => Message.Subject ?? base.ToString();
+    public override string ToString() => Message.Subject ?? base.ToString()!;
 }

--- a/Sources/Mailozaurr/INonDeliveryReportService.cs
+++ b/Sources/Mailozaurr/INonDeliveryReportService.cs
@@ -2,7 +2,20 @@ using Mailozaurr.NonDeliveryReports;
 
 namespace Mailozaurr;
 
+/// <summary>
+/// Service for searching non-delivery reports.
+/// </summary>
 public interface INonDeliveryReportService {
+    /// <summary>
+    /// Searches for non-delivery reports matching provided criteria.
+    /// </summary>
+    /// <param name="since">Start date for the search range.</param>
+    /// <param name="before">End date for the search range.</param>
+    /// <param name="recipientContains">Filter by recipient substring.</param>
+    /// <param name="messageId">Filter by message identifier.</param>
+    /// <param name="maxResults">Maximum number of results to return.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>List of matching non-delivery report results.</returns>
     Task<IList<NonDeliveryReportResult>> SearchAsync(
         DateTime? since = null,
         DateTime? before = null,

--- a/Sources/Mailozaurr/ImapEmailMessage.cs
+++ b/Sources/Mailozaurr/ImapEmailMessage.cs
@@ -16,6 +16,7 @@ public class ImapEmailMessage {
     /// </summary>
     /// <param name="uid">Unique identifier of the message.</param>
     /// <param name="message">The actual MIME message.</param>
+    /// <param name="nonDeliveryReports">Optional pre-parsed non delivery reports.</param>
     public ImapEmailMessage(UniqueId uid, MimeMessage message, IList<NonDeliveryReport>? nonDeliveryReports = null) {
         Uid = uid;
         Message = message;
@@ -36,5 +37,5 @@ public class ImapEmailMessage {
     public IList<NonDeliveryReport> NonDeliveryReports { get; }
 
     /// <inheritdoc />
-    public override string ToString() => Message.Subject ?? base.ToString();
+    public override string ToString() => Message.Subject ?? base.ToString()!;
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAuthorization.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAuthorization.cs
@@ -12,11 +12,11 @@ namespace Mailozaurr;
 public class GraphAuthorization {
     /// <summary>The type of token issued.</summary>
     [JsonPropertyName("token_type")]
-    public string TokenType { get; set; }
+    public string TokenType { get; set; } = string.Empty;
 
     /// <summary>The access token value.</summary>
     [JsonPropertyName("access_token")]
-    public string AccessToken { get; set; }
+    public string AccessToken { get; set; } = string.Empty;
 
     /// <summary>Time when the access token expires.</summary>
     [JsonPropertyName("expires_on")]

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphInternetMessageHeader.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphInternetMessageHeader.cs
@@ -11,10 +11,10 @@ namespace Mailozaurr;
 public class GraphInternetMessageHeader {
     /// <summary>Header name.</summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 
     /// <summary>Header value.</summary>
     [JsonPropertyName("value")]
-    public string Value { get; set; }
+    public string Value { get; set; } = string.Empty;
 }
 

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxFolderStatistics.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxFolderStatistics.cs
@@ -9,10 +9,10 @@ namespace Mailozaurr;
 /// </remarks>
 public class GraphMailboxFolderStatistics {
     /// <summary>Folder identifier.</summary>
-    public string Id { get; set; }
+    public string Id { get; set; } = string.Empty;
 
     /// <summary>Display name of the folder.</summary>
-    public string DisplayName { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
 
     /// <summary>Optional well-known name such as 'inbox' or 'sentitems'.</summary>
     public string? WellKnownName { get; set; }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxGrantee.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxGrantee.cs
@@ -18,25 +18,28 @@ public class GraphMailboxGrantee {
     public string? User { get; set; }
 
     /// <summary>Creates an instance from a dictionary.</summary>
-    public static GraphMailboxGrantee FromDictionary(IDictionary<string, object> dict) {
+    /// <param name="dict">Dictionary containing grantee fields.</param>
+    public static GraphMailboxGrantee FromDictionary(IDictionary<string, object?> dict) {
         var g = new GraphMailboxGrantee();
         if (dict.TryGetValue("user", out var u)) g.User = u?.ToString();
         return g;
     }
 
     /// <summary>Creates an instance from a PowerShell hashtable.</summary>
+    /// <param name="table">Hashtable containing grantee fields.</param>
     public static GraphMailboxGrantee FromHashtable(Hashtable table) {
-        var dict = table.Cast<DictionaryEntry>().ToDictionary(e => (string)e.Key, e => e.Value);
+        var dict = table.Cast<DictionaryEntry>().ToDictionary(e => (string)e.Key, e => (object?)e.Value);
         return FromDictionary(dict);
     }
 
     /// <summary>Converts the grantee to a dictionary.</summary>
-    public Dictionary<string, object> ToDictionary() {
-        var dict = new Dictionary<string, object>();
+    public Dictionary<string, object?> ToDictionary() {
+        var dict = new Dictionary<string, object?>();
         if (User != null) dict["user"] = User!;
         return dict;
     }
 
     /// <inheritdoc />
-    public override string ToString() => User ?? base.ToString();
+    public override string ToString() => User ?? base.ToString()!;
 }
+

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxPermission.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxPermission.cs
@@ -19,7 +19,7 @@ public class GraphMailboxPermission {
     /// Initializes a new instance of the <see cref="GraphMailboxPermission"/> class.
     /// </summary>
     public GraphMailboxPermission() {
-        Raw = new Dictionary<string, object>();
+        Raw = new Dictionary<string, object?>();
     }
 
     /// <summary>
@@ -27,14 +27,15 @@ public class GraphMailboxPermission {
     /// </summary>
     /// <param name="raw">Dictionary with Graph permission fields.</param>
     /// <param name="userPrincipalName">Mailbox owner.</param>
-    public GraphMailboxPermission(Dictionary<string, object> raw, string? userPrincipalName = null) {
-        Raw = raw ?? new Dictionary<string, object>();
+    public GraphMailboxPermission(Dictionary<string, object?> raw, string? userPrincipalName = null) {
+        var source = raw ?? new Dictionary<string, object?>();
+        Raw = source;
         UserPrincipalName = userPrincipalName;
-        if (raw.TryGetValue("id", out var idObj)) Id = idObj as string;
-        if (raw.TryGetValue("roles", out var rolesObj) && rolesObj is object[] arr)
-            Roles = arr.Select(r => Enum.TryParse<GraphMailboxRole>(r?.ToString(), ignoreCase: true, out var role) ? role : GraphMailboxRole.Custom).ToArray();
-        if (raw.TryGetValue("grantedTo", out var granted) && granted is Dictionary<string, object> gdict)
-            GrantedTo = GraphMailboxGrantee.FromDictionary(gdict);
+        if (source.TryGetValue("id", out var idObj)) Id = idObj as string;
+        if (source.TryGetValue("roles", out var rolesObj) && rolesObj is object[] arr)
+            Roles = arr.Select(r => Enum.TryParse<GraphMailboxRole>(r?.ToString() ?? string.Empty, true, out var role) ? role : GraphMailboxRole.Custom).ToArray();
+        if (source.TryGetValue("grantedTo", out var granted) && granted is Dictionary<string, object> gdict)
+            GrantedTo = GraphMailboxGrantee.FromDictionary(gdict.ToDictionary(k => k.Key, v => (object?)v.Value));
     }
 
     /// <summary>Unique permission identifier.</summary>
@@ -50,7 +51,7 @@ public class GraphMailboxPermission {
     public GraphMailboxGrantee? GrantedTo { get; set; }
 
     /// <summary>Raw dictionary returned by Graph.</summary>
-    public Dictionary<string, object> Raw { get; }
+    public Dictionary<string, object?> Raw { get; }
 
     /// <summary>
     /// Creates an instance from PowerShell hashtable input.
@@ -59,15 +60,15 @@ public class GraphMailboxPermission {
     /// <param name="userPrincipalName">Mailbox owner.</param>
     /// <returns>Created permission object.</returns>
     public static GraphMailboxPermission FromHashtable(Hashtable table, string? userPrincipalName = null) {
-        var dict = table.Cast<DictionaryEntry>().ToDictionary(e => (string)e.Key, e => e.Value);
+        var dict = table.Cast<DictionaryEntry>().ToDictionary(e => (string)e.Key, e => (object?)e.Value);
         return new GraphMailboxPermission(dict, userPrincipalName);
     }
 
     /// <summary>
     /// Converts the permission to a dictionary suitable for Graph requests.
     /// </summary>
-    public Dictionary<string, object> ToDictionary() {
-        var dict = new Dictionary<string, object>(Raw);
+    public Dictionary<string, object?> ToDictionary() {
+        var dict = new Dictionary<string, object?>(Raw);
         if (Id != null) dict["id"] = Id;
         if (Roles != null)
             dict["roles"] = Roles.Select(r => r.ToString().ToLowerInvariant()).ToArray();
@@ -97,5 +98,5 @@ public class GraphMailboxPermission {
     }
 
     /// <inheritdoc />
-    public override string ToString() => Id ?? base.ToString();
+    public override string ToString() => Id ?? base.ToString()!;
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMessageContainer.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMessageContainer.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Mailozaurr;
 
 /// <summary>
@@ -12,7 +14,7 @@ public class GraphMessageContainer {
     /// Gets or sets the message payload.
     /// </summary>
     [JsonPropertyName("message")]
-    public GraphMessage Message { get; set; }
+    public GraphMessage Message { get; set; } = new();
 
     /// <summary>
     /// Gets or sets a value indicating whether the message should be saved to the Sent Items folder.

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMessageInfo.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMessageInfo.cs
@@ -91,7 +91,7 @@ public class GraphMessageInfo {
     public string? Summary { get; set; }
 
     /// <inheritdoc />
-    public override string ToString() => Subject ?? base.ToString();
+    public override string ToString() => Subject ?? base.ToString()!;
 
     private static string? ExtractAddress(object obj) {
         if (obj is Dictionary<string, object> dict &&

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphUploadSessionResult.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphUploadSessionResult.cs
@@ -14,6 +14,6 @@ public class GraphUploadSessionResult {
     /// Gets or sets the URL that should be used to upload the attachment bytes.
     /// </summary>
     [JsonPropertyName("uploadUrl")]
-    public string UploadUrl { get; set; }
+    public string UploadUrl { get; set; } = string.Empty;
 }
 

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -403,14 +403,14 @@ namespace Mailozaurr {
                     if (!first) query.Append('&');
                     query.Append(Uri.EscapeDataString(kvp.Key));
                     query.Append('=');
-                    query.Append(Uri.EscapeDataString(kvp.Value.ToString()));
+                    query.Append(Uri.EscapeDataString(kvp.Value.ToString()!));
                     first = false;
                 }
                 uriBuilder.Query = query.ToString();
             }
             var result = uriBuilder.Uri.AbsoluteUri;
             if (escapeUriString) {
-                result = Uri.EscapeUriString(result);
+                result = Uri.EscapeDataString(result);
             }
             return result;
         }
@@ -936,7 +936,7 @@ namespace Mailozaurr {
             var result = new List<GraphMailboxPermission>();
             if (doc.RootElement.TryGetProperty("value", out var val) && val.ValueKind == JsonValueKind.Array) {
                 foreach (var item in val.EnumerateArray()) {
-                    var dict = ConvertJsonElementToNativeObject(item) as Dictionary<string, object>;
+                    var dict = ConvertJsonElementToNativeObject(item) as Dictionary<string, object?>;
                     if (dict != null) result.Add(new GraphMailboxPermission(dict, userPrincipalName));
                 }
             }

--- a/Sources/Mailozaurr/Pop3EmailMessage.cs
+++ b/Sources/Mailozaurr/Pop3EmailMessage.cs
@@ -15,6 +15,7 @@ public class Pop3EmailMessage {
     /// </summary>
     /// <param name="index">Index of the message within the mailbox.</param>
     /// <param name="message">The actual MIME message.</param>
+    /// <param name="nonDeliveryReports">Optional pre-parsed non delivery reports.</param>
     public Pop3EmailMessage(int index, MimeMessage message, IList<NonDeliveryReport>? nonDeliveryReports = null) {
         Index = index;
         Message = message;
@@ -35,5 +36,5 @@ public class Pop3EmailMessage {
     public IList<NonDeliveryReport> NonDeliveryReports { get; }
 
     /// <inheritdoc />
-    public override string ToString() => Message.Subject ?? base.ToString();
+    public override string ToString() => Message.Subject ?? base.ToString()!;
 }

--- a/Sources/Mailozaurr/Pop3MessageInfo.cs
+++ b/Sources/Mailozaurr/Pop3MessageInfo.cs
@@ -58,5 +58,5 @@ public class Pop3MessageInfo {
     public EmailEncryption Encryption => Raw.Encryption;
 
     /// <inheritdoc />
-    public override string ToString() => Subject ?? base.ToString();
+    public override string ToString() => Subject ?? base.ToString()!;
 }

--- a/Sources/Mailozaurr/SentMessages/ISentMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/ISentMessageRepository.cs
@@ -1,6 +1,17 @@
 namespace Mailozaurr;
 
+/// <summary>
+/// Abstraction for storing and retrieving sent message records.
+/// </summary>
 public interface ISentMessageRepository {
+    /// <summary>Saves a sent message record.</summary>
+    /// <param name="record">Record to persist.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task SaveAsync(SentMessageRecord record, CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves a sent message record by its message identifier.</summary>
+    /// <param name="messageId">Identifier of the message.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The stored record or <see langword="null" /> if not found.</returns>
     Task<SentMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- initialize conversion result fields and clarify `EmailMessage.ConvertEmlToMsg` cref
- document sent message repository contract and parameters
- harden Graph mailbox types and Graph utils for nullable data and modern URI escaping
- add null-safe `ToString` implementations and optional NDR parameter docs

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj` *(warnings: CS0618, CS8618, CS8603, CS8602, CS1998)*
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68a41193aeac832e95321cc55714773b