### PR TITLE
Refactor mailbox search concurrency

### DIFF
--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -117,6 +117,33 @@ public class SearchNonDeliveryReportsTests {
         }
     }
 
+    private class CountingPop3Client : Pop3Client {
+        private readonly List<MimeMessage> _messages;
+        private readonly int _delay;
+        private readonly object _lock = new();
+        private int _current;
+        public int MaxConcurrency { get; private set; }
+        public CountingPop3Client(IEnumerable<MimeMessage> messages, int delay) {
+            _messages = new List<MimeMessage>(messages);
+            _delay = delay;
+        }
+        public override bool IsConnected => true;
+        public override bool IsAuthenticated => true;
+        public override int Count => _messages.Count;
+        public override async Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {
+            lock (_lock) {
+                _current++;
+                if (_current > MaxConcurrency) MaxConcurrency = _current;
+            }
+            try {
+                await Task.Delay(_delay, cancellationToken).ConfigureAwait(false);
+            } finally {
+                lock (_lock) { _current--; }
+            }
+            return _messages[index];
+        }
+    }
+
     [Fact]
     public async Task SearchNonDeliveryReportsAsync_Pop3_DownloadsInParallel() {
         var now = DateTimeOffset.UtcNow;
@@ -137,5 +164,19 @@ public class SearchNonDeliveryReportsTests {
         sw.Stop();
         Assert.Equal(4, reports.Count);
         Assert.True(sw.Elapsed < seq.Elapsed, $"sequential: {seq.ElapsedMilliseconds}, parallel: {sw.ElapsedMilliseconds}");
+    }
+
+    [Fact]
+    public async Task SearchNonDeliveryReportsAsync_Pop3_RespectsParallelLimit() {
+        var now = DateTimeOffset.UtcNow;
+        var msgs = new List<MimeMessage>();
+        for (int i = 0; i < 20; i++) msgs.Add(CreateNdr($"u{i}@example.com", $"<id{i}>", now));
+        var client = new CountingPop3Client(msgs, 100);
+        var reports = await MailboxSearcher.SearchNonDeliveryReportsAsync(
+            client,
+            parallelDownloadLimit: 4,
+            cancellationToken: CancellationToken.None);
+        Assert.Equal(msgs.Count, reports.Count);
+        Assert.Equal(4, client.MaxConcurrency);
     }
 }

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -159,22 +159,27 @@ public static class MailboxSearcher {
         } else {
             using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
             var tasks = new List<Task>();
+
+            async Task DownloadMessageAsync(UniqueId uid) {
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
+                    lock (messages) messages.Add(msg);
+                } finally {
+                    semaphore.Release();
+                }
+            }
+
             foreach (var uid in uids) {
                 cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(Task.Run(async () => {
-                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    try {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-                        lock (messages) messages.Add(msg);
-                    } finally {
-                        semaphore.Release();
-                    }
-                }, cancellationToken));
+                tasks.Add(DownloadMessageAsync(uid));
                 if (maxResults > 0 && tasks.Count >= maxResults) break;
             }
+
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
+
         return FilterNonDeliveryReports(messages, since, before, recipientContains, messageId);
     }
 
@@ -206,22 +211,27 @@ public static class MailboxSearcher {
         } else {
             using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
             var tasks = new List<Task>();
+
+            async Task DownloadMessageAsync(int idx) {
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
+                    lock (messages) messages.Add(msg);
+                } finally {
+                    semaphore.Release();
+                }
+            }
+
             foreach (var idx in indices) {
                 cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(Task.Run(async () => {
-                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    try {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
-                        lock (messages) messages.Add(msg);
-                    } finally {
-                        semaphore.Release();
-                    }
-                }, cancellationToken));
+                tasks.Add(DownloadMessageAsync(idx));
                 if (maxResults > 0 && tasks.Count >= maxResults) break;
             }
+
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
+
         return FilterNonDeliveryReports(messages, since, before, recipientContains, messageId);
     }
 
@@ -262,23 +272,28 @@ public static class MailboxSearcher {
         } else {
             using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
             var tasks = new List<Task>();
+
+            async Task DownloadMessageAsync(string id) {
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                    lock (mimeMessages) mimeMessages.Add(mime);
+                } finally {
+                    semaphore.Release();
+                }
+            }
+
             foreach (var m in msgs) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (m.TryGetValue("id", out var idObj) && idObj is string id) {
-                    tasks.Add(Task.Run(async () => {
-                        await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                        try {
-                            cancellationToken.ThrowIfCancellationRequested();
-                            var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
-                            lock (mimeMessages) mimeMessages.Add(mime);
-                        } finally {
-                            semaphore.Release();
-                        }
-                    }, cancellationToken));
+                    tasks.Add(DownloadMessageAsync(id));
                 }
             }
+
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
+
         return FilterNonDeliveryReports(mimeMessages, since, before, recipientContains, messageId);
     }
 
@@ -312,24 +327,29 @@ public static class MailboxSearcher {
         } else {
             using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
             var tasks = new List<Task>();
+
+            async Task DownloadMessageAsync(string id) {
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var mime = await client.GetMimeMessageAsync(userId, id, cancellationToken).ConfigureAwait(false);
+                    lock (mimeMessages) mimeMessages.Add(mime);
+                } finally {
+                    semaphore.Release();
+                }
+            }
+
             foreach (var m in msgs) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (!string.IsNullOrEmpty(m.Id)) {
-                    tasks.Add(Task.Run(async () => {
-                        await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                        try {
-                            cancellationToken.ThrowIfCancellationRequested();
-                            var mime = await client.GetMimeMessageAsync(userId, m.Id, cancellationToken).ConfigureAwait(false);
-                            lock (mimeMessages) mimeMessages.Add(mime);
-                        } finally {
-                            semaphore.Release();
-                        }
-                    }, cancellationToken));
+                    tasks.Add(DownloadMessageAsync(m.Id));
                 }
                 if (maxResults > 0 && tasks.Count >= maxResults) break;
             }
+
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
+
         return FilterNonDeliveryReports(mimeMessages, since, before, recipientContains, messageId);
     }
 
@@ -363,22 +383,27 @@ public static class MailboxSearcher {
         } else {
             using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
             var tasks = new List<Task>();
+
+            async Task DownloadMessageAsync(UniqueId uid) {
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
+                    lock (messages) messages.Add(msg);
+                } finally {
+                    semaphore.Release();
+                }
+            }
+
             foreach (var uid in uids) {
                 cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(Task.Run(async () => {
-                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    try {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-                        lock (messages) messages.Add(msg);
-                    } finally {
-                        semaphore.Release();
-                    }
-                }, cancellationToken));
+                tasks.Add(DownloadMessageAsync(uid));
                 if (maxResults > 0 && tasks.Count >= maxResults) break;
             }
+
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
+
         return FilterDmarcReports(messages, since, before, domain);
     }
 
@@ -409,22 +434,27 @@ public static class MailboxSearcher {
         } else {
             using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
             var tasks = new List<Task>();
+
+            async Task DownloadMessageAsync(int idx) {
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
+                    lock (messages) messages.Add(msg);
+                } finally {
+                    semaphore.Release();
+                }
+            }
+
             foreach (var idx in indices) {
                 cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(Task.Run(async () => {
-                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    try {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
-                        lock (messages) messages.Add(msg);
-                    } finally {
-                        semaphore.Release();
-                    }
-                }, cancellationToken));
+                tasks.Add(DownloadMessageAsync(idx));
                 if (maxResults > 0 && tasks.Count >= maxResults) break;
             }
+
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
+
         return FilterDmarcReports(messages, since, before, domain);
     }
 
@@ -465,23 +495,28 @@ public static class MailboxSearcher {
         } else {
             using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
             var tasks = new List<Task>();
+
+            async Task DownloadMessageAsync(string id) {
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                    lock (mimeMessages) mimeMessages.Add(mime);
+                } finally {
+                    semaphore.Release();
+                }
+            }
+
             foreach (var m in msgs) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (m.TryGetValue("id", out var idObj) && idObj is string id) {
-                    tasks.Add(Task.Run(async () => {
-                        await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                        try {
-                            cancellationToken.ThrowIfCancellationRequested();
-                            var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
-                            lock (mimeMessages) mimeMessages.Add(mime);
-                        } finally {
-                            semaphore.Release();
-                        }
-                    }, cancellationToken));
+                    tasks.Add(DownloadMessageAsync(id));
                 }
             }
+
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
+
         return FilterDmarcReports(mimeMessages, since, before, domain);
     }
 
@@ -514,24 +549,29 @@ public static class MailboxSearcher {
         } else {
             using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
             var tasks = new List<Task>();
+
+            async Task DownloadMessageAsync(string id) {
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var mime = await client.GetMimeMessageAsync(userId, id, cancellationToken).ConfigureAwait(false);
+                    lock (mimeMessages) mimeMessages.Add(mime);
+                } finally {
+                    semaphore.Release();
+                }
+            }
+
             foreach (var m in msgs) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (!string.IsNullOrEmpty(m.Id)) {
-                    tasks.Add(Task.Run(async () => {
-                        await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                        try {
-                            cancellationToken.ThrowIfCancellationRequested();
-                            var mime = await client.GetMimeMessageAsync(userId, m.Id, cancellationToken).ConfigureAwait(false);
-                            lock (mimeMessages) mimeMessages.Add(mime);
-                        } finally {
-                            semaphore.Release();
-                        }
-                    }, cancellationToken));
+                    tasks.Add(DownloadMessageAsync(m.Id));
                 }
                 if (maxResults > 0 && tasks.Count >= maxResults) break;
             }
+
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
+
         return FilterDmarcReports(mimeMessages, since, before, domain);
     }
 


### PR DESCRIPTION
## Summary
- simplify mailbox search tasks by queuing async lambdas with SemaphoreSlim instead of Task.Run
- add POP3 concurrency limit test

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`
- `pwsh -NoLogo -File ./Mailozaurr.Tests.ps1` *(fails: Unable to find type [Mailozaurr.PowerShell.GraphConnectionInfo], etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa97d60538832e9317383369dee4e7