### PR TITLE
queue failed SMTP messages for retry

### DIFF
--- a/Sources/Mailozaurr.Examples/SmtpPendingMessageExample.cs
+++ b/Sources/Mailozaurr.Examples/SmtpPendingMessageExample.cs
@@ -1,0 +1,25 @@
+using Mailozaurr;
+using System.IO;
+
+/// <summary>
+/// Example showing how failed sends are persisted for later retry.
+/// </summary>
+public static class SmtpPendingMessageExample {
+    /// <summary>Runs the example.</summary>
+    public static async Task RunAsync() {
+        var path = Path.Combine(Path.GetTempPath(), "pending.log");
+        var repository = new FilePendingMessageRepository(path);
+
+        var smtp = new Smtp { PendingMessageRepository = repository };
+        smtp.From = "sender@example.com";
+        smtp.To = new[] { "recipient@example.com" };
+        smtp.Subject = "Pending";
+        smtp.TextBody = "Hello";
+        smtp.CreateMessage();
+
+        // Without a configured server this send will fail and the message will be queued
+        var result = await smtp.SendAsync();
+        Console.WriteLine($"Queued message id: {result.MessageId}");
+    }
+}
+

--- a/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
@@ -1,0 +1,89 @@
+using System.Reflection;
+using MailKit;
+using MimeKit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class SmtpPendingMessageTests {
+    private sealed class FailClient : ClientSmtp {
+        public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {
+            throw new Exception("fail");
+        }
+    }
+
+    private sealed class SuccessClient : ClientSmtp {
+        public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {
+            return Task.FromResult(string.Empty);
+        }
+    }
+
+    private sealed class InMemoryPendingRepository : IPendingMessageRepository {
+        public List<PendingMessageRecord> Saved { get; } = new();
+        public List<string> Removed { get; } = new();
+
+        public Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
+            Saved.Add(record);
+            return Task.CompletedTask;
+        }
+
+        public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Saved.FirstOrDefault(r => r.MessageId == messageId));
+
+        public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync(CancellationToken cancellationToken = default) {
+            foreach (var r in Saved) {
+                yield return r;
+                await Task.Yield();
+            }
+        }
+
+        public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+            Removed.Add(messageId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private static void SetClient(Smtp smtp, ClientSmtp client) {
+        var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(smtp, client);
+    }
+
+    [Fact]
+    public async Task SendFailureQueuesMessage() {
+        var repo = new InMemoryPendingRepository();
+        var smtp = new Smtp { PendingMessageRepository = repo, RetryCount = 0 };
+        SetClient(smtp, new FailClient());
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "b@c.com" };
+        smtp.Subject = "test";
+        smtp.TextBody = "body";
+        smtp.CreateMessage();
+
+        var result = await smtp.SendAsync();
+
+        Assert.False(result.Status);
+        Assert.NotNull(result.MessageId);
+        Assert.Single(repo.Saved);
+        Assert.Equal(result.MessageId, repo.Saved[0].MessageId);
+        Assert.False(string.IsNullOrWhiteSpace(repo.Saved[0].MimeMessage));
+    }
+
+    [Fact]
+    public async Task SuccessfulSendRemovesQueuedMessage() {
+        var repo = new InMemoryPendingRepository();
+        var smtp = new Smtp { PendingMessageRepository = repo };
+        SetClient(smtp, new SuccessClient());
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "b@c.com" };
+        smtp.Subject = "test";
+        smtp.TextBody = "body";
+        smtp.CreateMessage();
+        smtp.Message.MessageId = "msg-1";
+
+        var result = await smtp.SendAsync();
+
+        Assert.True(result.Status);
+        Assert.Single(repo.Removed);
+        Assert.Equal("msg-1", repo.Removed[0]);
+    }
+}
+

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -32,6 +32,8 @@ public class Smtp {
 
     /// <summary>Repository used to persist sent message metadata.</summary>
     public ISentMessageRepository? SentMessageRepository { get; set; }
+    /// <summary>Repository used to persist pending messages for later retry.</summary>
+    public IPendingMessageRepository? PendingMessageRepository { get; set; }
 
     /// <summary>Underlying SMTP client used to send messages.</summary>
     public ClientSmtp Client { get; private set; }
@@ -684,7 +686,12 @@ public class Smtp {
                     };
                     await SentMessageRepository.SaveAsync(record, cancellationToken);
                 }
-                var result = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
+                if (PendingMessageRepository != null && !string.IsNullOrEmpty(Message.MessageId)) {
+                    await PendingMessageRepository.RemoveAsync(Message.MessageId, cancellationToken);
+                }
+                var result = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging) {
+                    MessageId = Message.MessageId
+                };
                 await Helpers.PostWebhookAsync(WebhookUrl, result, cancellationToken);
                 return result;
             } catch (Exception ex) {
@@ -694,7 +701,23 @@ public class Smtp {
                     if (ErrorAction == ActionPreference.Stop) {
                         throw;
                     }
-                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message);
+                    var id = Message.MessageId;
+                    if (string.IsNullOrEmpty(id)) {
+                        Message.MessageId = id = MimeKit.Utils.MimeUtils.GenerateMessageId();
+                    }
+                    if (PendingMessageRepository != null) {
+                        using var ms = new MemoryStream();
+                        await Message.WriteToAsync(ms, cancellationToken);
+                        var record = new PendingMessageRecord {
+                            MessageId = id,
+                            MimeMessage = Convert.ToBase64String(ms.ToArray()),
+                            Timestamp = DateTimeOffset.UtcNow
+                        };
+                        await PendingMessageRepository.SaveAsync(record, cancellationToken);
+                    }
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message) {
+                        MessageId = id
+                    };
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
                     return failResult;
                 }
@@ -707,7 +730,23 @@ public class Smtp {
             attempts++;
         } while (attempts <= RetryCount);
 
-        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", lastException?.Message);
+        var finalId = Message.MessageId;
+        if (string.IsNullOrEmpty(finalId)) {
+            Message.MessageId = finalId = MimeKit.Utils.MimeUtils.GenerateMessageId();
+        }
+        if (PendingMessageRepository != null) {
+            using var ms = new MemoryStream();
+            await Message.WriteToAsync(ms, cancellationToken);
+            var record = new PendingMessageRecord {
+                MessageId = finalId,
+                MimeMessage = Convert.ToBase64String(ms.ToArray()),
+                Timestamp = DateTimeOffset.UtcNow
+            };
+            await PendingMessageRepository.SaveAsync(record, cancellationToken);
+        }
+        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", lastException?.Message) {
+            MessageId = finalId
+        };
         await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken);
         return finalResult;
     }

--- a/Sources/Mailozaurr/Smtp/SmtpResult.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpResult.cs
@@ -16,6 +16,8 @@ public class SmtpResult {
     public string SentTo { get; set; }
     /// <summary>The sender address.</summary>
     public string SentFrom { get; set; }
+    /// <summary>Identifier of the message associated with the result.</summary>
+    public string? MessageId { get; set; }
     /// <summary>Optional message returned by the operation.</summary>
     public string? Message { get; set; }
     /// <summary>Time taken to perform the action.</summary>


### PR DESCRIPTION
## Summary
- capture pending emails on final send failure and tag results with message ids
- purge pending entries after a successful retry
- cover pending message save and removal with unit tests and example

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_68baf3d7a940832ea3da1ca30b02425e