### PR TITLE
feat: add configurable pending message storage

### DIFF
--- a/Examples/Example-MailozaurrPendingMessages.ps1
+++ b/Examples/Example-MailozaurrPendingMessages.ps1
@@ -1,13 +1,13 @@
 $pending = Join-Path $PSScriptRoot 'pending.log'
 
 # Review queued messages
-Get-MailozaurrPendingMessage -PendingPath $pending
+Get-MailozaurrPendingMessage -PendingMessagesPath $pending
 
 # Replay messages. Server details and credentials are taken from
 # the pending log so each message is sent using its original
 # configuration, allowing mixed servers in a single file.
-Send-MailozaurrPendingMessage -PendingPath $pending
+Send-MailozaurrPendingMessage -PendingMessagesPath $pending
 
 # Remove a specific message by ID
 # $id = 'message-id'
-# Remove-MailozaurrPendingMessage -PendingPath $pending -MessageId $id
+# Remove-MailozaurrPendingMessage -PendingMessagesPath $pending -MessageId $id

--- a/Examples/Example-ProcessPendingMessages.ps1
+++ b/Examples/Example-ProcessPendingMessages.ps1
@@ -2,7 +2,7 @@ $pending = Join-Path $PSScriptRoot 'pending.json'
 $sent = Join-Path $PSScriptRoot 'sentlog.json'
 $smtp = [Mailozaurr.Smtp]::new()
 $smtp.Server = 'smtp.server'
-$smtp.PendingMessageRepository = [Mailozaurr.FilePendingMessageRepository]::new($pending)
+$smtp.PendingMessagesPath = $pending
 $smtp.SentMessageRepository = [Mailozaurr.FileSentMessageRepository]::new($sent)
 $smtp.ProcessPendingMessagesAsync().GetAwaiter().GetResult()
 

--- a/Sources/Mailozaurr.Examples/PendingMessageRepositoryExample.cs
+++ b/Sources/Mailozaurr.Examples/PendingMessageRepositoryExample.cs
@@ -9,8 +9,10 @@ using Mailozaurr;
 public static class PendingMessageRepositoryExample {
     /// <summary>Runs the example.</summary>
     public static async Task RunAsync() {
-        var path = Path.Combine(Path.GetTempPath(), "pending.log");
-        var repository = new FilePendingMessageRepository(path);
+        var repository = new FilePendingMessageRepository(new PendingMessageRepositoryOptions {
+            DirectoryPath = Path.GetTempPath(),
+            FileNameFactory = _ => "pending.log"
+        });
 
         var message = new MimeMessage();
         message.From.Add(MailboxAddress.Parse("sender@example.com"));

--- a/Sources/Mailozaurr.Examples/SmtpPendingMessageExample.cs
+++ b/Sources/Mailozaurr.Examples/SmtpPendingMessageExample.cs
@@ -8,9 +8,8 @@ public static class SmtpPendingMessageExample {
     /// <summary>Runs the example.</summary>
     public static async Task RunAsync() {
         var path = Path.Combine(Path.GetTempPath(), "pending.log");
-        var repository = new FilePendingMessageRepository(path);
 
-        var smtp = new Smtp { PendingMessageRepository = repository };
+        var smtp = new Smtp { PendingMessagesPath = path };
         smtp.From = "sender@example.com";
         smtp.To = new[] { "recipient@example.com" };
         smtp.Subject = "Pending";

--- a/Sources/Mailozaurr.Examples/SmtpProcessPendingMessagesExample.cs
+++ b/Sources/Mailozaurr.Examples/SmtpProcessPendingMessagesExample.cs
@@ -8,13 +8,11 @@ public static class SmtpProcessPendingMessagesExample {
     /// <summary>Runs the example.</summary>
     public static async Task RunAsync() {
         var pendingPath = Path.Combine(Path.GetTempPath(), "pending.log");
-        var pendingRepo = new FilePendingMessageRepository(pendingPath);
         var sentPath = Path.Combine(Path.GetTempPath(), "sent.log");
-        var sentRepo = new FileSentMessageRepository(sentPath);
 
         var smtp = new Smtp {
-            PendingMessageRepository = pendingRepo,
-            SentMessageRepository = sentRepo
+            PendingMessagesPath = pendingPath,
+            SentMessageRepository = new FileSentMessageRepository(sentPath)
         };
 
         await smtp.ProcessPendingMessagesAsync();

--- a/Sources/Mailozaurr.PowerShell/CmdletGetMailozaurrPendingMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetMailozaurrPendingMessage.cs
@@ -11,11 +11,11 @@ namespace Mailozaurr.PowerShell;
 public sealed class CmdletGetMailozaurrPendingMessage : AsyncPSCmdlet {
     /// <summary>Path to the pending message log file.</summary>
     [Parameter(Mandatory = true)]
-    public string? PendingPath { get; set; }
+    public string? PendingMessagesPath { get; set; }
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
-        var repo = new FilePendingMessageRepository(PendingPath!);
+        var repo = new FilePendingMessageRepository(PendingMessagesPath!);
         await foreach (var record in repo.GetAllAsync(CancelToken)) {
             WriteObject(record);
         }

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveMailozaurrPendingMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveMailozaurrPendingMessage.cs
@@ -14,14 +14,14 @@ public sealed class CmdletRemoveMailozaurrPendingMessage : AsyncPSCmdlet {
 
     /// <summary>Path to the pending message log file.</summary>
     [Parameter(Mandatory = true)]
-    public string? PendingPath { get; set; }
+    public string? PendingMessagesPath { get; set; }
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         if (!ShouldProcess(MessageId ?? string.Empty, "Removing pending message")) {
             return;
         }
-        var repo = new FilePendingMessageRepository(PendingPath!);
+        var repo = new FilePendingMessageRepository(PendingMessagesPath!);
         await repo.RemoveAsync(MessageId!, CancelToken);
     }
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
@@ -432,6 +432,15 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
     public string? SentLogPath { get; set; }
 
     /// <summary>
+    /// <para>Specifies the path used to store pending messages when sending fails. Defaults to the system temporary directory.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
+    [Parameter(Mandatory = false, ParameterSetName = "SecureString")]
+    [Parameter(Mandatory = false, ParameterSetName = "oAuth")]
+    [Parameter(Mandatory = false, ParameterSetName = "Compatibility")]
+    public string? PendingMessagesPath { get; set; }
+
+    /// <summary>
     /// <para>Enables logging of communication with the server to the console.</para>
     /// </summary>
     [Parameter(Mandatory = false)]

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -397,6 +397,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             sentLogPath = providedSentLogPath;
         }
         smtpClient.SentMessageRepository = new FileSentMessageRepository(sentLogPath);
+        smtpClient.PendingMessagesPath = PendingMessagesPath;
         smtpClient.From = Helpers.GetFromObject(fromEmail, fromName);
         smtpClient.ReplyTo = ReplyTo;
         smtpClient.Cc = Cc;

--- a/Sources/Mailozaurr.PowerShell/CmdletSendMailozaurrPendingMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendMailozaurrPendingMessage.cs
@@ -10,11 +10,11 @@ namespace Mailozaurr.PowerShell;
 public sealed class CmdletSendMailozaurrPendingMessage : AsyncPSCmdlet {
     /// <summary>Path to the pending message log file.</summary>
     [Parameter(Mandatory = true)]
-    public string? PendingPath { get; set; }
+    public string? PendingMessagesPath { get; set; }
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
-        var smtp = new Smtp { PendingMessageRepository = new FilePendingMessageRepository(PendingPath!) };
+        var smtp = new Smtp { PendingMessagesPath = PendingMessagesPath };
         await smtp.ProcessPendingMessagesAsync(CancelToken);
     }
 }

--- a/Sources/Mailozaurr.Tests/FilePendingMessageRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/FilePendingMessageRepositoryTests.cs
@@ -40,4 +40,22 @@ public sealed class FilePendingMessageRepositoryTests {
             }
         }
     }
+
+    [Fact]
+    public async Task UsesOptions() {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var opts = new PendingMessageRepositoryOptions {
+            DirectoryPath = dir,
+            FileNameFactory = _ => "custom.log"
+        };
+        var repo = new FilePendingMessageRepository(opts);
+        var record = new PendingMessageRecord {
+            MessageId = "1",
+            MimeMessage = string.Empty,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+        await repo.SaveAsync(record);
+        Assert.True(File.Exists(Path.Combine(dir, "custom.log")));
+        File.Delete(Path.Combine(dir, "custom.log"));
+    }
 }

--- a/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
@@ -135,6 +135,14 @@ public sealed class SmtpPendingMessageTests {
     }
 
     [Fact]
+    public void SettingPendingMessagesPathCreatesRepository() {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var smtp = new Smtp { PendingMessagesPath = path };
+        Assert.IsType<FilePendingMessageRepository>(smtp.PendingMessageRepository);
+        Assert.Equal(path, ((FilePendingMessageRepository)smtp.PendingMessageRepository!).FilePath);
+    }
+
+    [Fact]
     public async Task ProcessPendingMessages_SendsAndLogs() {
         var pending = new InMemoryPendingRepository();
         var sent = new InMemorySentRepository();

--- a/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
@@ -1,42 +1,64 @@
-using System.Runtime.CompilerServices;
-
-namespace Mailozaurr;
-
+using System.Runtime.CompilerServices;
+
+namespace Mailozaurr;
+
 /// <summary>
 /// Stores pending message records in a single newline-delimited JSON file.
 /// </summary>
 public sealed class FilePendingMessageRepository : IPendingMessageRepository {
     private readonly string filePath;
-    private readonly SemaphoreSlim gate = new(1, 1);
-    private readonly Dictionary<string, long> index = new(StringComparer.OrdinalIgnoreCase);
-    private readonly byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+    private readonly SemaphoreSlim gate = new(1, 1);
+    private readonly Dictionary<string, long> index = new(StringComparer.OrdinalIgnoreCase);
+    private readonly byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+
+    /// <summary>
+    /// Path to the file storing pending messages.
+    /// </summary>
+    public string FilePath => filePath;
 
     /// <summary>
     /// Creates a new repository using the specified file path.
     /// </summary>
     /// <param name="filePath">Path to the file that stores pending messages.</param>
-    public FilePendingMessageRepository(string filePath) {
-        this.filePath = filePath;
+    public FilePendingMessageRepository(string filePath)
+        : this(new PendingMessageRepositoryOptions {
+            DirectoryPath = Path.GetDirectoryName(filePath),
+            FileNameFactory = _ => Path.GetFileName(filePath)
+        }) {
+    }
+
+    /// <summary>
+    /// Creates a new repository using options.
+    /// </summary>
+    /// <param name="options">Configuration options for the repository.</param>
+    public FilePendingMessageRepository(PendingMessageRepositoryOptions? options = null) {
+        options ??= new PendingMessageRepositoryOptions();
+        var directory = options.DirectoryPath;
+        if (string.IsNullOrWhiteSpace(directory)) {
+            directory = Path.Combine(Path.GetTempPath(), "Mailozaurr");
+        }
+        var fileName = options.FileNameFactory?.Invoke(DateTimeOffset.UtcNow) ?? "pending.log";
+        filePath = Path.Combine(directory, fileName);
         if (File.Exists(filePath)) {
             BuildIndex();
         }
     }
-
-    private void BuildIndex() {
-        long position = 0;
-        foreach (var line in File.ReadLines(filePath)) {
-            if (string.IsNullOrWhiteSpace(line)) {
-                position += newlineBytes.Length;
-                continue;
-            }
-            var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
-            if (record != null && !string.IsNullOrEmpty(record.MessageId)) {
-                index[record.MessageId] = position;
-            }
-            position += Encoding.UTF8.GetByteCount(line) + newlineBytes.Length;
-        }
-    }
-
+
+    private void BuildIndex() {
+        long position = 0;
+        foreach (var line in File.ReadLines(filePath)) {
+            if (string.IsNullOrWhiteSpace(line)) {
+                position += newlineBytes.Length;
+                continue;
+            }
+            var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
+            if (record != null && !string.IsNullOrEmpty(record.MessageId)) {
+                index[record.MessageId] = position;
+            }
+            position += Encoding.UTF8.GetByteCount(line) + newlineBytes.Length;
+        }
+    }
+
     /// <summary>Saves a pending message to the repository.</summary>
     public async Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
         await gate.WaitAsync(cancellationToken);
@@ -57,97 +79,97 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
             gate.Release();
         }
     }
-
-    /// <summary>Retrieves a pending message by its ID.</summary>
-    public async Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
-        if (!File.Exists(filePath)) {
-            return null;
-        }
-        await gate.WaitAsync(cancellationToken);
-        try {
-            if (!index.TryGetValue(messageId, out var offset)) {
-                return null;
-            }
-            using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            read.Seek(offset, SeekOrigin.Begin);
-            using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
-            string? line = await reader.ReadLineAsync();
-            if (string.IsNullOrWhiteSpace(line)) {
-                return null;
-            }
-            var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
-            if (record != null && string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
-                return record;
-            }
-            return null;
-        } finally {
-            gate.Release();
-        }
-    }
-
-    /// <summary>Enumerates all pending messages.</summary>
-    public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {
-        if (!File.Exists(filePath)) {
-            yield break;
-        }
-        await gate.WaitAsync(cancellationToken);
-        try {
-            using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
-            string? line;
-            while ((line = await reader.ReadLineAsync()) != null) {
-                cancellationToken.ThrowIfCancellationRequested();
-                if (string.IsNullOrWhiteSpace(line)) {
-                    continue;
-                }
-                var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
-                if (record != null) {
-                    yield return record;
-                }
-            }
-        } finally {
-            gate.Release();
-        }
-    }
-
-    /// <summary>Removes a pending message by its ID.</summary>
-    public async Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
-        if (!File.Exists(filePath)) {
-            return;
-        }
-        await gate.WaitAsync(cancellationToken);
-        try {
-            if (!index.ContainsKey(messageId)) {
-                return;
-            }
-            var temp = filePath + ".tmp";
-            using (var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None))
-            using (var write = new FileStream(temp, FileMode.Create, FileAccess.Write, FileShare.None)) {
-                using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
-                long position = 0;
-                string? line;
-                index.Clear();
-                while ((line = await reader.ReadLineAsync()) != null) {
-                    if (string.IsNullOrWhiteSpace(line)) {
-                        await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
-                        position += newlineBytes.Length;
-                        continue;
-                    }
-                    var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
-                    if (record == null || string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
-                        continue;
-                    }
-                    var bytes = Encoding.UTF8.GetBytes(line);
-                    await write.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
-                    await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
-                    index[record.MessageId] = position;
-                    position += bytes.Length + newlineBytes.Length;
-                }
-            }
-            File.Delete(filePath);
-            File.Move(temp, filePath);
-        } finally {
-            gate.Release();
-        }
-    }
-}
+
+    /// <summary>Retrieves a pending message by its ID.</summary>
+    public async Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+        if (!File.Exists(filePath)) {
+            return null;
+        }
+        await gate.WaitAsync(cancellationToken);
+        try {
+            if (!index.TryGetValue(messageId, out var offset)) {
+                return null;
+            }
+            using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            read.Seek(offset, SeekOrigin.Begin);
+            using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
+            string? line = await reader.ReadLineAsync();
+            if (string.IsNullOrWhiteSpace(line)) {
+                return null;
+            }
+            var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
+            if (record != null && string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
+                return record;
+            }
+            return null;
+        } finally {
+            gate.Release();
+        }
+    }
+
+    /// <summary>Enumerates all pending messages.</summary>
+    public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {
+        if (!File.Exists(filePath)) {
+            yield break;
+        }
+        await gate.WaitAsync(cancellationToken);
+        try {
+            using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
+            string? line;
+            while ((line = await reader.ReadLineAsync()) != null) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (string.IsNullOrWhiteSpace(line)) {
+                    continue;
+                }
+                var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
+                if (record != null) {
+                    yield return record;
+                }
+            }
+        } finally {
+            gate.Release();
+        }
+    }
+
+    /// <summary>Removes a pending message by its ID.</summary>
+    public async Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+        if (!File.Exists(filePath)) {
+            return;
+        }
+        await gate.WaitAsync(cancellationToken);
+        try {
+            if (!index.ContainsKey(messageId)) {
+                return;
+            }
+            var temp = filePath + ".tmp";
+            using (var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None))
+            using (var write = new FileStream(temp, FileMode.Create, FileAccess.Write, FileShare.None)) {
+                using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
+                long position = 0;
+                string? line;
+                index.Clear();
+                while ((line = await reader.ReadLineAsync()) != null) {
+                    if (string.IsNullOrWhiteSpace(line)) {
+                        await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
+                        position += newlineBytes.Length;
+                        continue;
+                    }
+                    var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
+                    if (record == null || string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
+                        continue;
+                    }
+                    var bytes = Encoding.UTF8.GetBytes(line);
+                    await write.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
+                    await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
+                    index[record.MessageId] = position;
+                    position += bytes.Length + newlineBytes.Length;
+                }
+            }
+            File.Delete(filePath);
+            File.Move(temp, filePath);
+        } finally {
+            gate.Release();
+        }
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
@@ -1,91 +1,234 @@
-using System.Runtime.CompilerServices;
-
-namespace Mailozaurr;
-
-/// <summary>
-/// Stores pending message records in a single newline-delimited JSON file.
-/// </summary>
-public sealed class FilePendingMessageRepository : IPendingMessageRepository {
-    private readonly string filePath;
-    private readonly SemaphoreSlim gate = new(1, 1);
-    private readonly Dictionary<string, long> index = new(StringComparer.OrdinalIgnoreCase);
-    private readonly byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
-
-    /// <summary>
-    /// Path to the file storing pending messages.
-    /// </summary>
-    public string FilePath => filePath;
+using System.Runtime.CompilerServices;
 
-    /// <summary>
-    /// Creates a new repository using the specified file path.
-    /// </summary>
-    /// <param name="filePath">Path to the file that stores pending messages.</param>
-    public FilePendingMessageRepository(string filePath)
-        : this(new PendingMessageRepositoryOptions {
-            DirectoryPath = Path.GetDirectoryName(filePath),
-            FileNameFactory = _ => Path.GetFileName(filePath)
-        }) {
-    }
 
-    /// <summary>
-    /// Creates a new repository using options.
-    /// </summary>
-    /// <param name="options">Configuration options for the repository.</param>
-    public FilePendingMessageRepository(PendingMessageRepositoryOptions? options = null) {
-        options ??= new PendingMessageRepositoryOptions();
-        var directory = options.DirectoryPath;
-        if (string.IsNullOrWhiteSpace(directory)) {
-            directory = Path.Combine(Path.GetTempPath(), "Mailozaurr");
+
+namespace Mailozaurr;
+
+
+
+    private readonly SemaphoreSlim gate = new(1, 1);
+
+    private readonly Dictionary<string, long> index = new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+
+
+
+        if (Path.IsPathRooted(fileName) ||
+            fileName.Contains("..") ||
+            fileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0) {
+            throw new ArgumentException("Invalid file name returned by FileNameFactory", nameof(options));
         }
-        var fileName = options.FileNameFactory?.Invoke(DateTimeOffset.UtcNow) ?? "pending.log";
-        filePath = Path.Combine(directory, fileName);
-        if (File.Exists(filePath)) {
-            BuildIndex();
+
+
+    private void BuildIndex() {
+
+        long position = 0;
+        foreach (var line in File.ReadLines(filePath)) {
+            if (string.IsNullOrWhiteSpace(line)) {
+                position += newlineBytes.Length;
+                continue;
+            }
+            using var doc = JsonDocument.Parse(line);
+            if (doc.RootElement.TryGetProperty("MessageId", out var idElement)) {
+                var id = idElement.GetString();
+                if (!string.IsNullOrEmpty(id)) {
+                    index[id] = position;
+                }
+            }
+            position += Encoding.UTF8.GetByteCount(line) + newlineBytes.Length;
         }
     }
-
-    private void BuildIndex() {
-        long position = 0;
-        foreach (var line in File.ReadLines(filePath)) {
-            if (string.IsNullOrWhiteSpace(line)) {
-                position += newlineBytes.Length;
-                continue;
-            }
-            var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
-            if (record != null && !string.IsNullOrEmpty(record.MessageId)) {
-                index[record.MessageId] = position;
-            }
-            position += Encoding.UTF8.GetByteCount(line) + newlineBytes.Length;
-        }
-    }
-
-    /// <summary>Saves a pending message to the repository.</summary>
-    public async Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
+
+
+            if (!string.IsNullOrWhiteSpace(directory)) {
+
+
+    /// <summary>Retrieves a pending message by its ID.</summary>
+
+    public async Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+
+        if (!File.Exists(filePath)) {
+
+            return null;
+
+        }
+
         await gate.WaitAsync(cancellationToken);
+
         try {
-            var directory = Path.GetDirectoryName(filePath);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
+
+            if (!index.TryGetValue(messageId, out var offset)) {
+
+                return null;
+
             }
-            if (record.NextAttemptAt == default) {
-                record.NextAttemptAt = DateTimeOffset.UtcNow;
+
+            using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+            read.Seek(offset, SeekOrigin.Begin);
+
+            using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
+
+            string? line = await reader.ReadLineAsync();
+
+            if (string.IsNullOrWhiteSpace(line)) {
+
+                return null;
+
             }
-            using var write = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
-            var offset = write.Position;
-            await JsonSerializer.SerializeAsync(write, record, cancellationToken: cancellationToken);
-            await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
-            index[record.MessageId] = offset;
+
+            var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
+
+            if (record != null && string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
+
+                return record;
+
+            }
+
+            return null;
+
         } finally {
+
             gate.Release();
+
         }
+
     }
-
-    /// <summary>Retrieves a pending message by its ID.</summary>
-    public async Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
-        if (!File.Exists(filePath)) {
-            return null;
-        }
-        await gate.WaitAsync(cancellationToken);
+
+
+
+    /// <summary>Enumerates all pending messages.</summary>
+
+    public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {
+
+        if (!File.Exists(filePath)) {
+
+            yield break;
+
+        }
+
+        await gate.WaitAsync(cancellationToken);
+
+        try {
+
+            using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+            using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
+
+            string? line;
+
+            while ((line = await reader.ReadLineAsync()) != null) {
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (string.IsNullOrWhiteSpace(line)) {
+
+                    continue;
+
+                }
+
+                var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
+
+                if (record != null) {
+
+                    yield return record;
+
+                }
+
+            }
+
+        } finally {
+
+            gate.Release();
+
+        }
+
+    }
+
+
+
+    /// <summary>Removes a pending message by its ID.</summary>
+
+    public async Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+
+        if (!File.Exists(filePath)) {
+
+            return;
+
+        }
+
+        await gate.WaitAsync(cancellationToken);
+
+        try {
+
+            if (!index.ContainsKey(messageId)) {
+
+                return;
+
+            }
+
+            var temp = filePath + ".tmp";
+
+            using (var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None))
+
+            using (var write = new FileStream(temp, FileMode.Create, FileAccess.Write, FileShare.None)) {
+
+                using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
+
+                long position = 0;
+
+                string? line;
+
+                index.Clear();
+
+                while ((line = await reader.ReadLineAsync()) != null) {
+
+                    if (string.IsNullOrWhiteSpace(line)) {
+
+                        await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
+
+                        position += newlineBytes.Length;
+
+                        continue;
+
+                    }
+
+                    var record = JsonSerializer.Deserialize<PendingMessageRecord>(line);
+
+                    if (record == null || string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
+
+                        continue;
+
+                    }
+
+                    var bytes = Encoding.UTF8.GetBytes(line);
+
+                    await write.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
+
+                    await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
+
+                    index[record.MessageId] = position;
+
+                    position += bytes.Length + newlineBytes.Length;
+
+                }
+
+            }
+
+            File.Delete(filePath);
+
+            File.Move(temp, filePath);
+
+        } finally {
+
+            gate.Release();
+
+        }
+
+    }
+
+}
         try {
             if (!index.TryGetValue(messageId, out var offset)) {
                 return null;
@@ -172,4 +315,4 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
             gate.Release();
         }
     }
-}
+}

--- a/Sources/Mailozaurr/SentMessages/PendingMessageRepositoryOptions.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageRepositoryOptions.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Options for configuring <see cref="FilePendingMessageRepository"/>.
+/// </summary>
+public sealed class PendingMessageRepositoryOptions {
+    /// <summary>Directory where pending message files are stored.</summary>
+    public string? DirectoryPath { get; set; }
+
+    /// <summary>
+    /// Function that returns the file name used within <see cref="DirectoryPath"/>.
+    /// The current timestamp is provided to the delegate.
+    /// </summary>
+    public Func<DateTimeOffset, string>? FileNameFactory { get; set; }
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -36,6 +36,13 @@ public class Smtp {
     public ISentMessageRepository? SentMessageRepository { get; set; }
     /// <summary>Repository used to persist pending messages for later retry.</summary>
     public IPendingMessageRepository? PendingMessageRepository { get; set; }
+    /// <summary>Path to the file used for storing pending messages.</summary>
+    public string? PendingMessagesPath {
+        get => (PendingMessageRepository as FilePendingMessageRepository)?.FilePath;
+        set => PendingMessageRepository = string.IsNullOrWhiteSpace(value)
+            ? null
+            : new FilePendingMessageRepository(value!);
+    }
 
     /// <summary>Underlying SMTP client used to send messages.</summary>
     public ClientSmtp Client { get; private set; }

--- a/Tests/Get-MailozaurrPendingMessage.Tests.ps1
+++ b/Tests/Get-MailozaurrPendingMessage.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Get-MailozaurrPendingMessage' {
         $record.NextAttemptAt = [DateTimeOffset]::UtcNow
         $repo.SaveAsync($record).GetAwaiter().GetResult()
 
-        $result = Get-MailozaurrPendingMessage -PendingPath $path
+        $result = Get-MailozaurrPendingMessage -PendingMessagesPath $path
         $result.MessageId | Should -Be $msg.MessageId
     }
 }

--- a/Tests/Remove-MailozaurrPendingMessage.Tests.ps1
+++ b/Tests/Remove-MailozaurrPendingMessage.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Remove-MailozaurrPendingMessage' {
         $record.NextAttemptAt = [DateTimeOffset]::UtcNow
         $repo.SaveAsync($record).GetAwaiter().GetResult()
 
-        Remove-MailozaurrPendingMessage -PendingPath $path -MessageId $record.MessageId -Confirm:$false
-        (Get-MailozaurrPendingMessage -PendingPath $path | Measure-Object).Count | Should -Be 0
+        Remove-MailozaurrPendingMessage -PendingMessagesPath $path -MessageId $record.MessageId -Confirm:$false
+        (Get-MailozaurrPendingMessage -PendingMessagesPath $path | Measure-Object).Count | Should -Be 0
     }
 }

--- a/Tests/Send-EmailMessage.PendingMessagesPath.Tests.ps1
+++ b/Tests/Send-EmailMessage.PendingMessagesPath.Tests.ps1
@@ -1,0 +1,32 @@
+Describe 'Send-EmailMessage PendingMessagesPath' {
+    It 'Queues message when send fails' {
+        $path = Join-Path $TestDrive 'pending.log'
+        $refs = @(
+            [Mailozaurr.ClientSmtp].Assembly.Location,
+            [MimeKit.MimeMessage].Assembly.Location,
+            [MailKit.Net.Smtp.SmtpClient].Assembly.Location
+        )
+        Add-Type -ReferencedAssemblies $refs -TypeDefinition @"
+using Mailozaurr;
+using MimeKit;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using System.Threading;
+using System.Threading.Tasks;
+public class FailClient : ClientSmtp {
+    public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {}
+    public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {
+        throw new System.Exception("fail");
+    }
+}
+"@
+        $fake = [FailClient]::new()
+        [Mailozaurr.Smtp]::ClientFactory = { $fake }
+        try {
+            Send-EmailMessage -From 'a@b.com' -To 'b@c.com' -Server 's' -Subject 't' -Text 'b' -PendingMessagesPath $path -ErrorAction SilentlyContinue | Out-Null
+            (Get-MailozaurrPendingMessage -PendingMessagesPath $path | Measure-Object).Count | Should -Be 1
+        } finally {
+            [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
+        }
+    }
+}

--- a/Tests/Send-MailozaurrPendingMessage.Tests.ps1
+++ b/Tests/Send-MailozaurrPendingMessage.Tests.ps1
@@ -39,9 +39,9 @@ public class FakeSendClient : ClientSmtp {
 "@
         $fake = [FakeSendClient]::new()
         [Mailozaurr.Smtp]::ClientFactory = { $fake }
-        Send-MailozaurrPendingMessage -PendingPath $path
+        Send-MailozaurrPendingMessage -PendingMessagesPath $path
         [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
 
-        (Get-MailozaurrPendingMessage -PendingPath $path | Measure-Object).Count | Should -Be 0
+        (Get-MailozaurrPendingMessage -PendingMessagesPath $path | Measure-Object).Count | Should -Be 0
     }
 }


### PR DESCRIPTION
## Summary
- allow configuring pending message storage via PendingMessageRepositoryOptions
- expose PendingMessagesPath on Smtp and PowerShell cmdlets
- add tests and examples for pending message path

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release`
- `pwsh -NoLogo -NoProfile -Command "Import-Module Pester; Import-Module ./Mailozaurr.psd1; Invoke-Pester -Path Tests/Get-MailozaurrPendingMessage.Tests.ps1,Tests/Remove-MailozaurrPendingMessage.Tests.ps1,Tests/Send-MailozaurrPendingMessage.Tests.ps1,Tests/Send-EmailMessage.PendingMessagesPath.Tests.ps1"` *(fails: Cannot add type. Compilation errors occurred.)*

------
https://chatgpt.com/codex/tasks/task_e_68be73556460832eb99223758369075a