### PR TITLE
Harden PowerShell email cmdlets with null checks and docs

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -191,7 +191,12 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
                     LoggingMessages.Logger.WriteWarning($"Connect-IMAP - Failed to open inbox: {ex.Message}");
                 }
             }
-            var inbox = (ImapFolder)client.GetCachedFolder(null, MailKit.FolderAccess.ReadOnly);
+            var folder = client.GetCachedFolder(null, MailKit.FolderAccess.ReadOnly);
+            if (folder is not ImapFolder inbox) {
+                WriteWarning("Connect-IMAP - Inbox folder not found.");
+                await client.DisconnectAsync(true);
+                return;
+            }
             var info = new ImapConnectionInfo {
                 Uri = $"imaps://{Server}:{Port}/",
                 AuthenticationMechanisms = client.AuthenticationMechanisms,

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -195,7 +195,7 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
                 AuthenticationMechanisms = client.AuthenticationMechanisms,
                 Capabilities = client.Capabilities,
                 Stream = null, // Not exposed
-                State = null, // Not exposed
+                State = null,
                 IsConnected = client.IsConnected,
                 ApopToken = null, // Not directly available
                 ExpirePolicy = null, // Not directly available

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -65,6 +65,9 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
     }
 
     private void ProcessSendGrid(string fromEmail, string fromName) {
+        if (Credential == null) {
+            throw new InvalidOperationException("Credential is required for SendGrid processing.");
+        }
         var logCollector = new LogCollector();
         SendGridClient sendGrid = new SendGridClient();
         sendGrid.LogCollector = logCollector;
@@ -87,7 +90,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         sendGrid.RetryDelayMilliseconds = RetryDelayMilliseconds;
         sendGrid.RetryDelayBackoff = RetryDelayBackoff;
         sendGrid.RetryAlways = RetryAlways.IsPresent;
-        NetworkCredential networkCredential = new NetworkCredential(Credential?.UserName, Credential?.Password);
+        NetworkCredential networkCredential = new NetworkCredential(Credential.UserName, Credential.Password);
         sendGrid.Credentials = networkCredential;
         sendGrid.CreateMessage();
         if (ShouldProcess(sendGrid.SentTo, "Sending email message via SendGrid")) {
@@ -102,6 +105,9 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
     }
 
     private void ProcessMailgun(string fromEmail, string fromName) {
+        if (Credential == null) {
+            throw new InvalidOperationException("Credential is required for Mailgun processing.");
+        }
         var logCollector = new LogCollector();
         using MailgunClient mailgun = new MailgunClient();
         mailgun.LogCollector = logCollector;
@@ -125,7 +131,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         mailgun.RetryDelayMilliseconds = RetryDelayMilliseconds;
         mailgun.RetryDelayBackoff = RetryDelayBackoff;
         mailgun.RetryAlways = RetryAlways.IsPresent;
-        NetworkCredential networkCredential = new NetworkCredential(Credential?.UserName, Credential?.Password);
+        NetworkCredential networkCredential = new NetworkCredential(Credential.UserName, Credential.Password);
         mailgun.Credentials = networkCredential;
         if (ShouldProcess(mailgun.SentTo, "Sending email message via Mailgun")) {
             var result = mailgun.SendEmailAsync().GetAwaiter().GetResult();
@@ -139,6 +145,9 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
     }
 
     private void ProcessSes(string fromEmail, string fromName) {
+        if (Credential == null) {
+            throw new InvalidOperationException("Credential is required for SES processing.");
+        }
         var logCollector = new LogCollector();
         using SesClient ses = new SesClient();
         ses.LogCollector = logCollector;
@@ -166,7 +175,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         if (region != null && region.Length > 0) {
             ses.Region = region;
         }
-        NetworkCredential networkCredential = new NetworkCredential(Credential?.UserName, Credential?.Password);
+        NetworkCredential networkCredential = new NetworkCredential(Credential.UserName, Credential.Password);
         ses.Credentials = networkCredential;
         if (ShouldProcess(ses.SentTo, "Sending email message via SES")) {
             var result = ses.SendEmailAsync().GetAwaiter().GetResult();
@@ -226,6 +235,9 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
     }
 
     private void ProcessGraph(string fromEmail, string fromName) {
+        if (Credential == null) {
+            throw new InvalidOperationException("Credential is required for Graph processing.");
+        }
         using Graph graph = new Graph();
         graph.ChunkSize = ChunkSize;
         graph.From = Helpers.GetFromObject(fromEmail, fromName);
@@ -267,7 +279,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             return;
         }
 
-        NetworkCredential networkCredential = new NetworkCredential(Credential?.UserName, Credential?.Password);
+        NetworkCredential networkCredential = new NetworkCredential(Credential.UserName, Credential.Password);
         graph.Authenticate(networkCredential);
         try {
             var status = graph.ConnectO365GraphAsync().GetAwaiter().GetResult();

--- a/Sources/Mailozaurr.PowerShell/Communication/InternalLoggerPowerShell.cs
+++ b/Sources/Mailozaurr.PowerShell/Communication/InternalLoggerPowerShell.cs
@@ -1,6 +1,10 @@
-﻿namespace Mailozaurr.PowerShell;
+using System;
+using System.Management.Automation;
+
+namespace Mailozaurr.PowerShell;
+
 /// <summary>
-/// This class allow connecting to the InternalLogger class of ADPlayground and act on events from it in different streams
+/// Enables routing of <see cref="InternalLogger"/> events to PowerShell streams.
 /// </summary>
 public class InternalLoggerPowerShell : IDisposable {
     private readonly InternalLogger _logger;
@@ -12,15 +16,15 @@ public class InternalLoggerPowerShell : IDisposable {
     private readonly Action<ProgressRecord>? _writeProgressAction;
 
     /// <summary>
-    /// Initialize the InternalLoggerPowerShell class
+    /// Creates a new instance of the <see cref="InternalLoggerPowerShell"/> class.
     /// </summary>
-    /// <param name="logger"></param>
-    /// <param name="writeVerboseAction"></param>
-    /// <param name="writeWarningAction"></param>
-    /// <param name="writeDebugAction"></param>
-    /// <param name="writeErrorAction"></param>
-    /// <param name="writeProgressAction"></param>
-    /// <param name="writeInformationAction"></param>
+    /// <param name="logger">Source logger that exposes events.</param>
+    /// <param name="writeVerboseAction">Delegate used to write verbose messages.</param>
+    /// <param name="writeWarningAction">Delegate used to write warning messages.</param>
+    /// <param name="writeDebugAction">Delegate used to write debug messages.</param>
+    /// <param name="writeErrorAction">Delegate used to write error records.</param>
+    /// <param name="writeProgressAction">Delegate used to write progress records.</param>
+    /// <param name="writeInformationAction">Delegate used to write information records.</param>
     public InternalLoggerPowerShell(InternalLogger logger, Action<string>? writeVerboseAction = null, Action<string>? writeWarningAction = null, Action<string>? writeDebugAction = null, Action<ErrorRecord>? writeErrorAction = null, Action<ProgressRecord>? writeProgressAction = null, Action<InformationRecord>? writeInformationAction = null) {
         _logger = logger;
 
@@ -56,10 +60,10 @@ public class InternalLoggerPowerShell : IDisposable {
     }
 
     /// <summary>
-    /// Message event handler
+    /// Handles verbose messages from the logger.
     /// </summary>
-    /// <param name="sender"></param>
-    /// <param name="e"></param>
+    /// <param name="sender">Event source.</param>
+    /// <param name="e">Event data.</param>
     private void Logger_OnVerboseMessage(object? sender, LogEventArgs e) {
         if (e.Args != null && e.Args.Length > 0) {
             WriteVerbose(e.Message, e.Args);
@@ -67,24 +71,28 @@ public class InternalLoggerPowerShell : IDisposable {
             WriteVerbose(e.Message);
         }
     }
+
     private void Logger_OnDebugMessage(object? sender, LogEventArgs e) {
         WriteDebug(e.Message);
     }
+
     private void Logger_OnWarningMessage(object? sender, LogEventArgs e) {
         WriteWarning(e.Message);
     }
+
     private void Logger_OnErrorMessage(object? sender, LogEventArgs e) {
         ErrorRecord errorRecord = new ErrorRecord(new Exception(e.Message), "1", ErrorCategory.NotSpecified, null);
         WriteError(errorRecord);
     }
-    private int _activityIdCounter = 0;
 
+    private int _activityIdCounter = 0;
     private int _currentActivityId = 1;
     private bool _isCurrentActivityCompleted = true;
 
     private int GetNextActivityId() {
         return ++_activityIdCounter;
     }
+
     private void Logger_OnProgressMessage(object? sender, LogEventArgs e) {
         if (_isCurrentActivityCompleted) {
             _currentActivityId = GetNextActivityId();
@@ -107,6 +115,7 @@ public class InternalLoggerPowerShell : IDisposable {
         }
         WriteProgress(progressRecord);
     }
+
     private void Logger_OnInformationMessage(object? sender, LogEventArgs e) {
         WriteInformation(e.Message);
     }
@@ -116,43 +125,33 @@ public class InternalLoggerPowerShell : IDisposable {
     }
 
     /// <summary>
-    /// Method to write verbose message to PowerShell
+    /// Writes a formatted verbose message.
     /// </summary>
-    /// <param name="message"></param>
-    /// <param name="eArgs"></param>
+    /// <param name="message">Message template.</param>
+    /// <param name="eArgs">Arguments for the template.</param>
     private void WriteVerbose(string message, object[] eArgs) {
-        // Write to PowerShell verbose stream
         var fullMessage = string.Format(message, eArgs);
         _writeVerboseAction?.Invoke(fullMessage);
     }
 
     private void WriteDebug(string message) {
-        // Write to PowerShell debug stream
         _writeDebugAction?.Invoke(message);
     }
 
     private void WriteInformation(string message) {
         InformationRecord informationRecord = new InformationRecord(message, "Mailozaurr");
-        // Write to PowerShell information stream
         _writeInformationAction?.Invoke(informationRecord);
     }
 
     private void WriteWarning(string message) {
-        // Write to PowerShell warning stream
         _writeWarningAction?.Invoke(message);
     }
 
-    //private void WriteError(string message) {
-    //    // Write to PowerShell error stream
-    //    _writeErrorAction?.Invoke(message);
-    //}
     private void WriteError(ErrorRecord errorRecord) {
-        // Write to PowerShell error stream
         _writeErrorAction?.Invoke(errorRecord);
     }
 
     private void WriteProgress(ProgressRecord progressRecord) {
-        // Write to PowerShell progress stream
         _writeProgressAction?.Invoke(progressRecord);
     }
 
@@ -176,5 +175,7 @@ public class InternalLoggerPowerShell : IDisposable {
         if (_writeInformationAction != null) {
             _logger.OnInformationMessage -= Logger_OnInformationMessage;
         }
+        GC.SuppressFinalize(this);
     }
 }
+

--- a/Sources/Mailozaurr.PowerShell/Definitions/ImapConnectionInfo.cs
+++ b/Sources/Mailozaurr.PowerShell/Definitions/ImapConnectionInfo.cs
@@ -1,5 +1,8 @@
-using MailKit.Net.Imap;
+using System;
 using System.Collections.Generic;
+using System.IO;
+using MailKit;
+using MailKit.Net.Imap;
 
 namespace Mailozaurr.PowerShell;
 
@@ -10,21 +13,21 @@ public class ImapConnectionInfo : ConnectionInfoBase {
     /// <summary>IMAP server URI.</summary>
     public string Uri { get; set; } = string.Empty;
     /// <summary>Authentication mechanisms supported by the server.</summary>
-    public object? AuthenticationMechanisms { get; set; }
+    public ISet<string>? AuthenticationMechanisms { get; set; }
     /// <summary>Server capabilities.</summary>
-    public object? Capabilities { get; set; }
+    public ImapCapabilities Capabilities { get; set; }
     /// <summary>The underlying stream.</summary>
-    public object? Stream { get; set; }
+    public Stream? Stream { get; set; }
     /// <summary>Current state of the connection.</summary>
     public object? State { get; set; }
     /// <summary>APOP token, if any.</summary>
-    public object? ApopToken { get; set; }
+    public string? ApopToken { get; set; }
     /// <summary>Expire policy.</summary>
-    public object? ExpirePolicy { get; set; }
+    public TimeSpan? ExpirePolicy { get; set; }
     /// <summary>Server implementation info.</summary>
-    public object? Implementation { get; set; }
+    public ImapImplementation? Implementation { get; set; }
     /// <summary>Login delay, if any.</summary>
-    public object? LoginDelay { get; set; }
+    public TimeSpan? LoginDelay { get; set; }
     /// <summary>Whether the client is authenticated.</summary>
     public bool IsAuthenticated { get; set; }
     /// <summary>Whether the connection is secure.</summary>
@@ -34,7 +37,7 @@ public class ImapConnectionInfo : ConnectionInfoBase {
     /// <summary>Message count.</summary>
     public int Count { get; set; }
     /// <summary>Messages collection (if available).</summary>
-    public object? Messages { get; set; }
+    public ImapFolder? Messages { get; set; }
     /// <summary>Recent message count.</summary>
     public int Recent { get; set; }
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/Definitions/PopConnectionInfo.cs
+++ b/Sources/Mailozaurr.PowerShell/Definitions/PopConnectionInfo.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MailKit;
 using MailKit.Net.Pop3;
 
 namespace Mailozaurr.PowerShell;
@@ -9,21 +13,21 @@ public class PopConnectionInfo : ConnectionInfoBase {
     /// <summary>POP3 server URI.</summary>
     public string Uri { get; set; } = string.Empty;
     /// <summary>Authentication mechanisms supported by the server.</summary>
-    public object? AuthenticationMechanisms { get; set; }
+    public ISet<string>? AuthenticationMechanisms { get; set; }
     /// <summary>Server capabilities.</summary>
-    public object? Capabilities { get; set; }
+    public Pop3Capabilities Capabilities { get; set; }
     /// <summary>The underlying stream.</summary>
-    public object? Stream { get; set; }
+    public Stream? Stream { get; set; }
     /// <summary>Current state of the connection.</summary>
     public object? State { get; set; }
     /// <summary>APOP token, if any.</summary>
-    public object? ApopToken { get; set; }
+    public string? ApopToken { get; set; }
     /// <summary>Expire policy.</summary>
-    public object? ExpirePolicy { get; set; }
+    public TimeSpan? ExpirePolicy { get; set; }
     /// <summary>Server implementation info.</summary>
     public object? Implementation { get; set; }
     /// <summary>Login delay, if any.</summary>
-    public object? LoginDelay { get; set; }
+    public TimeSpan? LoginDelay { get; set; }
     /// <summary>Whether the client is authenticated.</summary>
     public bool IsAuthenticated { get; set; }
     /// <summary>Whether the connection is secure.</summary>


### PR DESCRIPTION
## Summary
- guard provider-specific email send paths with credential checks
- document and wire InternalLogger to PowerShell streams with proper disposal
- type IMAP/POP connection info models and handle missing inbox folder

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -p:WarningLevel=4`

------
https://chatgpt.com/codex/tasks/task_e_68a411972658832e83c5622336f3392c