### PR TITLE
Stream DMARC attachments and validate domain

### DIFF
--- a/Sources/Mailozaurr.Examples/RetrieveDmarcReportsExample.cs
+++ b/Sources/Mailozaurr.Examples/RetrieveDmarcReportsExample.cs
@@ -8,7 +8,7 @@ namespace Mailozaurr.Examples;
 
 public static class RetrieveDmarcReportsExample {
     public static async Task RunAsync(ImapClient client) {
-        var reports = await MailboxSearcher.SearchDmarcReportsAsync(client, "INBOX", since: DateTime.UtcNow.AddDays(-7));
+        var reports = await MailboxSearcher.SearchDmarcReportsAsync(client, "INBOX", since: DateTime.UtcNow.AddDays(-7), domain: "example.com");
         foreach (var report in reports) {
             foreach (var att in report.Attachments) {
                 using (att) {
@@ -22,6 +22,6 @@ public static class RetrieveDmarcReportsExample {
 public static class DomainDetective {
     public static void Process(Stream zip, string name) {
         // Placeholder for integration with Domain Detective analysis
-        Console.WriteLine($"Processing {name} ({zip.Length} bytes)");
+        Console.WriteLine($"Processing {name}");
     }
 }

--- a/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
@@ -4,6 +4,7 @@ using MimeKit;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Text;
 using Xunit;
 
@@ -32,10 +33,34 @@ public class SearchDmarcReportsTests {
         message.Date = date;
         message.From.Add(new MailboxAddress("reporter", "reporter@example.com"));
         var builder = new BodyBuilder();
-        var ms = new MemoryStream(Encoding.UTF8.GetBytes("<feedback/>"));
+        var xml = $"<feedback><policy_published><domain>{domain}</domain></policy_published></feedback>";
+        var ms = new MemoryStream(Encoding.UTF8.GetBytes(xml));
         var part = new MimePart(mediaType, mediaSubtype) {
             Content = new MimeContent(ms),
             FileName = fileName
+        };
+        builder.Attachments.Add(part);
+        message.Body = builder.ToMessageBody();
+        return message;
+    }
+
+    private static MimeMessage CreateZippedXmlDmarc(string domain, DateTimeOffset date) {
+        var message = new MimeMessage();
+        message.Subject = "Report";
+        message.Date = date;
+        message.From.Add(new MailboxAddress("reporter", "reporter@example.com"));
+        var builder = new BodyBuilder();
+        var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, true)) {
+            var entry = zip.CreateEntry("report.xml");
+            using var entryStream = entry.Open();
+            var bytes = Encoding.UTF8.GetBytes($"<feedback><policy_published><domain>{domain}</domain></policy_published></feedback>");
+            entryStream.Write(bytes, 0, bytes.Length);
+        }
+        ms.Position = 0;
+        var part = new MimePart("application", "zip") {
+            Content = new MimeContent(ms),
+            FileName = "report.zip"
         };
         builder.Attachments.Add(part);
         message.Body = builder.ToMessageBody();
@@ -53,7 +78,42 @@ public class SearchDmarcReportsTests {
         Assert.Equal("reporter@example.com", report.From);
         Assert.Single(report.Attachments);
         Assert.EndsWith(".zip", report.Attachments[0].Name);
-        Assert.True(report.Attachments[0].Content.Length > 0);
+        using var ms = new MemoryStream();
+        report.Attachments[0].Content.CopyTo(ms);
+        Assert.True(ms.Length > 0);
+    }
+
+    [Fact]
+    public void FilterDmarcReports_MatchesDomainInAttachmentName() {
+        var now = DateTimeOffset.UtcNow;
+        var msg = CreateDmarc("example.com", now);
+        msg.Subject = "Report";
+        var list = new List<MimeMessage> { msg };
+        var reports = MailboxSearcher.FilterDmarcReports(list, since: now.AddMinutes(-1).DateTime, before: now.AddMinutes(1).DateTime, domain: "example.com");
+        Assert.Single(reports);
+        Assert.Single(reports[0].Attachments);
+    }
+
+    [Fact]
+    public void FilterDmarcReports_MatchesDomainInXmlContent() {
+        var now = DateTimeOffset.UtcNow;
+        var msg = CreateZippedXmlDmarc("example.com", now);
+        var list = new List<MimeMessage> { msg };
+        var reports = MailboxSearcher.FilterDmarcReports(list, since: now.AddMinutes(-1).DateTime, before: now.AddMinutes(1).DateTime, domain: "example.com");
+        Assert.Single(reports);
+    }
+
+    [Fact]
+    public void FilterDmarcReports_FiltersOutMismatchedDomain() {
+        var now = DateTimeOffset.UtcNow;
+        var good = CreateDmarc("example.com", now);
+        good.Subject = "Report";
+        var bad = CreateDmarc("other.com", now);
+        bad.Subject = "Report";
+        var list = new List<MimeMessage> { good, bad };
+        var reports = MailboxSearcher.FilterDmarcReports(list, since: now.AddMinutes(-1).DateTime, before: now.AddMinutes(1).DateTime, domain: "example.com");
+        Assert.Single(reports);
+        Assert.All(reports[0].Attachments, a => Assert.Contains("example.com", a.Name, StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/Sources/Mailozaurr/Mailozaurr.csproj
+++ b/Sources/Mailozaurr/Mailozaurr.csproj
@@ -36,6 +36,8 @@
         <PackageReference Include="MsgReader" Version="5.7.3" />
         <PackageReference Include="System.Text.Json" Version="8.0.5" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
+        <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+        <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     </ItemGroup>
 
 

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -160,7 +161,7 @@ public static class MailboxSearcher {
             using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
             var tasks = new List<Task>();
 
-            async Task DownloadMessageAsync(UniqueId uid) {
+            async Task DownloadMessageAsync(MailKit.UniqueId uid) {
                 await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -384,7 +385,7 @@ public static class MailboxSearcher {
             using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
             var tasks = new List<Task>();
 
-            async Task DownloadMessageAsync(UniqueId uid) {
+            async Task DownloadMessageAsync(MailKit.UniqueId uid) {
                 await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -592,23 +593,57 @@ public static class MailboxSearcher {
             var msgDate = message.Date.UtcDateTime;
             if (sinceUtc.HasValue && msgDate < sinceUtc.Value) continue;
             if (beforeUtc.HasValue && msgDate > beforeUtc.Value) continue;
-            if (!string.IsNullOrWhiteSpace(domain) && (message.Subject == null || message.Subject.IndexOf(domain, StringComparison.OrdinalIgnoreCase) < 0)) continue;
             var report = new DmarcReport {
                 From = message.From.Mailboxes.FirstOrDefault()?.Address,
                 Subject = message.Subject,
                 Date = message.Date
             };
+            var domainMatched = string.IsNullOrWhiteSpace(domain);
             foreach (var att in message.Attachments) {
                 if (IsDmarcAttachment(att) && att is MimePart part) {
-                    var ms = new MemoryStream();
-                    part.Content.DecodeTo(ms);
-                    ms.Position = 0;
-                    report.Attachments.Add(new DmarcReportAttachment(part.FileName ?? "report.zip", ms));
+                    if (!string.IsNullOrWhiteSpace(domain) && !AttachmentMatchesDomain(part, domain!)) continue;
+                    var stream = part.Content.Open();
+                    report.Attachments.Add(new DmarcReportAttachment(part.FileName ?? "report.zip", stream));
+                    if (!domainMatched) domainMatched = true;
                 }
             }
-            if (report.Attachments.Count > 0) results.Add(report);
+            if (report.Attachments.Count > 0 && domainMatched) results.Add(report);
         }
         return results;
+    }
+
+    private static bool AttachmentMatchesDomain(MimePart part, string domain) {
+        if (part.FileName?.IndexOf(domain, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        try {
+            using var stream = part.Content.Open();
+            var name = part.FileName ?? string.Empty;
+            if (name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)) {
+                using var zip = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
+                foreach (var entry in zip.Entries) {
+                    using var entryStream = entry.Open();
+                    if (XmlStreamContainsDomain(entryStream, domain)) return true;
+                }
+            } else if (name.EndsWith(".gz", StringComparison.OrdinalIgnoreCase)) {
+                using var gz = new GZipStream(stream, CompressionMode.Decompress);
+                if (XmlStreamContainsDomain(gz, domain)) return true;
+            } else {
+                if (XmlStreamContainsDomain(stream, domain)) return true;
+            }
+        } catch {
+        }
+        return false;
+    }
+
+    private static bool XmlStreamContainsDomain(Stream stream, string domain) {
+        var settings = new System.Xml.XmlReaderSettings { IgnoreComments = true, IgnoreWhitespace = true };
+        using var reader = System.Xml.XmlReader.Create(stream, settings);
+        while (reader.Read()) {
+            if (reader.NodeType == System.Xml.XmlNodeType.Element && reader.LocalName.Equals("domain", StringComparison.OrdinalIgnoreCase)) {
+                var value = reader.ReadElementContentAsString();
+                if (value.Equals(domain, StringComparison.OrdinalIgnoreCase)) return true;
+            }
+        }
+        return false;
     }
 
     internal static SearchQuery BuildDmarcReportSearchQuery(DateTime? since, DateTime? before, string? domain) {


### PR DESCRIPTION
## Summary
- stream DMARC report attachments instead of buffering
- verify domain by inspecting attachment names or XML contents
- add tests and example demonstrating domain-based filtering

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ab09e0bc38832eb9d185d874a2370b