### PR TITLE
Limit concurrency in mailbox searches

### DIFF
--- a/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
@@ -1,6 +1,8 @@
 using Mailozaurr;
 using Mailozaurr.DmarcReports;
 using MimeKit;
+using MailKit;
+using MailKit.Net.Pop3;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -142,5 +144,52 @@ public class SearchDmarcReportsTests {
         Assert.Single(reports);
         Assert.Single(reports[0].Attachments);
         Assert.Equal("example", reports[0].Attachments[0].Name);
+    }
+
+    private class CountingPop3Client : Pop3Client {
+        private readonly List<MimeMessage> _messages;
+        private readonly int _delay;
+        private readonly object _lock = new();
+        private int _current;
+        public int MaxConcurrency { get; private set; }
+        public int CallCount { get; private set; }
+        public CountingPop3Client(IEnumerable<MimeMessage> messages, int delay) {
+            _messages = new List<MimeMessage>(messages);
+            _delay = delay;
+        }
+        public override bool IsConnected => true;
+        public override bool IsAuthenticated => true;
+        public override int Count => _messages.Count;
+        public override async Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {
+            lock (_lock) {
+                _current++;
+                CallCount++;
+                if (_current > MaxConcurrency) MaxConcurrency = _current;
+            }
+            try {
+                await Task.Delay(_delay, cancellationToken).ConfigureAwait(false);
+            } finally {
+                lock (_lock) { _current--; }
+            }
+            return _messages[index];
+        }
+    }
+
+    [Fact]
+    public async Task SearchDmarcReportsAsync_Pop3_RespectsParallelLimitAndMaxResults() {
+        var now = DateTimeOffset.UtcNow;
+        var msgs = new List<MimeMessage>();
+        for (int i = 0; i < 10; i++) msgs.Add(CreateDmarc("example.com", now));
+        var client = new CountingPop3Client(msgs, 100);
+        var maxResults = 3;
+        var reports = await MailboxSearcher.SearchDmarcReportsAsync(
+            client,
+            domain: "example.com",
+            maxResults: maxResults,
+            parallelDownloadLimit: 2,
+            cancellationToken: CancellationToken.None);
+        Assert.Equal(maxResults, reports.Count);
+        Assert.Equal(2, client.MaxConcurrency);
+        Assert.True(client.CallCount <= maxResults + 1);
     }
 }

--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -138,6 +138,7 @@ public class SearchNonDeliveryReportsTests {
         private readonly object _lock = new();
         private int _current;
         public int MaxConcurrency { get; private set; }
+        public int CallCount { get; private set; }
         public CountingPop3Client(IEnumerable<MimeMessage> messages, int delay) {
             _messages = new List<MimeMessage>(messages);
             _delay = delay;
@@ -148,6 +149,7 @@ public class SearchNonDeliveryReportsTests {
         public override async Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {
             lock (_lock) {
                 _current++;
+                CallCount++;
                 if (_current > MaxConcurrency) MaxConcurrency = _current;
             }
             try {
@@ -193,5 +195,21 @@ public class SearchNonDeliveryReportsTests {
             cancellationToken: CancellationToken.None);
         Assert.Equal(msgs.Count, reports.Count);
         Assert.Equal(4, client.MaxConcurrency);
+    }
+
+    [Fact]
+    public async Task SearchNonDeliveryReportsAsync_Pop3_RespectsMaxResults() {
+        var now = DateTimeOffset.UtcNow;
+        var msgs = new List<MimeMessage>();
+        for (int i = 0; i < 10; i++) msgs.Add(CreateNdr($"u{i}@example.com", $"<id{i}>", now));
+        var client = new CountingPop3Client(msgs, 100);
+        var maxResults = 3;
+        var reports = await MailboxSearcher.SearchNonDeliveryReportsAsync(
+            client,
+            maxResults: maxResults,
+            parallelDownloadLimit: 2,
+            cancellationToken: CancellationToken.None);
+        Assert.Equal(maxResults, reports.Count);
+        Assert.True(client.CallCount <= maxResults + 1);
     }
 }

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -5,6 +5,7 @@ using MailKit.Search;
 using MimeKit;
 using System.Text;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -148,36 +149,42 @@ public static class MailboxSearcher {
         var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
         var search = BuildNonDeliveryReportSearchQuery(since, before);
         var uids = await mailFolder.SearchAsync(search, cancellationToken).ConfigureAwait(false);
-        var messages = new List<MimeMessage>(uids.Count);
+        IEnumerable<MimeMessage> messages;
         if (parallelDownloadLimit <= 1) {
+            var list = new List<MimeMessage>();
             foreach (var uid in uids) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-                messages.Add(msg);
-                if (maxResults > 0 && messages.Count >= maxResults) break;
+                list.Add(msg);
+                if (maxResults > 0 && list.Count >= maxResults) break;
             }
+            messages = list;
         } else {
-            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
+            var bag = new ConcurrentBag<MimeMessage>();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             var tasks = new List<Task>();
-
-            async Task DownloadMessageAsync(UniqueId uid) {
-                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-                    lock (messages) messages.Add(msg);
-                } finally {
-                    semaphore.Release();
+            int collected = 0;
+            using var enumerator = uids.GetEnumerator();
+            while (!cts.IsCancellationRequested) {
+                while (tasks.Count < parallelDownloadLimit &&
+                       (maxResults <= 0 || Volatile.Read(ref collected) < maxResults) &&
+                       enumerator.MoveNext()) {
+                    var uid = enumerator.Current;
+                    tasks.Add(Task.Run(async () => {
+                        try {
+                            var msg = await mailFolder.GetMessageAsync(uid, cts.Token).ConfigureAwait(false);
+                            var current = Interlocked.Increment(ref collected);
+                            if (maxResults <= 0 || current <= maxResults) bag.Add(msg);
+                            if (maxResults > 0 && current >= maxResults) cts.Cancel();
+                        } catch (OperationCanceledException) { }
+                    }, CancellationToken.None));
                 }
+                if (tasks.Count == 0) break;
+                var finished = await Task.WhenAny(tasks).ConfigureAwait(false);
+                tasks.Remove(finished);
             }
-
-            foreach (var uid in uids) {
-                cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(DownloadMessageAsync(uid));
-                if (maxResults > 0 && tasks.Count >= maxResults) break;
-            }
-
             await Task.WhenAll(tasks).ConfigureAwait(false);
+            messages = bag;
         }
 
         return FilterNonDeliveryReports(messages, since, before, recipientContains, messageId);
@@ -197,39 +204,43 @@ public static class MailboxSearcher {
         int maxResults = 0,
         int parallelDownloadLimit = 4,
         CancellationToken cancellationToken = default) {
-        var count = client.Count;
-        var indices = new List<int>(count);
-        for (int i = 0; i < count; i++) indices.Add(i);
-        var messages = new List<MimeMessage>(indices.Count);
+        var indices = Enumerable.Range(0, client.Count);
+        IEnumerable<MimeMessage> messages;
         if (parallelDownloadLimit <= 1) {
+            var list = new List<MimeMessage>();
             foreach (var idx in indices) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
-                messages.Add(msg);
-                if (maxResults > 0 && messages.Count >= maxResults) break;
+                list.Add(msg);
+                if (maxResults > 0 && list.Count >= maxResults) break;
             }
+            messages = list;
         } else {
-            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
+            var bag = new ConcurrentBag<MimeMessage>();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             var tasks = new List<Task>();
-
-            async Task DownloadMessageAsync(int idx) {
-                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
-                    lock (messages) messages.Add(msg);
-                } finally {
-                    semaphore.Release();
+            int collected = 0;
+            using var enumerator = indices.GetEnumerator();
+            while (!cts.IsCancellationRequested) {
+                while (tasks.Count < parallelDownloadLimit &&
+                       (maxResults <= 0 || Volatile.Read(ref collected) < maxResults) &&
+                       enumerator.MoveNext()) {
+                    var idx = enumerator.Current;
+                    tasks.Add(Task.Run(async () => {
+                        try {
+                            var msg = await client.GetMessageAsync(idx, cts.Token).ConfigureAwait(false);
+                            var current = Interlocked.Increment(ref collected);
+                            if (maxResults <= 0 || current <= maxResults) bag.Add(msg);
+                            if (maxResults > 0 && current >= maxResults) cts.Cancel();
+                        } catch (OperationCanceledException) { }
+                    }, CancellationToken.None));
                 }
+                if (tasks.Count == 0) break;
+                var finished = await Task.WhenAny(tasks).ConfigureAwait(false);
+                tasks.Remove(finished);
             }
-
-            foreach (var idx in indices) {
-                cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(DownloadMessageAsync(idx));
-                if (maxResults > 0 && tasks.Count >= maxResults) break;
-            }
-
             await Task.WhenAll(tasks).ConfigureAwait(false);
+            messages = bag;
         }
 
         return FilterNonDeliveryReports(messages, since, before, recipientContains, messageId);
@@ -372,36 +383,42 @@ public static class MailboxSearcher {
         var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
         var search = BuildDmarcReportSearchQuery(since, before, domain);
         var uids = await mailFolder.SearchAsync(search, cancellationToken).ConfigureAwait(false);
-        var messages = new List<MimeMessage>(uids.Count);
+        IEnumerable<MimeMessage> messages;
         if (parallelDownloadLimit <= 1) {
+            var list = new List<MimeMessage>();
             foreach (var uid in uids) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-                messages.Add(msg);
-                if (maxResults > 0 && messages.Count >= maxResults) break;
+                list.Add(msg);
+                if (maxResults > 0 && list.Count >= maxResults) break;
             }
+            messages = list;
         } else {
-            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
+            var bag = new ConcurrentBag<MimeMessage>();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             var tasks = new List<Task>();
-
-            async Task DownloadMessageAsync(UniqueId uid) {
-                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-                    lock (messages) messages.Add(msg);
-                } finally {
-                    semaphore.Release();
+            int collected = 0;
+            using var enumerator = uids.GetEnumerator();
+            while (!cts.IsCancellationRequested) {
+                while (tasks.Count < parallelDownloadLimit &&
+                       (maxResults <= 0 || Volatile.Read(ref collected) < maxResults) &&
+                       enumerator.MoveNext()) {
+                    var uid = enumerator.Current;
+                    tasks.Add(Task.Run(async () => {
+                        try {
+                            var msg = await mailFolder.GetMessageAsync(uid, cts.Token).ConfigureAwait(false);
+                            var current = Interlocked.Increment(ref collected);
+                            if (maxResults <= 0 || current <= maxResults) bag.Add(msg);
+                            if (maxResults > 0 && current >= maxResults) cts.Cancel();
+                        } catch (OperationCanceledException) { }
+                    }, CancellationToken.None));
                 }
+                if (tasks.Count == 0) break;
+                var finished = await Task.WhenAny(tasks).ConfigureAwait(false);
+                tasks.Remove(finished);
             }
-
-            foreach (var uid in uids) {
-                cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(DownloadMessageAsync(uid));
-                if (maxResults > 0 && tasks.Count >= maxResults) break;
-            }
-
             await Task.WhenAll(tasks).ConfigureAwait(false);
+            messages = bag;
         }
 
         return FilterDmarcReports(messages, since, before, domain);
@@ -420,39 +437,43 @@ public static class MailboxSearcher {
         int maxResults = 0,
         int parallelDownloadLimit = 4,
         CancellationToken cancellationToken = default) {
-        var count = client.Count;
-        var indices = new List<int>(count);
-        for (int i = 0; i < count; i++) indices.Add(i);
-        var messages = new List<MimeMessage>(indices.Count);
+        var indices = Enumerable.Range(0, client.Count);
+        IEnumerable<MimeMessage> messages;
         if (parallelDownloadLimit <= 1) {
+            var list = new List<MimeMessage>();
             foreach (var idx in indices) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
-                messages.Add(msg);
-                if (maxResults > 0 && messages.Count >= maxResults) break;
+                list.Add(msg);
+                if (maxResults > 0 && list.Count >= maxResults) break;
             }
+            messages = list;
         } else {
-            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
+            var bag = new ConcurrentBag<MimeMessage>();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             var tasks = new List<Task>();
-
-            async Task DownloadMessageAsync(int idx) {
-                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
-                    lock (messages) messages.Add(msg);
-                } finally {
-                    semaphore.Release();
+            int collected = 0;
+            using var enumerator = indices.GetEnumerator();
+            while (!cts.IsCancellationRequested) {
+                while (tasks.Count < parallelDownloadLimit &&
+                       (maxResults <= 0 || Volatile.Read(ref collected) < maxResults) &&
+                       enumerator.MoveNext()) {
+                    var idx = enumerator.Current;
+                    tasks.Add(Task.Run(async () => {
+                        try {
+                            var msg = await client.GetMessageAsync(idx, cts.Token).ConfigureAwait(false);
+                            var current = Interlocked.Increment(ref collected);
+                            if (maxResults <= 0 || current <= maxResults) bag.Add(msg);
+                            if (maxResults > 0 && current >= maxResults) cts.Cancel();
+                        } catch (OperationCanceledException) { }
+                    }, CancellationToken.None));
                 }
+                if (tasks.Count == 0) break;
+                var finished = await Task.WhenAny(tasks).ConfigureAwait(false);
+                tasks.Remove(finished);
             }
-
-            foreach (var idx in indices) {
-                cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(DownloadMessageAsync(idx));
-                if (maxResults > 0 && tasks.Count >= maxResults) break;
-            }
-
             await Task.WhenAll(tasks).ConfigureAwait(false);
+            messages = bag;
         }
 
         return FilterDmarcReports(messages, since, before, domain);


### PR DESCRIPTION
## Summary
- bound IMAP/POP3 report retrieval with a worker queue
- respect `maxResults` to avoid extra downloads
- test POP3 NDR and DMARC search limits

## Testing
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_68ab05c09e88832ea94c3d36b3c83bc1