### PR TITLE
Escape Gmail query strings

### DIFF
--- a/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
@@ -189,6 +189,20 @@ public class SearchDmarcReportsTests {
     }
 
     [Fact]
+    public void BuildGmailDmarcReportQuery_DomainWithDots_ReturnsQuery() {
+        var domain = "sub.example.co.uk";
+        var q = MailboxSearcher.BuildGmailDmarcReportQuery(null, null, domain);
+        Assert.Contains(domain, q);
+    }
+
+    [Fact]
+    public void BuildGmailDmarcReportQuery_DomainWithQuotes_EscapesQuotes() {
+        var domain = "exa\"mple.com";
+        var q = MailboxSearcher.BuildGmailDmarcReportQuery(null, null, domain);
+        Assert.Contains("exa\\\"mple.com", q);
+    }
+
+    [Fact]
     public void FilterDmarcReports_FiltersAcrossTimeZones() {
         var msg1 = CreateDmarc("example.com", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.FromHours(2)));
         var msg2 = CreateDmarc("example.com", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.FromHours(-5)));

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -760,9 +760,18 @@ public static class MailboxSearcher {
         return search;
     }
 
+    private static string EscapeGmailQueryValue(string value) {
+        var sb = new StringBuilder(value.Length);
+        foreach (var c in value) {
+            if (c == '\\' || c == '"' || c == '(' || c == ')' || c == '[' || c == ']' || c == '{' || c == '}') sb.Append('\\');
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
     internal static string BuildGmailDmarcReportQuery(DateTime? since, DateTime? before, string? domain) {
         var sb = new StringBuilder("subject:\"report domain\" has:attachment");
-        if (!string.IsNullOrWhiteSpace(domain)) sb.Append(' ').Append("subject:\"").Append(domain).Append("\"");
+        if (!string.IsNullOrWhiteSpace(domain)) sb.Append(' ').Append("subject:\"").Append(EscapeGmailQueryValue(domain)).Append("\"");
         if (since.HasValue) sb.Append(' ').Append("after:").Append(since.Value.ToUniversalTime().ToString("yyyy/MM/dd"));
         if (before.HasValue) sb.Append(' ').Append("before:").Append(before.Value.ToUniversalTime().ToString("yyyy/MM/dd"));
         return sb.ToString().Trim();
@@ -817,7 +826,7 @@ public static class MailboxSearcher {
         bool first = true;
         foreach (var pattern in NonDeliveryReportSubjectPatterns.Values) {
             if (!first) sb.Append(" OR ");
-            sb.Append("subject:\"").Append(pattern).Append("\"");
+            sb.Append("subject:\"").Append(EscapeGmailQueryValue(pattern)).Append("\"");
             first = false;
         }
         if (sb.Length > 0) {


### PR DESCRIPTION
## Summary
- escape special characters in Gmail DMARC and non-delivery report queries
- cover quoted and dotted domains in Gmail query tests

## Testing
- `dotnet test Sources/Mailozaurr.sln`

------
https://chatgpt.com/codex/tasks/task_e_68ab45600d04832e99065de3ac0113ef