### PR TITLE
Make LastAttemptDate nullable and respect DSN last attempt date

### DIFF
--- a/Sources/Mailozaurr.Examples/ParseNonDeliveryReportExample.cs
+++ b/Sources/Mailozaurr.Examples/ParseNonDeliveryReportExample.cs
@@ -14,10 +14,11 @@ public static class ParseNonDeliveryReportExample {
             ["Reporting-MTA"] = "dns; mx.example.com",
             ["Diagnostic-Code"] = "smtp; 550 5.1.1 User unknown",
             ["Status"] = "5.1.1",
-            ["Arrival-Date"] = DateTimeOffset.UtcNow.ToString("R")
+            ["Arrival-Date"] = DateTimeOffset.UtcNow.ToString("R"),
+            ["Last-Attempt-Date"] = DateTimeOffset.UtcNow.ToString("R")
         };
 
         var ndr = NonDeliveryReport.FromHeaders(headers);
-        Console.WriteLine($"NDR Type: {ndr.Type}, Status: {ndr.Status}");
+        Console.WriteLine($"NDR Type: {ndr.Type}, Last Attempt: {ndr.LastAttemptDate?.ToString() ?? "n/a"}, Status: {ndr.Status}");
     }
 }

--- a/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
@@ -76,5 +76,16 @@ public class NonDeliveryReportTests {
         Assert.True(DateUtils.TryParse(dateHeader, out var expected));
         Assert.Equal(expected, report.Timestamp);
         Assert.Equal(expected, report.LastAttemptDate);
+
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("not a date")]
+    public void LastAttemptDateMissingOrInvalid_ReturnsNull(string? header) {
+        var headers = new Dictionary<string, string>();
+        if (header != null) headers["Last-Attempt-Date"] = header;
+        var report = NonDeliveryReport.FromHeaders(headers);
+        Assert.Null(report.LastAttemptDate);
     }
 }

--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -17,9 +17,12 @@ using Xunit;
 namespace Mailozaurr.Tests;
 
 public class SearchNonDeliveryReportsTests {
-    private static MimeMessage CreateNdr(string recipient, string messageId, DateTimeOffset date) {
+    private static MimeMessage CreateNdr(string recipient, string messageId, DateTimeOffset date, DateTimeOffset? lastAttempt = null) {
         string arrival = date.ToString("ddd, dd MMM yyyy HH:mm:ss K", CultureInfo.InvariantCulture);
-        string raw = $"Content-Type: multipart/report; report-type=delivery-status; boundary=\"XXX\"\r\n\r\n--XXX\r\nContent-Type: text/plain; charset=utf-8\r\n\r\ntext\r\n\r\n--XXX\r\nContent-Type: message/delivery-status\r\n\r\nOriginal-Recipient: rfc822; {recipient}\r\nFinal-Recipient: rfc822; {recipient}\r\nOriginal-Message-ID: {messageId}\r\nReporting-MTA: dns; mx.example.com\r\nDiagnostic-Code: smtp; 550 5.1.1 User unknown\r\nStatus: 5.1.1\r\nArrival-Date: {arrival}\r\n\r\n--XXX--";
+        string? lastAttemptStr = lastAttempt?.ToString("ddd, dd MMM yyyy HH:mm:ss K", CultureInfo.InvariantCulture);
+        string raw = $"Content-Type: multipart/report; report-type=delivery-status; boundary=\"XXX\"\r\n\r\n--XXX\r\nContent-Type: text/plain; charset=utf-8\r\n\r\ntext\r\n\r\n--XXX\r\nContent-Type: message/delivery-status\r\n\r\nOriginal-Recipient: rfc822; {recipient}\r\nFinal-Recipient: rfc822; {recipient}\r\nOriginal-Message-ID: {messageId}\r\nReporting-MTA: dns; mx.example.com\r\nDiagnostic-Code: smtp; 550 5.1.1 User unknown\r\nStatus: 5.1.1\r\nArrival-Date: {arrival}\r\n";
+        if (lastAttemptStr != null) raw += $"Last-Attempt-Date: {lastAttemptStr}\r\n";
+        raw += "\r\n--XXX--";
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(raw));
         return MimeMessage.Load(stream);
     }
@@ -49,6 +52,16 @@ public class SearchNonDeliveryReportsTests {
         var reports = MailboxSearcher.FilterNonDeliveryReports(list, since: now.AddMinutes(-5).DateTime, before: null, recipientContains: null, messageId: null);
         Assert.Single(reports);
         Assert.Equal("<id2>", reports[0].OriginalMessageId);
+    }
+
+    [Fact]
+    public void FilterNonDeliveryReports_UsesLastAttemptDateWhenPresent() {
+        var now = DateTimeOffset.UtcNow;
+        var msg = CreateNdr("user@example.com", "<id1>", now.AddDays(-2), lastAttempt: now);
+        var list = new List<MimeMessage> { msg };
+        var reports = MailboxSearcher.FilterNonDeliveryReports(list, since: now.AddHours(-1).DateTime, before: null, recipientContains: null, messageId: null);
+        Assert.Single(reports);
+        Assert.Equal("<id1>", reports[0].OriginalMessageId);
     }
 
     [Fact]

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
@@ -31,7 +31,7 @@ public sealed class NonDeliveryReport {
     public string? RemoteMta { get; set; }
 
     /// <summary>Date of the last delivery attempt.</summary>
-    public DateTimeOffset LastAttemptDate { get; set; }
+    public DateTimeOffset? LastAttemptDate { get; set; }
 
     /// <summary>Identifier of the final log entry.</summary>
     public string? FinalLogId { get; set; }
@@ -71,11 +71,11 @@ public sealed class NonDeliveryReport {
             ReportingMta = reportingMta,
             Action = action,
             RemoteMta = remoteMta,
-            LastAttemptDate = ParseTimestamp(lastAttemptDate),
+            LastAttemptDate = TryParseTimestamp(lastAttemptDate),
             FinalLogId = finalLogId,
             DiagnosticCode = diagnosticCode is not null ? DsnDiagnosticCode.Parse(diagnosticCode) : null,
             Status = statusCode is not null && DsnStatus.TryParse(statusCode, out var status) ? status : null,
-            Timestamp = ParseTimestamp(arrivalDate)
+            Timestamp = TryParseTimestamp(arrivalDate) ?? TryParseTimestamp(lastAttemptDate) ?? DateTimeOffset.MinValue
         };
         return ndr;
     }
@@ -88,12 +88,8 @@ public sealed class NonDeliveryReport {
         return idx >= 0 ? header.Substring(idx + 1).Trim() : header.Trim();
     }
 
-    private static DateTimeOffset ParseTimestamp(string? value) {
-        if (DateUtils.TryParse(value, out var dt)) {
-            return dt;
-        }
-        return DateTimeOffset.MinValue;
-    }
+    private static DateTimeOffset? TryParseTimestamp(string? value)
+        => DateUtils.TryParse(value, out var dt) ? dt : null;
 
     /// <summary>Maps a <see cref="DsnStatus"/> to an <see cref="NonDeliveryReportType"/>.</summary>
     public static NonDeliveryReportType GetReportType(DsnStatus? status) {

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -662,7 +662,7 @@ public static class MailboxSearcher {
         var beforeUtc = before?.ToUniversalTime();
         foreach (var message in messages) {
             foreach (var report in MimeKitUtils.GetNonDeliveryReports(message)) {
-                var reportDate = report.Timestamp.UtcDateTime;
+                var reportDate = (report.LastAttemptDate ?? report.Timestamp).UtcDateTime;
                 if (sinceUtc.HasValue && reportDate < sinceUtc.Value) continue;
                 if (beforeUtc.HasValue && reportDate > beforeUtc.Value) continue;
                 if (!string.IsNullOrWhiteSpace(recipientContains) && !RecipientMatches(report, recipientContains!)) continue;


### PR DESCRIPTION
## Summary
- allow null for `LastAttemptDate` in `NonDeliveryReport`
- parse DSN timestamps safely and fall back to last attempt when needed
- use last attempt date in mailbox filters
- add tests for missing or invalid last attempt date parsing

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `dotnet build Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_68ab05cba51c832ebeaaf32377fa65ac