### PR TITLE
feat: add thread-safe smtp pool configuration

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -51,8 +51,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             }
         }
 
-        SmtpConnectionPool.MaxPoolSize = ConnectionPoolSize;
-        SmtpConnectionPool.PoolingEnabled = UseConnectionPool.IsPresent;
+        SmtpConnectionPool.Configure(UseConnectionPool.IsPresent, ConnectionPoolSize);
     }
     /// <summary>
     /// Process the record.

--- a/Sources/Mailozaurr.Tests/SmtpConnectionPoolConcurrencyTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConnectionPoolConcurrencyTests.cs
@@ -14,9 +14,8 @@ public class SmtpConnectionPoolConcurrencyTests {
 
     [Fact]
     public void ReturnClient_ConcurrentCallsRespectMaxPoolSize() {
-        SmtpConnectionPool.PoolingEnabled = true;
+        SmtpConnectionPool.Configure(true, 2);
         SmtpConnectionPool.ClearConnectionPool();
-        SmtpConnectionPool.MaxPoolSize = 2;
 
         var clients = Enumerable.Range(0, 20).Select(_ => new FakeClient()).ToArray();
         Parallel.ForEach(clients, c => SmtpConnectionPool.ReturnClient("h", 25, c));
@@ -31,14 +30,13 @@ public class SmtpConnectionPoolConcurrencyTests {
         Assert.Equal(SmtpConnectionPool.MaxPoolSize, rented);
 
         SmtpConnectionPool.ClearConnectionPool();
-        SmtpConnectionPool.PoolingEnabled = false;
+        SmtpConnectionPool.SetPoolingEnabled(false);
     }
 
     [Fact]
     public void TryRentClient_ConcurrentCallsEmptyPool() {
-        SmtpConnectionPool.PoolingEnabled = true;
+        SmtpConnectionPool.Configure(true, 5);
         SmtpConnectionPool.ClearConnectionPool();
-        SmtpConnectionPool.MaxPoolSize = 5;
 
         foreach (var _ in Enumerable.Range(0, SmtpConnectionPool.MaxPoolSize)) {
             SmtpConnectionPool.ReturnClient("h", 25, new FakeClient());
@@ -57,6 +55,6 @@ public class SmtpConnectionPoolConcurrencyTests {
         Assert.Null(SmtpConnectionPool.TryRentClient("h", 25));
 
         SmtpConnectionPool.ClearConnectionPool();
-        SmtpConnectionPool.PoolingEnabled = false;
+        SmtpConnectionPool.SetPoolingEnabled(false);
     }
 }

--- a/Sources/Mailozaurr.Tests/SmtpConnectionPoolMetricsTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConnectionPoolMetricsTests.cs
@@ -12,7 +12,7 @@ public class SmtpConnectionPoolMetricsTests {
 
     [Fact]
     public void CurrentPoolSize_TracksClients() {
-        SmtpConnectionPool.PoolingEnabled = true;
+        SmtpConnectionPool.SetPoolingEnabled(true);
         SmtpConnectionPool.ClearConnectionPool();
 
         Assert.Equal(0, SmtpConnectionPool.CurrentPoolSize);
@@ -26,12 +26,12 @@ public class SmtpConnectionPoolMetricsTests {
         Assert.Equal(0, SmtpConnectionPool.CurrentPoolSize);
 
         SmtpConnectionPool.ClearConnectionPool();
-        SmtpConnectionPool.PoolingEnabled = false;
+        SmtpConnectionPool.SetPoolingEnabled(false);
     }
 
     [Fact]
     public void PoolSizeChanged_Raised() {
-        SmtpConnectionPool.PoolingEnabled = true;
+        SmtpConnectionPool.SetPoolingEnabled(true);
         SmtpConnectionPool.ClearConnectionPool();
 
         var values = new List<int>();
@@ -47,14 +47,14 @@ public class SmtpConnectionPoolMetricsTests {
         SmtpConnectionPool.ClearConnectionPool();
 
         SmtpConnectionPool.PoolSizeChanged -= Handler;
-        SmtpConnectionPool.PoolingEnabled = false;
+        SmtpConnectionPool.SetPoolingEnabled(false);
 
         Assert.Equal(new[] { 1, 0, 0 }, values);
     }
 
     [Fact]
     public void GetSnapshot_ReturnsEntries() {
-        SmtpConnectionPool.PoolingEnabled = true;
+        SmtpConnectionPool.SetPoolingEnabled(true);
         SmtpConnectionPool.ClearConnectionPool();
 
         var client = new FakeClient();
@@ -69,7 +69,7 @@ public class SmtpConnectionPoolMetricsTests {
         Assert.Equal(1, entry.Count);
 
         SmtpConnectionPool.ClearConnectionPool();
-        SmtpConnectionPool.PoolingEnabled = false;
+        SmtpConnectionPool.SetPoolingEnabled(false);
     }
 }
 

--- a/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
@@ -18,7 +18,7 @@ public class SmtpConnectionPoolTests {
 
     [Fact]
     public void Disconnect_ReturnsClientToPool() {
-        SmtpConnectionPool.PoolingEnabled = true;
+        SmtpConnectionPool.SetPoolingEnabled(true);
         SmtpConnectionPool.ClearConnectionPool();
         var fake = new FakeClient();
         Smtp.ClientFactory = _ => fake;
@@ -36,12 +36,12 @@ public class SmtpConnectionPoolTests {
 
         Smtp.ClientFactory = logger => new ClientSmtp();
         SmtpConnectionPool.ClearConnectionPool();
-        SmtpConnectionPool.PoolingEnabled = false;
+        SmtpConnectionPool.SetPoolingEnabled(false);
     }
 
     [Fact]
     public void ReturnClosedClient_IsDiscarded() {
-        SmtpConnectionPool.PoolingEnabled = true;
+        SmtpConnectionPool.SetPoolingEnabled(true);
         SmtpConnectionPool.ClearConnectionPool();
 
         var fake = new FakeClient();
@@ -52,6 +52,6 @@ public class SmtpConnectionPoolTests {
         Assert.Null(pooled);
 
         SmtpConnectionPool.ClearConnectionPool();
-        SmtpConnectionPool.PoolingEnabled = false;
+        SmtpConnectionPool.SetPoolingEnabled(false);
     }
 }

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
@@ -16,12 +16,23 @@ public static class SmtpConnectionPool {
 
     private static readonly ConcurrentDictionary<string, PoolEntry> _connectionPool = new();
 
+    private static int _maxPoolSize = 2;
+    private static int _poolingEnabled = 0;
 
     /// <summary>Maximum number of pooled connections per server/port.</summary>
-    public static int MaxPoolSize { get; set; } = 2;
+    public static int MaxPoolSize => Volatile.Read(ref _maxPoolSize);
 
     /// <summary>Enables or disables connection pooling.</summary>
-    public static bool PoolingEnabled { get; set; } = false;
+    public static bool PoolingEnabled => Volatile.Read(ref _poolingEnabled) == 1;
+
+    public static void SetMaxPoolSize(int value) => Interlocked.Exchange(ref _maxPoolSize, value);
+
+    public static void SetPoolingEnabled(bool enabled) => Interlocked.Exchange(ref _poolingEnabled, enabled ? 1 : 0);
+
+    public static void Configure(bool poolingEnabled, int maxPoolSize) {
+        SetPoolingEnabled(poolingEnabled);
+        SetMaxPoolSize(maxPoolSize);
+    }
 
     /// <summary>Number of pooled SMTP clients across all servers.</summary>
     public static int CurrentPoolSize {

--- a/Tests/Clear-SmtpConnectionPool.Tests.ps1
+++ b/Tests/Clear-SmtpConnectionPool.Tests.ps1
@@ -22,7 +22,7 @@ public class FakeClientPs2 : ClientSmtp {
 }
 "@
 
-        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $true
+        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($true)
         [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
         $fake = [FakeClientPs2]::new()
         [Mailozaurr.Smtp]::ClientFactory = { $fake }
@@ -39,6 +39,6 @@ public class FakeClientPs2 : ClientSmtp {
 
         [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
         [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
-        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $false
+        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($false)
     }
 }

--- a/Tests/Get-SmtpConnectionPool.Tests.ps1
+++ b/Tests/Get-SmtpConnectionPool.Tests.ps1
@@ -2,11 +2,11 @@ Describe 'Get-SmtpConnectionPool' {
     BeforeAll { Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force }
 
     It 'Returns empty snapshot for new pool' {
-        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $true
+        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($true)
         [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
         $snapshot = Get-SmtpConnectionPool
         $snapshot.CurrentPoolSize | Should -Be 0
         $snapshot.Entries.Count | Should -Be 0
-        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $false
+        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($false)
     }
 }

--- a/Tests/Send-EmailMessageConnectionPool.Tests.ps1
+++ b/Tests/Send-EmailMessageConnectionPool.Tests.ps1
@@ -22,7 +22,7 @@ public class FakeClientPs : ClientSmtp {
 }
 "@
 
-        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $true
+        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($true)
         [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
         $fake = [FakeClientPs]::new()
         [Mailozaurr.Smtp]::ClientFactory = { $fake }
@@ -35,6 +35,6 @@ public class FakeClientPs : ClientSmtp {
 
         [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
         [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
-        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $false
+        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($false)
     }
 }

--- a/Tests/Watch-SmtpConnectionPool.Tests.ps1
+++ b/Tests/Watch-SmtpConnectionPool.Tests.ps1
@@ -2,13 +2,13 @@ Describe 'Watch-SmtpConnectionPool' {
     BeforeAll { Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force }
 
     It 'Registers watcher for pool updates' {
-        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $true
+        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($true)
         [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
         $values = [System.Collections.Generic.List[int]]::new()
         $watcher = Watch-SmtpConnectionPool -Action { param($s) $values.Add($s.CurrentPoolSize) }
         [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
         [Mailozaurr.SmtpConnectionPool]::remove_PoolSizeChanged($watcher)
-        [Mailozaurr.SmtpConnectionPool]::PoolingEnabled = $false
+        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($false)
         $values.Count | Should -BeGreaterThan 0
     }
 }


### PR DESCRIPTION
## Summary
- make SMTP connection pool settings thread-safe with Interlocked-based setters
- expose Configure helper and update Send-EmailMessage to use it
- adjust tests and PowerShell scripts to new API

## Testing
- `dotnet test Sources/Mailozaurr.sln -v minimal`
- `pwsh -f Mailozaurr.Tests.ps1` *(fails: Cannot add type. Compilation errors occurred.)*

------
https://chatgpt.com/codex/tasks/task_e_68adc700f9c8832e982f0d87295b2a2a