### PR TITLE
Stream mailbox searches with bounded concurrency

### DIFF
--- a/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
@@ -1,11 +1,15 @@
 using Mailozaurr;
 using Mailozaurr.DmarcReports;
+using MailKit;
 using MimeKit;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Pop3;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -65,6 +69,22 @@ public class SearchDmarcReportsTests {
         builder.Attachments.Add(part);
         message.Body = builder.ToMessageBody();
         return message;
+    }
+
+    private class TrackingPop3Client : Pop3Client {
+        private readonly List<MimeMessage> _messages;
+        public int FetchCount { get; private set; }
+        public TrackingPop3Client(IEnumerable<MimeMessage> messages) {
+            _messages = new List<MimeMessage>(messages);
+        }
+        public override bool IsConnected => true;
+        public override bool IsAuthenticated => true;
+        public override int Count => _messages.Count;
+        public override async Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {
+            await Task.Yield();
+            FetchCount++;
+            return _messages[index];
+        }
     }
 
     [Fact]
@@ -202,5 +222,23 @@ public class SearchDmarcReportsTests {
         Assert.Single(reports);
         Assert.Single(reports[0].Attachments);
         Assert.Equal("example", reports[0].Attachments[0].Name);
+    }
+
+    [Fact]
+    public async Task SearchDmarcReportsAsync_Pop3_StopsAfterMaxResults() {
+        var now = DateTimeOffset.UtcNow;
+        var msgs = new List<MimeMessage>();
+        msgs.Add(new MimeMessage());
+        msgs.Add(CreateDmarc("example.com", now));
+        msgs.Add(CreateDmarc("example.com", now));
+        msgs.Add(CreateDmarc("example.com", now));
+        var client = new TrackingPop3Client(msgs);
+        var reports = await MailboxSearcher.SearchDmarcReportsAsync(
+            client,
+            maxResults: 2,
+            parallelDownloadLimit: 2,
+            cancellationToken: CancellationToken.None);
+        Assert.Equal(2, reports.Count);
+        Assert.True(client.FetchCount <= 4, $"fetched {client.FetchCount}");
     }
 }

--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -172,6 +172,22 @@ public class SearchNonDeliveryReportsTests {
         }
     }
 
+    private class TrackingPop3Client : Pop3Client {
+        private readonly List<MimeMessage> _messages;
+        public int FetchCount { get; private set; }
+        public TrackingPop3Client(IEnumerable<MimeMessage> messages) {
+            _messages = new List<MimeMessage>(messages);
+        }
+        public override bool IsConnected => true;
+        public override bool IsAuthenticated => true;
+        public override int Count => _messages.Count;
+        public override async Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {
+            await Task.Yield();
+            FetchCount++;
+            return _messages[index];
+        }
+    }
+
     [Fact]
     public async Task SearchNonDeliveryReportsAsync_Pop3_DownloadsInParallel() {
         var now = DateTimeOffset.UtcNow;
@@ -206,5 +222,23 @@ public class SearchNonDeliveryReportsTests {
             cancellationToken: CancellationToken.None);
         Assert.Equal(msgs.Count, reports.Count);
         Assert.Equal(4, client.MaxConcurrency);
+    }
+
+    [Fact]
+    public async Task SearchNonDeliveryReportsAsync_Pop3_StopsAfterMaxResults() {
+        var now = DateTimeOffset.UtcNow;
+        var msgs = new List<MimeMessage>();
+        msgs.Add(new MimeMessage());
+        msgs.Add(CreateNdr("u1@example.com", "<id1>", now));
+        msgs.Add(CreateNdr("u2@example.com", "<id2>", now));
+        msgs.Add(CreateNdr("u3@example.com", "<id3>", now));
+        var client = new TrackingPop3Client(msgs);
+        var reports = await MailboxSearcher.SearchNonDeliveryReportsAsync(
+            client,
+            maxResults: 2,
+            parallelDownloadLimit: 2,
+            cancellationToken: CancellationToken.None);
+        Assert.Equal(2, reports.Count);
+        Assert.True(client.FetchCount <= 4, $"fetched {client.FetchCount}");
     }
 }

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -149,39 +149,67 @@ public static class MailboxSearcher {
         var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
         var search = BuildNonDeliveryReportSearchQuery(since, before);
         var uids = await mailFolder.SearchAsync(search, cancellationToken).ConfigureAwait(false);
-        var messages = new List<MimeMessage>(uids.Count);
+        var results = new List<NonDeliveryReport>();
         if (parallelDownloadLimit <= 1) {
             foreach (var uid in uids) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-                messages.Add(msg);
-                if (maxResults > 0 && messages.Count >= maxResults) break;
-            }
-        } else {
-            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
-            var tasks = new List<Task>();
-
-            async Task DownloadMessageAsync(MailKit.UniqueId uid) {
-                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-                    lock (messages) messages.Add(msg);
-                } finally {
-                    semaphore.Release();
+                var reports = FilterNonDeliveryReports(new[] { msg }, since, before, recipientContains, messageId);
+                if (reports.Count > 0) {
+                    foreach (var r in reports) {
+                        if (maxResults > 0 && results.Count >= maxResults) break;
+                        results.Add(r);
+                    }
+                    if (maxResults > 0 && results.Count >= maxResults) break;
                 }
             }
-
-            foreach (var uid in uids) {
-                cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(DownloadMessageAsync(uid));
-                if (maxResults > 0 && tasks.Count >= maxResults) break;
+        } else {
+            var uidArray = uids.ToArray();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var workers = new Task[Math.Min(parallelDownloadLimit, uidArray.Length)];
+            int next = 0;
+            int resultCount = 0;
+            var gate = new object();
+            for (int i = 0; i < workers.Length; i++) {
+                workers[i] = Task.Run(async () => {
+                    while (true) {
+                        int current;
+                        lock (gate) {
+                            if (cts.IsCancellationRequested || next >= uidArray.Length || (maxResults > 0 && resultCount >= maxResults)) return;
+                            current = next++;
+                        }
+                        MimeMessage msg;
+                        try {
+                            msg = await mailFolder.GetMessageAsync(uidArray[current], cts.Token).ConfigureAwait(false);
+                        } catch (OperationCanceledException) {
+                            return;
+                        }
+                        var reports = FilterNonDeliveryReports(new[] { msg }, since, before, recipientContains, messageId);
+                        if (reports.Count == 0) continue;
+                        lock (gate) {
+                            foreach (var r in reports) {
+                                if (maxResults > 0 && resultCount >= maxResults) {
+                                    cts.Cancel();
+                                    break;
+                                }
+                                results.Add(r);
+                                resultCount++;
+                                if (maxResults > 0 && resultCount >= maxResults) {
+                                    cts.Cancel();
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }, CancellationToken.None);
             }
-
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            try {
+                await Task.WhenAll(workers).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+            }
         }
 
-        return FilterNonDeliveryReports(messages, since, before, recipientContains, messageId);
+        return maxResults > 0 && results.Count > maxResults ? results.GetRange(0, maxResults) : results;
     }
 
     /// <summary>
@@ -198,42 +226,66 @@ public static class MailboxSearcher {
         int maxResults = 0,
         int parallelDownloadLimit = 4,
         CancellationToken cancellationToken = default) {
-        var count = client.Count;
-        var indices = new List<int>(count);
-        for (int i = 0; i < count; i++) indices.Add(i);
-        var messages = new List<MimeMessage>(indices.Count);
+        var results = new List<NonDeliveryReport>();
         if (parallelDownloadLimit <= 1) {
-            foreach (var idx in indices) {
+            for (int idx = 0; idx < client.Count; idx++) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
-                messages.Add(msg);
-                if (maxResults > 0 && messages.Count >= maxResults) break;
-            }
-        } else {
-            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
-            var tasks = new List<Task>();
-
-            async Task DownloadMessageAsync(int idx) {
-                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
-                    lock (messages) messages.Add(msg);
-                } finally {
-                    semaphore.Release();
+                var reports = FilterNonDeliveryReports(new[] { msg }, since, before, recipientContains, messageId);
+                if (reports.Count > 0) {
+                    foreach (var r in reports) {
+                        if (maxResults > 0 && results.Count >= maxResults) break;
+                        results.Add(r);
+                    }
+                    if (maxResults > 0 && results.Count >= maxResults) break;
                 }
             }
-
-            foreach (var idx in indices) {
-                cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(DownloadMessageAsync(idx));
-                if (maxResults > 0 && tasks.Count >= maxResults) break;
+        } else {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var workers = new Task[Math.Min(parallelDownloadLimit, client.Count)];
+            int next = 0;
+            int resultCount = 0;
+            var gate = new object();
+            for (int i = 0; i < workers.Length; i++) {
+                workers[i] = Task.Run(async () => {
+                    while (true) {
+                        int current;
+                        lock (gate) {
+                            if (cts.IsCancellationRequested || next >= client.Count || (maxResults > 0 && resultCount >= maxResults)) return;
+                            current = next++;
+                        }
+                        MimeMessage msg;
+                        try {
+                            msg = await client.GetMessageAsync(current, cts.Token).ConfigureAwait(false);
+                        } catch (OperationCanceledException) {
+                            return;
+                        }
+                        var reports = FilterNonDeliveryReports(new[] { msg }, since, before, recipientContains, messageId);
+                        if (reports.Count == 0) continue;
+                        lock (gate) {
+                            foreach (var r in reports) {
+                                if (maxResults > 0 && resultCount >= maxResults) {
+                                    cts.Cancel();
+                                    break;
+                                }
+                                results.Add(r);
+                                resultCount++;
+                                if (maxResults > 0 && resultCount >= maxResults) {
+                                    cts.Cancel();
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }, CancellationToken.None);
             }
-
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            try {
+                await Task.WhenAll(workers).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+            }
         }
 
-        return FilterNonDeliveryReports(messages, since, before, recipientContains, messageId);
+        return maxResults > 0 && results.Count > maxResults ? results.GetRange(0, maxResults) : results;
     }
 
     /// <summary>
@@ -373,39 +425,67 @@ public static class MailboxSearcher {
         var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
         var search = BuildDmarcReportSearchQuery(since, before, domain);
         var uids = await mailFolder.SearchAsync(search, cancellationToken).ConfigureAwait(false);
-        var messages = new List<MimeMessage>(uids.Count);
+        var results = new List<DmarcReport>();
         if (parallelDownloadLimit <= 1) {
             foreach (var uid in uids) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-                messages.Add(msg);
-                if (maxResults > 0 && messages.Count >= maxResults) break;
-            }
-        } else {
-            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
-            var tasks = new List<Task>();
-
-            async Task DownloadMessageAsync(MailKit.UniqueId uid) {
-                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-                    lock (messages) messages.Add(msg);
-                } finally {
-                    semaphore.Release();
+                var reports = FilterDmarcReports(new[] { msg }, since, before, domain);
+                if (reports.Count > 0) {
+                    foreach (var r in reports) {
+                        if (maxResults > 0 && results.Count >= maxResults) break;
+                        results.Add(r);
+                    }
+                    if (maxResults > 0 && results.Count >= maxResults) break;
                 }
             }
-
-            foreach (var uid in uids) {
-                cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(DownloadMessageAsync(uid));
-                if (maxResults > 0 && tasks.Count >= maxResults) break;
+        } else {
+            var uidArray = uids.ToArray();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var workers = new Task[Math.Min(parallelDownloadLimit, uidArray.Length)];
+            int next = 0;
+            int resultCount = 0;
+            var gate = new object();
+            for (int i = 0; i < workers.Length; i++) {
+                workers[i] = Task.Run(async () => {
+                    while (true) {
+                        int current;
+                        lock (gate) {
+                            if (cts.IsCancellationRequested || next >= uidArray.Length || (maxResults > 0 && resultCount >= maxResults)) return;
+                            current = next++;
+                        }
+                        MimeMessage msg;
+                        try {
+                            msg = await mailFolder.GetMessageAsync(uidArray[current], cts.Token).ConfigureAwait(false);
+                        } catch (OperationCanceledException) {
+                            return;
+                        }
+                        var reports = FilterDmarcReports(new[] { msg }, since, before, domain);
+                        if (reports.Count == 0) continue;
+                        lock (gate) {
+                            foreach (var r in reports) {
+                                if (maxResults > 0 && resultCount >= maxResults) {
+                                    cts.Cancel();
+                                    break;
+                                }
+                                results.Add(r);
+                                resultCount++;
+                                if (maxResults > 0 && resultCount >= maxResults) {
+                                    cts.Cancel();
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }, CancellationToken.None);
             }
-
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            try {
+                await Task.WhenAll(workers).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+            }
         }
 
-        return FilterDmarcReports(messages, since, before, domain);
+        return maxResults > 0 && results.Count > maxResults ? results.GetRange(0, maxResults) : results;
     }
 
     /// <summary>
@@ -421,42 +501,66 @@ public static class MailboxSearcher {
         int maxResults = 0,
         int parallelDownloadLimit = 4,
         CancellationToken cancellationToken = default) {
-        var count = client.Count;
-        var indices = new List<int>(count);
-        for (int i = 0; i < count; i++) indices.Add(i);
-        var messages = new List<MimeMessage>(indices.Count);
+        var results = new List<DmarcReport>();
         if (parallelDownloadLimit <= 1) {
-            foreach (var idx in indices) {
+            for (int idx = 0; idx < client.Count; idx++) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
-                messages.Add(msg);
-                if (maxResults > 0 && messages.Count >= maxResults) break;
-            }
-        } else {
-            using var semaphore = new SemaphoreSlim(parallelDownloadLimit);
-            var tasks = new List<Task>();
-
-            async Task DownloadMessageAsync(int idx) {
-                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
-                    lock (messages) messages.Add(msg);
-                } finally {
-                    semaphore.Release();
+                var reports = FilterDmarcReports(new[] { msg }, since, before, domain);
+                if (reports.Count > 0) {
+                    foreach (var r in reports) {
+                        if (maxResults > 0 && results.Count >= maxResults) break;
+                        results.Add(r);
+                    }
+                    if (maxResults > 0 && results.Count >= maxResults) break;
                 }
             }
-
-            foreach (var idx in indices) {
-                cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(DownloadMessageAsync(idx));
-                if (maxResults > 0 && tasks.Count >= maxResults) break;
+        } else {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var workers = new Task[Math.Min(parallelDownloadLimit, client.Count)];
+            int next = 0;
+            int resultCount = 0;
+            var gate = new object();
+            for (int i = 0; i < workers.Length; i++) {
+                workers[i] = Task.Run(async () => {
+                    while (true) {
+                        int current;
+                        lock (gate) {
+                            if (cts.IsCancellationRequested || next >= client.Count || (maxResults > 0 && resultCount >= maxResults)) return;
+                            current = next++;
+                        }
+                        MimeMessage msg;
+                        try {
+                            msg = await client.GetMessageAsync(current, cts.Token).ConfigureAwait(false);
+                        } catch (OperationCanceledException) {
+                            return;
+                        }
+                        var reports = FilterDmarcReports(new[] { msg }, since, before, domain);
+                        if (reports.Count == 0) continue;
+                        lock (gate) {
+                            foreach (var r in reports) {
+                                if (maxResults > 0 && resultCount >= maxResults) {
+                                    cts.Cancel();
+                                    break;
+                                }
+                                results.Add(r);
+                                resultCount++;
+                                if (maxResults > 0 && resultCount >= maxResults) {
+                                    cts.Cancel();
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }, CancellationToken.None);
             }
-
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            try {
+                await Task.WhenAll(workers).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+            }
         }
 
-        return FilterDmarcReports(messages, since, before, domain);
+        return maxResults > 0 && results.Count > maxResults ? results.GetRange(0, maxResults) : results;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- stream non-delivery report searches for IMAP/POP3 with bounded parallelism and early termination
- stream DMARC report searches for IMAP/POP3 with bounded parallelism and early termination
- cover max-results behavior with new POP3 tests

## Testing
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_68ab1896c618832eadf242e9dc92027e