### PR TITLE
Handle SendGrid email inputs

### DIFF
--- a/Sources/Mailozaurr.Tests/SendGridConvertToEmailObjectTests.cs
+++ b/Sources/Mailozaurr.Tests/SendGridConvertToEmailObjectTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Mailozaurr.Tests;
+
+public class SendGridConvertToEmailObjectTests
+{
+    [Fact]
+    public void ConvertToEmailObject_String_ReturnsEmail()
+    {
+        var client = new SendGridClient();
+        MethodInfo? method = typeof(SendGridClient).GetMethod("ConvertToEmailObject", BindingFlags.NonPublic | BindingFlags.Instance);
+        var result = method?.Invoke(client, new object?[] { "user@example.com" }) as SendGridEmailAddress;
+        Assert.NotNull(result);
+        Assert.Equal("user@example.com", result!.Email);
+        Assert.Null(result.Name);
+    }
+
+    [Fact]
+    public void ConvertToEmailObject_Dictionary_ReturnsEmail()
+    {
+        var client = new SendGridClient();
+        MethodInfo? method = typeof(SendGridClient).GetMethod("ConvertToEmailObject", BindingFlags.NonPublic | BindingFlags.Instance);
+        var input = new Dictionary<string, object>
+        {
+            ["Email"] = "dict@example.com",
+            ["Name"] = "Dict"
+        };
+        var result = method?.Invoke(client, new object?[] { input }) as SendGridEmailAddress;
+        Assert.NotNull(result);
+        Assert.Equal("dict@example.com", result!.Email);
+        Assert.Equal("Dict", result.Name);
+    }
+
+    [Fact]
+    public void ConvertToEmailObject_SendGridEmailAddress_ReturnsSameInstance()
+    {
+        var client = new SendGridClient();
+        MethodInfo? method = typeof(SendGridClient).GetMethod("ConvertToEmailObject", BindingFlags.NonPublic | BindingFlags.Instance);
+        var address = new SendGridEmailAddress { Email = "sg@example.com", Name = "SG" };
+        var result = method?.Invoke(client, new object?[] { address }) as SendGridEmailAddress;
+        Assert.Same(address, result);
+    }
+}
+

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -166,6 +166,10 @@ public class SendGridClient {
             return null;
         }
 
+        if (emailAddress is SendGridEmailAddress sendGridEmail) {
+            return sendGridEmail;
+        }
+
         var emailAsString = Convert.ToString(emailAddress);
         if (string.IsNullOrWhiteSpace(emailAsString)) {
             return null;
@@ -189,7 +193,9 @@ public class SendGridClient {
             return new SendGridEmailAddress { Email = emailValue, Name = nameValue };
         }
 
-        throw new ArgumentException($"email object type {emailAddress.GetType().Name} requires addition");
+        throw new ArgumentException(
+            $"Unsupported email address type {emailAddress.GetType().Name}. Expected string, SendGridEmailAddress, or IDictionary<string, object>.",
+            nameof(emailAddress));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Return SendGridEmailAddress directly from ConvertToEmailObject
- Clarify exception message for unsupported address formats
- Test string, dictionary, and SendGridEmailAddress conversions

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --filter "FullyQualifiedName~SendGridConvertToEmailObjectTests" -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68ab42c5b4bc832ea7978ed31496aec1