### PR TITLE
feat: add cancellation support for graph utils

### DIFF
--- a/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsCancellationTests.cs
+++ b/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsCancellationTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class MicrosoftGraphUtilsCancellationTests
+{
+    [Fact]
+    public async Task ConnectO365GraphAsync_CancelledToken_Throws()
+    {
+        var credential = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+        var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
+        cache.Clear();
+        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
+        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+        oauthField?.SetValue(null, null);
+        string cachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
+        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAsync<TaskCanceledException>(() => MicrosoftGraphUtils.ConnectO365GraphAsync(credential, "tenant", "https://graph.microsoft.com", cts.Token));
+    }
+
+    private static FieldInfo GetHandlerField()
+        => typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? typeof(HttpMessageInvoker).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("HttpClient handler field not found");
+
+    private class FailingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("fail");
+        }
+    }
+
+    [Fact]
+    public async Task ConnectO365GraphWithRetryAsync_CancellationDuringDelay_Throws()
+    {
+        var handler = new FailingHandler();
+        var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)field.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
+        cache.Clear();
+        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
+        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+        oauthField?.SetValue(null, null);
+        string cachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
+        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        try
+        {
+            var credential = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            using var cts = new CancellationTokenSource(100);
+            await Assert.ThrowsAsync<TaskCanceledException>(() => MicrosoftGraphUtils.ConnectO365GraphWithRetryAsync(credential, "tenant", 3, 1000, 1, "https://graph.microsoft.com", cts.Token));
+        }
+        finally
+        {
+            handlerField.SetValue(client, original);
+        }
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -112,7 +112,7 @@ namespace Mailozaurr {
         /// <summary>
         /// Connects to O365 Graph and returns the Authorization header value ("Bearer ...").
         /// </summary>
-        public static async Task<string> ConnectO365GraphAsync(GraphCredential credential, string tenantDomain, string resource = "https://manage.office.com") {
+        public static async Task<string> ConnectO365GraphAsync(GraphCredential credential, string tenantDomain, string resource = "https://manage.office.com", CancellationToken cancellationToken = default) {
             var key = $"{credential.ClientId}|{tenantDomain}|{credential.CertificatePath}|{credential.ClientSecret}|{resource}";
             if (TokenCache.TryGetValue(key, out var cached) && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
                 return $"{cached.TokenType} {cached.AccessToken}";
@@ -164,19 +164,24 @@ namespace Mailozaurr {
             }
             var content = new FormUrlEncodedContent(body);
             var url = $"https://login.microsoftonline.com/{tenantDomain}/oauth2/token";
-            await ConcurrencySemaphore.WaitAsync();
+            await ConcurrencySemaphore.WaitAsync(cancellationToken);
             HttpResponseMessage? response = null;
             try {
-                response = await HttpClient.PostAsync(url, content);
+                response = await HttpClient.PostAsync(url, content, cancellationToken);
                 if ((int)response.StatusCode == 429) {
                     var delay = GetRetryAfterDelay(response);
                     response.Dispose();
                     if (delay > TimeSpan.Zero) {
-                        await Task.Delay(delay);
+                        await Task.Delay(delay, cancellationToken);
                     }
-                    response = await HttpClient.PostAsync(url, content);
+                    response = await HttpClient.PostAsync(url, content, cancellationToken);
                 }
-                var json = await response.Content.ReadAsStringAsync();
+                string json;
+#if NET5_0_OR_GREATER
+                json = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
+                json = await response.Content.ReadAsStringAsync();
+#endif
                 if (!response.IsSuccessStatusCode) {
                     throw new GraphApiException(
                         response.StatusCode,
@@ -217,12 +222,13 @@ namespace Mailozaurr {
             int retryCount,
             int retryDelayMilliseconds,
             double retryDelayBackoff,
-            string resource = "https://manage.office.com") {
+            string resource = "https://manage.office.com",
+            CancellationToken cancellationToken = default) {
             int attempts = 0;
             Exception? lastException = null;
             do {
                 try {
-                    return await ConnectO365GraphAsync(credential, tenantDomain, resource);
+                    return await ConnectO365GraphAsync(credential, tenantDomain, resource, cancellationToken);
                 } catch (Exception ex) {
                     lastException = ex;
                     LoggingMessages.Logger.WriteWarning($"Connect-EmailGraph - {ex.Message}");
@@ -231,7 +237,7 @@ namespace Mailozaurr {
                     }
                     var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
                     if (delay > 0) {
-                        await Task.Delay(delay);
+                        await Task.Delay(delay, cancellationToken);
                     }
                 }
                 attempts++;
@@ -276,7 +282,8 @@ namespace Mailozaurr {
             string method,
             string uri,
             IDictionary<string, string>? headers = null,
-            string? body = null) {
+            string? body = null,
+            CancellationToken cancellationToken = default) {
             var request = new HttpRequestMessage(new HttpMethod(method), uri);
             if (headers != null) {
                 foreach (var kvp in headers) {
@@ -286,19 +293,24 @@ namespace Mailozaurr {
             if (!string.IsNullOrWhiteSpace(body) && (method == "POST" || method == "PUT" || method == "PATCH")) {
                 request.Content = new StringContent(body, Encoding.UTF8, "application/json");
             }
-            await ConcurrencySemaphore.WaitAsync();
+            await ConcurrencySemaphore.WaitAsync(cancellationToken);
             HttpResponseMessage? response = null;
             try {
-                response = await HttpClient.SendAsync(request);
+                response = await HttpClient.SendAsync(request, cancellationToken);
                 if ((int)response.StatusCode == 429) {
                     var delay = GetRetryAfterDelay(response);
                     response.Dispose();
                     if (delay > TimeSpan.Zero) {
-                        await Task.Delay(delay);
+                        await Task.Delay(delay, cancellationToken);
                     }
-                    response = await HttpClient.SendAsync(request);
+                    response = await HttpClient.SendAsync(request, cancellationToken);
                 }
-                var responseContent = await response.Content.ReadAsStringAsync();
+                string responseContent;
+#if NET5_0_OR_GREATER
+                responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+#else
+                responseContent = await response.Content.ReadAsStringAsync();
+#endif
                 if (!response.IsSuccessStatusCode) {
                     throw new GraphApiException(
                         response.StatusCode,
@@ -315,13 +327,13 @@ namespace Mailozaurr {
         /// <summary>
         /// Sends multiple requests to Microsoft Graph in a single batch.
         /// </summary>
-        public static async Task<IReadOnlyList<GraphBatchResult>> SendBatchAsync(GraphCredential credential, IEnumerable<GraphBatchRequest> requests) {
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+        public static async Task<IReadOnlyList<GraphBatchResult>> SendBatchAsync(GraphCredential credential, IEnumerable<GraphBatchRequest> requests, CancellationToken cancellationToken = default) {
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com", cancellationToken);
             var headers = new Dictionary<string, string> { { "Authorization", token } };
             var batchPayload = new { requests = requests.Select(r => new { id = r.Id, method = r.Method.ToString(), url = r.Url.TrimStart('/') , headers = r.Headers, body = r.Body }) };
             var jsonBody = JsonSerializer.Serialize(batchPayload);
             var batchUri = BuildGraphUri(GraphEndpoint.V1, "/$batch");
-            var doc = await InvokeGraphApiAsync("POST", batchUri, headers, jsonBody);
+            var doc = await InvokeGraphApiAsync("POST", batchUri, headers, jsonBody, cancellationToken);
             var results = new List<GraphBatchResult>();
             if (doc.RootElement.TryGetProperty("responses", out var responses) && responses.ValueKind == JsonValueKind.Array) {
                 foreach (var item in responses.EnumerateArray()) {


### PR DESCRIPTION
## Summary
- pass cancellation tokens through MicrosoftGraphUtils helpers
- cover cancellation scenarios in new tests

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -f net472`
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -f net8.0`
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -f net9.0` *(fails: Assets file doesn't have a target for 'net9.0')*
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68b2d34d8c34832e87de341707d5e261