### PR TITLE
Normalize NDR message id comparison

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailNonDeliveryReportsTests.cs
@@ -43,7 +43,7 @@ public class GmailNonDeliveryReportsTests {
         field.SetValue(client, new HttpClient(handler) { BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/") });
         var reports = await MailboxSearcher.SearchNonDeliveryReportsAsync(client, "me", parallelDownloadLimit: 1, cancellationToken: CancellationToken.None);
         Assert.Single(reports);
-        Assert.Equal("<id1>", reports[0].OriginalMessageId);
+        Assert.Equal("id1", reports[0].OriginalMessageId);
     }
 }
 

--- a/Sources/Mailozaurr.Tests/NonDeliveryReportServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportServiceTests.cs
@@ -73,10 +73,10 @@ public class NonDeliveryReportServiceTests {
     [Fact]
     public async Task SearchAsync_ResolvesSentMessage() {
         var repo = new InMemorySentMessageRepository();
-        var record = new SentMessageRecord { MessageId = "<id1>", Recipients = "user@example.com", Subject = "s", Timestamp = DateTimeOffset.UtcNow };
+        var record = new SentMessageRecord { MessageId = "id1", Recipients = "user@example.com", Subject = "s", Timestamp = DateTimeOffset.UtcNow };
         await repo.SaveAsync(record);
         var resolver = new SendLogResolver(repo);
-        var report = new NonDeliveryReport { OriginalMessageId = "<id1>", FinalRecipient = "user@example.com", Timestamp = DateTimeOffset.UtcNow };
+        var report = new NonDeliveryReport { OriginalMessageId = "id1", FinalRecipient = "user@example.com", Timestamp = DateTimeOffset.UtcNow };
         var service = new TestService(new List<NonDeliveryReport> { report }, resolver);
 
         IList<NonDeliveryReportResult> results = await service.SearchAsync();

--- a/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
+++ b/Sources/Mailozaurr.Tests/NonDeliveryReportTests.cs
@@ -60,7 +60,7 @@ public class NonDeliveryReportTests {
             ["Original-Message-ID"] = "<msg1@local>"
         };
         var report = NonDeliveryReport.FromHeaders(headers);
-        Assert.Equal("<msg1@local>", report.OriginalMessageId);
+        Assert.Equal("msg1@local", report.OriginalMessageId);
     }
 
     [Theory]

--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -39,9 +39,27 @@ public class SearchNonDeliveryReportsTests {
             since: now.AddMinutes(-5).DateTime,
             before: now.AddMinutes(5).DateTime,
             recipientContains: "user@example.com",
-            messageId: "<id1>");
+            messageId: "id1");
         Assert.Single(reports);
-        Assert.Equal("<id1>", reports[0].OriginalMessageId);
+        Assert.Equal("id1", reports[0].OriginalMessageId);
+    }
+
+    [Theory]
+    [InlineData("<id1>", "<id1>")]
+    [InlineData("<id1>", "id1")]
+    [InlineData("id1", "<id1>")]
+    [InlineData("id1", "id1")]
+    public void FilterNonDeliveryReports_MatchesMessageIdWithOrWithoutBrackets(string headerId, string filter) {
+        var now = DateTimeOffset.UtcNow;
+        var msg = CreateNdr("user@example.com", headerId, now);
+        var reports = MailboxSearcher.FilterNonDeliveryReports(
+            new List<MimeMessage> { msg },
+            since: now.AddMinutes(-5).DateTime,
+            before: now.AddMinutes(5).DateTime,
+            recipientContains: null,
+            messageId: filter);
+        Assert.Single(reports);
+        Assert.Equal("id1", reports[0].OriginalMessageId);
     }
 
     [Fact]
@@ -52,7 +70,7 @@ public class SearchNonDeliveryReportsTests {
         var list = new List<MimeMessage> { msg1, msg2 };
         var reports = MailboxSearcher.FilterNonDeliveryReports(list, since: now.AddMinutes(-5).DateTime, before: null, recipientContains: null, messageId: null);
         Assert.Single(reports);
-        Assert.Equal("<id2>", reports[0].OriginalMessageId);
+        Assert.Equal("id2", reports[0].OriginalMessageId);
     }
 
     [Fact]
@@ -62,7 +80,7 @@ public class SearchNonDeliveryReportsTests {
         var list = new List<MimeMessage> { msg };
         var reports = MailboxSearcher.FilterNonDeliveryReports(list, since: now.AddHours(-1).DateTime, before: null, recipientContains: null, messageId: null);
         Assert.Single(reports);
-        Assert.Equal("<id1>", reports[0].OriginalMessageId);
+        Assert.Equal("id1", reports[0].OriginalMessageId);
     }
 
     [Fact]
@@ -74,7 +92,7 @@ public class SearchNonDeliveryReportsTests {
         var before = new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Utc);
         var reports = MailboxSearcher.FilterNonDeliveryReports(list, since, before, recipientContains: null, messageId: null);
         Assert.Single(reports);
-        Assert.Equal("<id1>", reports[0].OriginalMessageId);
+        Assert.Equal("id1", reports[0].OriginalMessageId);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/SendLogResolverTests.cs
+++ b/Sources/Mailozaurr.Tests/SendLogResolverTests.cs
@@ -17,27 +17,27 @@ public class SendLogResolverTests {
 
     [Fact]
     public async Task ResolveAsync_ReturnsMatchingRecord() {
-        var record = new SentMessageRecord { MessageId = "<id1>", Recipients = "user@example.com", Subject = "s", Timestamp = DateTimeOffset.UtcNow };
+        var record = new SentMessageRecord { MessageId = "id1", Recipients = "user@example.com", Subject = "s", Timestamp = DateTimeOffset.UtcNow };
         var repo = new InMemoryRepository(record);
         var resolver = new SendLogResolver(repo);
-        var report = new NonDeliveryReport { OriginalMessageId = "<id1>" };
+        var report = new NonDeliveryReport { OriginalMessageId = "id1" };
         var result = await resolver.ResolveAsync(report);
         Assert.Equal(record, result);
     }
 
     [Fact]
     public async Task ResolveAsync_ReturnsNullWhenNotFound() {
-        var record = new SentMessageRecord { MessageId = "<id1>", Recipients = "user@example.com" };
+        var record = new SentMessageRecord { MessageId = "id1", Recipients = "user@example.com" };
         var repo = new InMemoryRepository(record);
         var resolver = new SendLogResolver(repo);
-        var report = new NonDeliveryReport { OriginalMessageId = "<other>" };
+        var report = new NonDeliveryReport { OriginalMessageId = "other" };
         var result = await resolver.ResolveAsync(report);
         Assert.Null(result);
     }
 
     [Fact]
     public async Task ResolveAsync_MatchesRecipientWithPrefix() {
-        var record = new SentMessageRecord { MessageId = "<id1>", Recipients = "user@example.com" };
+        var record = new SentMessageRecord { MessageId = "id1", Recipients = "user@example.com" };
         var repo = new InMemoryRepository(record);
         var resolver = new SendLogResolver(repo);
         var headers = new Dictionary<string, string> {

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReport.cs
@@ -67,7 +67,7 @@ public sealed class NonDeliveryReport {
             OriginalRecipientAddress = ExtractAddress(originalRecipient),
             FinalRecipient = finalRecipient,
             FinalRecipientAddress = ExtractAddress(finalRecipient),
-            OriginalMessageId = originalMessageId,
+            OriginalMessageId = NormalizeMessageId(originalMessageId),
             ReportingMta = reportingMta,
             Action = action,
             RemoteMta = remoteMta,
@@ -86,6 +86,17 @@ public sealed class NonDeliveryReport {
         }
         var idx = header!.IndexOf(';');
         return idx >= 0 ? header.Substring(idx + 1).Trim() : header.Trim();
+    }
+
+    internal static string? NormalizeMessageId(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+        var trimmed = value.Trim();
+        if (trimmed.Length > 1 && trimmed[0] == '<' && trimmed[trimmed.Length - 1] == '>') {
+            trimmed = trimmed.Substring(1, trimmed.Length - 2);
+        }
+        return trimmed;
     }
 
     private static DateTimeOffset? TryParseTimestamp(string? value)

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -815,6 +815,7 @@ public static class MailboxSearcher {
         DateTime? before,
         string? recipientContains,
         string? messageId) {
+        messageId = NonDeliveryReport.NormalizeMessageId(messageId);
         var results = new List<NonDeliveryReport>();
         var sinceUtc = since?.ToUniversalTime();
         var beforeUtc = before?.ToUniversalTime();


### PR DESCRIPTION
## Summary
- strip angle brackets from NDR `OriginalMessageId`
- normalize `messageId` filter before matching
- extend tests for message-id comparison with and without brackets

## Testing
- `dotnet test Sources/Mailozaurr.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68ac02e7674c832e8170a8dbdc62bf71