### PR TITLE
Add ConfigureAwait to library async calls

### DIFF
--- a/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
+++ b/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
@@ -104,6 +104,27 @@ namespace Mailozaurr.Tests {
         }
 
         [Fact]
+        public async Task SendEmail_SendGrid_ServerError_Fails() {
+            var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("err") });
+            var client = new SendGridClient();
+            var field = typeof(SendGridClient).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            field.SetValue(client, new HttpClient(handler));
+
+            client.From = "sender@example.com";
+            client.To = new System.Collections.Generic.List<object> { "recipient@example.com" };
+            client.Subject = "Test Email (SendGrid Failure)";
+            client.Html = "<b>Body</b>";
+            client.Text = "Body";
+            client.Credentials = new NetworkCredential("apikey", "SENDGRID_API_KEY");
+            client.CreateMessage();
+
+            var result = await client.SendEmailAsync();
+
+            Assert.False(result.Status);
+            Assert.Single(handler.Requests);
+        }
+
+        [Fact]
         public async Task SendEmail_Graph_WithValidInput_Succeeds() {
             var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
             using var graph = new Graph();

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -52,13 +52,13 @@ public sealed class GmailApiClient : IDisposable {
         if (response.StatusCode == HttpStatusCode.Unauthorized ||
             response.StatusCode == HttpStatusCode.Forbidden) {
             if (_refreshToken != null) {
-                string token = await _refreshToken(cancellationToken);
+                string token = await _refreshToken(cancellationToken).ConfigureAwait(false);
                 _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             }
 #if NET5_0_OR_GREATER
-            string content = await response.Content.ReadAsStringAsync(cancellationToken);
+            string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
-            string content = await response.Content.ReadAsStringAsync();
+            string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
             throw new GmailAuthenticationException(response.StatusCode, content);
         }
@@ -69,20 +69,20 @@ public sealed class GmailApiClient : IDisposable {
     /// </summary>
     public async Task<GmailMessage> SendAsync(string userId, MimeMessage message, CancellationToken cancellationToken = default) {
         using var ms = new MemoryStream();
-        await message.WriteToAsync(ms, cancellationToken);
+        await message.WriteToAsync(ms, cancellationToken).ConfigureAwait(false);
         var raw = Convert.ToBase64String(ms.ToArray())
             .Replace('+', '-')
             .Replace('/', '_')
             .Replace("=", string.Empty);
         var json = JsonSerializer.Serialize(new { raw }, s_jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var response = await _client.PostAsync($"users/{userId}/messages/send", content, cancellationToken);
-        await ThrowIfAuthErrorAsync(response, cancellationToken);
+        using var response = await _client.PostAsync($"users/{userId}/messages/send", content, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 #if NET5_0_OR_GREATER
-        var resultJson = await response.Content.ReadAsStringAsync(cancellationToken);
+        var resultJson = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
-        var resultJson = await response.Content.ReadAsStringAsync();
+        var resultJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
         var result = JsonSerializer.Deserialize<GmailMessage>(resultJson, s_jsonOptions);
         if (result is null) {
@@ -107,13 +107,13 @@ public sealed class GmailApiClient : IDisposable {
             if (qs.Count > 0) {
                 url.Append('?').Append(string.Join("&", qs));
             }
-            using var response = await _client.GetAsync(url.ToString(), cancellationToken);
-            await ThrowIfAuthErrorAsync(response, cancellationToken);
+            using var response = await _client.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
+            await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 #if NET5_0_OR_GREATER
-            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
-            var json = await response.Content.ReadAsStringAsync();
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
             var list = JsonSerializer.Deserialize<GmailListResponse>(json, s_jsonOptions);
             if (list?.Messages != null) {
@@ -138,13 +138,13 @@ public sealed class GmailApiClient : IDisposable {
     /// Retrieves a single message by id.
     /// </summary>
     public async Task<GmailMessage> GetAsync(string userId, string id, CancellationToken cancellationToken = default) {
-        using var response = await _client.GetAsync($"users/{userId}/messages/{id}", cancellationToken);
-        await ThrowIfAuthErrorAsync(response, cancellationToken);
+        using var response = await _client.GetAsync($"users/{userId}/messages/{id}", cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 #if NET5_0_OR_GREATER
-        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
-        var json = await response.Content.ReadAsStringAsync();
+        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
         var message = JsonSerializer.Deserialize<GmailMessage>(json, s_jsonOptions);
         if (message is null) {
@@ -157,13 +157,13 @@ public sealed class GmailApiClient : IDisposable {
     /// Retrieves a MIME message by id.
     /// </summary>
     public async Task<MimeMessage> GetMimeMessageAsync(string userId, string id, CancellationToken cancellationToken = default) {
-        using var response = await _client.GetAsync($"users/{userId}/messages/{id}?format=raw", cancellationToken);
-        await ThrowIfAuthErrorAsync(response, cancellationToken);
+        using var response = await _client.GetAsync($"users/{userId}/messages/{id}?format=raw", cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 #if NET5_0_OR_GREATER
-        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
-        var json = await response.Content.ReadAsStringAsync();
+        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
         var msg = JsonSerializer.Deserialize<GmailMessage>(json, s_jsonOptions);
         if (string.IsNullOrEmpty(msg?.Raw)) {
@@ -181,8 +181,8 @@ public sealed class GmailApiClient : IDisposable {
     /// Deletes a message by id.
     /// </summary>
     public async Task DeleteAsync(string userId, string id, CancellationToken cancellationToken = default) {
-        using var response = await _client.DeleteAsync($"users/{userId}/messages/{id}", cancellationToken);
-        await ThrowIfAuthErrorAsync(response, cancellationToken);
+        using var response = await _client.DeleteAsync($"users/{userId}/messages/{id}", cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 
@@ -201,13 +201,13 @@ public sealed class GmailApiClient : IDisposable {
             if (qs.Count > 0) {
                 url.Append('?').Append(string.Join("&", qs));
             }
-            using var response = await _client.GetAsync(url.ToString(), cancellationToken);
-            await ThrowIfAuthErrorAsync(response, cancellationToken);
+            using var response = await _client.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
+            await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 #if NET5_0_OR_GREATER
-            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
-            var json = await response.Content.ReadAsStringAsync();
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
             var list = JsonSerializer.Deserialize<GmailThreadListResponse>(json, s_jsonOptions);
             if (list?.Threads != null) {
@@ -223,13 +223,13 @@ public sealed class GmailApiClient : IDisposable {
     /// Retrieves a single thread by id.
     /// </summary>
     public async Task<GmailThread> GetThreadAsync(string userId, string id, CancellationToken cancellationToken = default) {
-        using var response = await _client.GetAsync($"users/{userId}/threads/{id}", cancellationToken);
-        await ThrowIfAuthErrorAsync(response, cancellationToken);
+        using var response = await _client.GetAsync($"users/{userId}/threads/{id}", cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 #if NET5_0_OR_GREATER
-        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
-        var json = await response.Content.ReadAsStringAsync();
+        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
         var thread = JsonSerializer.Deserialize<GmailThread>(json, s_jsonOptions);
         if (thread is null) {
@@ -242,15 +242,15 @@ public sealed class GmailApiClient : IDisposable {
     /// Lists attachment metadata for a message.
     /// </summary>
     public async Task<IList<GmailAttachmentInfo>> ListAttachmentsAsync(string userId, string id, CancellationToken cancellationToken = default) {
-        using var response = await _client.GetAsync($"users/{userId}/messages/{id}?format=full", cancellationToken);
-        await ThrowIfAuthErrorAsync(response, cancellationToken);
+        using var response = await _client.GetAsync($"users/{userId}/messages/{id}?format=full", cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 #if NET5_0_OR_GREATER
-        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #else
-        using var stream = await response.Content.ReadAsStreamAsync();
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
-        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
         var list = new List<GmailAttachmentInfo>();
         if (doc.RootElement.TryGetProperty("payload", out var payload)) {
             ExtractAttachments(payload, list);
@@ -262,13 +262,13 @@ public sealed class GmailApiClient : IDisposable {
     /// Downloads a single attachment by id.
     /// </summary>
     public async Task<byte[]> DownloadAttachmentAsync(string userId, string messageId, string attachmentId, CancellationToken cancellationToken = default) {
-        using var response = await _client.GetAsync($"users/{userId}/messages/{messageId}/attachments/{attachmentId}", cancellationToken);
-        await ThrowIfAuthErrorAsync(response, cancellationToken);
+        using var response = await _client.GetAsync($"users/{userId}/messages/{messageId}/attachments/{attachmentId}", cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 #if NET5_0_OR_GREATER
-        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
-        var json = await response.Content.ReadAsStringAsync();
+        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
         var result = JsonSerializer.Deserialize<AttachmentResponse>(json, s_jsonOptions);
         if (string.IsNullOrEmpty(result?.Data)) {

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -119,7 +119,7 @@ public class MailgunClient : IDisposable {
         var bytes = new byte[fs.Length];
         var read = 0;
         while (read < bytes.Length) {
-            var r = await fs.ReadAsync(bytes, read, bytes.Length - read, cancellationToken);
+            var r = await fs.ReadAsync(bytes, read, bytes.Length - read, cancellationToken).ConfigureAwait(false);
             if (r == 0) break;
             read += r;
         }
@@ -152,7 +152,7 @@ public class MailgunClient : IDisposable {
                     continue;
                 }
 
-                var bytes = await ReadFileBytesAsync(path, cancellationToken);
+                var bytes = await ReadFileBytesAsync(path, cancellationToken).ConfigureAwait(false);
                 var fileContent = new ByteArrayContent(bytes);
                 fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
                 content.Add(fileContent, "attachment", Path.GetFileName(path));
@@ -167,7 +167,7 @@ public class MailgunClient : IDisposable {
                     continue;
                 }
 
-                var bytes = await ReadFileBytesAsync(path, cancellationToken);
+                var bytes = await ReadFileBytesAsync(path, cancellationToken).ConfigureAwait(false);
                 var fileContent = new ByteArrayContent(bytes);
                 fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
                 content.Add(fileContent, "inline", Path.GetFileName(path));
@@ -199,22 +199,22 @@ public class MailgunClient : IDisposable {
         Exception? lastException = null;
         do {
             try {
-                using var content = await CreateContentAsync(cancellationToken);
+                using var content = await CreateContentAsync(cancellationToken).ConfigureAwait(false);
                 using var request = new HttpRequestMessage(HttpMethod.Post, url) {
                     Content = content
                 };
                 request.Headers.Authorization = new AuthenticationHeaderValue("Basic", auth);
-                using var response = await _client.SendAsync(request, cancellationToken);
+                using var response = await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode) {
                     var statusCode = response.StatusCode.ToString();
                     var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, statusCode, "");
-                    await Helpers.PostWebhookAsync(WebhookUrl, okResult, cancellationToken);
+                    await Helpers.PostWebhookAsync(WebhookUrl, okResult, cancellationToken).ConfigureAwait(false);
                     return okResult;
                 }
 #if NET5_0_OR_GREATER
-                var error = await response.Content.ReadAsStringAsync(cancellationToken);
+                var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
-                var error = await response.Content.ReadAsStringAsync();
+                var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
                 throw new HttpRequestException(error);
             } catch (HttpRequestException ex) {
@@ -223,16 +223,16 @@ public class MailgunClient : IDisposable {
                 if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
                     if (ErrorAction == ActionPreference.Stop) throw;
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", ex.Message);
-                    await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
+                    await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;
                 }
                 var delay = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-                if (delay > 0) await Task.Delay(TimeSpan.FromMilliseconds(delay), cancellationToken);
+                if (delay > 0) await Task.Delay(TimeSpan.FromMilliseconds(delay), cancellationToken).ConfigureAwait(false);
             }
             attempts++;
         } while (attempts <= RetryCount);
         var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", lastException?.Message);
-        await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken);
+        await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken).ConfigureAwait(false);
         return finalResult;
     }
 

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -117,7 +117,7 @@ namespace Mailozaurr {
             if (TokenCache.TryGetValue(key, out var cached) && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
                 return $"{cached.TokenType} {cached.AccessToken}";
             }
-            var cachedFile = await OAuthTokenCache.GetAsync($"graph:{key}");
+            var cachedFile = await OAuthTokenCache.GetAsync($"graph:{key}").ConfigureAwait(false);
             if (cachedFile != null && cachedFile.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
                 TokenCache[key] = new GraphAuthorization { AccessToken = cachedFile.AccessToken, TokenType = "Bearer", ExpiresOn = cachedFile.ExpiresOn };
                 return $"Bearer {cachedFile.AccessToken}";
@@ -129,7 +129,7 @@ namespace Mailozaurr {
                     tenantDomain,
                     credential.CertificatePath!,
                     credential.CertificatePassword ?? string.Empty,
-                    scopes);
+                    scopes).ConfigureAwait(false);
                 TokenCache[key] = auth;
                 return $"{auth.TokenType} {auth.AccessToken}";
             }
@@ -140,7 +140,7 @@ namespace Mailozaurr {
                     tenantDomain,
                     credential.CertificateBytes,
                     credential.CertificatePassword ?? string.Empty,
-                    scopes);
+                    scopes).ConfigureAwait(false);
                 return $"{auth.TokenType} {auth.AccessToken}";
             }
             if (!string.IsNullOrWhiteSpace(credential.CertificatePemPath)) {
@@ -149,7 +149,7 @@ namespace Mailozaurr {
                     credential.ClientId,
                     tenantDomain,
                     credential.CertificatePemPath!,
-                    scopes);
+                    scopes).ConfigureAwait(false);
                 return $"{auth.TokenType} {auth.AccessToken}";
             }
 
@@ -164,19 +164,19 @@ namespace Mailozaurr {
             }
             var content = new FormUrlEncodedContent(body);
             var url = $"https://login.microsoftonline.com/{tenantDomain}/oauth2/token";
-            await ConcurrencySemaphore.WaitAsync();
+            await ConcurrencySemaphore.WaitAsync().ConfigureAwait(false);
             HttpResponseMessage? response = null;
             try {
-                response = await HttpClient.PostAsync(url, content);
+                response = await HttpClient.PostAsync(url, content).ConfigureAwait(false);
                 if ((int)response.StatusCode == 429) {
                     var delay = GetRetryAfterDelay(response);
                     response.Dispose();
                     if (delay > TimeSpan.Zero) {
-                        await Task.Delay(delay);
+                        await Task.Delay(delay).ConfigureAwait(false);
                     }
-                    response = await HttpClient.PostAsync(url, content);
+                    response = await HttpClient.PostAsync(url, content).ConfigureAwait(false);
                 }
-                var json = await response.Content.ReadAsStringAsync();
+                var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode) {
                     throw new GraphApiException(
                         response.StatusCode,
@@ -200,7 +200,7 @@ namespace Mailozaurr {
                     UserName = credential.ClientId,
                     AccessToken = accessToken ?? string.Empty,
                     ExpiresOn = expiresOn
-                });
+                }).ConfigureAwait(false);
                 return $"{tokenType} {accessToken}";
             } finally {
                 response?.Dispose();
@@ -222,7 +222,7 @@ namespace Mailozaurr {
             Exception? lastException = null;
             do {
                 try {
-                    return await ConnectO365GraphAsync(credential, tenantDomain, resource);
+                    return await ConnectO365GraphAsync(credential, tenantDomain, resource).ConfigureAwait(false);
                 } catch (Exception ex) {
                     lastException = ex;
                     LoggingMessages.Logger.WriteWarning($"Connect-EmailGraph - {ex.Message}");
@@ -231,7 +231,7 @@ namespace Mailozaurr {
                     }
                     var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
                     if (delay > 0) {
-                        await Task.Delay(delay);
+                        await Task.Delay(delay).ConfigureAwait(false);
                     }
                 }
                 attempts++;
@@ -286,19 +286,19 @@ namespace Mailozaurr {
             if (!string.IsNullOrWhiteSpace(body) && (method == "POST" || method == "PUT" || method == "PATCH")) {
                 request.Content = new StringContent(body, Encoding.UTF8, "application/json");
             }
-            await ConcurrencySemaphore.WaitAsync();
+            await ConcurrencySemaphore.WaitAsync().ConfigureAwait(false);
             HttpResponseMessage? response = null;
             try {
-                response = await HttpClient.SendAsync(request);
+                response = await HttpClient.SendAsync(request).ConfigureAwait(false);
                 if ((int)response.StatusCode == 429) {
                     var delay = GetRetryAfterDelay(response);
                     response.Dispose();
                     if (delay > TimeSpan.Zero) {
-                        await Task.Delay(delay);
+                        await Task.Delay(delay).ConfigureAwait(false);
                     }
-                    response = await HttpClient.SendAsync(request);
+                    response = await HttpClient.SendAsync(request).ConfigureAwait(false);
                 }
-                var responseContent = await response.Content.ReadAsStringAsync();
+                var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode) {
                     throw new GraphApiException(
                         response.StatusCode,
@@ -316,12 +316,12 @@ namespace Mailozaurr {
         /// Sends multiple requests to Microsoft Graph in a single batch.
         /// </summary>
         public static async Task<IReadOnlyList<GraphBatchResult>> SendBatchAsync(GraphCredential credential, IEnumerable<GraphBatchRequest> requests) {
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             var headers = new Dictionary<string, string> { { "Authorization", token } };
             var batchPayload = new { requests = requests.Select(r => new { id = r.Id, method = r.Method.ToString(), url = r.Url.TrimStart('/') , headers = r.Headers, body = r.Body }) };
             var jsonBody = JsonSerializer.Serialize(batchPayload);
             var batchUri = BuildGraphUri(GraphEndpoint.V1, "/$batch");
-            var doc = await InvokeGraphApiAsync("POST", batchUri, headers, jsonBody);
+            var doc = await InvokeGraphApiAsync("POST", batchUri, headers, jsonBody).ConfigureAwait(false);
             var results = new List<GraphBatchResult>();
             if (doc.RootElement.TryGetProperty("responses", out var responses) && responses.ValueKind == JsonValueKind.Array) {
                 foreach (var item in responses.EnumerateArray()) {
@@ -458,7 +458,7 @@ namespace Mailozaurr {
         /// </summary>
         public static async Task<List<Dictionary<string, object>>> GetMailMessagesAsync(GraphCredential credential, string userPrincipalName, IEnumerable<string>? properties = null, string? filter = null, int? limit = null) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token ?? string.Empty;
             var queryParams = new Dictionary<string, object>();
             if (!string.IsNullOrWhiteSpace(filter)) queryParams["$filter"] = filter!;
@@ -466,7 +466,7 @@ namespace Mailozaurr {
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/messages", queryParams);
             var messages = new List<Dictionary<string, object>>();
             while (!string.IsNullOrEmpty(uri)) {
-                var doc = await InvokeGraphApiAsync("GET", uri, headers);
+                var doc = await InvokeGraphApiAsync("GET", uri, headers).ConfigureAwait(false);
                 if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                     foreach (var item in valueElement.EnumerateArray()) {
                         var native = ConvertJsonElementToNativeObject(item) as Dictionary<string, object>;
@@ -495,12 +495,12 @@ namespace Mailozaurr {
         /// </summary>
         public static async Task<List<Attachment>> GetMailMessageAttachmentsAsync(GraphCredential credential, string userPrincipalName, string messageId, IEnumerable<string>? properties = null) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var queryParams = new Dictionary<string, object>();
             if (properties != null && properties.Any()) queryParams["$select"] = string.Join(",", properties);
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/messages/{messageId}/attachments", queryParams);
-            var doc = await InvokeGraphApiAsync("GET", uri, headers);
+            var doc = await InvokeGraphApiAsync("GET", uri, headers).ConfigureAwait(false);
             var attachments = new List<Attachment>();
             if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                 foreach (var item in valueElement.EnumerateArray()) {
@@ -518,10 +518,10 @@ namespace Mailozaurr {
         /// </summary>
         public static async Task<List<JsonElement>> GetMailFoldersAsync(GraphCredential credential, string userPrincipalName) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders");
-            var doc = await InvokeGraphApiAsync("GET", uri, headers);
+            var doc = await InvokeGraphApiAsync("GET", uri, headers).ConfigureAwait(false);
             var folders = new List<JsonElement>();
             if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                 foreach (var item in valueElement.EnumerateArray()) {
@@ -588,7 +588,7 @@ namespace Mailozaurr {
             int from = 0,
             int size = 25) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
 
             var requests = new List<object>();
@@ -604,7 +604,7 @@ namespace Mailozaurr {
 
             var body = JsonSerializer.Serialize(new { requests });
             var searchUri = BuildGraphUri(GraphEndpoint.V1, "/search/query");
-            var doc = await InvokeGraphApiAsync("POST", searchUri, headers, body);
+            var doc = await InvokeGraphApiAsync("POST", searchUri, headers, body).ConfigureAwait(false);
 
             var results = new List<GraphMessageInfo>();
             int index = 0;
@@ -638,7 +638,7 @@ namespace Mailozaurr {
         /// </summary>
         public static async Task ExecuteMailMessageActionAsync(GraphCredential credential, string userPrincipalName, string messageId, GraphMessageAction action, string? destinationFolderId = null) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
 
             string method;
@@ -666,21 +666,21 @@ namespace Mailozaurr {
                     throw new ArgumentOutOfRangeException(nameof(action), action, null);
             }
 
-            await InvokeGraphApiAsync(method, uri, headers, body);
+            await InvokeGraphApiAsync(method, uri, headers, body).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Moves a mail message to another folder.
         /// </summary>
         public static async Task MoveMailMessageAsync(GraphCredential credential, string userPrincipalName, string messageId, string destinationFolderId) {
-            await ExecuteMailMessageActionAsync(credential, userPrincipalName, messageId, GraphMessageAction.Move, destinationFolderId);
+            await ExecuteMailMessageActionAsync(credential, userPrincipalName, messageId, GraphMessageAction.Move, destinationFolderId).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Copies a mail message to another folder.
         /// </summary>
         public static async Task CopyMailMessageAsync(GraphCredential credential, string userPrincipalName, string messageId, string destinationFolderId) {
-            await ExecuteMailMessageActionAsync(credential, userPrincipalName, messageId, GraphMessageAction.Copy, destinationFolderId);
+            await ExecuteMailMessageActionAsync(credential, userPrincipalName, messageId, GraphMessageAction.Copy, destinationFolderId).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -688,28 +688,28 @@ namespace Mailozaurr {
         /// </summary>
         public static async Task SetMailMessageAsync(GraphCredential credential, string userPrincipalName, string messageId, bool isRead) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/messages/{messageId}");
             var body = JsonSerializer.Serialize(new { isRead });
-            await InvokeGraphApiAsync("PATCH", uri, headers, body);
+            await InvokeGraphApiAsync("PATCH", uri, headers, body).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Deletes a mail message.
         /// </summary>
         public static async Task DeleteMailMessageAsync(GraphCredential credential, string userPrincipalName, string messageId) {
-            await ExecuteMailMessageActionAsync(credential, userPrincipalName, messageId, GraphMessageAction.Delete);
+            await ExecuteMailMessageActionAsync(credential, userPrincipalName, messageId, GraphMessageAction.Delete).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Retrieves the raw MIME content of a mail message.
         /// </summary>
         public static async Task<MimeMessage> GetMailMessageMimeAsync(GraphCredential credential, string userPrincipalName, string messageId) {
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             var request = new HttpRequestMessage(HttpMethod.Get, $"https://graph.microsoft.com/v1.0/users/{userPrincipalName}/messages/{messageId}/$value");
             request.Headers.TryAddWithoutValidation("Authorization", token);
-            await ConcurrencySemaphore.WaitAsync();
+            await ConcurrencySemaphore.WaitAsync().ConfigureAwait(false);
             try {
                 using var response = await HttpClient.SendAsync(request).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
@@ -747,12 +747,12 @@ namespace Mailozaurr {
                 skipTo,
                 skipSubjectContains,
                 skipHasAttachment,
-                skipAttachmentExtension);
+                skipAttachmentExtension).ConfigureAwait(false);
 
             foreach (var msg in messages) {
                 var id = msg["id"] as string;
                 if (string.IsNullOrWhiteSpace(id)) continue;
-                await DeleteMailMessageAsync(credential, userPrincipalName, id!);
+                await DeleteMailMessageAsync(credential, userPrincipalName, id!).ConfigureAwait(false);
             }
         }
 
@@ -836,7 +836,7 @@ namespace Mailozaurr {
             bool skipHasAttachment = false,
             IEnumerable<string>? skipAttachmentExtension = null) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var props = properties != null ? new List<string>(properties) : new List<string>();
             if (skipHasAttachment || skipAttachmentExtension != null) {
@@ -847,7 +847,7 @@ namespace Mailozaurr {
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/junkemail/messages", query);
             var messages = new List<Dictionary<string, object>>();
             while (!string.IsNullOrWhiteSpace(uri)) {
-                var doc = await InvokeGraphApiAsync("GET", uri!, headers);
+                var doc = await InvokeGraphApiAsync("GET", uri!, headers).ConfigureAwait(false);
                 if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                     foreach (var item in valueElement.EnumerateArray()) {
                         var native = ConvertJsonElementToNativeObject(item) as Dictionary<string, object>;
@@ -872,7 +872,7 @@ namespace Mailozaurr {
                             credential,
                             userPrincipalName,
                             id,
-                            new[] { "name" });
+                            new[] { "name" }).ConfigureAwait(false);
                         if (atts.Any(att =>
                                 skipAttachmentExtension.Contains(
                                     System.IO.Path.GetExtension(att.Name ?? string.Empty).TrimStart('.'),
@@ -901,11 +901,11 @@ namespace Mailozaurr {
             string folderId,
             string destinationFolderId) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/{folderId}/move");
             var body = JsonSerializer.Serialize(new { destinationId = destinationFolderId });
-            await InvokeGraphApiAsync("POST", uri, headers, body);
+            await InvokeGraphApiAsync("POST", uri, headers, body).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -922,11 +922,11 @@ namespace Mailozaurr {
             string folderId,
             string newDisplayName) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/{folderId}");
             var body = JsonSerializer.Serialize(new { displayName = newDisplayName });
-            await InvokeGraphApiAsync("PATCH", uri, headers, body);
+            await InvokeGraphApiAsync("PATCH", uri, headers, body).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -941,10 +941,10 @@ namespace Mailozaurr {
             string userPrincipalName,
             string folderId) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/{folderId}");
-            await InvokeGraphApiAsync("DELETE", uri, headers);
+            await InvokeGraphApiAsync("DELETE", uri, headers).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -952,10 +952,10 @@ namespace Mailozaurr {
         /// </summary>
         public static async Task<List<GraphMailboxPermission>> GetMailboxPermissionsAsync(GraphCredential credential, string userPrincipalName) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/permissions");
-            var doc = await InvokeGraphApiAsync("GET", uri, headers);
+            var doc = await InvokeGraphApiAsync("GET", uri, headers).ConfigureAwait(false);
             var result = new List<GraphMailboxPermission>();
             if (doc.RootElement.TryGetProperty("value", out var val) && val.ValueKind == JsonValueKind.Array) {
                 foreach (var item in val.EnumerateArray()) {
@@ -971,10 +971,10 @@ namespace Mailozaurr {
         /// </summary>
         public static async Task AddMailboxPermissionAsync(GraphCredential credential, string userPrincipalName, string body) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/permissions");
-            await InvokeGraphApiAsync("POST", uri, headers, body);
+            await InvokeGraphApiAsync("POST", uri, headers, body).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -982,7 +982,7 @@ namespace Mailozaurr {
         /// </summary>
         public static async Task RemoveMailboxPermissionAsync(GraphCredential credential, string userPrincipalName, string permissionId) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/permissions/{permissionId}");
         }
@@ -994,7 +994,7 @@ namespace Mailozaurr {
             GraphCredential credential,
             string userPrincipalName) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
 
             var folderQuery = new Dictionary<string, object> {
@@ -1006,7 +1006,7 @@ namespace Mailozaurr {
             int folderCount = 0;
             var foldersStats = new List<GraphMailboxFolderStatistics>();
             while (!string.IsNullOrWhiteSpace(folderUri)) {
-                var doc = await InvokeGraphApiAsync("GET", folderUri!, headers);
+                var doc = await InvokeGraphApiAsync("GET", folderUri!, headers).ConfigureAwait(false);
                 if (doc.RootElement.TryGetProperty("value", out var folders) && folders.ValueKind == JsonValueKind.Array) {
                     foreach (var item in folders.EnumerateArray()) {
                         var stat = new GraphMailboxFolderStatistics {
@@ -1036,7 +1036,7 @@ namespace Mailozaurr {
             };
             var msgUri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/messages", msgQuery);
             while (!string.IsNullOrWhiteSpace(msgUri)) {
-                var doc = await InvokeGraphApiAsync("GET", msgUri!, headers);
+                var doc = await InvokeGraphApiAsync("GET", msgUri!, headers).ConfigureAwait(false);
                 if (doc.RootElement.TryGetProperty("value", out var msgs) && msgs.ValueKind == JsonValueKind.Array) {
                     foreach (var msg in msgs.EnumerateArray()) {
                         if (!msg.TryGetProperty("id", out var idEl) || idEl.ValueKind != JsonValueKind.String) {
@@ -1055,7 +1055,7 @@ namespace Mailozaurr {
                             credential,
                             userPrincipalName,
                             id!,
-                            new[] { "size" });
+                            new[] { "size" }).ConfigureAwait(false);
                         foreach (var att in atts) {
                             attachmentSize += att.Size;
                         }
@@ -1090,12 +1090,12 @@ namespace Mailozaurr {
             string userPrincipalName,
             string? filter = null) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             Dictionary<string, object>? qp = null;
             if (!string.IsNullOrWhiteSpace(filter)) qp = new Dictionary<string, object> { ["$filter"] = filter! };
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/inbox/messageRules", qp);
-            var doc = await InvokeGraphApiAsync("GET", uri, headers);
+            var doc = await InvokeGraphApiAsync("GET", uri, headers).ConfigureAwait(false);
             var rules = new List<GraphInboxRule>();
             if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                 foreach (var item in valueElement.EnumerateArray()) {
@@ -1118,11 +1118,11 @@ namespace Mailozaurr {
             string userPrincipalName,
             GraphInboxRule rule) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var body = JsonSerializer.Serialize(rule, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/inbox/messageRules");
-            var doc = await InvokeGraphApiAsync("POST", uri, headers, body);
+            var doc = await InvokeGraphApiAsync("POST", uri, headers, body).ConfigureAwait(false);
             var created = JsonSerializer.Deserialize<GraphInboxRule>(doc.RootElement.GetRawText());
             if (created is null) {
                 throw new InvalidDataException("Microsoft Graph returned an invalid inbox rule response.");
@@ -1139,11 +1139,11 @@ namespace Mailozaurr {
             string ruleId,
             GraphInboxRule rule) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var body = JsonSerializer.Serialize(rule, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/inbox/messageRules/{ruleId}");
-            var doc = await InvokeGraphApiAsync("PATCH", uri, headers, body);
+            var doc = await InvokeGraphApiAsync("PATCH", uri, headers, body).ConfigureAwait(false);
             var updated = JsonSerializer.Deserialize<GraphInboxRule>(doc.RootElement.GetRawText());
             if (updated is null) {
                 throw new InvalidDataException("Microsoft Graph returned an invalid inbox rule response.");
@@ -1163,10 +1163,10 @@ namespace Mailozaurr {
             string userPrincipalName,
             string ruleId) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders/inbox/messageRules/{ruleId}");
-            await InvokeGraphApiAsync("DELETE", uri, headers);
+            await InvokeGraphApiAsync("DELETE", uri, headers).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1179,13 +1179,13 @@ namespace Mailozaurr {
             string? filter = null,
             int? limit = null) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var qp = new Dictionary<string, object>();
             if (!string.IsNullOrWhiteSpace(filter)) qp["$filter"] = filter!;
             if (properties != null && properties.Any()) qp["$select"] = string.Join(",", properties);
             var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/events", qp);
-            var doc = await InvokeGraphApiAsync("GET", uri, headers);
+            var doc = await InvokeGraphApiAsync("GET", uri, headers).ConfigureAwait(false);
             var events = new List<Dictionary<string, object>>();
             if (doc.RootElement.TryGetProperty("value", out var val) && val.ValueKind == JsonValueKind.Array) {
                 foreach (var item in val.EnumerateArray()) {
@@ -1205,11 +1205,11 @@ namespace Mailozaurr {
             string userPrincipalName,
             GraphEvent ev) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var body = JsonSerializer.Serialize(ev, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
             var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/events");
-            var doc = await InvokeGraphApiAsync("POST", uri, headers, body);
+            var doc = await InvokeGraphApiAsync("POST", uri, headers, body).ConfigureAwait(false);
             var created = JsonSerializer.Deserialize<GraphEvent>(doc.RootElement.GetRawText());
             if (created is null) {
                 throw new InvalidDataException("Microsoft Graph returned an invalid event response.");
@@ -1226,11 +1226,11 @@ namespace Mailozaurr {
             string eventId,
             GraphEvent ev) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var body = JsonSerializer.Serialize(ev, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
             var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/events/{eventId}");
-            var doc = await InvokeGraphApiAsync("PATCH", uri, headers, body);
+            var doc = await InvokeGraphApiAsync("PATCH", uri, headers, body).ConfigureAwait(false);
             var updated = JsonSerializer.Deserialize<GraphEvent>(doc.RootElement.GetRawText());
             if (updated is null) {
                 throw new InvalidDataException("Microsoft Graph returned an invalid event response.");
@@ -1246,10 +1246,10 @@ namespace Mailozaurr {
             string userPrincipalName,
             string eventId) {
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var uri = JoinUriQuery("https://graph.microsoft.com/v1.0", $"/users/{userPrincipalName}/events/{eventId}");
-            await InvokeGraphApiAsync("DELETE", uri, headers);
+            await InvokeGraphApiAsync("DELETE", uri, headers).ConfigureAwait(false);
         }
     }
 }

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -321,7 +321,7 @@ public class SendGridClient {
                 throw new InvalidCastException(message);
             }
             var credFail = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, string.Empty, message);
-            await Helpers.PostWebhookAsync(WebhookUrl, credFail, cancellationToken);
+            await Helpers.PostWebhookAsync(WebhookUrl, credFail, cancellationToken).ConfigureAwait(false);
             return credFail;
         }
 
@@ -335,17 +335,17 @@ public class SendGridClient {
                 };
                 request.Headers.Add("Authorization", $"Bearer {apiKey}");
 
-                using var response = await _client.SendAsync(request, cancellationToken);
+                using var response = await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
-                lastContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                lastContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
-                lastContent = await response.Content.ReadAsStringAsync();
+                lastContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
                 LogCollector.LogVerbose($"Send-EmailMessage - Sent email to {SentTo} using SendGrid");
 
                 if (response.IsSuccessStatusCode) {
                     var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString());
-                    await Helpers.PostWebhookAsync(WebhookUrl, okResult, cancellationToken);
+                    await Helpers.PostWebhookAsync(WebhookUrl, okResult, cancellationToken).ConfigureAwait(false);
                     return okResult;
                 }
 
@@ -360,13 +360,13 @@ public class SendGridClient {
                         throw lastException;
                     }
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
-                    await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
+                    await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;
                 }
 
                 var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
                 if (delayMilliseconds > 0) {
-                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken);
+                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken).ConfigureAwait(false);
                 }
             } catch (TaskCanceledException ex) {
                 lastException = ex;
@@ -376,19 +376,19 @@ public class SendGridClient {
                         throw lastException;
                     }
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
-                    await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
+                    await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;
                 }
                 var delayMs = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
                 if (delayMs > 0) {
-                    await Task.Delay(TimeSpan.FromMilliseconds(delayMs), cancellationToken);
+                    await Task.Delay(TimeSpan.FromMilliseconds(delayMs), cancellationToken).ConfigureAwait(false);
                 }
             }
             attempts++;
         } while (attempts <= RetryCount);
 
         var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
-        await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken);
+        await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken).ConfigureAwait(false);
         return finalResult;
     }
 


### PR DESCRIPTION
## Summary
- use ConfigureAwait(false) on async calls in SendGridClient, MailgunClient, GmailApiClient, and MicrosoftGraphUtils
- add test covering SendGridClient error path

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --no-build -c Release` *(fails: The argument ...Mailozaurr.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d3436120832e83ed5831f82f0096