### PR TITLE
Add size limits and error logging for DMARC attachments

### DIFF
--- a/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
@@ -241,4 +241,66 @@ public class SearchDmarcReportsTests {
         Assert.Equal(2, reports.Count);
         Assert.True(client.FetchCount <= 4, $"fetched {client.FetchCount}");
     }
+
+    [Fact]
+    public void FilterDmarcReports_IgnoresMalformedArchive() {
+        var now = DateTimeOffset.UtcNow;
+        var message = new MimeMessage();
+        message.Subject = "Report";
+        message.Date = now;
+        message.From.Add(new MailboxAddress("reporter", "reporter@example.com"));
+        var builder = new BodyBuilder();
+        var ms = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+        var part = new MimePart("application", "zip") {
+            Content = new MimeContent(ms),
+            FileName = "report.zip"
+        };
+        builder.Attachments.Add(part);
+        message.Body = builder.ToMessageBody();
+        bool logged = false;
+        void Handler(object? s, LogEventArgs e) => logged = true;
+        LoggingMessages.Logger.OnErrorMessage += Handler;
+        try {
+            var reports = MailboxSearcher.FilterDmarcReports(new[] { message }, since: now.AddMinutes(-1).DateTime, before: now.AddMinutes(1).DateTime, domain: "example.com", maxUncompressedSize: 1024);
+            Assert.Empty(reports);
+            Assert.True(logged);
+        } finally {
+            LoggingMessages.Logger.OnErrorMessage -= Handler;
+        }
+    }
+
+    [Fact]
+    public void FilterDmarcReports_SkipsOversizedAttachment() {
+        var now = DateTimeOffset.UtcNow;
+        var message = new MimeMessage();
+        message.Subject = "Report";
+        message.Date = now;
+        message.From.Add(new MailboxAddress("reporter", "reporter@example.com"));
+        var builder = new BodyBuilder();
+        var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, true)) {
+            var entry = zip.CreateEntry("report.xml");
+            using var entryStream = entry.Open();
+            var large = new string('a', 2048);
+            var bytes = Encoding.UTF8.GetBytes($"<feedback><policy_published><domain>example.com</domain></policy_published><data>{large}</data></feedback>");
+            entryStream.Write(bytes, 0, bytes.Length);
+        }
+        ms.Position = 0;
+        var part = new MimePart("application", "zip") {
+            Content = new MimeContent(ms),
+            FileName = "report.zip"
+        };
+        builder.Attachments.Add(part);
+        message.Body = builder.ToMessageBody();
+        bool logged = false;
+        void Handler(object? s, LogEventArgs e) => logged = true;
+        LoggingMessages.Logger.OnErrorMessage += Handler;
+        try {
+            var reports = MailboxSearcher.FilterDmarcReports(new[] { message }, since: now.AddMinutes(-1).DateTime, before: now.AddMinutes(1).DateTime, domain: "example.com", maxUncompressedSize: 512);
+            Assert.Empty(reports);
+            Assert.True(logged);
+        } finally {
+            LoggingMessages.Logger.OnErrorMessage -= Handler;
+        }
+    }
 }

--- a/Sources/Mailozaurr/Helpers/LimitedStream.cs
+++ b/Sources/Mailozaurr/Helpers/LimitedStream.cs
@@ -1,0 +1,43 @@
+namespace Mailozaurr;
+
+using System;
+using System.IO;
+
+/// <summary>
+/// Stream wrapper that limits the number of bytes that can be read.
+/// </summary>
+internal sealed class LimitedStream : Stream {
+    private readonly Stream _inner;
+    private readonly long _maxBytes;
+    private long _totalBytes;
+
+    public LimitedStream(Stream inner, long maxBytes) {
+        _inner = inner;
+        _maxBytes = maxBytes;
+    }
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => _inner.Length;
+    public override long Position {
+        get => _inner.Position;
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() => _inner.Flush();
+
+    public override int Read(byte[] buffer, int offset, int count) {
+        var remaining = _maxBytes - _totalBytes;
+        if (remaining <= 0) throw new InvalidDataException("Uncompressed data exceeds allowed limit.");
+        if (count > remaining) count = (int)remaining;
+        var read = _inner.Read(buffer, offset, count);
+        _totalBytes += read;
+        if (_totalBytes > _maxBytes) throw new InvalidDataException("Uncompressed data exceeds allowed limit.");
+        return read;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -421,6 +421,7 @@ public static class MailboxSearcher {
         string? domain = null,
         int maxResults = 0,
         int parallelDownloadLimit = 4,
+        long maxUncompressedSize = 10 * 1024 * 1024,
         CancellationToken cancellationToken = default) {
         var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
         var search = BuildDmarcReportSearchQuery(since, before, domain);
@@ -430,7 +431,7 @@ public static class MailboxSearcher {
             foreach (var uid in uids) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var msg = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-                var reports = FilterDmarcReports(new[] { msg }, since, before, domain);
+                var reports = FilterDmarcReports(new[] { msg }, since, before, domain, maxUncompressedSize);
                 if (reports.Count > 0) {
                     foreach (var r in reports) {
                         if (maxResults > 0 && results.Count >= maxResults) break;
@@ -460,7 +461,7 @@ public static class MailboxSearcher {
                         } catch (OperationCanceledException) {
                             return;
                         }
-                        var reports = FilterDmarcReports(new[] { msg }, since, before, domain);
+                        var reports = FilterDmarcReports(new[] { msg }, since, before, domain, maxUncompressedSize);
                         if (reports.Count == 0) continue;
                         lock (gate) {
                             foreach (var r in reports) {
@@ -500,13 +501,14 @@ public static class MailboxSearcher {
         string? domain = null,
         int maxResults = 0,
         int parallelDownloadLimit = 4,
+        long maxUncompressedSize = 10 * 1024 * 1024,
         CancellationToken cancellationToken = default) {
         var results = new List<DmarcReport>();
         if (parallelDownloadLimit <= 1) {
             for (int idx = 0; idx < client.Count; idx++) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var msg = await client.GetMessageAsync(idx, cancellationToken).ConfigureAwait(false);
-                var reports = FilterDmarcReports(new[] { msg }, since, before, domain);
+                var reports = FilterDmarcReports(new[] { msg }, since, before, domain, maxUncompressedSize);
                 if (reports.Count > 0) {
                     foreach (var r in reports) {
                         if (maxResults > 0 && results.Count >= maxResults) break;
@@ -535,7 +537,7 @@ public static class MailboxSearcher {
                         } catch (OperationCanceledException) {
                             return;
                         }
-                        var reports = FilterDmarcReports(new[] { msg }, since, before, domain);
+                        var reports = FilterDmarcReports(new[] { msg }, since, before, domain, maxUncompressedSize);
                         if (reports.Count == 0) continue;
                         lock (gate) {
                             foreach (var r in reports) {
@@ -576,6 +578,7 @@ public static class MailboxSearcher {
         string? domain = null,
         int maxResults = 0,
         int parallelDownloadLimit = 4,
+        long maxUncompressedSize = 10 * 1024 * 1024,
         CancellationToken cancellationToken = default) {
         var filters = new List<string> { "hasAttachments eq true", "contains(subject,'report domain')" };
         if (since.HasValue) filters.Add($"receivedDateTime ge {since.Value.ToUniversalTime():o}");
@@ -622,7 +625,7 @@ public static class MailboxSearcher {
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
-        return FilterDmarcReports(mimeMessages, since, before, domain);
+        return FilterDmarcReports(mimeMessages, since, before, domain, maxUncompressedSize);
     }
 
     /// <summary>
@@ -638,6 +641,7 @@ public static class MailboxSearcher {
         string? domain = null,
         int maxResults = 0,
         int parallelDownloadLimit = 4,
+        long maxUncompressedSize = 10 * 1024 * 1024,
         CancellationToken cancellationToken = default) {
         string query = BuildGmailDmarcReportQuery(since, before, domain);
         var msgs = await client.ListAsync(userId, query, maxResults > 0 ? maxResults : (int?)null, cancellationToken).ConfigureAwait(false);
@@ -677,7 +681,7 @@ public static class MailboxSearcher {
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
-        return FilterDmarcReports(mimeMessages, since, before, domain);
+        return FilterDmarcReports(mimeMessages, since, before, domain, maxUncompressedSize);
     }
 
     /// <summary>
@@ -689,7 +693,8 @@ public static class MailboxSearcher {
         IEnumerable<MimeMessage> messages,
         DateTime? since,
         DateTime? before,
-        string? domain) {
+        string? domain,
+        long maxUncompressedSize = 10 * 1024 * 1024) {
         var results = new List<DmarcReport>();
         var sinceUtc = since?.ToUniversalTime();
         var beforeUtc = before?.ToUniversalTime();
@@ -705,7 +710,7 @@ public static class MailboxSearcher {
             var domainMatched = string.IsNullOrWhiteSpace(domain);
             foreach (var att in message.Attachments) {
                 if (IsDmarcAttachment(att) && att is MimePart part) {
-                    if (!string.IsNullOrWhiteSpace(domain) && !AttachmentMatchesDomain(part, domain!)) continue;
+                    if (!string.IsNullOrWhiteSpace(domain) && !AttachmentMatchesDomain(part, domain!, maxUncompressedSize)) continue;
                     var stream = part.Content.Open();
                     report.Attachments.Add(new DmarcReportAttachment(part.FileName ?? "report.zip", stream));
                     if (!domainMatched) domainMatched = true;
@@ -716,7 +721,7 @@ public static class MailboxSearcher {
         return results;
     }
 
-    private static bool AttachmentMatchesDomain(MimePart part, string domain) {
+    private static bool AttachmentMatchesDomain(MimePart part, string domain, long maxUncompressedSize) {
         if (part.FileName?.IndexOf(domain, StringComparison.OrdinalIgnoreCase) >= 0) return true;
         try {
             using var stream = part.Content.Open();
@@ -724,23 +729,28 @@ public static class MailboxSearcher {
             if (name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)) {
                 using var zip = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
                 foreach (var entry in zip.Entries) {
+                    if (entry.Length > maxUncompressedSize) {
+                        LoggingMessages.Logger.WriteError("Zip entry {0} exceeds max size {1}", entry.FullName, maxUncompressedSize);
+                        continue;
+                    }
                     using var entryStream = entry.Open();
-                    if (XmlStreamContainsDomain(entryStream, domain)) return true;
+                    if (XmlStreamContainsDomain(entryStream, domain, maxUncompressedSize)) return true;
                 }
             } else if (name.EndsWith(".gz", StringComparison.OrdinalIgnoreCase)) {
                 using var gz = new GZipStream(stream, CompressionMode.Decompress);
-                if (XmlStreamContainsDomain(gz, domain)) return true;
+                if (XmlStreamContainsDomain(gz, domain, maxUncompressedSize)) return true;
             } else {
-                if (XmlStreamContainsDomain(stream, domain)) return true;
+                if (XmlStreamContainsDomain(stream, domain, maxUncompressedSize)) return true;
             }
-        } catch {
+        } catch (Exception ex) {
+            LoggingMessages.Logger.WriteError("Failed to process attachment {0}: {1}", part.FileName ?? string.Empty, ex.Message);
         }
         return false;
     }
 
-    private static bool XmlStreamContainsDomain(Stream stream, string domain) {
-        var settings = new System.Xml.XmlReaderSettings { IgnoreComments = true, IgnoreWhitespace = true };
-        using var reader = System.Xml.XmlReader.Create(stream, settings);
+    private static bool XmlStreamContainsDomain(Stream stream, string domain, long maxUncompressedSize) {
+        var settings = new System.Xml.XmlReaderSettings { IgnoreComments = true, IgnoreWhitespace = true, CloseInput = true };
+        using var reader = System.Xml.XmlReader.Create(new LimitedStream(stream, maxUncompressedSize), settings);
         while (reader.Read()) {
             if (reader.NodeType == System.Xml.XmlNodeType.Element && reader.LocalName.Equals("domain", StringComparison.OrdinalIgnoreCase)) {
                 var value = reader.ReadElementContentAsString();


### PR DESCRIPTION
## Summary
- guard DMARC report extraction with configurable max uncompressed size
- log decompression failures to surface malformed archives
- add tests for malformed and oversized DMARC attachments

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68ab45674b8c832ead38cf26741b0947