### PR TITLE
feat: parse graph error details

### DIFF
--- a/Examples/Example-ParseGraphError.ps1
+++ b/Examples/Example-ParseGraphError.ps1
@@ -1,0 +1,15 @@
+$sample = @'
+POST https://graph.microsoft.com/v1.0/users/przemyslaw.klys@company.pl/sendMail
+HTTP/2.0 404 Not Found
+request-id: 2ff18766-1395-4fb9-abd1-162774d4b063
+client-request-id: 6c57f9e6-3cad-48ee-8f7a-d566dc92aca3
+x-ms-ags-diagnostic: {"ServerInfo":{"DataCenter":"Poland Central","Slice":"E","Ring":"2","ScaleUnit":"002","RoleInstance":"WA3PEPF000004A2"}}
+Date: Sun, 24 Aug 2025 12:55:18 GMT
+Content-Type: application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false; charset=utf-8
+
+{"error":{"code":"ErrorInvalidUser","message":"The requested user 'przemyslaw.klys@company.pl' is invalid."}}
+'
+
+$parsed = [Mailozaurr.GraphApiErrorParser]::Parse($sample)
+$parsed.Headers.Diagnostic.ServerInfo
+$parsed.Error.Error

--- a/Examples/Example-ParseGraphError.ps1
+++ b/Examples/Example-ParseGraphError.ps1
@@ -12,4 +12,4 @@ Content-Type: application/json; odata.metadata=minimal; odata.streaming=true; IE
 
 $parsed = [Mailozaurr.GraphApiErrorParser]::Parse($sample)
 $parsed.Headers.Diagnostic.ServerInfo
-$parsed.Error.Error
+$parsed.Error

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -508,7 +508,10 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
                 throw;
             }
             if (!Suppress) {
-                WriteObject(new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message));
+                var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
+                    GraphError = GraphApiErrorParser.Parse(ex.Message)
+                };
+                WriteObject(result);
             }
         }
     }
@@ -539,7 +542,10 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
                 }
 
                 if (!Suppress) {
-                    WriteObject(new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message));
+                    var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
+                        GraphError = GraphApiErrorParser.Parse(ex.Message)
+                    };
+                    WriteObject(result);
                 }
             }
         }
@@ -579,7 +585,10 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
                 throw;
             }
             if (!Suppress) {
-                WriteObject(new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message));
+                var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
+                    GraphError = GraphApiErrorParser.Parse(ex.Message)
+                };
+                WriteObject(result);
             }
         }
 
@@ -617,7 +626,10 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
                 throw;
             }
             if (!Suppress) {
-                WriteObject(new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message));
+                var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
+                    GraphError = GraphApiErrorParser.Parse(ex.Message)
+                };
+                WriteObject(result);
             }
         }
 

--- a/Sources/Mailozaurr.Tests/GraphApiErrorParserTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphApiErrorParserTests.cs
@@ -23,4 +23,10 @@ public class GraphApiErrorParserTests {
         Assert.Equal("Poland Central", parsed.Headers.Diagnostic?.ServerInfo.DataCenter);
         Assert.Equal("ErrorInvalidUser", parsed.Error?.Code);
     }
+
+    [Fact]
+    public void Parse_InvalidInput_ReturnsNull() {
+        var parsed = GraphApiErrorParser.Parse("not a graph error");
+        Assert.Null(parsed);
+    }
 }

--- a/Sources/Mailozaurr.Tests/GraphApiErrorParserTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphApiErrorParserTests.cs
@@ -25,8 +25,11 @@ public class GraphApiErrorParserTests {
     }
 
     [Fact]
-    public void Parse_InvalidInput_ReturnsNull() {
-        var parsed = GraphApiErrorParser.Parse("not a graph error");
-        Assert.Null(parsed);
+    public void Parse_InvalidInput_ReturnsRaw() {
+        const string sample = "not a graph error";
+        var parsed = GraphApiErrorParser.Parse(sample);
+        Assert.NotNull(parsed);
+        Assert.Equal(sample, parsed!.Raw);
+        Assert.Null(parsed.Error);
     }
 }

--- a/Sources/Mailozaurr.Tests/GraphApiErrorParserTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphApiErrorParserTests.cs
@@ -18,8 +18,9 @@ public class GraphApiErrorParserTests {
         var parsed = GraphApiErrorParser.Parse(sample);
         Assert.NotNull(parsed);
         Assert.Equal(HttpStatusCode.NotFound, parsed!.StatusCode);
+        Assert.Equal(GraphHttpMethod.POST, parsed.Method);
         Assert.Equal("2ff18766-1395-4fb9-abd1-162774d4b063", parsed.Headers.RequestId);
         Assert.Equal("Poland Central", parsed.Headers.Diagnostic?.ServerInfo.DataCenter);
-        Assert.Equal("ErrorInvalidUser", parsed.Error?.Error.Code);
+        Assert.Equal("ErrorInvalidUser", parsed.Error?.Code);
     }
 }

--- a/Sources/Mailozaurr.Tests/GraphApiErrorParserTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphApiErrorParserTests.cs
@@ -1,0 +1,25 @@
+using System.Net;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class GraphApiErrorParserTests {
+    [Fact]
+    public void Parse_ShouldExtractInformation() {
+        var sample = "POST https://graph.microsoft.com/v1.0/users/przemyslaw.klys@company.pl/sendMail\n" +
+                     "HTTP/2.0 404 Not Found\n" +
+                     "request-id: 2ff18766-1395-4fb9-abd1-162774d4b063\n" +
+                     "client-request-id: 6c57f9e6-3cad-48ee-8f7a-d566dc92aca3\n" +
+                     "x-ms-ags-diagnostic: {\"ServerInfo\":{\"DataCenter\":\"Poland Central\",\"Slice\":\"E\",\"Ring\":\"2\",\"ScaleUnit\":\"002\",\"RoleInstance\":\"WA3PEPF000004A2\"}}\n" +
+                     "Date: Sun, 24 Aug 2025 12:55:18 GMT\n" +
+                     "Content-Type: application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false; charset=utf-8\n\n" +
+                     "{\"error\":{\"code\":\"ErrorInvalidUser\",\"message\":\"The requested user 'przemyslaw.klys@company.pl' is invalid.\"}}";
+
+        var parsed = GraphApiErrorParser.Parse(sample);
+        Assert.NotNull(parsed);
+        Assert.Equal(HttpStatusCode.NotFound, parsed!.StatusCode);
+        Assert.Equal("2ff18766-1395-4fb9-abd1-162774d4b063", parsed.Headers.RequestId);
+        Assert.Equal("Poland Central", parsed.Headers.Diagnostic?.ServerInfo.DataCenter);
+        Assert.Equal("ErrorInvalidUser", parsed.Error?.Error.Code);
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiDiagnostic.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiDiagnostic.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Diagnostic information returned by the Graph API.
+/// </summary>
+public class GraphApiDiagnostic {
+    /// <summary>Gets or sets server information details.</summary>
+    [JsonPropertyName("ServerInfo")]
+    public GraphApiServerInfo ServerInfo { get; set; } = new();
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorHeaders.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorHeaders.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents HTTP headers returned with a Graph API error response.
+/// </summary>
+public class GraphApiErrorHeaders {
+    /// <summary>Gets or sets the Cache-Control header.</summary>
+    public string CacheControl { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the Strict-Transport-Security header.</summary>
+    public string StrictTransportSecurity { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the request-id header.</summary>
+    public string RequestId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the client-request-id header.</summary>
+    public string ClientRequestId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the Date header.</summary>
+    public DateTime? Date { get; set; }
+
+    /// <summary>Gets or sets the diagnostic header.</summary>
+    public GraphApiDiagnostic? Diagnostic { get; set; }
+
+    /// <summary>Gets or sets additional headers.</summary>
+    public Dictionary<string, string> AdditionalHeaders { get; set; } = new();
+
+    /// <summary>Gets or sets additional JSON headers.</summary>
+    public Dictionary<string, JsonElement> AdditionalJsonHeaders { get; set; } = new();
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorParser.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorParser.cs
@@ -21,87 +21,90 @@ public static class GraphApiErrorParser {
             return null;
         }
 
-        var lines = message.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-        if (lines.Length == 0) {
-            return null;
-        }
-
-        var response = new GraphApiErrorResponse();
-        var index = 0;
-
-        var first = lines[index++];
-        var firstParts = first.Split(new[] { ' ' }, 2);
-        if (firstParts.Length == 2) {
-            if (Enum.TryParse<GraphHttpMethod>(firstParts[0], true, out var method)) {
-                response.Method = method;
+        try {
+            var lines = message.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            if (lines.Length == 0) {
+                return null;
             }
+
+            var response = new GraphApiErrorResponse();
+            var index = 0;
+
+            var first = lines[index++];
+            var firstParts = first.Split(new[] { ' ' }, 2);
+            if (firstParts.Length != 2 || !Enum.TryParse<GraphHttpMethod>(firstParts[0], true, out var method)) {
+                return null;
+            }
+            response.Method = method;
             response.Uri = firstParts[1];
-        }
 
-        if (index < lines.Length) {
-            var second = lines[index++];
-            var match = Regex.Match(second, @"HTTP/\S+\s+(\d+)");
-            if (match.Success && int.TryParse(match.Groups[1].Value, out var status)) {
-                response.StatusCode = (HttpStatusCode)status;
-            }
-        }
-
-        for (; index < lines.Length; index++) {
-            var line = lines[index];
-            if (line.StartsWith("{", StringComparison.Ordinal)) {
-                var body = string.Join(Environment.NewLine, lines, index, lines.Length - index);
-                try {
-                    var error = JsonSerializer.Deserialize<GraphApiError>(body);
-                    response.Error = error?.Error;
-                } catch {
-                    // ignore
+            if (index < lines.Length) {
+                var second = lines[index++];
+                var match = Regex.Match(second, @"HTTP/\S+\s+(\d+)");
+                if (match.Success && int.TryParse(match.Groups[1].Value, out var status)) {
+                    response.StatusCode = (HttpStatusCode)status;
                 }
-                break;
             }
 
-            var separator = line.IndexOf(':');
-            if (separator <= 0) {
-                continue;
-            }
-
-            var key = line.Substring(0, separator);
-            var value = line.Substring(separator + 1).Trim();
-            switch (key.ToLowerInvariant()) {
-                case "cache-control":
-                    response.Headers.CacheControl = value;
-                    break;
-                case "strict-transport-security":
-                    response.Headers.StrictTransportSecurity = value;
-                    break;
-                case "request-id":
-                    response.Headers.RequestId = value;
-                    break;
-                case "client-request-id":
-                    response.Headers.ClientRequestId = value;
-                    break;
-                case "date":
-                    if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var dt)) {
-                        response.Headers.Date = dt;
-                    }
-                    break;
-                case "x-ms-ags-diagnostic":
+            for (; index < lines.Length; index++) {
+                var line = lines[index];
+                if (line.StartsWith("{", StringComparison.Ordinal)) {
+                    var body = string.Join(Environment.NewLine, lines, index, lines.Length - index);
                     try {
-                        response.Headers.Diagnostic = JsonSerializer.Deserialize<GraphApiDiagnostic>(value);
+                        var error = JsonSerializer.Deserialize<GraphApiError>(body);
+                        response.Error = error?.Error;
                     } catch {
                         // ignore
                     }
                     break;
-                default:
-                    try {
-                        var json = JsonSerializer.Deserialize<JsonElement>(value);
-                        response.Headers.AdditionalJsonHeaders[key] = json;
-                    } catch {
-                        response.Headers.AdditionalHeaders[key] = value;
-                    }
-                    break;
-            }
-        }
+                }
 
-        return response;
+                var separator = line.IndexOf(':');
+                if (separator <= 0) {
+                    continue;
+                }
+
+                var key = line.Substring(0, separator);
+                var value = line.Substring(separator + 1).Trim();
+                switch (key.ToLowerInvariant()) {
+                    case "cache-control":
+                        response.Headers.CacheControl = value;
+                        break;
+                    case "strict-transport-security":
+                        response.Headers.StrictTransportSecurity = value;
+                        break;
+                    case "request-id":
+                        response.Headers.RequestId = value;
+                        break;
+                    case "client-request-id":
+                        response.Headers.ClientRequestId = value;
+                        break;
+                    case "date":
+                        if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var dt)) {
+                            response.Headers.Date = dt;
+                        }
+                        break;
+                    case "x-ms-ags-diagnostic":
+                        try {
+                            response.Headers.Diagnostic = JsonSerializer.Deserialize<GraphApiDiagnostic>(value);
+                        } catch {
+                            // ignore
+                        }
+                        break;
+                    default:
+                        try {
+                            var json = JsonSerializer.Deserialize<JsonElement>(value);
+                            response.Headers.AdditionalJsonHeaders[key] = json;
+                        } catch {
+                            response.Headers.AdditionalHeaders[key] = value;
+                        }
+                        break;
+                }
+            }
+
+            return response;
+        } catch {
+            return null;
+        }
     }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorParser.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -31,7 +32,9 @@ public static class GraphApiErrorParser {
         var first = lines[index++];
         var firstParts = first.Split(new[] { ' ' }, 2);
         if (firstParts.Length == 2) {
-            response.Method = firstParts[0];
+            if (Enum.TryParse<GraphHttpMethod>(firstParts[0], true, out var method)) {
+                response.Method = method;
+            }
             response.Uri = firstParts[1];
         }
 
@@ -48,7 +51,8 @@ public static class GraphApiErrorParser {
             if (line.StartsWith("{", StringComparison.Ordinal)) {
                 var body = string.Join(Environment.NewLine, lines, index, lines.Length - index);
                 try {
-                    response.Error = JsonSerializer.Deserialize<GraphApiError>(body);
+                    var error = JsonSerializer.Deserialize<GraphApiError>(body);
+                    response.Error = error?.Error;
                 } catch {
                     // ignore
                 }
@@ -76,7 +80,7 @@ public static class GraphApiErrorParser {
                     response.Headers.ClientRequestId = value;
                     break;
                 case "date":
-                    if (DateTime.TryParse(value, out var dt)) {
+                    if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var dt)) {
                         response.Headers.Date = dt;
                     }
                     break;

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorParser.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorParser.cs
@@ -15,25 +15,26 @@ public static class GraphApiErrorParser {
     /// Parses a raw error string returned by Graph API.
     /// </summary>
     /// <param name="message">Raw error message.</param>
-    /// <returns>Parsed <see cref="GraphApiErrorResponse"/> or <c>null</c> if parsing fails.</returns>
+    /// <returns>Parsed <see cref="GraphApiErrorResponse"/> or <c>null</c> if input is empty.</returns>
     public static GraphApiErrorResponse? Parse(string? message) {
         if (string.IsNullOrWhiteSpace(message)) {
             return null;
         }
 
+        var response = new GraphApiErrorResponse { Raw = message };
+
         try {
             var lines = message.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
             if (lines.Length == 0) {
-                return null;
+                return response;
             }
 
-            var response = new GraphApiErrorResponse();
             var index = 0;
 
             var first = lines[index++];
             var firstParts = first.Split(new[] { ' ' }, 2);
             if (firstParts.Length != 2 || !Enum.TryParse<GraphHttpMethod>(firstParts[0], true, out var method)) {
-                return null;
+                return response;
             }
             response.Method = method;
             response.Uri = firstParts[1];
@@ -101,10 +102,10 @@ public static class GraphApiErrorParser {
                         break;
                 }
             }
-
-            return response;
         } catch {
-            return null;
+            // ignore failures and return raw response
         }
+
+        return response;
     }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorParser.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorParser.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Net;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Parses raw Graph API error messages into structured objects.
+/// </summary>
+public static class GraphApiErrorParser {
+    /// <summary>
+    /// Parses a raw error string returned by Graph API.
+    /// </summary>
+    /// <param name="message">Raw error message.</param>
+    /// <returns>Parsed <see cref="GraphApiErrorResponse"/> or <c>null</c> if parsing fails.</returns>
+    public static GraphApiErrorResponse? Parse(string? message) {
+        if (string.IsNullOrWhiteSpace(message)) {
+            return null;
+        }
+
+        var lines = message.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length == 0) {
+            return null;
+        }
+
+        var response = new GraphApiErrorResponse();
+        var index = 0;
+
+        var first = lines[index++];
+        var firstParts = first.Split(new[] { ' ' }, 2);
+        if (firstParts.Length == 2) {
+            response.Method = firstParts[0];
+            response.Uri = firstParts[1];
+        }
+
+        if (index < lines.Length) {
+            var second = lines[index++];
+            var match = Regex.Match(second, @"HTTP/\S+\s+(\d+)");
+            if (match.Success && int.TryParse(match.Groups[1].Value, out var status)) {
+                response.StatusCode = (HttpStatusCode)status;
+            }
+        }
+
+        for (; index < lines.Length; index++) {
+            var line = lines[index];
+            if (line.StartsWith("{", StringComparison.Ordinal)) {
+                var body = string.Join(Environment.NewLine, lines, index, lines.Length - index);
+                try {
+                    response.Error = JsonSerializer.Deserialize<GraphApiError>(body);
+                } catch {
+                    // ignore
+                }
+                break;
+            }
+
+            var separator = line.IndexOf(':');
+            if (separator <= 0) {
+                continue;
+            }
+
+            var key = line.Substring(0, separator);
+            var value = line.Substring(separator + 1).Trim();
+            switch (key.ToLowerInvariant()) {
+                case "cache-control":
+                    response.Headers.CacheControl = value;
+                    break;
+                case "strict-transport-security":
+                    response.Headers.StrictTransportSecurity = value;
+                    break;
+                case "request-id":
+                    response.Headers.RequestId = value;
+                    break;
+                case "client-request-id":
+                    response.Headers.ClientRequestId = value;
+                    break;
+                case "date":
+                    if (DateTime.TryParse(value, out var dt)) {
+                        response.Headers.Date = dt;
+                    }
+                    break;
+                case "x-ms-ags-diagnostic":
+                    try {
+                        response.Headers.Diagnostic = JsonSerializer.Deserialize<GraphApiDiagnostic>(value);
+                    } catch {
+                        // ignore
+                    }
+                    break;
+                default:
+                    try {
+                        var json = JsonSerializer.Deserialize<JsonElement>(value);
+                        response.Headers.AdditionalJsonHeaders[key] = json;
+                    } catch {
+                        response.Headers.AdditionalHeaders[key] = value;
+                    }
+                    break;
+            }
+        }
+
+        return response;
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorResponse.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorResponse.cs
@@ -18,6 +18,9 @@ public class GraphApiErrorResponse {
     /// <summary>Gets or sets the headers.</summary>
     public GraphApiErrorHeaders Headers { get; set; } = new();
 
+    /// <summary>Gets or sets the original raw error message.</summary>
+    public string Raw { get; set; } = string.Empty;
+
     /// <summary>Gets or sets the error details.</summary>
     public GraphApiErrorDetail? Error { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorResponse.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorResponse.cs
@@ -1,0 +1,23 @@
+using System.Net;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Parsed details of a Graph API error message.
+/// </summary>
+public class GraphApiErrorResponse {
+    /// <summary>Gets or sets the HTTP method.</summary>
+    public string Method { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the request URI.</summary>
+    public string Uri { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the status code.</summary>
+    public HttpStatusCode StatusCode { get; set; }
+
+    /// <summary>Gets or sets the headers.</summary>
+    public GraphApiErrorHeaders Headers { get; set; } = new();
+
+    /// <summary>Gets or sets the error body.</summary>
+    public GraphApiError? Error { get; set; }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorResponse.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiErrorResponse.cs
@@ -7,7 +7,7 @@ namespace Mailozaurr;
 /// </summary>
 public class GraphApiErrorResponse {
     /// <summary>Gets or sets the HTTP method.</summary>
-    public string Method { get; set; } = string.Empty;
+    public GraphHttpMethod? Method { get; set; }
 
     /// <summary>Gets or sets the request URI.</summary>
     public string Uri { get; set; } = string.Empty;
@@ -18,6 +18,6 @@ public class GraphApiErrorResponse {
     /// <summary>Gets or sets the headers.</summary>
     public GraphApiErrorHeaders Headers { get; set; } = new();
 
-    /// <summary>Gets or sets the error body.</summary>
-    public GraphApiError? Error { get; set; }
+    /// <summary>Gets or sets the error details.</summary>
+    public GraphApiErrorDetail? Error { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiServerInfo.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiServerInfo.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Details about the server handling the request.
+/// </summary>
+public class GraphApiServerInfo {
+    /// <summary>Gets or sets the data center.</summary>
+    [JsonPropertyName("DataCenter")]
+    public string DataCenter { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the slice.</summary>
+    [JsonPropertyName("Slice")]
+    public string Slice { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the ring.</summary>
+    [JsonPropertyName("Ring")]
+    public string Ring { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the scale unit.</summary>
+    [JsonPropertyName("ScaleUnit")]
+    public string ScaleUnit { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the role instance.</summary>
+    [JsonPropertyName("RoleInstance")]
+    public string RoleInstance { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr/Smtp/SmtpResult.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpResult.cs
@@ -26,6 +26,9 @@ public class SmtpResult {
     public int Port { get; set; }
     /// <summary>Error information if the operation failed.</summary>
     public string? Error { get; set; }
+    /// <summary>Parsed Graph API error details if available.</summary>
+    public GraphApiErrorResponse? GraphError { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SmtpResult"/> class.
     /// </summary>

--- a/Tests/GraphApiErrorParser.Tests.ps1
+++ b/Tests/GraphApiErrorParser.Tests.ps1
@@ -13,8 +13,9 @@ Content-Type: application/json; odata.metadata=minimal; odata.streaming=true; IE
 {"error":{"code":"ErrorInvalidUser","message":"The requested user 'przemyslaw.klys@company.pl' is invalid."}}
 '@
         $parsed = [Mailozaurr.GraphApiErrorParser]::Parse($sample)
+        $parsed.Method | Should -Be ([Mailozaurr.GraphHttpMethod]::POST)
         $parsed.Headers.RequestId | Should -Be '2ff18766-1395-4fb9-abd1-162774d4b063'
         $parsed.Headers.Diagnostic.ServerInfo.DataCenter | Should -Be 'Poland Central'
-        $parsed.Error.Error.Code | Should -Be 'ErrorInvalidUser'
+        $parsed.Error.Code | Should -Be 'ErrorInvalidUser'
     }
 }

--- a/Tests/GraphApiErrorParser.Tests.ps1
+++ b/Tests/GraphApiErrorParser.Tests.ps1
@@ -1,0 +1,20 @@
+Import-Module $PSScriptRoot/../Mailozaurr.psd1 -Force
+Describe 'GraphApiErrorParser' {
+    It 'parses sample error string' {
+        $sample = @'
+POST https://graph.microsoft.com/v1.0/users/przemyslaw.klys@company.pl/sendMail
+HTTP/2.0 404 Not Found
+request-id: 2ff18766-1395-4fb9-abd1-162774d4b063
+client-request-id: 6c57f9e6-3cad-48ee-8f7a-d566dc92aca3
+x-ms-ags-diagnostic: {"ServerInfo":{"DataCenter":"Poland Central","Slice":"E","Ring":"2","ScaleUnit":"002","RoleInstance":"WA3PEPF000004A2"}}
+Date: Sun, 24 Aug 2025 12:55:18 GMT
+Content-Type: application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false; charset=utf-8
+
+{"error":{"code":"ErrorInvalidUser","message":"The requested user 'przemyslaw.klys@company.pl' is invalid."}}
+'@
+        $parsed = [Mailozaurr.GraphApiErrorParser]::Parse($sample)
+        $parsed.Headers.RequestId | Should -Be '2ff18766-1395-4fb9-abd1-162774d4b063'
+        $parsed.Headers.Diagnostic.ServerInfo.DataCenter | Should -Be 'Poland Central'
+        $parsed.Error.Error.Code | Should -Be 'ErrorInvalidUser'
+    }
+}

--- a/Tests/GraphApiErrorParser.Tests.ps1
+++ b/Tests/GraphApiErrorParser.Tests.ps1
@@ -19,8 +19,10 @@ Content-Type: application/json; odata.metadata=minimal; odata.streaming=true; IE
         $parsed.Error.Code | Should -Be 'ErrorInvalidUser'
     }
 
-    It 'returns null for invalid input' {
-        $parsed = [Mailozaurr.GraphApiErrorParser]::Parse('not a graph error')
-        $parsed | Should -Be $null
+    It 'returns raw message for invalid input' {
+        $sample = 'not a graph error'
+        $parsed = [Mailozaurr.GraphApiErrorParser]::Parse($sample)
+        $parsed.Raw | Should -Be $sample
+        $parsed.Error | Should -Be $null
     }
 }

--- a/Tests/GraphApiErrorParser.Tests.ps1
+++ b/Tests/GraphApiErrorParser.Tests.ps1
@@ -18,4 +18,9 @@ Content-Type: application/json; odata.metadata=minimal; odata.streaming=true; IE
         $parsed.Headers.Diagnostic.ServerInfo.DataCenter | Should -Be 'Poland Central'
         $parsed.Error.Code | Should -Be 'ErrorInvalidUser'
     }
+
+    It 'returns null for invalid input' {
+        $parsed = [Mailozaurr.GraphApiErrorParser]::Parse('not a graph error')
+        $parsed | Should -Be $null
+    }
 }


### PR DESCRIPTION
## Summary
- parse Microsoft Graph error responses into structured objects
- surface parsed Graph errors from Send-EmailMessage
- expose Graph error details on result object

## Testing
- `dotnet test Sources/Mailozaurr.sln -v minimal`
- `pwsh -NoLogo -NoProfile -File Mailozaurr.Tests.ps1` *(fails: Cannot add type. Compilation errors occurred.)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester Tests/GraphApiErrorParser.Tests.ps1 -PassThru"`


------
https://chatgpt.com/codex/tasks/task_e_68ab0cd6dc08832eb7a8e4450c7329c6