### PR TITLE
Ensure DMARC IMAP search requires attachments

### DIFF
--- a/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
@@ -60,6 +60,28 @@ public class SearchDmarcReportsTests {
     }
 
     [Fact]
+    public void BuildDmarcReportSearchQuery_RequiresAttachments() {
+        var query = MailboxSearcher.BuildDmarcReportSearchQuery(null, null, null);
+        bool ContainsAttachment(MailKit.Search.SearchQuery q) {
+            var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic;
+            var term = q.GetType().GetProperty("Term", flags)?.GetValue(q)?.ToString();
+            if (term == "HasAttachment") return true;
+            if (term == "HeaderContains") {
+                var field = q.GetType().GetProperty("Field", flags)?.GetValue(q)?.ToString();
+                var value = q.GetType().GetProperty("Value", flags)?.GetValue(q)?.ToString();
+                if (field?.Equals("Content-Disposition", StringComparison.OrdinalIgnoreCase) == true &&
+                    value?.IndexOf("attachment", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            }
+            var left = q.GetType().GetProperty("Left", flags)?.GetValue(q) as MailKit.Search.SearchQuery;
+            var right = q.GetType().GetProperty("Right", flags)?.GetValue(q) as MailKit.Search.SearchQuery;
+            if (left != null && ContainsAttachment(left)) return true;
+            if (right != null && ContainsAttachment(right)) return true;
+            return false;
+        }
+        Assert.True(ContainsAttachment(query));
+    }
+
+    [Fact]
     public void BuildGmailDmarcReportQuery_IncludesDomainAndDates() {
         var since = new DateTime(2024, 1, 1);
         var before = new DateTime(2024, 2, 1);
@@ -67,5 +89,6 @@ public class SearchDmarcReportsTests {
         Assert.Contains("example.com", q);
         Assert.Contains("after:2024/01/01", q);
         Assert.Contains("before:2024/02/01", q);
+        Assert.Contains("has:attachment", q);
     }
 }

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -542,6 +542,8 @@ public static class MailboxSearcher {
 
     internal static SearchQuery BuildDmarcReportSearchQuery(DateTime? since, DateTime? before, string? domain) {
         SearchQuery search = SearchQuery.SubjectContains("report domain");
+        var hasAtt = typeof(SearchQuery).GetProperty("HasAttachment", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)?.GetValue(null) as SearchQuery;
+        search = search.And(hasAtt ?? SearchQuery.HeaderContains("Content-Disposition", "attachment"));
         if (!string.IsNullOrWhiteSpace(domain)) search = search.And(SearchQuery.SubjectContains(domain));
         if (since.HasValue) search = search.And(SearchQuery.DeliveredAfter(since.Value));
         if (before.HasValue) search = search.And(SearchQuery.DeliveredBefore(before.Value));


### PR DESCRIPTION
## Summary
- require attachments in DMARC IMAP searches
- test DMARC search query enforces attachment filter
- verify Gmail DMARC query includes `has:attachment`

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68aa0cb18f38832ebf5598215d02258f