### PR TITLE
Cache DMARC attachment search query

### DIFF
--- a/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
@@ -98,6 +98,34 @@ public class SearchDmarcReportsTests {
     }
 
     [Fact]
+    public void BuildDmarcReportSearchQuery_ReusesAttachmentQueryInstance() {
+        var q1 = MailboxSearcher.BuildDmarcReportSearchQuery(null, null, null);
+        var q2 = MailboxSearcher.BuildDmarcReportSearchQuery(null, null, null);
+
+        MailKit.Search.SearchQuery? FindAttachment(MailKit.Search.SearchQuery q) {
+            var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic;
+            var term = q.GetType().GetProperty("Term", flags)?.GetValue(q)?.ToString();
+            if (term == "HasAttachment") return q;
+            if (term == "HeaderContains") {
+                var field = q.GetType().GetProperty("Field", flags)?.GetValue(q)?.ToString();
+                var value = q.GetType().GetProperty("Value", flags)?.GetValue(q)?.ToString();
+                if (field?.Equals("Content-Disposition", StringComparison.OrdinalIgnoreCase) == true &&
+                    value?.IndexOf("attachment", StringComparison.OrdinalIgnoreCase) >= 0) return q;
+            }
+            var left = q.GetType().GetProperty("Left", flags)?.GetValue(q) as MailKit.Search.SearchQuery;
+            var right = q.GetType().GetProperty("Right", flags)?.GetValue(q) as MailKit.Search.SearchQuery;
+            var leftRes = left != null ? FindAttachment(left) : null;
+            return leftRes ?? (right != null ? FindAttachment(right) : null);
+        }
+
+        var a1 = FindAttachment(q1);
+        var a2 = FindAttachment(q2);
+
+        Assert.NotNull(a1);
+        Assert.Same(a1, a2);
+    }
+
+    [Fact]
     public void BuildGmailDmarcReportQuery_IncludesDomainAndDates() {
         var since = new DateTime(2024, 1, 1);
         var before = new DateTime(2024, 2, 1);

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -19,6 +19,8 @@ namespace Mailozaurr;
 /// Provides mailbox search helpers for IMAP and POP3.
 /// </summary>
 public static class MailboxSearcher {
+    private static readonly SearchQuery HasAttachmentSearchQuery = InitializeHasAttachmentQuery();
+
     /// <summary>
     /// Searches an IMAP mailbox and returns matching messages.
     /// </summary>
@@ -612,13 +614,20 @@ public static class MailboxSearcher {
     }
 
     internal static SearchQuery BuildDmarcReportSearchQuery(DateTime? since, DateTime? before, string? domain) {
-        SearchQuery search = SearchQuery.SubjectContains("report domain");
-        var hasAtt = typeof(SearchQuery).GetProperty("HasAttachment", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)?.GetValue(null) as SearchQuery;
-        search = search.And(hasAtt ?? SearchQuery.HeaderContains("Content-Disposition", "attachment"));
+        SearchQuery search = SearchQuery.SubjectContains("report domain").And(HasAttachmentSearchQuery);
         if (!string.IsNullOrWhiteSpace(domain)) search = search.And(SearchQuery.SubjectContains(domain));
         if (since.HasValue) search = search.And(SearchQuery.DeliveredAfter(since.Value.ToUniversalTime()));
         if (before.HasValue) search = search.And(SearchQuery.DeliveredBefore(before.Value.ToUniversalTime()));
         return search;
+    }
+
+    private static SearchQuery InitializeHasAttachmentQuery() {
+#if MAILKIT_HAS_HASATTACHMENT
+        return SearchQuery.HasAttachment;
+#else
+        var prop = typeof(SearchQuery).GetProperty("HasAttachment", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+        return prop?.GetValue(null) as SearchQuery ?? SearchQuery.HeaderContains("Content-Disposition", "attachment");
+#endif
     }
 
     internal static string BuildGmailDmarcReportQuery(DateTime? since, DateTime? before, string? domain) {


### PR DESCRIPTION
## Summary
- cache the HasAttachment search query when building DMARC queries
- replace per-call reflection with a static lookup
- test that the attachment query instance is reused

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68ab05da19bc832e9002e3f582b62932