### PR TITLE
Refactor NDR and DMARC types into separate files

### DIFF
--- a/Sources/Mailozaurr/DmarcReports/DmarcReport.cs
+++ b/Sources/Mailozaurr/DmarcReports/DmarcReport.cs
@@ -16,21 +16,3 @@ public sealed class DmarcReport {
     /// <summary>Collection of zipped XML attachments.</summary>
     public IList<DmarcReportAttachment> Attachments { get; } = new List<DmarcReportAttachment>();
 }
-
-/// <summary>
-/// Represents a zipped XML attachment belonging to a DMARC report.
-/// </summary>
-public sealed class DmarcReportAttachment : IDisposable {
-    /// <summary>File name of the attachment.</summary>
-    public string Name { get; }
-
-    /// <summary>Stream containing the zipped attachment.</summary>
-    public Stream Content { get; }
-
-    public DmarcReportAttachment(string name, Stream content) {
-        Name = name;
-        Content = content;
-    }
-
-    public void Dispose() => Content.Dispose();
-}

--- a/Sources/Mailozaurr/DmarcReports/DmarcReportAttachment.cs
+++ b/Sources/Mailozaurr/DmarcReports/DmarcReportAttachment.cs
@@ -1,0 +1,19 @@
+namespace Mailozaurr.DmarcReports;
+
+/// <summary>
+/// Represents a zipped XML attachment belonging to a DMARC report.
+/// </summary>
+public sealed class DmarcReportAttachment : IDisposable {
+    /// <summary>File name of the attachment.</summary>
+    public string Name { get; }
+
+    /// <summary>Stream containing the zipped attachment.</summary>
+    public Stream Content { get; }
+
+    public DmarcReportAttachment(string name, Stream content) {
+        Name = name;
+        Content = content;
+    }
+
+    public void Dispose() => Content.Dispose();
+}

--- a/Sources/Mailozaurr/NonDeliveryReports/DsnStatus.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/DsnStatus.cs
@@ -47,15 +47,3 @@ public sealed class DsnStatus {
     /// <inheritdoc />
     public override string ToString() => $"{(int)Class}.{Subject}.{Detail}";
 }
-
-/// <summary>
-/// Top level DSN status classes as defined in RFC 3463.
-/// </summary>
-public enum DsnStatusClass {
-    /// <summary>Success (2.x.x).</summary>
-    Success = 2,
-    /// <summary>Persistent transient failure (4.x.x).</summary>
-    PersistentTransientFailure = 4,
-    /// <summary>Permanent failure (5.x.x).</summary>
-    PermanentFailure = 5
-}

--- a/Sources/Mailozaurr/NonDeliveryReports/DsnStatusClass.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/DsnStatusClass.cs
@@ -1,0 +1,13 @@
+namespace Mailozaurr.NonDeliveryReports;
+
+/// <summary>
+/// Top level DSN status classes as defined in RFC 3463.
+/// </summary>
+public enum DsnStatusClass {
+    /// <summary>Success (2.x.x).</summary>
+    Success = 2,
+    /// <summary>Persistent transient failure (4.x.x).</summary>
+    PersistentTransientFailure = 4,
+    /// <summary>Permanent failure (5.x.x).</summary>
+    PermanentFailure = 5
+}


### PR DESCRIPTION
## Summary
- split `DsnStatusClass` enum into dedicated file
- extract `DmarcReportAttachment` class from `DmarcReport`
- normalize file endings

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --filter "FullyQualifiedName~NonDeliveryReport|FullyQualifiedName~Dmarc"`


------
https://chatgpt.com/codex/tasks/task_e_68ab103544b0832e8953045c2040ab42