### PR TITLE
Ensure subject-only NDRs include message date

### DIFF
--- a/Sources/Mailozaurr.Tests/MimeKitNonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/MimeKitNonDeliveryReportTests.cs
@@ -40,6 +40,17 @@ public class MimeKitNonDeliveryReportTests {
     }
 
     [Fact]
+    public void GetNonDeliveryReports_SubjectReportUsesMessageDate() {
+        var date = new DateTimeOffset(2024, 7, 24, 10, 0, 0, TimeSpan.Zero);
+        string raw = $"Date: {date:R}\r\nSubject: Mail Delivery Subsystem\r\n\r\ntext";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));
+        var message = MimeMessage.Load(stream);
+        var reports = MimeKitUtils.GetNonDeliveryReports(message);
+        Assert.Single(reports);
+        Assert.Equal(date, reports[0].Timestamp);
+    }
+
+    [Fact]
     public void GetNonDeliveryReports_IgnoresDuplicateHeaders() {
         const string raw = "Content-Type: multipart/report; report-type=delivery-status; boundary=\"XXX\"\n\n--XXX\nContent-Type: text/plain; charset=utf-8\n\ntext\n\n--XXX\nContent-Type: message/delivery-status\n\nFinal-Recipient: rfc822; user@example.com\nFinal-Recipient: rfc822; other@example.com\nStatus: 5.1.1\n\n--XXX--";
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));

--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -63,6 +63,21 @@ public class SearchNonDeliveryReportsTests {
         Assert.Equal("<id1>", reports[0].OriginalMessageId);
     }
 
+    [Fact]
+    public void FilterNonDeliveryReports_SubjectDetectedReportSurvivesDateFilter() {
+        var now = DateTimeOffset.UtcNow;
+        var date = new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second, now.Offset);
+        string raw = $"Date: {date:R}\r\nSubject: Mail Delivery Subsystem\r\n\r\ntext";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));
+        var message = MimeMessage.Load(stream);
+        var list = new List<MimeMessage> { message };
+        var since = date.AddMinutes(-5).UtcDateTime;
+        var before = date.AddMinutes(5).UtcDateTime;
+        var reports = MailboxSearcher.FilterNonDeliveryReports(list, since, before, recipientContains: null, messageId: null);
+        Assert.Single(reports);
+        Assert.Equal(date, reports[0].Timestamp);
+    }
+
     private static bool Contains(SearchQuery query, Func<SearchQuery, bool> predicate) {
         if (predicate(query)) return true;
         var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic;

--- a/Sources/Mailozaurr/MimeKitUtils.cs
+++ b/Sources/Mailozaurr/MimeKitUtils.cs
@@ -54,7 +54,7 @@ public static class MimeKitUtils {
                 reports.Add(headers.Count > 0 ? NonDeliveryReport.FromHeaders(headers) : new NonDeliveryReport());
             }
         } else {
-            reports.Add(new NonDeliveryReport());
+            reports.Add(new NonDeliveryReport { Timestamp = message.Date });
         }
 
         return reports;


### PR DESCRIPTION
## Summary
- set timestamp on non-delivery reports detected by subject line
- ensure subject-derived reports survive date filtering
- add regression tests for timestamp and date filtering

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68aaac4bc46c832ea5fafea015cefc83