### PR TITLE
Reuse shared HttpClient for webhook posts

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -164,6 +164,15 @@ public class HelpersTests {
             => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
     }
 
+    private class CountingHandler : HttpMessageHandler {
+        public int Calls;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Calls++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
     [Fact]
     public async Task PostWebhookAsync_CancellationRequested_ThrowsAsync() {
         using var cts = new CancellationTokenSource();
@@ -201,5 +210,23 @@ public class HelpersTests {
 
         Mailozaurr.LoggingMessages.Logger.OnWarningMessage -= Handler;
         Assert.Contains(messages, static m => m.Contains("Failed to post webhook"));
+    }
+
+    [Fact]
+    public async Task PostWebhookAsync_UsesSharedClient_WhenClientNotProvided() {
+        var original = Mailozaurr.Helpers.SharedHttpClient;
+        var handler = new CountingHandler();
+        var client = new HttpClient(handler);
+        Mailozaurr.Helpers.SharedHttpClient = client;
+
+        try {
+            var result = new SmtpResult(true, EmailAction.Send, string.Empty, string.Empty, string.Empty, 0, TimeSpan.Zero);
+            await Mailozaurr.Helpers.PostWebhookAsync("http://localhost", result);
+            await Mailozaurr.Helpers.PostWebhookAsync("http://localhost", result);
+            Assert.Equal(2, handler.Calls);
+        } finally {
+            Mailozaurr.Helpers.SharedHttpClient = original;
+            client.Dispose();
+        }
     }
 }

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -13,6 +13,12 @@ namespace Mailozaurr;
 /// Utility methods used throughout the library.
 /// </summary>
 public static class Helpers {
+    private static HttpClient s_sharedHttpClient = new HttpClient();
+
+    internal static HttpClient SharedHttpClient {
+        get => s_sharedHttpClient;
+        set => s_sharedHttpClient = value ?? throw new ArgumentNullException(nameof(value));
+    }
     /// <summary>Converts a credential into an OAuth token tuple.</summary>
     /// <param name="credential">The credential containing the token.</param>
     /// <returns>The username and token.</returns>
@@ -154,13 +160,9 @@ public static class Helpers {
             return;
         }
 
-        HttpClient? ownedClient = null;
+        client ??= SharedHttpClient;
 
         try {
-            if (client == null) {
-                ownedClient = new HttpClient();
-                client = ownedClient;
-            }
             var json = JsonSerializer.Serialize(result);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
             using var response = await client.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
@@ -170,8 +172,6 @@ public static class Helpers {
             }
         } catch (HttpRequestException ex) {
             LoggingMessages.Logger.WriteWarning($"Failed to post webhook: {ex.Message}");
-        } finally {
-            ownedClient?.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary
- reuse a shared HttpClient for webhook posts
- add unit test ensuring shared client is used

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68b2d35247f8832ea65b574ff0d182f7