### PR TITLE
Add file-based pending message repository

### DIFF
--- a/Sources/Mailozaurr.Examples/PendingMessageRepositoryExample.cs
+++ b/Sources/Mailozaurr.Examples/PendingMessageRepositoryExample.cs
@@ -1,0 +1,33 @@
+using MimeKit;
+using System.IO;
+using System.Threading.Tasks;
+using Mailozaurr;
+
+/// <summary>
+/// Example demonstrating how to persist and retrieve pending messages.
+/// </summary>
+public static class PendingMessageRepositoryExample {
+    /// <summary>Runs the example.</summary>
+    public static async Task RunAsync() {
+        var path = Path.Combine(Path.GetTempPath(), "pending.log");
+        var repository = new FilePendingMessageRepository(path);
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+        message.Subject = "Pending";
+        message.Body = new TextPart("plain") { Text = "Hello" };
+        using var ms = new MemoryStream();
+        await message.WriteToAsync(ms);
+        var record = new PendingMessageRecord {
+            MessageId = message.MessageId ?? MimeKit.Utils.MimeUtils.GenerateMessageId(),
+            MimeMessage = Convert.ToBase64String(ms.ToArray()),
+            Timestamp = DateTimeOffset.UtcNow
+        };
+        await repository.SaveAsync(record);
+
+        await foreach (var r in repository.GetAllAsync()) {
+            Console.WriteLine($"Pending: {r.MessageId}");
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/FilePendingMessageRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/FilePendingMessageRepositoryTests.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using System.Threading.Tasks;
+using MimeKit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class FilePendingMessageRepositoryTests {
+    [Fact]
+    public async Task SaveRetrieveAndRemove() {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try {
+            var repo = new FilePendingMessageRepository(path);
+            var message = new MimeMessage();
+            message.From.Add(MailboxAddress.Parse("sender@example.com"));
+            message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+            message.Subject = "Pending";
+            message.Body = new TextPart("plain") { Text = "Hello" };
+            using var ms = new MemoryStream();
+            await message.WriteToAsync(ms);
+            var record = new PendingMessageRecord {
+                MessageId = message.MessageId ?? MimeKit.Utils.MimeUtils.GenerateMessageId(),
+                MimeMessage = Convert.ToBase64String(ms.ToArray()),
+                Timestamp = DateTimeOffset.UtcNow
+            };
+            await repo.SaveAsync(record);
+
+            var loaded = await repo.GetByMessageIdAsync(record.MessageId);
+            Assert.NotNull(loaded);
+            using var ms2 = new MemoryStream(Convert.FromBase64String(loaded!.MimeMessage));
+            var restored = await MimeMessage.LoadAsync(ms2);
+            Assert.Equal("Pending", restored.Subject);
+
+            await repo.RemoveAsync(record.MessageId);
+            var removed = await repo.GetByMessageIdAsync(record.MessageId);
+            Assert.Null(removed);
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
@@ -1,0 +1,150 @@
+using System.Runtime.CompilerServices;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Stores pending message records in a single newline-delimited JSON file.
+/// </summary>
+public sealed class FilePendingMessageRepository : IPendingMessageRepository {
+    private readonly string filePath;
+    private readonly SemaphoreSlim gate = new(1, 1);
+    private readonly Dictionary<string, long> index = new(StringComparer.OrdinalIgnoreCase);
+    private readonly byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+
+    /// <summary>
+    /// Creates a new repository using the specified file path.
+    /// </summary>
+    /// <param name="filePath">Path to the file that stores pending messages.</param>
+    public FilePendingMessageRepository(string filePath) {
+        this.filePath = filePath;
+        if (File.Exists(filePath)) {
+            BuildIndex();
+        }
+    }
+
+    private void BuildIndex() {
+        long position = 0;
+        foreach (var line in File.ReadLines(filePath)) {
+            if (string.IsNullOrWhiteSpace(line)) {
+                position += newlineBytes.Length;
+                continue;
+            }
+            var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
+            if (record != null && !string.IsNullOrEmpty(record.MessageId)) {
+                index[record.MessageId] = position;
+            }
+            position += Encoding.UTF8.GetByteCount(line) + newlineBytes.Length;
+        }
+    }
+
+    /// <summary>Saves a pending message to the repository.</summary>
+    public async Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
+        await gate.WaitAsync(cancellationToken);
+        try {
+            var directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
+                Directory.CreateDirectory(directory);
+            }
+            using var write = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+            var offset = write.Position;
+            await JsonSerializer.SerializeAsync(write, record, cancellationToken: cancellationToken);
+            await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
+            index[record.MessageId] = offset;
+        } finally {
+            gate.Release();
+        }
+    }
+
+    /// <summary>Retrieves a pending message by its ID.</summary>
+    public async Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+        if (!File.Exists(filePath)) {
+            return null;
+        }
+        await gate.WaitAsync(cancellationToken);
+        try {
+            if (!index.TryGetValue(messageId, out var offset)) {
+                return null;
+            }
+            using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            read.Seek(offset, SeekOrigin.Begin);
+            using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
+            string? line = await reader.ReadLineAsync();
+            if (string.IsNullOrWhiteSpace(line)) {
+                return null;
+            }
+            var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
+            if (record != null && string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
+                return record;
+            }
+            return null;
+        } finally {
+            gate.Release();
+        }
+    }
+
+    /// <summary>Enumerates all pending messages.</summary>
+    public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {
+        if (!File.Exists(filePath)) {
+            yield break;
+        }
+        await gate.WaitAsync(cancellationToken);
+        try {
+            using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
+            string? line;
+            while ((line = await reader.ReadLineAsync()) != null) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (string.IsNullOrWhiteSpace(line)) {
+                    continue;
+                }
+                var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
+                if (record != null) {
+                    yield return record;
+                }
+            }
+        } finally {
+            gate.Release();
+        }
+    }
+
+    /// <summary>Removes a pending message by its ID.</summary>
+    public async Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+        if (!File.Exists(filePath)) {
+            return;
+        }
+        await gate.WaitAsync(cancellationToken);
+        try {
+            if (!index.ContainsKey(messageId)) {
+                return;
+            }
+            var temp = filePath + ".tmp";
+            using (var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None))
+            using (var write = new FileStream(temp, FileMode.Create, FileAccess.Write, FileShare.None)) {
+                using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
+                long position = 0;
+                string? line;
+                index.Clear();
+                while ((line = await reader.ReadLineAsync()) != null) {
+                    if (string.IsNullOrWhiteSpace(line)) {
+                        await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
+                        position += newlineBytes.Length;
+                        continue;
+                    }
+                    var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
+                    if (record == null || string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
+                        continue;
+                    }
+                    var bytes = Encoding.UTF8.GetBytes(line);
+                    await write.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
+                    await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
+                    index[record.MessageId] = position;
+                    position += bytes.Length + newlineBytes.Length;
+                }
+            }
+            File.Delete(filePath);
+            File.Move(temp, filePath);
+        } finally {
+            gate.Release();
+        }
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/IPendingMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/IPendingMessageRepository.cs
@@ -1,0 +1,8 @@
+namespace Mailozaurr;
+
+public interface IPendingMessageRepository {
+    Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default);
+    Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<PendingMessageRecord> GetAllAsync(CancellationToken cancellationToken = default);
+    Task RemoveAsync(string messageId, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents a message pending to be sent.
+/// </summary>
+public sealed class PendingMessageRecord {
+    /// <summary>Identifier of the message.</summary>
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>Time at which the message was queued.</summary>
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>Base64-encoded MIME message.</summary>
+    public string MimeMessage { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- add IPendingMessageRepository and record type
- implement file-based pending message repository with indexing and concurrency
- demonstrate and test pending message persistence

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bad7fc9d68832eb16fa70fa24b8ada