### PR TITLE
Scope logger per cmdlet using AsyncLocal

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -12,6 +12,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
 {
     private ActionPreference errorAction;
     private InternalLogger? _logger;
+    private InternalLogger? _previousLogger;
     private LogCollector? _logCollector;
     private EventHandler<LogEventArgs>? _onVerbose;
     private EventHandler<LogEventArgs>? _onWarning;
@@ -36,6 +37,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         _logger.OnErrorMessage += _onError;
         _logger.OnInformationMessage += _onInformation;
 
+        _previousLogger = LoggingMessages.Logger;
         LoggingMessages.Logger = _logger;
 
         // Get the error action preference as user requested
@@ -726,8 +728,15 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             if (_onError != null) _logger.OnErrorMessage -= _onError;
             if (_onInformation != null) _logger.OnInformationMessage -= _onInformation;
         }
+        _onVerbose = null;
+        _onWarning = null;
+        _onError = null;
+        _onInformation = null;
         _logCollector = null;
-        LoggingMessages.Logger = new InternalLogger();
+        if (_previousLogger != null) {
+            LoggingMessages.Logger = _previousLogger;
+            _previousLogger = null;
+        }
         _logger = null;
     }
 }

--- a/Sources/Mailozaurr.Tests/LoggingMessagesTests.cs
+++ b/Sources/Mailozaurr.Tests/LoggingMessagesTests.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class LoggingMessagesTests
+{
+    [Fact]
+    public async Task Logger_IsAsyncLocalPerTask()
+    {
+        var original = LoggingMessages.Logger;
+        InternalLogger? task1Logger = null;
+        InternalLogger? task2Logger = null;
+
+        await Task.WhenAll(
+            Task.Run(() =>
+            {
+                LoggingMessages.Logger = new InternalLogger();
+                task1Logger = LoggingMessages.Logger;
+            }),
+            Task.Run(() =>
+            {
+                LoggingMessages.Logger = new InternalLogger();
+                task2Logger = LoggingMessages.Logger;
+            })
+        );
+
+        Assert.NotSame(task1Logger, task2Logger);
+        Assert.Same(original, LoggingMessages.Logger);
+    }
+}

--- a/Sources/Mailozaurr/Logging/LoggingMessages.cs
+++ b/Sources/Mailozaurr/Logging/LoggingMessages.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Mailozaurr;
 
 /// <summary>
@@ -8,8 +10,13 @@ namespace Mailozaurr;
 /// control how much diagnostic information is emitted.
 /// </remarks>
 public class LoggingMessages {
-    /// <summary>Gets the global logger.</summary>
-    public static InternalLogger Logger = new InternalLogger();
+    private static readonly AsyncLocal<InternalLogger?> _logger = new AsyncLocal<InternalLogger?>();
+
+    /// <summary>Gets the global logger for the current asynchronous context.</summary>
+    public static InternalLogger Logger {
+        get => _logger.Value ??= new InternalLogger();
+        set => _logger.Value = value;
+    }
 
     /// <summary>Enable or disable error logging.</summary>
     public static bool Error {

--- a/Tests/Send-EmailMessage.LoggerScope.Tests.ps1
+++ b/Tests/Send-EmailMessage.LoggerScope.Tests.ps1
@@ -1,0 +1,10 @@
+Import-Module (Resolve-Path "$PSScriptRoot/../Mailozaurr.psd1") -Force
+
+Describe 'Send-EmailMessage - Logger scope' {
+    It 'restores previous logger after execution' {
+        $original = [Mailozaurr.LoggingMessages]::Logger
+        Send-EmailMessage -From 'from@example.com' -To 'to@example.com' -Server 'smtp.example.com' \
+            -Subject 'Test' -Text 'Body' -Port 25 -WhatIf
+        [Mailozaurr.LoggingMessages]::Logger | Should -Be $original
+    }
+}


### PR DESCRIPTION
## Summary
- use AsyncLocal to hold a per-context `InternalLogger`
- scope `CmdletSendEmailMessage` logger and restore any prior logger on completion
- add unit and Pester tests covering logger scoping

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh -NoLogo -File ./Mailozaurr.Tests.ps1` *(fails: Cannot add type. Compilation errors occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68aca63b0308832eb678620b82a72fb6