### PR TITLE
Add pending message processing and examples

### DIFF
--- a/Examples/Example-ProcessPendingMessages.ps1
+++ b/Examples/Example-ProcessPendingMessages.ps1
@@ -1,0 +1,8 @@
+$pending = Join-Path $PSScriptRoot 'pending.json'
+$sent = Join-Path $PSScriptRoot 'sentlog.json'
+$smtp = [Mailozaurr.Smtp]::new()
+$smtp.Server = 'smtp.server'
+$smtp.PendingMessageRepository = [Mailozaurr.FilePendingMessageRepository]::new($pending)
+$smtp.SentMessageRepository = [Mailozaurr.FileSentMessageRepository]::new($sent)
+$smtp.ProcessPendingMessagesAsync().GetAwaiter().GetResult()
+

--- a/Sources/Mailozaurr.Examples/SmtpProcessPendingMessagesExample.cs
+++ b/Sources/Mailozaurr.Examples/SmtpProcessPendingMessagesExample.cs
@@ -1,0 +1,23 @@
+using Mailozaurr;
+using System.IO;
+
+/// <summary>
+/// Example showing how to replay messages from a pending repository.
+/// </summary>
+public static class SmtpProcessPendingMessagesExample {
+    /// <summary>Runs the example.</summary>
+    public static async Task RunAsync() {
+        var pendingPath = Path.Combine(Path.GetTempPath(), "pending.log");
+        var pendingRepo = new FilePendingMessageRepository(pendingPath);
+        var sentPath = Path.Combine(Path.GetTempPath(), "sent.log");
+        var sentRepo = new FileSentMessageRepository(sentPath);
+
+        var smtp = new Smtp {
+            PendingMessageRepository = pendingRepo,
+            SentMessageRepository = sentRepo
+        };
+
+        await smtp.ProcessPendingMessagesAsync();
+    }
+}
+

--- a/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
@@ -42,6 +42,18 @@ public sealed class SmtpPendingMessageTests {
         }
     }
 
+    private sealed class InMemorySentRepository : ISentMessageRepository {
+        public List<SentMessageRecord> Saved { get; } = new();
+
+        public Task SaveAsync(SentMessageRecord record, CancellationToken cancellationToken = default) {
+            Saved.Add(record);
+            return Task.CompletedTask;
+        }
+
+        public Task<SentMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Saved.FirstOrDefault(r => r.MessageId == messageId));
+    }
+
     private static void SetClient(Smtp smtp, ClientSmtp client) {
         var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
         field.SetValue(smtp, client);
@@ -84,6 +96,66 @@ public sealed class SmtpPendingMessageTests {
         Assert.True(result.Status);
         Assert.Single(repo.Removed);
         Assert.Equal("msg-1", repo.Removed[0]);
+    }
+
+    [Fact]
+    public async Task ProcessPendingMessages_SendsAndLogs() {
+        var pending = new InMemoryPendingRepository();
+        var sent = new InMemorySentRepository();
+        var smtp = new Smtp { PendingMessageRepository = pending, SentMessageRepository = sent };
+        SetClient(smtp, new SuccessClient());
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("a@b.com"));
+        message.To.Add(MailboxAddress.Parse("b@c.com"));
+        message.Subject = "queued";
+        message.Body = new TextPart("plain") { Text = "body" };
+        message.MessageId = "msg-1";
+        using (var ms = new MemoryStream()) {
+            await message.WriteToAsync(ms);
+            var record = new PendingMessageRecord {
+                MessageId = "msg-1",
+                MimeMessage = Convert.ToBase64String(ms.ToArray()),
+                Timestamp = DateTimeOffset.UtcNow
+            };
+            await pending.SaveAsync(record);
+        }
+
+        await smtp.ProcessPendingMessagesAsync();
+
+        Assert.Single(pending.Removed);
+        Assert.Equal("msg-1", pending.Removed[0]);
+        Assert.Single(sent.Saved);
+        Assert.Equal("msg-1", sent.Saved[0].MessageId);
+    }
+
+    [Fact]
+    public async Task ProcessPendingMessages_FailedSendRetainsMessage() {
+        var pending = new InMemoryPendingRepository();
+        var sent = new InMemorySentRepository();
+        var smtp = new Smtp { PendingMessageRepository = pending, SentMessageRepository = sent };
+        SetClient(smtp, new FailClient());
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("a@b.com"));
+        message.To.Add(MailboxAddress.Parse("b@c.com"));
+        message.Subject = "queued";
+        message.Body = new TextPart("plain") { Text = "body" };
+        message.MessageId = "msg-2";
+        using (var ms = new MemoryStream()) {
+            await message.WriteToAsync(ms);
+            var record = new PendingMessageRecord {
+                MessageId = "msg-2",
+                MimeMessage = Convert.ToBase64String(ms.ToArray()),
+                Timestamp = DateTimeOffset.UtcNow
+            };
+            await pending.SaveAsync(record);
+        }
+
+        await smtp.ProcessPendingMessagesAsync();
+
+        Assert.Empty(pending.Removed);
+        Assert.Empty(sent.Saved);
     }
 }
 

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -649,6 +649,54 @@ public class Smtp {
     }
 
     /// <summary>
+    /// Attempts to send all messages stored in <see cref="PendingMessageRepository"/>.
+    /// </summary>
+    /// <remarks>
+    /// Messages are removed from the repository only when sending succeeds. On
+    /// success the message is also logged via <see cref="SentMessageRepository"/>,
+    /// if configured.
+    /// </remarks>
+    public async Task ProcessPendingMessagesAsync(CancellationToken cancellationToken = default) {
+        if (PendingMessageRepository == null) {
+            return;
+        }
+
+        await foreach (var record in PendingMessageRepository.GetAllAsync(cancellationToken)) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(record.MimeMessage) || string.IsNullOrEmpty(record.MessageId)) {
+                continue;
+            }
+
+            MimeMessage message;
+            try {
+                var bytes = Convert.FromBase64String(record.MimeMessage);
+                using var ms = new MemoryStream(bytes);
+                message = await MimeMessage.LoadAsync(ms, cancellationToken);
+            } catch (Exception ex) {
+                LogWarning($"ProcessPendingMessages - Failed to parse {record.MessageId}: {ex.Message}");
+                continue;
+            }
+
+            try {
+                await Client.SendAsync(message, cancellationToken);
+                LogVerbose($"Send-EmailMessage - Sent email to {message.To}");
+                if (SentMessageRepository != null) {
+                    var sentRecord = new SentMessageRecord {
+                        MessageId = message.MessageId ?? record.MessageId,
+                        Recipients = message.To.ToString(),
+                        Subject = message.Subject ?? string.Empty,
+                        Timestamp = DateTimeOffset.UtcNow
+                    };
+                    await SentMessageRepository.SaveAsync(sentRecord, cancellationToken);
+                }
+                await PendingMessageRepository.RemoveAsync(record.MessageId, cancellationToken);
+            } catch (Exception ex) {
+                LogWarning($"ProcessPendingMessages - Error sending {record.MessageId}: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
     /// Logs a verbose message using LogCollector if available, otherwise uses LoggingMessages.Logger.
     /// </summary>
     private void LogVerbose(string message) {


### PR DESCRIPTION
## Summary
- add Smtp.ProcessPendingMessagesAsync to send and remove queued messages while logging successes
- include tests for pending message replay
- provide examples to trigger pending message replay

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh -NoLogo -NoProfile -Command ./Mailozaurr.Tests.ps1` *(fails: InvalidOperationException: Cannot add type. Compilation errors occurred.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb24f9ac0c832eacf320861aca6798