### PR TITLE
Use streams for DMARC attachments

### DIFF
--- a/Examples/Example-GetGraphDmarcReport.ps1
+++ b/Examples/Example-GetGraphDmarcReport.ps1
@@ -8,8 +8,8 @@ Connect-EmailGraph -ClientId $ClientId -DirectoryId $TenantId -DeviceCode -Scope
 Get-DmarcReport -Protocol Graph -UserPrincipalName 'user@example.com' -Since (Get-Date).AddDays(-7) |
     ForEach-Object {
         foreach ($att in $_.Attachments) {
-            # Pass the zipped XML to Domain Detective for analysis
-            # Invoke-DomainDetective -InputObject $att.Content -Name $att.Name
+            # Pass the zipped XML stream to Domain Detective for analysis
+            # Invoke-DomainDetective -InputStream $att.Content -Name $att.Name
         }
     }
 Disconnect-EmailGraph

--- a/Examples/Example-GetImapDmarcReport.ps1
+++ b/Examples/Example-GetImapDmarcReport.ps1
@@ -4,8 +4,8 @@ Connect-IMAP -Server 'imap.example.com' -Credential (Get-Credential) | Out-Null
 Get-DmarcReport -Protocol Imap -Folder 'INBOX' -Since (Get-Date).AddDays(-7) |
     ForEach-Object {
         foreach ($att in $_.Attachments) {
-            # Pass the zipped XML to Domain Detective for analysis
-            # Invoke-DomainDetective -InputObject $att.Content -Name $att.Name
+            # Pass the zipped XML stream to Domain Detective for analysis
+            # Invoke-DomainDetective -InputStream $att.Content -Name $att.Name
         }
     }
 Disconnect-IMAP

--- a/Examples/Example-GetPop3DmarcReport.ps1
+++ b/Examples/Example-GetPop3DmarcReport.ps1
@@ -4,8 +4,8 @@ Connect-POP3 -Server 'pop3.example.com' -Credential (Get-Credential) | Out-Null
 Get-DmarcReport -Protocol Pop3 -Since (Get-Date).AddDays(-7) |
     ForEach-Object {
         foreach ($att in $_.Attachments) {
-            # Pass the zipped XML to Domain Detective for analysis
-            # Invoke-DomainDetective -InputObject $att.Content -Name $att.Name
+            # Pass the zipped XML stream to Domain Detective for analysis
+            # Invoke-DomainDetective -InputStream $att.Content -Name $att.Name
         }
     }
 Disconnect-POP3

--- a/Examples/Example-GmailApi-15-GetDmarcReport.ps1
+++ b/Examples/Example-GmailApi-15-GetDmarcReport.ps1
@@ -5,7 +5,7 @@ $cred = Connect-OAuthGoogle -GmailAccount 'user@gmail.com' -ClientID 'id' -Clien
 Get-DmarcReport -Protocol GmailApi -GmailAccount 'user@gmail.com' -Credential $cred -Since (Get-Date).AddDays(-7) |
     ForEach-Object {
         foreach ($att in $_.Attachments) {
-            # Pass the zipped XML to Domain Detective for analysis
-            # Invoke-DomainDetective -InputObject $att.Content -Name $att.Name
+            # Pass the zipped XML stream to Domain Detective for analysis
+            # Invoke-DomainDetective -InputStream $att.Content -Name $att.Name
         }
     }

--- a/Sources/Mailozaurr.Examples/RetrieveDmarcReportsExample.cs
+++ b/Sources/Mailozaurr.Examples/RetrieveDmarcReportsExample.cs
@@ -11,14 +11,16 @@ public static class RetrieveDmarcReportsExample {
         var reports = await MailboxSearcher.SearchDmarcReportsAsync(client, "INBOX", since: DateTime.UtcNow.AddDays(-7));
         foreach (var report in reports) {
             foreach (var att in report.Attachments) {
-                DomainDetective.Process(att.Content, att.Name);
+                using (att) {
+                    DomainDetective.Process(att.Content, att.Name);
+                }
             }
         }
     }
 }
 
 public static class DomainDetective {
-    public static void Process(byte[] zip, string name) {
+    public static void Process(Stream zip, string name) {
         // Placeholder for integration with Domain Detective analysis
         Console.WriteLine($"Processing {name} ({zip.Length} bytes)");
     }

--- a/Sources/Mailozaurr/DmarcReports/DmarcReport.cs
+++ b/Sources/Mailozaurr/DmarcReports/DmarcReport.cs
@@ -20,15 +20,17 @@ public sealed class DmarcReport {
 /// <summary>
 /// Represents a zipped XML attachment belonging to a DMARC report.
 /// </summary>
-public sealed class DmarcReportAttachment {
+public sealed class DmarcReportAttachment : IDisposable {
     /// <summary>File name of the attachment.</summary>
     public string Name { get; }
 
-    /// <summary>Binary content of the zipped attachment.</summary>
-    public byte[] Content { get; }
+    /// <summary>Stream containing the zipped attachment.</summary>
+    public Stream Content { get; }
 
-    public DmarcReportAttachment(string name, byte[] content) {
+    public DmarcReportAttachment(string name, Stream content) {
         Name = name;
         Content = content;
     }
+
+    public void Dispose() => Content.Dispose();
 }

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -560,9 +560,10 @@ public static class MailboxSearcher {
             };
             foreach (var att in message.Attachments) {
                 if (IsDmarcAttachment(att) && att is MimePart part) {
-                    using var ms = new MemoryStream();
+                    var ms = new MemoryStream();
                     part.Content.DecodeTo(ms);
-                    report.Attachments.Add(new DmarcReportAttachment(part.FileName ?? "report.zip", ms.ToArray()));
+                    ms.Position = 0;
+                    report.Attachments.Add(new DmarcReportAttachment(part.FileName ?? "report.zip", ms));
                 }
             }
             if (report.Attachments.Count > 0) results.Add(report);


### PR DESCRIPTION
## Summary
- Switch `DmarcReportAttachment` to expose a stream and implement `IDisposable`
- Stream Gmail/IMAP attachment content directly in `FilterDmarcReports`
- Adjust examples to process and dispose DMARC attachment streams

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet build Sources/Mailozaurr.Examples/Mailozaurr.Examples.csproj`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68aa121bbc6c832ea55d941984fad541