### PR TITLE
Respect maxResults when listing Gmail messages

### DIFF
--- a/Sources/Mailozaurr.Examples/FetchGmailMessages.cs
+++ b/Sources/Mailozaurr.Examples/FetchGmailMessages.cs
@@ -1,0 +1,33 @@
+using Mailozaurr;
+using System;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Example demonstrating how to list messages using the Gmail API.
+/// </summary>
+public static class FetchGmailMessages {
+    /// <summary>Runs the example.</summary>
+    public static async Task RunAsync() {
+        // === CONFIGURATION ===
+        string gmailAccount = "user@gmail.com";
+        string accessToken = "ya29.your_token"; // OAuth access token
+        int maxResults = 5; // limit number of messages
+
+        // === EXAMPLE ===
+        try {
+            var cred = new OAuthCredential {
+                UserName = gmailAccount,
+                AccessToken = accessToken,
+                ExpiresOn = DateTimeOffset.MaxValue
+            };
+            var client = new GmailApiClient(cred);
+            var messages = await client.ListAsync("me", maxResults: maxResults);
+            Console.WriteLine($"Gmail API: fetched {messages.Count} messages");
+        } catch (GmailAuthenticationException ex) {
+            Console.WriteLine($"Gmail API Authentication Error: {ex.Message}");
+        } catch (Exception ex) {
+            Console.WriteLine($"Gmail API Example Error: {ex.Message}");
+        }
+    }
+}
+

--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -138,6 +138,36 @@ public class GmailApiClientTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task ListAsync_ExactMaxResults_StopsEarly() {
+        var page1 = "{\"messages\":[{\"id\":\"1\"},{\"id\":\"2\"}],\"nextPageToken\":\"tok\"}";
+        var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(page1) });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        var list = await client.ListAsync("me", maxResults: 2);
+        Assert.Equal(2, list.Count);
+        Assert.Single(handler.Requests);
+        Assert.Equal("?maxResults=2", handler.Requests[0].RequestUri!.Query);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ListAsync_PartialPageLimit_AdjustsRequests() {
+        var page1 = "{\"messages\":[{\"id\":\"1\"},{\"id\":\"2\"}],\"nextPageToken\":\"tok\"}";
+        var page2 = "{\"messages\":[{\"id\":\"3\"}],\"nextPageToken\":\"tok2\"}";
+        var handler = new RecordingHandler(
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(page1) },
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(page2) });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        var list = await client.ListAsync("me", maxResults: 3);
+        Assert.Equal(3, list.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("?maxResults=3", handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?maxResults=1&pageToken=tok", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task SendAsync_CanBeCancelled() {
         var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK));
         var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -97,11 +97,12 @@ public sealed class GmailApiClient : IDisposable {
     public async Task<IList<GmailMessage>> ListAsync(string userId, string? query = null, int? maxResults = null, CancellationToken cancellationToken = default) {
         var messages = new List<GmailMessage>();
         string? pageToken = null;
-        do {
+        int? remaining = maxResults;
+        while (true) {
             var url = new StringBuilder($"users/{userId}/messages");
             var qs = new List<string>();
             if (!string.IsNullOrWhiteSpace(query)) qs.Add($"q={Uri.EscapeDataString(query)}");
-            if (maxResults.HasValue) qs.Add($"maxResults={maxResults.Value}");
+            if (remaining.HasValue) qs.Add($"maxResults={remaining.Value}");
             if (!string.IsNullOrEmpty(pageToken)) qs.Add($"pageToken={pageToken}");
             if (qs.Count > 0) {
                 url.Append('?').Append(string.Join("&", qs));
@@ -118,8 +119,17 @@ public sealed class GmailApiClient : IDisposable {
             if (list?.Messages != null) {
                 messages.AddRange(list.Messages);
             }
+            if (maxResults.HasValue && messages.Count >= maxResults.Value) {
+                break;
+            }
             pageToken = list?.NextPageToken;
-        } while (!string.IsNullOrEmpty(pageToken));
+            if (string.IsNullOrEmpty(pageToken)) {
+                break;
+            }
+            if (maxResults.HasValue) {
+                remaining = maxResults.Value - messages.Count;
+            }
+        }
 
         return messages;
     }


### PR DESCRIPTION
## Summary
- stop Gmail listing when requested max results are reached
- adjust next page request size based on remaining items
- add examples and unit tests for max result limits

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh ./Mailozaurr.Tests.ps1` *(fails: InvalidOperationException in Test-SmtpConnection.Returns capabilities object)*


------
https://chatgpt.com/codex/tasks/task_e_68aaac3799a0832ea864598c3c5a4886