### PR TITLE
Support per-recipient SendGrid personalizations

### DIFF
--- a/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Reflection;
+using System.Text.Json;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -85,5 +86,33 @@ public class SendGridCreateMessageTests
         using var doc = System.Text.Json.JsonDocument.Parse(json!);
         var count = doc.RootElement.GetProperty("Attachments").GetArrayLength();
         Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void CreateMessage_WithSeparateTo_CreatesPersonalizationsPerRecipient()
+    {
+        var client = new SendGridClient
+        {
+            From = "from@example.com",
+            To = new List<object> { "a@example.com", "b@example.com", "a@example.com" },
+            Cc = new List<object> { "cc@example.com" },
+            Bcc = new List<object> { "b@example.com", "bcc@example.com" },
+            Subject = "subject",
+            Text = "text",
+            SeparateTo = true,
+            Credentials = new NetworkCredential("apikey", "test")
+        };
+        client.CreateMessage();
+        PropertyInfo? prop = typeof(SendGridClient).GetProperty("MessageJson", BindingFlags.NonPublic | BindingFlags.Instance);
+        var json = prop?.GetValue(client) as string;
+        Assert.NotNull(json);
+        using var doc = JsonDocument.Parse(json!);
+        var pers = doc.RootElement.GetProperty("Personalizations");
+        Assert.Equal(2, pers.GetArrayLength());
+        foreach (var p in pers.EnumerateArray()) {
+            Assert.Equal(1, p.GetProperty("To").GetArrayLength());
+            Assert.Equal(1, p.GetProperty("Cc").GetArrayLength());
+            Assert.Equal(1, p.GetProperty("Bcc").GetArrayLength());
+        }
     }
 }

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -244,29 +244,46 @@ public class SendGridClient {
 
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        var personalizations = new List<SendGridPersonalization>
-            {
-                new SendGridPersonalization
-                {
-                    To = To?.Where(t => t != null)
-                        .Select(ConvertToEmailObject)
-                        .Where(x => x != null && seen.Add(x.Email))
-                        .Select(x => x!)
-                        .ToList(),
-                    Cc = Cc?.Where(c => c != null)
-                        .Select(ConvertToEmailObject)
-                        .Where(x => x != null && seen.Add(x.Email))
-                        .Select(x => x!)
-                        .ToList(),
-                    Bcc = Bcc?.Where(b => b != null)
-                        .Select(ConvertToEmailObject)
-                        .Where(x => x != null && seen.Add(x.Email))
-                        .Select(x => x!)
-                        .ToList()
-                }
-            }
-            .Where(p => p.To != null || p.Cc != null || p.Bcc != null)
+        var toAddresses = To?.Where(t => t != null)
+            .Select(ConvertToEmailObject)
+            .Where(x => x != null && seen.Add(x.Email))
+            .Select(x => x!)
             .ToList();
+
+        var ccAddresses = Cc?.Where(c => c != null)
+            .Select(ConvertToEmailObject)
+            .Where(x => x != null && seen.Add(x.Email))
+            .Select(x => x!)
+            .ToList();
+
+        var bccAddresses = Bcc?.Where(b => b != null)
+            .Select(ConvertToEmailObject)
+            .Where(x => x != null && seen.Add(x.Email))
+            .Select(x => x!)
+            .ToList();
+
+        List<SendGridPersonalization> personalizations;
+        if (SeparateTo && toAddresses != null && toAddresses.Count > 0) {
+            personalizations = toAddresses
+                .Select(t => new SendGridPersonalization {
+                    To = new List<SendGridEmailAddress> { t },
+                    Cc = ccAddresses?.ToList(),
+                    Bcc = bccAddresses?.ToList()
+                })
+                .ToList();
+        } else {
+            personalizations = new List<SendGridPersonalization>
+                {
+                    new SendGridPersonalization
+                    {
+                        To = toAddresses,
+                        Cc = ccAddresses,
+                        Bcc = bccAddresses
+                    }
+                }
+                .Where(p => p.To != null || p.Cc != null || p.Bcc != null)
+                .ToList();
+        }
 
         var content = new List<SendGridContent> {
                 new SendGridContent { Type = "text/plain", Value = Text },

--- a/Tests/Send-EmailMessage.SendGridSeparateTo.Tests.ps1
+++ b/Tests/Send-EmailMessage.SendGridSeparateTo.Tests.ps1
@@ -1,0 +1,21 @@
+Describe 'SendGrid SeparateTo' {
+    It 'Creates separate personalizations per recipient' {
+        $client = [Mailozaurr.SendGridClient]::new()
+        $client.From = 'from@example.com'
+        $client.To = @('a@example.com','b@example.com','a@example.com')
+        $client.Cc = @('cc@example.com')
+        $client.Bcc = @('b@example.com','bcc@example.com')
+        $client.Subject = 'subject'
+        $client.Text = 'body'
+        $client.SeparateTo = $true
+        $client.CreateMessage()
+        $json = $client.GetType().GetProperty('MessageJson',[System.Reflection.BindingFlags] 'NonPublic,Instance').GetValue($client)
+        $data = $json | ConvertFrom-Json
+        $data.personalizations.Count | Should -Be 2
+        foreach ($p in $data.personalizations) {
+            $p.to.Count | Should -Be 1
+            $p.cc.Count | Should -Be 1
+            $p.bcc.Count | Should -Be 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- split SendGrid personalizations when `SeparateTo` is set
- ensure CC/BCC lists stay with each personalization
- add tests covering SeparateTo behavior for SendGrid

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `pwsh ./Mailozaurr.Tests.ps1` *(fails: Cannot add type or missing cmdlets in existing tests)*
- `pwsh -NoLogo -Command "Import-Module ./Mailozaurr.psd1; Invoke-Pester Tests/Send-EmailMessage.SendGridSeparateTo.Tests.ps1 -PassThru"`


------
https://chatgpt.com/codex/tasks/task_e_68ab42af7d4c832e90aee7f390cac582