### PR TITLE
Add scheduling to pending message outbox

### DIFF
--- a/Sources/Mailozaurr.Examples/PendingMessageRepositoryExample.cs
+++ b/Sources/Mailozaurr.Examples/PendingMessageRepositoryExample.cs
@@ -22,7 +22,8 @@ public static class PendingMessageRepositoryExample {
         var record = new PendingMessageRecord {
             MessageId = message.MessageId ?? MimeKit.Utils.MimeUtils.GenerateMessageId(),
             MimeMessage = Convert.ToBase64String(ms.ToArray()),
-            Timestamp = DateTimeOffset.UtcNow
+            Timestamp = DateTimeOffset.UtcNow,
+            NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(5)
         };
         await repository.SaveAsync(record);
 

--- a/Sources/Mailozaurr.Tests/FilePendingMessageRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/FilePendingMessageRepositoryTests.cs
@@ -26,6 +26,7 @@ public sealed class FilePendingMessageRepositoryTests {
 
             var loaded = await repo.GetByMessageIdAsync(record.MessageId);
             Assert.NotNull(loaded);
+            Assert.True(loaded!.NextAttemptAt <= DateTimeOffset.UtcNow);
             using var ms2 = new MemoryStream(Convert.FromBase64String(loaded!.MimeMessage));
             var restored = await MimeMessage.LoadAsync(ms2);
             Assert.Equal("Pending", restored.Subject);

--- a/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
@@ -22,7 +22,15 @@ public sealed class SmtpPendingMessageTests {
         public List<string> Removed { get; } = new();
 
         public Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
-            Saved.Add(record);
+            if (record.NextAttemptAt == default) {
+                record.NextAttemptAt = DateTimeOffset.UtcNow;
+            }
+            var existing = Saved.FindIndex(r => r.MessageId == record.MessageId);
+            if (existing >= 0) {
+                Saved[existing] = record;
+            } else {
+                Saved.Add(record);
+            }
             return Task.CompletedTask;
         }
 
@@ -30,7 +38,8 @@ public sealed class SmtpPendingMessageTests {
             Task.FromResult(Saved.FirstOrDefault(r => r.MessageId == messageId));
 
         public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync(CancellationToken cancellationToken = default) {
-            foreach (var r in Saved) {
+            var snapshot = Saved.ToList();
+            foreach (var r in snapshot) {
                 yield return r;
                 await Task.Yield();
             }
@@ -156,6 +165,76 @@ public sealed class SmtpPendingMessageTests {
 
         Assert.Empty(pending.Removed);
         Assert.Empty(sent.Saved);
+    }
+
+    [Fact]
+    public async Task ProcessPendingMessages_SkipsFutureNextAttempt() {
+        var pending = new InMemoryPendingRepository();
+        var sent = new InMemorySentRepository();
+        var smtp = new Smtp { PendingMessageRepository = pending, SentMessageRepository = sent };
+        SetClient(smtp, new SuccessClient());
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("a@b.com"));
+        message.To.Add(MailboxAddress.Parse("b@c.com"));
+        message.Subject = "queued";
+        message.Body = new TextPart("plain") { Text = "body" };
+        message.MessageId = "msg-3";
+        using (var ms = new MemoryStream()) {
+            await message.WriteToAsync(ms);
+            var record = new PendingMessageRecord {
+                MessageId = "msg-3",
+                MimeMessage = Convert.ToBase64String(ms.ToArray()),
+                Timestamp = DateTimeOffset.UtcNow,
+                NextAttemptAt = DateTimeOffset.UtcNow.AddDays(1)
+            };
+            await pending.SaveAsync(record);
+        }
+
+        await smtp.ProcessPendingMessagesAsync();
+
+        Assert.Empty(sent.Saved);
+        Assert.Empty(pending.Removed);
+    }
+
+    [Fact]
+    public async Task ProcessPendingMessages_SendsWhenNextAttemptReached() {
+        var pending = new InMemoryPendingRepository();
+        var sent = new InMemorySentRepository();
+        var smtp = new Smtp { PendingMessageRepository = pending, SentMessageRepository = sent };
+        SetClient(smtp, new SuccessClient());
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("a@b.com"));
+        message.To.Add(MailboxAddress.Parse("b@c.com"));
+        message.Subject = "queued";
+        message.Body = new TextPart("plain") { Text = "body" };
+        message.MessageId = "msg-4";
+        using (var ms = new MemoryStream()) {
+            await message.WriteToAsync(ms);
+            var record = new PendingMessageRecord {
+                MessageId = "msg-4",
+                MimeMessage = Convert.ToBase64String(ms.ToArray()),
+                Timestamp = DateTimeOffset.UtcNow,
+                NextAttemptAt = DateTimeOffset.UtcNow.AddDays(1)
+            };
+            await pending.SaveAsync(record);
+        }
+
+        await smtp.ProcessPendingMessagesAsync();
+        Assert.Empty(sent.Saved);
+
+        var existing = await pending.GetByMessageIdAsync("msg-4");
+        Assert.NotNull(existing);
+        existing!.NextAttemptAt = DateTimeOffset.UtcNow;
+        await pending.SaveAsync(existing);
+
+        await smtp.ProcessPendingMessagesAsync();
+
+        Assert.Single(sent.Saved);
+        Assert.Equal("msg-4", sent.Saved[0].MessageId);
+        Assert.Single(pending.Removed);
+        Assert.Equal("msg-4", pending.Removed[0]);
     }
 }
 

--- a/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
@@ -45,6 +45,9 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
             if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
                 Directory.CreateDirectory(directory);
             }
+            if (record.NextAttemptAt == default) {
+                record.NextAttemptAt = DateTimeOffset.UtcNow;
+            }
             using var write = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
             var offset = write.Position;
             await JsonSerializer.SerializeAsync(write, record, cancellationToken: cancellationToken);

--- a/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
@@ -10,6 +10,9 @@ public sealed class PendingMessageRecord {
     /// <summary>Time at which the message was queued.</summary>
     public DateTimeOffset Timestamp { get; set; }
 
+    /// <summary>Time when the next send attempt should occur.</summary>
+    public DateTimeOffset NextAttemptAt { get; set; }
+
     /// <summary>Base64-encoded MIME message.</summary>
     public string MimeMessage { get; set; } = string.Empty;
 }

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -666,6 +666,9 @@ public class Smtp {
             if (string.IsNullOrWhiteSpace(record.MimeMessage) || string.IsNullOrEmpty(record.MessageId)) {
                 continue;
             }
+            if (record.NextAttemptAt > DateTimeOffset.UtcNow) {
+                continue;
+            }
 
             MimeMessage message;
             try {
@@ -692,6 +695,8 @@ public class Smtp {
                 await PendingMessageRepository.RemoveAsync(record.MessageId, cancellationToken);
             } catch (Exception ex) {
                 LogWarning($"ProcessPendingMessages - Error sending {record.MessageId}: {ex.Message}");
+                record.NextAttemptAt = DateTimeOffset.UtcNow;
+                await PendingMessageRepository.SaveAsync(record, cancellationToken);
             }
         }
     }
@@ -759,7 +764,8 @@ public class Smtp {
                         var record = new PendingMessageRecord {
                             MessageId = id,
                             MimeMessage = Convert.ToBase64String(ms.ToArray()),
-                            Timestamp = DateTimeOffset.UtcNow
+                            Timestamp = DateTimeOffset.UtcNow,
+                            NextAttemptAt = DateTimeOffset.UtcNow
                         };
                         await PendingMessageRepository.SaveAsync(record, cancellationToken);
                     }
@@ -788,7 +794,8 @@ public class Smtp {
             var record = new PendingMessageRecord {
                 MessageId = finalId,
                 MimeMessage = Convert.ToBase64String(ms.ToArray()),
-                Timestamp = DateTimeOffset.UtcNow
+                Timestamp = DateTimeOffset.UtcNow,
+                NextAttemptAt = DateTimeOffset.UtcNow
             };
             await PendingMessageRepository.SaveAsync(record, cancellationToken);
         }


### PR DESCRIPTION
## Summary
- track a `NextAttemptAt` timestamp on pending outbox records
- skip or retry pending sends based on the timestamp
- cover delayed and resumed processing with unit tests

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bb38049ea0832ebe8279948f42e814