### PR TITLE
Propagate cancellation tokens through Graph utilities

### DIFF
--- a/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsCancellationTests.cs
+++ b/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsCancellationTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Mailozaurr;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+[Collection("GraphCollection")]
+public class MicrosoftGraphUtilsCancellationTests {
+    private static FieldInfo GetHandlerField() =>
+        typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? typeof(HttpMessageInvoker).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("HttpClient handler field not found");
+
+    [Fact]
+    public async Task GetMailMessagesAsync_HonorsCancellation() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StringContent("{\"value\":[{\"id\":\"1\"}]}")
+        };
+        var handler = new RecordingHandler(response);
+        var httpClientField = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)httpClientField.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        var tokenCacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var tokenCache = (ConcurrentDictionary<string, GraphAuthorization>)tokenCacheField.GetValue(null)!;
+        var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
+        var key = "id|tenant||secret|https://graph.microsoft.com";
+        tokenCache[key] = new GraphAuthorization { AccessToken = "token", TokenType = "Bearer", ExpiresOn = DateTimeOffset.UtcNow.AddHours(1) };
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        try {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => MicrosoftGraphUtils.GetMailMessagesAsync(cred, "u", cancellationToken: cts.Token));
+        } finally {
+            handlerField.SetValue(client, original);
+            tokenCache.TryRemove(key, out _);
+        }
+    }
+
+    [Fact]
+    public async Task GetMailMessageMimeAsync_HonorsCancellation() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StringContent("From: a@b.com\r\nTo: c@d.com\r\nSubject: t\r\n\r\nbody")
+        };
+        var handler = new RecordingHandler(response);
+        var httpClientField = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)httpClientField.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        var tokenCacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var tokenCache = (ConcurrentDictionary<string, GraphAuthorization>)tokenCacheField.GetValue(null)!;
+        var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
+        var key = "id|tenant||secret|https://graph.microsoft.com";
+        tokenCache[key] = new GraphAuthorization { AccessToken = "token", TokenType = "Bearer", ExpiresOn = DateTimeOffset.UtcNow.AddHours(1) };
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        try {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => MicrosoftGraphUtils.GetMailMessageMimeAsync(cred, "u", "1", cts.Token));
+        } finally {
+            handlerField.SetValue(client, original);
+            tokenCache.TryRemove(key, out _);
+        }
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -276,7 +276,8 @@ namespace Mailozaurr {
             string method,
             string uri,
             IDictionary<string, string>? headers = null,
-            string? body = null) {
+            string? body = null,
+            CancellationToken cancellationToken = default) {
             var request = new HttpRequestMessage(new HttpMethod(method), uri);
             if (headers != null) {
                 foreach (var kvp in headers) {
@@ -286,19 +287,19 @@ namespace Mailozaurr {
             if (!string.IsNullOrWhiteSpace(body) && (method == "POST" || method == "PUT" || method == "PATCH")) {
                 request.Content = new StringContent(body, Encoding.UTF8, "application/json");
             }
-            await ConcurrencySemaphore.WaitAsync();
+            await ConcurrencySemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             HttpResponseMessage? response = null;
             try {
-                response = await HttpClient.SendAsync(request);
+                response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 if ((int)response.StatusCode == 429) {
                     var delay = GetRetryAfterDelay(response);
                     response.Dispose();
                     if (delay > TimeSpan.Zero) {
-                        await Task.Delay(delay);
+                        await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                     }
-                    response = await HttpClient.SendAsync(request);
+                    response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 }
-                var responseContent = await response.Content.ReadAsStringAsync();
+                var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode) {
                     throw new GraphApiException(
                         response.StatusCode,
@@ -456,7 +457,7 @@ namespace Mailozaurr {
         /// <summary>
         /// Retrieves mail messages for the specified user.
         /// </summary>
-        public static async Task<List<Dictionary<string, object>>> GetMailMessagesAsync(GraphCredential credential, string userPrincipalName, IEnumerable<string>? properties = null, string? filter = null, int? limit = null) {
+        public static async Task<List<Dictionary<string, object>>> GetMailMessagesAsync(GraphCredential credential, string userPrincipalName, IEnumerable<string>? properties = null, string? filter = null, int? limit = null, CancellationToken cancellationToken = default) {
             var headers = new Dictionary<string, string>();
             var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
             headers["Authorization"] = token ?? string.Empty;
@@ -466,7 +467,7 @@ namespace Mailozaurr {
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/messages", queryParams);
             var messages = new List<Dictionary<string, object>>();
             while (!string.IsNullOrEmpty(uri)) {
-                var doc = await InvokeGraphApiAsync("GET", uri, headers);
+                var doc = await InvokeGraphApiAsync("GET", uri, headers, cancellationToken: cancellationToken).ConfigureAwait(false);
                 if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                     foreach (var item in valueElement.EnumerateArray()) {
                         var native = ConvertJsonElementToNativeObject(item) as Dictionary<string, object>;
@@ -705,16 +706,16 @@ namespace Mailozaurr {
         /// <summary>
         /// Retrieves the raw MIME content of a mail message.
         /// </summary>
-        public static async Task<MimeMessage> GetMailMessageMimeAsync(GraphCredential credential, string userPrincipalName, string messageId) {
+        public static async Task<MimeMessage> GetMailMessageMimeAsync(GraphCredential credential, string userPrincipalName, string messageId, CancellationToken cancellationToken = default) {
             var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
             var request = new HttpRequestMessage(HttpMethod.Get, $"https://graph.microsoft.com/v1.0/users/{userPrincipalName}/messages/{messageId}/$value");
             request.Headers.TryAddWithoutValidation("Authorization", token);
-            await ConcurrencySemaphore.WaitAsync();
+            await ConcurrencySemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try {
-                using var response = await HttpClient.SendAsync(request).ConfigureAwait(false);
+                using var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
                 using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                return await MimeMessage.LoadAsync(stream).ConfigureAwait(false);
+                return await MimeMessage.LoadAsync(stream, cancellationToken).ConfigureAwait(false);
             } finally {
                 ConcurrencySemaphore.Release();
             }

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -52,7 +52,7 @@ public class GraphMessageListener : IDisposable {
 
         _cancel = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-        var initial = await MicrosoftGraphUtils.GetMailMessagesAsync(_credential, _userPrincipalName).ConfigureAwait(false);
+        var initial = await MicrosoftGraphUtils.GetMailMessagesAsync(_credential, _userPrincipalName, cancellationToken: _cancel.Token).ConfigureAwait(false);
         foreach (var msg in initial) {
             if (msg.TryGetValue("id", out var idObj) && idObj is string id) {
                 _seenIds.Add(id);
@@ -86,7 +86,7 @@ public class GraphMessageListener : IDisposable {
         while (!_cancel!.IsCancellationRequested) {
             try {
                 await Task.Delay(_interval, _cancel.Token).ConfigureAwait(false);
-                var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(_credential, _userPrincipalName).ConfigureAwait(false);
+                var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(_credential, _userPrincipalName, cancellationToken: _cancel.Token).ConfigureAwait(false);
                 foreach (var msg in messages) {
                     if (msg.TryGetValue("id", out var idObj) && idObj is string id && !_seenIds.Contains(id)) {
                         _seenIds.Add(id);

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -259,13 +259,14 @@ public static class MailboxSearcher {
             userPrincipalName,
             new[] { "id" },
             filter!,
-            maxResults > 0 ? maxResults : (int?)null).ConfigureAwait(false);
+            maxResults > 0 ? maxResults : (int?)null,
+            cancellationToken).ConfigureAwait(false);
         var mimeMessages = new List<MimeMessage>(msgs.Count);
         if (parallelDownloadLimit <= 1) {
             foreach (var m in msgs) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (m.TryGetValue("id", out var idObj) && idObj is string id) {
-                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id, cancellationToken).ConfigureAwait(false);
                     mimeMessages.Add(mime);
                 }
             }
@@ -277,7 +278,7 @@ public static class MailboxSearcher {
                 await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id, cancellationToken).ConfigureAwait(false);
                     lock (mimeMessages) mimeMessages.Add(mime);
                 } finally {
                     semaphore.Release();
@@ -482,13 +483,14 @@ public static class MailboxSearcher {
             userPrincipalName,
             new[] { "id" },
             filter,
-            maxResults > 0 ? maxResults : (int?)null).ConfigureAwait(false);
+            maxResults > 0 ? maxResults : (int?)null,
+            cancellationToken).ConfigureAwait(false);
         var mimeMessages = new List<MimeMessage>(msgs.Count);
         if (parallelDownloadLimit <= 1) {
             foreach (var m in msgs) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (m.TryGetValue("id", out var idObj) && idObj is string id) {
-                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id, cancellationToken).ConfigureAwait(false);
                     mimeMessages.Add(mime);
                 }
             }
@@ -500,7 +502,7 @@ public static class MailboxSearcher {
                 await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id, cancellationToken).ConfigureAwait(false);
                     lock (mimeMessages) mimeMessages.Add(mime);
                 } finally {
                     semaphore.Release();


### PR DESCRIPTION
## Summary
- propagate cancellation tokens through Microsoft Graph helper calls
- forward tokens in Graph-based mailbox search and listener classes
- test cancellation support for Graph message retrieval

## Testing
- `dotnet test Sources/Mailozaurr.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68ab05b4d774832ebf907a6b0342aaa0