### PR TITLE
Add DMARC report retrieval

### DIFF
--- a/Examples/Example-GetDmarcReport.ps1
+++ b/Examples/Example-GetDmarcReport.ps1
@@ -1,0 +1,10 @@
+Import-Module Mailozaurr
+
+# Assumes an active IMAP connection established with Connect-IMAP
+Get-DmarcReport -Protocol Imap -Folder 'INBOX' -Since (Get-Date).AddDays(-7) |
+    ForEach-Object {
+        foreach ($att in $_.Attachments) {
+            # Pass the zipped XML to Domain Detective for analysis
+            Invoke-DomainDetective -InputObject $att.Content -Name $att.Name
+        }
+    }

--- a/Sources/Mailozaurr.Examples/RetrieveDmarcReportsExample.cs
+++ b/Sources/Mailozaurr.Examples/RetrieveDmarcReportsExample.cs
@@ -1,0 +1,25 @@
+using Mailozaurr;
+using Mailozaurr.DmarcReports;
+using MailKit.Net.Imap;
+using System;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.Examples;
+
+public static class RetrieveDmarcReportsExample {
+    public static async Task RunAsync(ImapClient client) {
+        var reports = await MailboxSearcher.SearchDmarcReportsAsync(client, "INBOX", since: DateTime.UtcNow.AddDays(-7));
+        foreach (var report in reports) {
+            foreach (var att in report.Attachments) {
+                DomainDetective.Process(att.Content, att.Name);
+            }
+        }
+    }
+}
+
+public static class DomainDetective {
+    public static void Process(byte[] zip, string name) {
+        // Placeholder for integration with Domain Detective analysis
+        Console.WriteLine($"Processing {name} ({zip.Length} bytes)");
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletGetDmarcReport.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetDmarcReport.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Management.Automation;
+using System.Threading.Tasks;
+using Mailozaurr.DmarcReports;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// <para type="synopsis">Searches for DMARC aggregate reports in a mailbox.</para>
+/// <para type="description">The <c>Get-DmarcReport</c> cmdlet queries IMAP, POP3, Microsoft Graph, or Gmail API to find DMARC aggregate reports and expose zipped XML attachments.</para>
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "DmarcReport")]
+[OutputType(typeof(DmarcReport))]
+public sealed class CmdletGetDmarcReport : AsyncPSCmdlet {
+    /// <summary>
+    /// <para type="description">Mail protocol to use.</para>
+    /// </summary>
+    [Parameter(Mandatory = true)]
+    public EmailProtocol Protocol { get; set; }
+
+    /// <summary>
+    /// <para type="description">Optional domain filter.</para>
+    /// </summary>
+    [Parameter]
+    public string? Domain { get; set; }
+
+    /// <summary>
+    /// <para type="description">Only reports since this time are returned.</para>
+    /// </summary>
+    [Parameter]
+    public DateTime? Since { get; set; }
+
+    /// <summary>
+    /// <para type="description">Only reports before this time are returned.</para>
+    /// </summary>
+    [Parameter]
+    public DateTime? Before { get; set; }
+
+    /// <summary>
+    /// <para type="description">Maximum number of reports to return. Default is unlimited.</para>
+    /// </summary>
+    [Parameter]
+    [ValidateRange(1, int.MaxValue)]
+    public int Count { get; set; }
+
+    /// <summary>
+    /// <para type="description">IMAP folder to search.</para>
+    /// </summary>
+    [Parameter]
+    public string? Folder { get; set; }
+
+    /// <summary>
+    /// <para type="description">User principal name when using Microsoft Graph.</para>
+    /// </summary>
+    [Parameter]
+    public string? UserPrincipalName { get; set; }
+
+    /// <summary>
+    /// <para type="description">Gmail account address when using Gmail API.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "GmailApi")]
+    public string? GmailAccount { get; set; }
+
+    /// <summary>
+    /// <para type="description">OAuth credential used for Gmail API authentication.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "GmailApi")]
+    [ValidateNotNull]
+    public PSCredential? Credential { get; set; }
+
+    /// <summary>
+    /// <para type="description">Maximum concurrent MIME downloads; set to 1 to disable parallelism.</para>
+    /// </summary>
+    [Parameter]
+    [ValidateRange(1, int.MaxValue)]
+    public int ParallelDownloadLimit { get; set; } = 4;
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        int max = Count > 0 ? Count : int.MaxValue;
+        switch (Protocol) {
+            case EmailProtocol.Imap: {
+                var conn = DefaultSessions.ImapSession;
+                if (conn != null && conn.Data != null) {
+                    var reports = await MailboxSearcher.SearchDmarcReportsAsync(
+                        conn.Data,
+                        Folder,
+                        Since,
+                        Before,
+                        Domain,
+                        max,
+                        parallelDownloadLimit: ParallelDownloadLimit,
+                        cancellationToken: CancelToken);
+                    foreach (var report in reports) WriteObject(report);
+                } else {
+                    ThrowTerminatingError(new ErrorRecord(
+                        new InvalidOperationException("Get-DmarcReport - IMAP client not provided or not connected."),
+                        "ClientNotConnected",
+                        ErrorCategory.InvalidOperation,
+                        null));
+                }
+                break;
+            }
+            case EmailProtocol.Pop3: {
+                var conn = DefaultSessions.Pop3Session;
+                if (conn != null && conn.Data != null) {
+                    var reports = await MailboxSearcher.SearchDmarcReportsAsync(
+                        conn.Data,
+                        Since,
+                        Before,
+                        Domain,
+                        max,
+                        parallelDownloadLimit: ParallelDownloadLimit,
+                        cancellationToken: CancelToken);
+                    foreach (var report in reports) WriteObject(report);
+                } else {
+                    ThrowTerminatingError(new ErrorRecord(
+                        new InvalidOperationException("Get-DmarcReport - POP3 client not provided or not connected."),
+                        "ClientNotConnected",
+                        ErrorCategory.InvalidOperation,
+                        null));
+                }
+                break;
+            }
+            case EmailProtocol.Graph: {
+                var conn = DefaultSessions.GraphSession;
+                if (conn != null && conn.Credential != null && !string.IsNullOrWhiteSpace(UserPrincipalName)) {
+                    var reports = await MailboxSearcher.SearchDmarcReportsAsync(
+                        conn.Credential,
+                        UserPrincipalName!,
+                        Since,
+                        Before,
+                        Domain,
+                        max,
+                        parallelDownloadLimit: ParallelDownloadLimit,
+                        cancellationToken: CancelToken);
+                    foreach (var report in reports) WriteObject(report);
+                } else {
+                    ThrowTerminatingError(new ErrorRecord(
+                        new InvalidOperationException("Get-DmarcReport - Graph connection or UserPrincipalName missing."),
+                        "ClientNotConnected",
+                        ErrorCategory.InvalidOperation,
+                        null));
+                }
+                break;
+            }
+            case EmailProtocol.GmailApi: {
+                if (Credential != null && !string.IsNullOrWhiteSpace(GmailAccount)) {
+                    var net = Credential.GetNetworkCredential();
+                    var oauth = new OAuthCredential { UserName = net.UserName, AccessToken = net.Password, ExpiresOn = DateTimeOffset.MaxValue };
+                    var client = new GmailApiClient(oauth);
+                    var reports = await MailboxSearcher.SearchDmarcReportsAsync(
+                        client,
+                        GmailAccount!,
+                        Since,
+                        Before,
+                        Domain,
+                        max,
+                        parallelDownloadLimit: ParallelDownloadLimit,
+                        cancellationToken: CancelToken);
+                    foreach (var report in reports) WriteObject(report);
+                } else {
+                    ThrowTerminatingError(new ErrorRecord(
+                        new InvalidOperationException("Get-DmarcReport - Gmail account or Credential missing."),
+                        "ClientNotConnected",
+                        ErrorCategory.InvalidOperation,
+                        null));
+                }
+                break;
+            }
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
@@ -1,0 +1,71 @@
+using Mailozaurr;
+using Mailozaurr.DmarcReports;
+using MimeKit;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SearchDmarcReportsTests {
+    private static MimeMessage CreateDmarc(string domain, DateTimeOffset date) {
+        var message = new MimeMessage();
+        message.Subject = $"Report domain: {domain}";
+        message.Date = date;
+        message.From.Add(new MailboxAddress("reporter", "reporter@example.com"));
+        var builder = new BodyBuilder();
+        var ms = new MemoryStream(Encoding.UTF8.GetBytes("dummy"));
+        var part = new MimePart("application", "zip") {
+            Content = new MimeContent(ms),
+            FileName = $"{domain}.zip"
+        };
+        builder.Attachments.Add(part);
+        message.Body = builder.ToMessageBody();
+        return message;
+    }
+
+    [Fact]
+    public void FilterDmarcReports_ExtractsAttachments() {
+        var now = DateTimeOffset.UtcNow;
+        var msg = CreateDmarc("example.com", now);
+        var list = new List<MimeMessage> { msg };
+        var reports = MailboxSearcher.FilterDmarcReports(list, since: now.AddMinutes(-1).DateTime, before: now.AddMinutes(1).DateTime, domain: "example.com");
+        Assert.Single(reports);
+        var report = reports[0];
+        Assert.Equal("reporter@example.com", report.From);
+        Assert.Single(report.Attachments);
+        Assert.EndsWith(".zip", report.Attachments[0].Name);
+        Assert.True(report.Attachments[0].Content.Length > 0);
+    }
+
+    [Fact]
+    public void BuildDmarcReportSearchQuery_ContainsSubject() {
+        var query = MailboxSearcher.BuildDmarcReportSearchQuery(null, null, "example.com");
+        bool Contains(MailKit.Search.SearchQuery q) {
+            var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic;
+            var term = q.GetType().GetProperty("Term", flags)?.GetValue(q)?.ToString();
+            if (term == "SubjectContains") {
+                var text = q.GetType().GetProperty("Text", flags)?.GetValue(q)?.ToString();
+                if (text?.IndexOf("example.com", StringComparison.OrdinalIgnoreCase) >= 0 == true) return true;
+            }
+            var left = q.GetType().GetProperty("Left", flags)?.GetValue(q) as MailKit.Search.SearchQuery;
+            var right = q.GetType().GetProperty("Right", flags)?.GetValue(q) as MailKit.Search.SearchQuery;
+            if (left != null && Contains(left)) return true;
+            if (right != null && Contains(right)) return true;
+            return false;
+        }
+        Assert.True(Contains(query));
+    }
+
+    [Fact]
+    public void BuildGmailDmarcReportQuery_IncludesDomainAndDates() {
+        var since = new DateTime(2024, 1, 1);
+        var before = new DateTime(2024, 2, 1);
+        var q = MailboxSearcher.BuildGmailDmarcReportQuery(since, before, "example.com");
+        Assert.Contains("example.com", q);
+        Assert.Contains("after:2024/01/01", q);
+        Assert.Contains("before:2024/02/01", q);
+    }
+}

--- a/Sources/Mailozaurr/DmarcReports/DmarcReport.cs
+++ b/Sources/Mailozaurr/DmarcReports/DmarcReport.cs
@@ -1,0 +1,34 @@
+namespace Mailozaurr.DmarcReports;
+
+/// <summary>
+/// Represents a DMARC aggregate report extracted from a message.
+/// </summary>
+public sealed class DmarcReport {
+    /// <summary>Sender of the DMARC report.</summary>
+    public string? From { get; set; }
+
+    /// <summary>Subject of the DMARC report message.</summary>
+    public string? Subject { get; set; }
+
+    /// <summary>Date the report message was received.</summary>
+    public DateTimeOffset Date { get; set; }
+
+    /// <summary>Collection of zipped XML attachments.</summary>
+    public IList<DmarcReportAttachment> Attachments { get; } = new List<DmarcReportAttachment>();
+}
+
+/// <summary>
+/// Represents a zipped XML attachment belonging to a DMARC report.
+/// </summary>
+public sealed class DmarcReportAttachment {
+    /// <summary>File name of the attachment.</summary>
+    public string Name { get; }
+
+    /// <summary>Binary content of the zipped attachment.</summary>
+    public byte[] Content { get; }
+
+    public DmarcReportAttachment(string name, byte[] content) {
+        Name = name;
+        Content = content;
+    }
+}

--- a/Sources/Mailozaurr/DmarcReports/DmarcReportServiceBase.cs
+++ b/Sources/Mailozaurr/DmarcReports/DmarcReportServiceBase.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.DmarcReports;
+
+/// <summary>
+/// Provides common functionality for DMARC report services.
+/// </summary>
+public abstract class DmarcReportServiceBase : IDmarcReportService {
+    private readonly SemaphoreSlim gate = new(1, 1);
+
+    /// <summary>
+    /// Searches for DMARC reports using implementation specific logic.
+    /// </summary>
+    public async Task<IList<DmarcReport>> SearchAsync(
+        DateTime? since = null,
+        DateTime? before = null,
+        string? domain = null,
+        int maxResults = 0,
+        CancellationToken cancellationToken = default) {
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            return await SearchInternalAsync(since, before, domain, maxResults, cancellationToken).ConfigureAwait(false);
+        } finally {
+            gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Performs the actual search for DMARC reports.
+    /// </summary>
+    protected abstract Task<IList<DmarcReport>> SearchInternalAsync(
+        DateTime? since,
+        DateTime? before,
+        string? domain,
+        int maxResults,
+        CancellationToken cancellationToken);
+}

--- a/Sources/Mailozaurr/DmarcReports/GmailDmarcReportService.cs
+++ b/Sources/Mailozaurr/DmarcReports/GmailDmarcReportService.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.DmarcReports;
+
+/// <summary>
+/// Retrieves DMARC aggregate reports using the Gmail API.
+/// </summary>
+public sealed class GmailDmarcReportService : DmarcReportServiceBase {
+    private readonly GmailApiClient client;
+    private readonly string userId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GmailDmarcReportService"/> class.
+    /// </summary>
+    /// <param name="client">Gmail API client.</param>
+    /// <param name="userId">Account identifier, typically 'me'.</param>
+    public GmailDmarcReportService(GmailApiClient client, string userId) {
+        this.client = client;
+        this.userId = userId;
+    }
+
+    /// <inheritdoc />
+    protected override Task<IList<DmarcReport>> SearchInternalAsync(
+        DateTime? since,
+        DateTime? before,
+        string? domain,
+        int maxResults,
+        CancellationToken cancellationToken) =>
+        MailboxSearcher.SearchDmarcReportsAsync(client, userId, since, before, domain, maxResults, cancellationToken: cancellationToken);
+}

--- a/Sources/Mailozaurr/DmarcReports/GraphDmarcReportService.cs
+++ b/Sources/Mailozaurr/DmarcReports/GraphDmarcReportService.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.DmarcReports;
+
+/// <summary>
+/// Retrieves DMARC aggregate reports using Microsoft Graph.
+/// </summary>
+public sealed class GraphDmarcReportService : DmarcReportServiceBase {
+    private readonly GraphCredential credential;
+    private readonly string userPrincipalName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GraphDmarcReportService"/> class.
+    /// </summary>
+    /// <param name="credential">Credential used to access Microsoft Graph.</param>
+    /// <param name="userPrincipalName">UPN of the mailbox to query.</param>
+    public GraphDmarcReportService(GraphCredential credential, string userPrincipalName) {
+        this.credential = credential;
+        this.userPrincipalName = userPrincipalName;
+    }
+
+    /// <inheritdoc />
+    protected override Task<IList<DmarcReport>> SearchInternalAsync(
+        DateTime? since,
+        DateTime? before,
+        string? domain,
+        int maxResults,
+        CancellationToken cancellationToken) =>
+        MailboxSearcher.SearchDmarcReportsAsync(credential, userPrincipalName, since, before, domain, maxResults, cancellationToken: cancellationToken);
+}

--- a/Sources/Mailozaurr/DmarcReports/ImapDmarcReportService.cs
+++ b/Sources/Mailozaurr/DmarcReports/ImapDmarcReportService.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Imap;
+
+namespace Mailozaurr.DmarcReports;
+
+/// <summary>
+/// Retrieves DMARC aggregate reports from an IMAP mailbox.
+/// </summary>
+public sealed class ImapDmarcReportService : DmarcReportServiceBase {
+    private readonly ImapClient client;
+    private readonly string? folder;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImapDmarcReportService"/> class.
+    /// </summary>
+    /// <param name="client">IMAP client used to access the mailbox.</param>
+    /// <param name="folder">Optional folder name to search within.</param>
+    public ImapDmarcReportService(ImapClient client, string? folder = null) {
+        this.client = client;
+        this.folder = folder;
+    }
+
+    /// <inheritdoc />
+    protected override Task<IList<DmarcReport>> SearchInternalAsync(
+        DateTime? since,
+        DateTime? before,
+        string? domain,
+        int maxResults,
+        CancellationToken cancellationToken) =>
+        MailboxSearcher.SearchDmarcReportsAsync(client, folder, since, before, domain, maxResults, cancellationToken: cancellationToken);
+}

--- a/Sources/Mailozaurr/DmarcReports/Pop3DmarcReportService.cs
+++ b/Sources/Mailozaurr/DmarcReports/Pop3DmarcReportService.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Pop3;
+
+namespace Mailozaurr.DmarcReports;
+
+/// <summary>
+/// Retrieves DMARC aggregate reports using the POP3 protocol.
+/// </summary>
+public sealed class Pop3DmarcReportService : DmarcReportServiceBase {
+    private readonly Pop3Client client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Pop3DmarcReportService"/> class.
+    /// </summary>
+    /// <param name="client">POP3 client used to access the mailbox.</param>
+    public Pop3DmarcReportService(Pop3Client client) => this.client = client;
+
+    /// <inheritdoc />
+    protected override Task<IList<DmarcReport>> SearchInternalAsync(
+        DateTime? since,
+        DateTime? before,
+        string? domain,
+        int maxResults,
+        CancellationToken cancellationToken) =>
+        MailboxSearcher.SearchDmarcReportsAsync(client, since, before, domain, maxResults, cancellationToken: cancellationToken);
+}

--- a/Sources/Mailozaurr/IDmarcReportService.cs
+++ b/Sources/Mailozaurr/IDmarcReportService.cs
@@ -1,0 +1,15 @@
+using Mailozaurr.DmarcReports;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Defines operations for searching DMARC reports.
+/// </summary>
+public interface IDmarcReportService {
+    Task<IList<DmarcReport>> SearchAsync(
+        DateTime? since = null,
+        DateTime? before = null,
+        string? domain = null,
+        int maxResults = 0,
+        CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -6,9 +6,12 @@ using MimeKit;
 using System.Text;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Mailozaurr.NonDeliveryReports;
+using Mailozaurr.DmarcReports;
 
 namespace Mailozaurr;
 
@@ -316,7 +319,257 @@ public static class MailboxSearcher {
         return FilterNonDeliveryReports(mimeMessages, since, before, recipientContains, messageId);
     }
 
-    internal static IList<NonDeliveryReport> FilterNonDeliveryReports(
+    // DMARC report helpers
+
+    /// <summary>
+    /// Searches for DMARC aggregate reports in an IMAP mailbox.
+    /// </summary>
+    public static async Task<IList<DmarcReport>> SearchDmarcReportsAsync(
+        ImapClient client,
+        string? folder = null,
+        DateTime? since = null,
+        DateTime? before = null,
+        string? domain = null,
+        int maxResults = 0,
+        int parallelDownloadLimit = 4,
+        CancellationToken cancellationToken = default) {
+        var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
+        var search = BuildDmarcReportSearchQuery(since, before, domain);
+        var uids = await mailFolder.SearchAsync(search, cancellationToken).ConfigureAwait(false);
+        var messages = new List<MimeMessage>(uids.Count);
+        if (parallelDownloadLimit <= 1) {
+            foreach (var uid in uids) {
+                cancellationToken.ThrowIfCancellationRequested();
+                var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
+                messages.Add(msg);
+                if (maxResults > 0 && messages.Count >= maxResults) break;
+            }
+        } else {
+            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
+            var tasks = new List<Task>();
+            foreach (var uid in uids) {
+                cancellationToken.ThrowIfCancellationRequested();
+                tasks.Add(Task.Run(async () => {
+                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
+                        lock (messages) messages.Add(msg);
+                    } finally {
+                        semaphore.Release();
+                    }
+                }, cancellationToken));
+                if (maxResults > 0 && tasks.Count >= maxResults) break;
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+        return FilterDmarcReports(messages, since, before, domain);
+    }
+
+    /// <summary>
+    /// Searches for DMARC aggregate reports in a POP3 mailbox.
+    /// </summary>
+    public static async Task<IList<DmarcReport>> SearchDmarcReportsAsync(
+        Pop3Client client,
+        DateTime? since = null,
+        DateTime? before = null,
+        string? domain = null,
+        int maxResults = 0,
+        int parallelDownloadLimit = 4,
+        CancellationToken cancellationToken = default) {
+        var count = client.Count;
+        var indices = new List<int>(count);
+        for (int i = 0; i < count; i++) indices.Add(i);
+        var messages = new List<MimeMessage>(indices.Count);
+        if (parallelDownloadLimit <= 1) {
+            foreach (var idx in indices) {
+                cancellationToken.ThrowIfCancellationRequested();
+                var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
+                messages.Add(msg);
+                if (maxResults > 0 && messages.Count >= maxResults) break;
+            }
+        } else {
+            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
+            var tasks = new List<Task>();
+            foreach (var idx in indices) {
+                cancellationToken.ThrowIfCancellationRequested();
+                tasks.Add(Task.Run(async () => {
+                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
+                        lock (messages) messages.Add(msg);
+                    } finally {
+                        semaphore.Release();
+                    }
+                }, cancellationToken));
+                if (maxResults > 0 && tasks.Count >= maxResults) break;
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+        return FilterDmarcReports(messages, since, before, domain);
+    }
+
+    /// <summary>
+    /// Searches for DMARC aggregate reports using Microsoft Graph.
+    /// </summary>
+    public static async Task<IList<DmarcReport>> SearchDmarcReportsAsync(
+        GraphCredential credential,
+        string userPrincipalName,
+        DateTime? since = null,
+        DateTime? before = null,
+        string? domain = null,
+        int maxResults = 0,
+        int parallelDownloadLimit = 4,
+        CancellationToken cancellationToken = default) {
+        var filters = new List<string> { "hasAttachments eq true", "contains(subject,'report domain')" };
+        if (since.HasValue) filters.Add($"receivedDateTime ge {since.Value:o}");
+        if (before.HasValue) filters.Add($"receivedDateTime le {before.Value:o}");
+        if (!string.IsNullOrWhiteSpace(domain)) filters.Add($"contains(subject,'{domain.Replace("'", "''")}')");
+        var filter = string.Join(" and ", filters);
+        var msgs = await MicrosoftGraphUtils.GetMailMessagesAsync(
+            credential,
+            userPrincipalName,
+            new[] { "id" },
+            filter,
+            maxResults > 0 ? maxResults : (int?)null).ConfigureAwait(false);
+        var mimeMessages = new List<MimeMessage>(msgs.Count);
+        if (parallelDownloadLimit <= 1) {
+            foreach (var m in msgs) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (m.TryGetValue("id", out var idObj) && idObj is string id) {
+                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                    mimeMessages.Add(mime);
+                }
+            }
+        } else {
+            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
+            var tasks = new List<Task>();
+            foreach (var m in msgs) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (m.TryGetValue("id", out var idObj) && idObj is string id) {
+                    tasks.Add(Task.Run(async () => {
+                        await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                        try {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                            lock (mimeMessages) mimeMessages.Add(mime);
+                        } finally {
+                            semaphore.Release();
+                        }
+                    }, cancellationToken));
+                }
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+        return FilterDmarcReports(mimeMessages, since, before, domain);
+    }
+
+    /// <summary>
+    /// Searches for DMARC aggregate reports using the Gmail API.
+    /// </summary>
+    public static async Task<IList<DmarcReport>> SearchDmarcReportsAsync(
+        GmailApiClient client,
+        string userId,
+        DateTime? since = null,
+        DateTime? before = null,
+        string? domain = null,
+        int maxResults = 0,
+        int parallelDownloadLimit = 4,
+        CancellationToken cancellationToken = default) {
+        string query = BuildGmailDmarcReportQuery(since, before, domain);
+        var msgs = await client.ListAsync(userId, query, maxResults > 0 ? maxResults : (int?)null, cancellationToken).ConfigureAwait(false);
+        var mimeMessages = new List<MimeMessage>(msgs.Count);
+        if (parallelDownloadLimit <= 1) {
+            foreach (var m in msgs) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!string.IsNullOrEmpty(m.Id)) {
+                    var mime = await client.GetMimeMessageAsync(userId, m.Id, cancellationToken).ConfigureAwait(false);
+                    mimeMessages.Add(mime);
+                    if (maxResults > 0 && mimeMessages.Count >= maxResults) break;
+                }
+            }
+        } else {
+            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
+            var tasks = new List<Task>();
+            foreach (var m in msgs) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!string.IsNullOrEmpty(m.Id)) {
+                    tasks.Add(Task.Run(async () => {
+                        await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                        try {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            var mime = await client.GetMimeMessageAsync(userId, m.Id, cancellationToken).ConfigureAwait(false);
+                            lock (mimeMessages) mimeMessages.Add(mime);
+                        } finally {
+                            semaphore.Release();
+                        }
+                    }, cancellationToken));
+                }
+                if (maxResults > 0 && tasks.Count >= maxResults) break;
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+        return FilterDmarcReports(mimeMessages, since, before, domain);
+    }
+
+    internal static IList<DmarcReport> FilterDmarcReports(
+        IEnumerable<MimeMessage> messages,
+        DateTime? since,
+        DateTime? before,
+        string? domain) {
+        var results = new List<DmarcReport>();
+        foreach (var message in messages) {
+            if (since.HasValue && message.Date.DateTime < since.Value) continue;
+            if (before.HasValue && message.Date.DateTime > before.Value) continue;
+            if (!string.IsNullOrWhiteSpace(domain) && (message.Subject == null || message.Subject.IndexOf(domain, StringComparison.OrdinalIgnoreCase) < 0)) continue;
+            var report = new DmarcReport {
+                From = message.From.Mailboxes.FirstOrDefault()?.Address,
+                Subject = message.Subject,
+                Date = message.Date
+            };
+            foreach (var att in message.Attachments) {
+                if (IsDmarcAttachment(att) && att is MimePart part) {
+                    using var ms = new MemoryStream();
+                    part.Content.DecodeTo(ms);
+                    report.Attachments.Add(new DmarcReportAttachment(part.FileName ?? "report.zip", ms.ToArray()));
+                }
+            }
+            if (report.Attachments.Count > 0) results.Add(report);
+        }
+        return results;
+    }
+
+    internal static SearchQuery BuildDmarcReportSearchQuery(DateTime? since, DateTime? before, string? domain) {
+        SearchQuery search = SearchQuery.SubjectContains("report domain");
+        if (!string.IsNullOrWhiteSpace(domain)) search = search.And(SearchQuery.SubjectContains(domain));
+        if (since.HasValue) search = search.And(SearchQuery.DeliveredAfter(since.Value));
+        if (before.HasValue) search = search.And(SearchQuery.DeliveredBefore(before.Value));
+        return search;
+    }
+
+    internal static string BuildGmailDmarcReportQuery(DateTime? since, DateTime? before, string? domain) {
+        var sb = new StringBuilder("subject:\"report domain\" has:attachment");
+        if (!string.IsNullOrWhiteSpace(domain)) sb.Append(' ').Append("subject:\"").Append(domain).Append("\"");
+        if (since.HasValue) sb.Append(' ').Append("after:").Append(since.Value.ToString("yyyy/MM/dd"));
+        if (before.HasValue) sb.Append(' ').Append("before:").Append(before.Value.ToString("yyyy/MM/dd"));
+        return sb.ToString().Trim();
+    }
+
+    private static bool IsDmarcAttachment(MimeEntity entity) {
+        if (entity is MimePart part) {
+            var name = part.FileName;
+            if (!string.IsNullOrEmpty(name) && (name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) || name.EndsWith(".gz", StringComparison.OrdinalIgnoreCase))) return true;
+            var ct = part.ContentType;
+            if (ct != null && ct.MediaType.Equals("application", StringComparison.OrdinalIgnoreCase)) {
+                if (ct.MediaSubtype.Equals("zip", StringComparison.OrdinalIgnoreCase) || ct.MediaSubtype.Equals("gzip", StringComparison.OrdinalIgnoreCase)) return true;
+            }
+        }
+        return false;
+    }
+
+
+internal static IList<NonDeliveryReport> FilterNonDeliveryReports(
         IEnumerable<MimeMessage> messages,
         DateTime? since,
         DateTime? before,

--- a/Tests/Get-DmarcReport.Tests.ps1
+++ b/Tests/Get-DmarcReport.Tests.ps1
@@ -1,0 +1,11 @@
+Describe 'Get-DmarcReport' {
+    It 'Exposes GmailApi parameter set' {
+        (Get-Command Get-DmarcReport).ParameterSets.Name | Should -Contain 'GmailApi'
+    }
+    It 'Includes Protocol parameter' {
+        (Get-Command Get-DmarcReport).Parameters.ContainsKey('Protocol') | Should -BeTrue
+    }
+    It 'Includes Domain parameter' {
+        (Get-Command Get-DmarcReport).Parameters.ContainsKey('Domain') | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- add DMARC report model and service base
- implement IMAP/POP3/Graph/Gmail DMARC report search
- expose Get-DmarcReport PowerShell cmdlet and examples

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh -NoLogo -Command "./Mailozaurr.Tests.ps1"` *(fails: 16 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e7389f1c832eae2f897717c7f296