### PR TITLE
feat: separate sendgrid personalizations

### DIFF
--- a/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
@@ -86,4 +86,34 @@ public class SendGridCreateMessageTests
         var count = doc.RootElement.GetProperty("Attachments").GetArrayLength();
         Assert.Equal(1, count);
     }
+
+    [Fact]
+    public void CreateMessage_SeparateTo_CreatesPersonalizationsPerRecipient()
+    {
+        var client = new SendGridClient
+        {
+            From = "from@example.com",
+            To = new List<object> { "to1@example.com", "to2@example.com", "to1@example.com" },
+            Cc = new List<object> { "cc@example.com" },
+            Bcc = new List<object> { "bcc@example.com" },
+            Subject = "subject",
+            Text = "text",
+            SeparateTo = true,
+            Credentials = new NetworkCredential("apikey", "test"),
+        };
+
+        client.CreateMessage();
+        PropertyInfo? prop = typeof(SendGridClient).GetProperty("MessageJson", BindingFlags.NonPublic | BindingFlags.Instance);
+        var json = prop?.GetValue(client) as string;
+        Assert.NotNull(json);
+        using var doc = System.Text.Json.JsonDocument.Parse(json!);
+        var pers = doc.RootElement.GetProperty("Personalizations");
+        Assert.Equal(2, pers.GetArrayLength());
+        foreach (var p in pers.EnumerateArray())
+        {
+            Assert.Equal(1, p.GetProperty("To").GetArrayLength());
+            Assert.Equal(1, p.GetProperty("Cc").GetArrayLength());
+            Assert.Equal(1, p.GetProperty("Bcc").GetArrayLength());
+        }
+    }
 }

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -250,27 +250,45 @@ public class SendGridClient {
 
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        var personalizations = new List<SendGridPersonalization>
-            {
-                new SendGridPersonalization
-                {
-                    To = To?.Where(t => t != null)
-                        .Select(ConvertToEmailObject)
-                        .Where(x => x != null && seen.Add(x.Email))
-                        .Select(x => x!)
-                        .ToList(),
-                    Cc = Cc?.Where(c => c != null)
-                        .Select(ConvertToEmailObject)
-                        .Where(x => x != null && seen.Add(x.Email))
-                        .Select(x => x!)
-                        .ToList(),
-                    Bcc = Bcc?.Where(b => b != null)
-                        .Select(ConvertToEmailObject)
-                        .Where(x => x != null && seen.Add(x.Email))
-                        .Select(x => x!)
-                        .ToList()
+        var toList = To?.Where(t => t != null)
+            .Select(ConvertToEmailObject)
+            .Where(x => x != null && seen.Add(x.Email))
+            .Select(x => x!)
+            .ToList();
+        var ccList = Cc?.Where(c => c != null)
+            .Select(ConvertToEmailObject)
+            .Where(x => x != null && seen.Add(x.Email))
+            .Select(x => x!)
+            .ToList();
+        var bccList = Bcc?.Where(b => b != null)
+            .Select(ConvertToEmailObject)
+            .Where(x => x != null && seen.Add(x.Email))
+            .Select(x => x!)
+            .ToList();
+
+        List<SendGridPersonalization> personalizations;
+        if (SeparateTo) {
+            personalizations = new List<SendGridPersonalization>();
+            if (toList != null) {
+                foreach (var toAddress in toList) {
+                    personalizations.Add(new SendGridPersonalization {
+                        To = new List<SendGridEmailAddress> { toAddress },
+                        Cc = ccList != null ? new List<SendGridEmailAddress>(ccList) : null,
+                        Bcc = bccList != null ? new List<SendGridEmailAddress>(bccList) : null
+                    });
                 }
             }
+            if (personalizations.Count == 0 && (ccList != null || bccList != null)) {
+                personalizations.Add(new SendGridPersonalization { Cc = ccList, Bcc = bccList });
+            }
+        } else {
+            personalizations = new List<SendGridPersonalization>
+                {
+                    new SendGridPersonalization { To = toList, Cc = ccList, Bcc = bccList }
+                };
+        }
+
+        personalizations = personalizations
             .Where(p => p.To != null || p.Cc != null || p.Bcc != null)
             .ToList();
 


### PR DESCRIPTION
## Summary
- build unique SendGrid personalizations per recipient when `SeparateTo` is set
- add regression test ensuring personalizations are duplicated as expected

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `pwsh -NoLogo -NoProfile -File ./Mailozaurr.Tests.ps1` *(fails: Cannot add type. Compilation errors occurred)*
- `dotnet build Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_68ac013d7e3c832ebc4d24d1bff83042