### PR TITLE
fix: address nullability warnings

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
@@ -50,10 +50,15 @@ public sealed class CmdletConnectOAuthGoogle : AsyncPSCmdlet {
     /// Performs the interactive OAuth2 authentication and returns a PSCredential with the access token.
     /// </summary>
     protected override async Task ProcessRecordAsync() {
+        if (GmailAccount is null || ClientID is null || ClientSecret is null || Scope is null) {
+            WriteError(new ErrorRecord(new PSArgumentNullException("GmailAccount"), "OAuthGoogleInvalidParameters", ErrorCategory.InvalidArgument, null));
+            return;
+        }
+
         OAuthCredential? cred = null;
         try {
             cred = await Mailozaurr.OAuthHelpers
-                .AcquireGoogleTokenCachedAsync(GmailAccount!, ClientID!, ClientSecret!, Scope!);
+                .AcquireGoogleTokenCachedAsync(GmailAccount, ClientID, ClientSecret, Scope);
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(ex, "OAuthGoogleAuthFailed", ErrorCategory.AuthenticationError, null));
             return;

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthO365.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthO365.cs
@@ -62,9 +62,14 @@ public class CmdletConnectOAuthO365 : PSCmdlet {
     /// Performs the interactive OAuth2 authentication and returns a PSCredential with the access token.
     /// </summary>
     protected override void ProcessRecord() {
+        if (ClientID is null || TenantID is null || RedirectUri is null || Scopes is null) {
+            WriteError(new ErrorRecord(new PSArgumentNullException("ClientID"), "OAuthO365InvalidParameters", ErrorCategory.InvalidArgument, null));
+            return;
+        }
+
         Mailozaurr.OAuthCredential? cred = null;
         try {
-            cred = Task.Run(() => Mailozaurr.OAuthHelpers.AcquireO365TokenCachedAsync(Login, ClientID!, TenantID!, RedirectUri!, Scopes!)).GetAwaiter().GetResult();
+            cred = Task.Run(() => Mailozaurr.OAuthHelpers.AcquireO365TokenCachedAsync(Login, ClientID, TenantID, RedirectUri, Scopes)).GetAwaiter().GetResult();
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(ex, "OAuthO365AuthFailed", ErrorCategory.AuthenticationError, null));
             return;

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertFromEmlToMsg.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertFromEmlToMsg.cs
@@ -26,7 +26,7 @@ public sealed class CmdletConvertFromEmlToMsg : AsyncPSCmdlet {
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     [ValidateNotNullOrEmpty]
-    public string[]? InputPath;
+    public string[]? InputPath { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the folder where the converted MSG files will be saved. This parameter is mandatory.</para>
@@ -56,7 +56,11 @@ public sealed class CmdletConvertFromEmlToMsg : AsyncPSCmdlet {
     /// Converts the specified EML files to MSG format and writes the results to the output folder.
     /// </summary>
     protected override Task ProcessRecordAsync() {
-        var outputMessage = EmailMessage.ConvertEmlToMsg(InputPath!, OutputFolder!, Force);
+        if (InputPath is null || OutputFolder is null) {
+            return Task.CompletedTask;
+        }
+
+        var outputMessage = EmailMessage.ConvertEmlToMsg(InputPath, OutputFolder, Force);
         foreach (var obj in outputMessage) {
             WriteObject(obj);
         }

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertFromMsgToEml.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertFromMsgToEml.cs
@@ -21,7 +21,7 @@ public sealed class CmdletConvertFromMsgToEml : AsyncPSCmdlet {
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     [ValidateNotNullOrEmpty]
-    public string[]? InputPath;
+    public string[]? InputPath { get; set; }
 
     /// <summary>
     /// <para type="description">Destination folder for the converted EML files.</para>
@@ -51,7 +51,11 @@ public sealed class CmdletConvertFromMsgToEml : AsyncPSCmdlet {
     /// Converts the specified MSG files to EML format.
     /// </summary>
     protected override Task ProcessRecordAsync() {
-        var outputMessage = EmailMessage.ConvertMsgToEml(InputPath!, OutputFolder!, Force);
+        if (InputPath is null || OutputFolder is null) {
+            return Task.CompletedTask;
+        }
+
+        var outputMessage = EmailMessage.ConvertMsgToEml(InputPath, OutputFolder, Force);
         foreach (var obj in outputMessage) {
             WriteObject(obj);
         }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessage.cs
@@ -21,7 +21,7 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "Graph")]
     [Parameter(Mandatory = true, ParameterSetName = "MgGraphRequest")]
     [ValidateNotNullOrEmpty]
-    public string? UserPrincipalName { get; set; }
+    public string UserPrincipalName { get; set; } = string.Empty;
 
     /// <summary>
     /// Graph connection information.
@@ -141,8 +141,10 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
+        var upn = UserPrincipalName;
+
         if (ParameterSetName == "MgGraphRequest") {
-            return ProcessMgGraph();
+            return ProcessMgGraph(upn);
         }
 
         var conn = Connection ?? DefaultSessions.GraphSession;
@@ -151,13 +153,13 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
             return Task.CompletedTask;
         }
 
-        return ProcessGraphAsync(conn.Credential);
+        return ProcessGraphAsync(conn.Credential, upn);
     }
 
     /// <summary>
     /// Executes the Graph API calls to fetch messages.
     /// </summary>
-    private async Task ProcessGraphAsync(GraphCredential cred) {
+    private async Task ProcessGraphAsync(GraphCredential cred, string userPrincipalName) {
         MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
         MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
         int attempts = 0;
@@ -167,16 +169,16 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
                 var filter = BuildFilter(Filter);
                 var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(
                     cred,
-                    UserPrincipalName!,
+                    userPrincipalName,
                     Property,
                     filter,
                     Limit);
 
                 foreach (var msg in messages) {
-                    var info = new GraphMessageInfo(msg, UserPrincipalName!);
+                    var info = new GraphMessageInfo(msg, userPrincipalName);
                     WriteObject(info);
                     if (Delete.IsPresent && msg.TryGetValue("id", out var idObj) && idObj is string id) {
-                        await MicrosoftGraphUtils.DeleteMailMessageAsync(cred, UserPrincipalName!, id);
+                        await MicrosoftGraphUtils.DeleteMailMessageAsync(cred, userPrincipalName, id);
                     }
                 }
                 return;
@@ -205,7 +207,7 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
     /// <summary>
     /// Uses Invoke-MgGraphRequest to retrieve messages.
     /// </summary>
-    private Task ProcessMgGraph() {
+    private Task ProcessMgGraph(string userPrincipalName) {
         var filter = BuildFilter(Filter);
         var query = new Dictionary<string, object>();
         if (!string.IsNullOrWhiteSpace(filter)) query["$filter"] = filter;
@@ -213,7 +215,7 @@ public sealed class CmdletGetEmailGraphMessage : AsyncPSCmdlet {
         if (Limit.HasValue) query["$top"] = Limit.Value.ToString();
         var uri = MicrosoftGraphUtils.JoinUriQuery(
             GraphEndpoint.V1,
-            $"/users/{UserPrincipalName}/messages",
+            $"/users/{userPrincipalName}/messages",
             query);
 
         var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveGraphMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveGraphMessage.cs
@@ -34,14 +34,15 @@ public class CmdletSaveGraphMessage : PSCmdlet {
     /// Saves the specified mail messages to disk at the given path.
     /// </summary>
     protected override void ProcessRecord() {
-        if (Message is null || Path is null) {
+        var targetPath = Path;
+        if (Message is null || string.IsNullOrEmpty(targetPath)) {
             return;
         }
         foreach (var m in Message) {
             if (m.BaseObject is EmailGraphMessage gm) {
-                MicrosoftGraphUtils.SaveMailMessages(new[] { gm }, Path!);
+                MicrosoftGraphUtils.SaveMailMessages(new[] { gm }, targetPath!);
             } else if (m.BaseObject is MimeKit.MimeMessage mm) {
-                var resolved = System.IO.Path.GetFullPath(Path!);
+                var resolved = System.IO.Path.GetFullPath(targetPath!);
                 if (!System.IO.Directory.Exists(resolved)) System.IO.Directory.CreateDirectory(resolved);
                 var file = System.IO.Path.Combine(resolved, System.IO.Path.ChangeExtension(System.IO.Path.GetRandomFileName(), "eml"));
                 mm.WriteTo(file);

--- a/Sources/Mailozaurr.PowerShell/CmdletTestEmailAddress.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletTestEmailAddress.cs
@@ -32,7 +32,7 @@ public sealed class CmdletTestEmailAddress : AsyncPSCmdlet {
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     [ValidateNotNullOrEmpty]
-    public string[]? EmailAddress;
+    public string[]? EmailAddress { get; set; }
 
     /// <summary>
     /// <para type="description">If set, the cmdlet will use the newer international email standards to validate the email addresses.</para>
@@ -67,6 +67,9 @@ public sealed class CmdletTestEmailAddress : AsyncPSCmdlet {
             return Task.CompletedTask;
         }
         foreach (var email in EmailAddress) {
+            if (string.IsNullOrWhiteSpace(email)) {
+                continue;
+            }
             _logger.WriteVerbose("Processing email: {0}", email);
             WriteObject(Validator.ValidateEmail(email, AllowInternational, AllowTopLevelDomains));
         }

--- a/Sources/Mailozaurr.Tests/FetchExamplesTests.cs
+++ b/Sources/Mailozaurr.Tests/FetchExamplesTests.cs
@@ -109,6 +109,7 @@ namespace Mailozaurr.Tests {
             await client.ConnectAsync("imap.example.com", 993, SecureSocketOptions.SslOnConnect);
             await client.AuthenticateAsync("user@example.com", "Pa55w0rd");
             var folder = client.GetFolder("Inbox/Reports");
+            Assert.NotNull(folder);
             await folder.OpenAsync(FolderAccess.ReadWrite);
             var uids = await folder.SearchAsync(null);
             foreach (var uid in uids) {

--- a/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -21,7 +22,8 @@ public class GraphUploadRangeTests
             "PrepareByteArrayContentForUpload",
             BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(method);
-        List<StreamContent> chunks = (List<StreamContent>)method!.Invoke(graph, new object[] { tmp, 10, default(System.Threading.CancellationToken) })!;
+        var nonNullMethod = method!;
+        List<StreamContent> chunks = (List<StreamContent>)nonNullMethod.Invoke(graph, new object[] { tmp, 10, CancellationToken.None })!;
         File.Delete(tmp);
         Assert.Equal(3, chunks.Count);
         Assert.Equal("bytes 0-9/25", chunks[0].Headers.GetValues("Content-Range").First());
@@ -40,9 +42,10 @@ public class GraphUploadRangeTests
             "PrepareByteArrayContentForUpload",
             BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(method);
-        List<StreamContent> chunks = (List<StreamContent>)method!.Invoke(
+        var nonNullMethod = method!;
+        List<StreamContent> chunks = (List<StreamContent>)nonNullMethod.Invoke(
             graph,
-            new object[] { tmp, 10, default(System.Threading.CancellationToken) })!;
+            new object[] { tmp, 10, CancellationToken.None })!;
         File.Delete(tmp);
         byte[] chunk0 = await chunks[0].ReadAsByteArrayAsync();
         byte[] chunk1 = await chunks[1].ReadAsByteArrayAsync();

--- a/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlAutoEmbedImageTests.cs
@@ -21,7 +21,9 @@ public class HtmlAutoEmbedImageTests {
         smtp.Subject = "test";
         smtp.HtmlBody = $"<img src=\"{tmp}\">";
         smtp.CreateMessage(CancellationToken.None);
-        var body = (MultipartRelated)smtp.Message.Body;
+        var message = smtp.Message;
+        Assert.NotNull(message);
+        var body = Assert.IsType<MultipartRelated>(message!.Body!);
         var inline = body.OfType<MimePart>().FirstOrDefault(p => p.ContentDisposition?.Disposition == ContentDisposition.Inline);
         File.Delete(tmp);
         Assert.NotNull(inline);
@@ -68,7 +70,9 @@ public class HtmlAutoEmbedImageTests {
             smtp.Subject = "test";
             smtp.HtmlBody = "<img src=\"https://example.com/img.png\">";
             smtp.CreateMessage(CancellationToken.None);
-            var body = (MultipartRelated)smtp.Message.Body!;
+            var message = smtp.Message;
+            Assert.NotNull(message);
+            var body = Assert.IsType<MultipartRelated>(message!.Body!);
             var inline = body.OfType<MimePart>().FirstOrDefault(p => p.ContentDisposition?.Disposition == ContentDisposition.Inline);
             Assert.NotNull(inline);
             Assert.Contains("cid:img.png", smtp.HtmlBody);

--- a/Sources/Mailozaurr.Tests/NonDeliveryReportServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportServiceTests.cs
@@ -18,6 +18,9 @@ public class NonDeliveryReportServiceTests {
         }
 
         public Task<SentMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+            if (messageId is null) {
+                return Task.FromResult<SentMessageRecord?>(null);
+            }
             store.TryGetValue(messageId, out SentMessageRecord? record);
             return Task.FromResult<SentMessageRecord?>(record);
         }

--- a/Sources/Mailozaurr/Definitions/EmlConversionResult.cs
+++ b/Sources/Mailozaurr/Definitions/EmlConversionResult.cs
@@ -4,18 +4,18 @@
 /// Result information returned when converting an EML file to MSG.
 /// </summary>
 /// <remarks>
-/// Used by <see cref="EmailMessage.ConvertEmlToMsg"/> to report
+/// Used by <see cref="EmailMessage.ConvertEmlToMsg(string[], string, bool)"/> to report
 /// the path of the generated message and whether the operation succeeded.
 /// </remarks>
 public class EmlConversionResult {
     /// <summary>
     /// Eml file path to file that was converted
     /// </summary>
-    public string EmlFile { get; set; }
+    public string EmlFile { get; set; } = string.Empty;
     /// <summary>
     /// Msg file path to file that was created
     /// </summary>
-    public string MsgFile { get; set; }
+    public string MsgFile { get; set; } = string.Empty;
     /// <summary>
     /// Status of the conversion
     /// </summary>
@@ -23,5 +23,5 @@ public class EmlConversionResult {
     /// <summary>
     /// Error message if conversion failed
     /// </summary>
-    public string Error { get; set; }
+    public string? Error { get; set; }
 }


### PR DESCRIPTION
## Summary
- handle null parameters in OAuth and conversion cmdlets
- add explicit non-null defaults for conversion results
- tighten unit tests with null assertions and cleaner setup

## Testing
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj -c Release --no-incremental`
- `dotnet build Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release --no-incremental`


------
https://chatgpt.com/codex/tasks/task_e_68a4119b9900832ea60b640e773facc7