### PR TITLE
Avoid sending duplicate Mailgun attachments

### DIFF
--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -5,6 +5,8 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -80,6 +82,83 @@ public class MailgunClientTests
         string body = await content.ReadAsStringAsync();
         Assert.Contains("h:X-Test", body, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("123", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CreateContentAsync_DuplicateAttachmentPaths_SkipsDuplicates()
+    {
+        var file = Path.GetTempFileName();
+        try
+        {
+            using var client = new MailgunClient
+            {
+                From = "sender@example.com",
+                To = new List<object> { "to@example.com" },
+                Attachment = new[] { file, file }
+            };
+            MethodInfo? method = typeof(MailgunClient).GetMethod("CreateContentAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            var task = (Task<MultipartFormDataContent>)method!.Invoke(client, new object[] { default(CancellationToken) })!;
+            using var content = await task;
+            var parts = content.Count(c => c.Headers.ContentDisposition?.Name?.Trim('"') == "attachment");
+            Assert.Equal(1, parts);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task CreateContentAsync_DuplicateInlineAttachmentPaths_SkipsDuplicates()
+    {
+        var file = Path.GetTempFileName();
+        try
+        {
+            using var client = new MailgunClient
+            {
+                From = "sender@example.com",
+                To = new List<object> { "to@example.com" },
+                InlineAttachment = new[] { file, file }
+            };
+            MethodInfo? method = typeof(MailgunClient).GetMethod("CreateContentAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            var task = (Task<MultipartFormDataContent>)method!.Invoke(client, new object[] { default(CancellationToken) })!;
+            using var content = await task;
+            var parts = content.Count(c => c.Headers.ContentDisposition?.Name?.Trim('"') == "inline");
+            Assert.Equal(1, parts);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task CreateContentAsync_AttachmentAndInlineDuplicatePaths_SkipsDuplicates()
+    {
+        var file1 = Path.GetTempFileName();
+        var file2 = Path.GetTempFileName();
+        try
+        {
+            using var client = new MailgunClient
+            {
+                From = "sender@example.com",
+                To = new List<object> { "to@example.com" },
+                Attachment = new[] { file1 },
+                InlineAttachment = new[] { file1, file2, file2 }
+            };
+            MethodInfo? method = typeof(MailgunClient).GetMethod("CreateContentAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            var task = (Task<MultipartFormDataContent>)method!.Invoke(client, new object[] { default(CancellationToken) })!;
+            using var content = await task;
+            var attachments = content.Count(c => c.Headers.ContentDisposition?.Name?.Trim('"') == "attachment");
+            var inlines = content.Count(c => c.Headers.ContentDisposition?.Name?.Trim('"') == "inline");
+            Assert.Equal(1, attachments);
+            Assert.Equal(1, inlines);
+        }
+        finally
+        {
+            File.Delete(file1);
+            File.Delete(file2);
+        }
     }
 
     [Fact]

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -142,8 +142,10 @@ public class MailgunClient : IDisposable {
         if (!string.IsNullOrWhiteSpace(Subject)) content.Add(new StringContent(Subject), "subject");
         if (!string.IsNullOrWhiteSpace(Text)) content.Add(new StringContent(Text), "text");
         if (!string.IsNullOrWhiteSpace(Html)) content.Add(new StringContent(Html), "html");
+        var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (Attachment != null) {
             foreach (var path in Attachment) {
+                if (!files.Add(path)) continue;
                 if (!File.Exists(path)) {
                     LogCollector.LogWarning($"Send-EmailMessage - Attachment file not found: {path}");
                     LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{path}' is invalid. Verify the file exists and the path is correct.");
@@ -158,6 +160,7 @@ public class MailgunClient : IDisposable {
         }
         if (InlineAttachment != null) {
             foreach (var path in InlineAttachment) {
+                if (!files.Add(path)) continue;
                 if (!File.Exists(path)) {
                     LogCollector.LogWarning($"Send-EmailMessage - Inline attachment file not found: {path}");
                     LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{path}' is invalid. Verify the file exists and the path is correct.");


### PR DESCRIPTION
## Summary
- avoid adding duplicate file paths when building Mailgun attachments
- test that duplicate attachment and inline attachment paths are skipped

## Testing
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_68ac02fc970c832e909ddec29df8d563