### PR TITLE
Stream DMARC attachments and verify domain

### DIFF
--- a/Sources/Mailozaurr.Examples/RetrieveDmarcReportsExample.cs
+++ b/Sources/Mailozaurr.Examples/RetrieveDmarcReportsExample.cs
@@ -8,7 +8,7 @@ namespace Mailozaurr.Examples;
 
 public static class RetrieveDmarcReportsExample {
     public static async Task RunAsync(ImapClient client) {
-        var reports = await MailboxSearcher.SearchDmarcReportsAsync(client, "INBOX", since: DateTime.UtcNow.AddDays(-7));
+        var reports = await MailboxSearcher.SearchDmarcReportsAsync(client, "INBOX", since: DateTime.UtcNow.AddDays(-7), domain: "example.com");
         foreach (var report in reports) {
             foreach (var att in report.Attachments) {
                 using (att) {
@@ -22,6 +22,7 @@ public static class RetrieveDmarcReportsExample {
 public static class DomainDetective {
     public static void Process(Stream zip, string name) {
         // Placeholder for integration with Domain Detective analysis
-        Console.WriteLine($"Processing {name} ({zip.Length} bytes)");
+        var size = zip.CanSeek ? zip.Length : 0;
+        Console.WriteLine($"Processing {name} ({size} bytes)");
     }
 }

--- a/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
@@ -32,7 +32,8 @@ public class SearchDmarcReportsTests {
         message.Date = date;
         message.From.Add(new MailboxAddress("reporter", "reporter@example.com"));
         var builder = new BodyBuilder();
-        var ms = new MemoryStream(Encoding.UTF8.GetBytes("<feedback/>"));
+        var xml = $"<feedback><policy_published><domain>{domain}</domain></policy_published></feedback>";
+        var ms = new MemoryStream(Encoding.UTF8.GetBytes(xml));
         var part = new MimePart(mediaType, mediaSubtype) {
             Content = new MimeContent(ms),
             FileName = fileName
@@ -53,7 +54,7 @@ public class SearchDmarcReportsTests {
         Assert.Equal("reporter@example.com", report.From);
         Assert.Single(report.Attachments);
         Assert.EndsWith(".zip", report.Attachments[0].Name);
-        Assert.True(report.Attachments[0].Content.Length > 0);
+        Assert.True(report.Attachments[0].Content.CanRead);
     }
 
     [Fact]
@@ -142,5 +143,33 @@ public class SearchDmarcReportsTests {
         Assert.Single(reports);
         Assert.Single(reports[0].Attachments);
         Assert.Equal("example", reports[0].Attachments[0].Name);
+    }
+
+    [Fact]
+    public void FilterDmarcReports_VerifiesDomainFromAttachment() {
+        var now = DateTimeOffset.UtcNow;
+        var msg = new MimeMessage();
+        msg.Subject = "Report domain";
+        msg.Date = now;
+        msg.From.Add(new MailboxAddress("reporter", "reporter@example.com"));
+        var builder = new BodyBuilder();
+        var xml = "<feedback><policy_published><domain>example.com</domain></policy_published></feedback>";
+        using var xmlStream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        using var zipStream = new MemoryStream();
+        using (var archive = new System.IO.Compression.ZipArchive(zipStream, System.IO.Compression.ZipArchiveMode.Create, true)) {
+            var entry = archive.CreateEntry("report.xml");
+            using var entryStream = entry.Open();
+            xmlStream.CopyTo(entryStream);
+        }
+        zipStream.Position = 0;
+        var part = new MimePart("application", "zip") {
+            Content = new MimeContent(zipStream),
+            FileName = "report.zip"
+        };
+        builder.Attachments.Add(part);
+        msg.Body = builder.ToMessageBody();
+        var list = new List<MimeMessage> { msg };
+        var reports = MailboxSearcher.FilterDmarcReports(list, since: now.AddMinutes(-1).DateTime, before: now.AddMinutes(1).DateTime, domain: "example.com");
+        Assert.Single(reports);
     }
 }

--- a/Sources/Mailozaurr/Mailozaurr.csproj
+++ b/Sources/Mailozaurr/Mailozaurr.csproj
@@ -36,6 +36,7 @@
         <PackageReference Include="MsgReader" Version="5.7.3" />
         <PackageReference Include="System.Text.Json" Version="8.0.5" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
+        <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     </ItemGroup>
 
 

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -584,7 +584,8 @@ public static class MailboxSearcher {
         IEnumerable<MimeMessage> messages,
         DateTime? since,
         DateTime? before,
-        string? domain) {
+        string? domain,
+        long? maxAttachmentBytes = null) {
         var results = new List<DmarcReport>();
         var sinceUtc = since?.ToUniversalTime();
         var beforeUtc = before?.ToUniversalTime();
@@ -592,19 +593,20 @@ public static class MailboxSearcher {
             var msgDate = message.Date.UtcDateTime;
             if (sinceUtc.HasValue && msgDate < sinceUtc.Value) continue;
             if (beforeUtc.HasValue && msgDate > beforeUtc.Value) continue;
-            if (!string.IsNullOrWhiteSpace(domain) && (message.Subject == null || message.Subject.IndexOf(domain, StringComparison.OrdinalIgnoreCase) < 0)) continue;
             var report = new DmarcReport {
                 From = message.From.Mailboxes.FirstOrDefault()?.Address,
                 Subject = message.Subject,
                 Date = message.Date
             };
             foreach (var att in message.Attachments) {
-                if (IsDmarcAttachment(att) && att is MimePart part) {
-                    var ms = new MemoryStream();
-                    part.Content.DecodeTo(ms);
-                    ms.Position = 0;
-                    report.Attachments.Add(new DmarcReportAttachment(part.FileName ?? "report.zip", ms));
+                if (!IsDmarcAttachment(att) || att is not MimePart part) continue;
+                if (!string.IsNullOrWhiteSpace(domain) && !AttachmentMatchesDomain(part, domain!, maxAttachmentBytes)) continue;
+                var stream = part.Content.Open();
+                if (maxAttachmentBytes.HasValue && stream.CanSeek && stream.Length > maxAttachmentBytes.Value) {
+                    stream.Dispose();
+                    continue;
                 }
+                report.Attachments.Add(new DmarcReportAttachment(part.FileName ?? "report.zip", stream));
             }
             if (report.Attachments.Count > 0) results.Add(report);
         }
@@ -640,6 +642,36 @@ public static class MailboxSearcher {
                 } else if (ct.MediaType.Equals("text", StringComparison.OrdinalIgnoreCase)) {
                     if (ct.MediaSubtype.Equals("xml", StringComparison.OrdinalIgnoreCase)) return true;
                 }
+            }
+        }
+        return false;
+    }
+
+    private static bool AttachmentMatchesDomain(MimePart part, string domain, long? maxBytes) {
+        var name = part.FileName;
+        if (!string.IsNullOrEmpty(name) && name.IndexOf(domain, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        using var stream = part.Content.Open();
+        if (maxBytes.HasValue && stream.CanSeek && stream.Length > maxBytes.Value) return false;
+        if (!string.IsNullOrEmpty(name) && name.EndsWith(".gz", StringComparison.OrdinalIgnoreCase)) {
+            using var gzip = new System.IO.Compression.GZipStream(stream, System.IO.Compression.CompressionMode.Decompress, leaveOpen: true);
+            return XmlContainsDomain(gzip, domain);
+        }
+        if (!string.IsNullOrEmpty(name) && name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)) {
+            using var archive = new System.IO.Compression.ZipArchive(stream, System.IO.Compression.ZipArchiveMode.Read, leaveOpen: true);
+            foreach (var entry in archive.Entries) {
+                using var entryStream = entry.Open();
+                if (XmlContainsDomain(entryStream, domain)) return true;
+            }
+            return false;
+        }
+        return XmlContainsDomain(stream, domain);
+    }
+
+    private static bool XmlContainsDomain(Stream xml, string domain) {
+        using var reader = System.Xml.XmlReader.Create(xml, new System.Xml.XmlReaderSettings { IgnoreComments = true, IgnoreWhitespace = true });
+        while (reader.Read()) {
+            if (reader.NodeType == System.Xml.XmlNodeType.Element && reader.Name.Equals("domain", StringComparison.OrdinalIgnoreCase)) {
+                if (reader.ReadElementContentAsString().Equals(domain, StringComparison.OrdinalIgnoreCase)) return true;
             }
         }
         return false;


### PR DESCRIPTION
## Summary
- Stream DMARC report attachments rather than buffering
- Validate domain filter by inspecting attachment names or XML contents
- Add DMARC retrieval example with domain filter and update tests

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68ab05d52844832ea3a09200093c3796