### PR TITLE
Skip empty SendGrid content entries

### DIFF
--- a/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
@@ -86,4 +86,28 @@ public class SendGridCreateMessageTests
         var count = doc.RootElement.GetProperty("Attachments").GetArrayLength();
         Assert.Equal(1, count);
     }
+
+    [Theory]
+    [InlineData("", "<b>body</b>", "text/html")]
+    [InlineData("text", "", "text/plain")]
+    public void CreateMessage_WithoutBody_OmitsCorrespondingContent(string text, string html, string expectedType)
+    {
+        var client = new SendGridClient
+        {
+            From = "from@example.com",
+            To = new List<object> { "to@example.com" },
+            Subject = "subject",
+            Text = text,
+            Html = html,
+            Credentials = new NetworkCredential("apikey", "test")
+        };
+        client.CreateMessage();
+        PropertyInfo? prop = typeof(SendGridClient).GetProperty("MessageJson", BindingFlags.NonPublic | BindingFlags.Instance);
+        var json = prop?.GetValue(client) as string;
+        Assert.NotNull(json);
+        using var doc = System.Text.Json.JsonDocument.Parse(json!);
+        var content = doc.RootElement.GetProperty("Content");
+        Assert.Equal(1, content.GetArrayLength());
+        Assert.Equal(expectedType, content[0].GetProperty("Type").GetString());
+    }
 }

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -277,7 +277,7 @@ public class SendGridClient {
         var content = new List<SendGridContent> {
                 new SendGridContent { Type = "text/plain", Value = Text },
                 new SendGridContent { Type = "text/html", Value = Html }
-            }.Where(c => c.Value != null).ToList();
+            }.Where(c => !string.IsNullOrEmpty(c.Value)).ToList();
 
 
         var fromAddress = ConvertToEmailObject(From) ?? throw new InvalidOperationException("From address is required.");


### PR DESCRIPTION
## Summary
- Ignore blank content entries when building SendGrid messages
- Test that empty text or HTML bodies do not produce corresponding SendGrid MIME parts

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ac03037b40832e847a49b755a16375