### PR TITLE
Implement full disposal pattern for MailgunClient

### DIFF
--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -56,6 +56,34 @@ public class MailgunClientTests
         }
     }
 
+    private sealed class DisposingHandler : HttpMessageHandler
+    {
+        public bool Disposed { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            Disposed = true;
+        }
+    }
+
+    private sealed class DerivedMailgunClient : MailgunClient
+    {
+        public bool Disposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Disposed = true;
+            }
+            base.Dispose(disposing);
+        }
+    }
+
     [Fact]
     public void EmailDomain_InvalidAddress_ThrowsArgumentException()
     {
@@ -192,6 +220,26 @@ public class MailgunClientTests
         var result = await client.SendEmailAsync();
         Assert.False(result.Status);
         Assert.True(handler.ResponseDisposed);
+    }
+
+    [Fact]
+    public void Dispose_DerivedType_DisposesHttpClient()
+    {
+        var handler = new DisposingHandler();
+        var httpClient = new HttpClient(handler);
+        var client = new DerivedMailgunClient
+        {
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            Credentials = new NetworkCredential(string.Empty, "key")
+        };
+        var field = typeof(MailgunClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(client, httpClient);
+
+        client.Dispose();
+
+        Assert.True(handler.Disposed);
+        Assert.True(client.Disposed);
     }
 
     private static MailgunClient CreateClient(HttpMessageHandler handler)

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -12,6 +12,7 @@ namespace Mailozaurr;
 /// </summary>
 public class MailgunClient : IDisposable {
     private readonly HttpClient _client;
+    private bool _disposed;
     /// <summary>Measures total time spent sending.</summary>
     public readonly Stopwatch Stopwatch;
 
@@ -239,7 +240,17 @@ public class MailgunClient : IDisposable {
     /// <summary>
     /// Releases resources used by the client.
     /// </summary>
+    protected virtual void Dispose(bool disposing) {
+        if (!_disposed) {
+            if (disposing) {
+                _client.Dispose();
+            }
+            _disposed = true;
+        }
+    }
+
     public void Dispose() {
-        _client.Dispose();
+        Dispose(true);
+        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
## Summary
- implement standard dispose pattern in MailgunClient
- add unit test ensuring derived MailgunClient disposes HttpClient

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh -NoLogo -NoProfile -File ./Mailozaurr.Tests.ps1` *(fails: InvalidOperationException: Cannot add type. Compilation errors occurred)*


------
https://chatgpt.com/codex/tasks/task_e_68b2d3483d28832eae0bc14fd484889d