### PR TITLE
Allow nullable logging path

### DIFF
--- a/Sources/Mailozaurr.Tests/LoggingConfiguratorTests.cs
+++ b/Sources/Mailozaurr.Tests/LoggingConfiguratorTests.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class LoggingConfiguratorTests
+{
+    [Fact]
+    public void ConfigureLogging_NullPath_UsesMemoryStream()
+    {
+        var configurator = new LoggingConfigurator();
+        configurator.ConfigureLogging(null, false, true, false, false);
+
+        Assert.Null(configurator.LogPath);
+        Assert.NotNull(configurator.LogStream);
+        Assert.NotNull(configurator.ProtocolLogger);
+    }
+
+    [Fact]
+    public void ConfigureLogging_EmptyPath_UsesMemoryStream()
+    {
+        var configurator = new LoggingConfigurator();
+        configurator.ConfigureLogging(string.Empty, false, true, false, false);
+
+        Assert.Equal(string.Empty, configurator.LogPath);
+        Assert.NotNull(configurator.LogStream);
+        Assert.NotNull(configurator.ProtocolLogger);
+    }
+
+    [Fact]
+    public void ConfigureLogging_ValidPath_CreatesFileLogger()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var configurator = new LoggingConfigurator();
+        try
+        {
+            configurator.ConfigureLogging(path, false, false, false, false);
+
+            Assert.Equal(path, configurator.LogPath);
+            Assert.Null(configurator.LogStream);
+            Assert.NotNull(configurator.ProtocolLogger);
+            Assert.True(File.Exists(path));
+        }
+        finally
+        {
+            configurator.ProtocolLogger?.Dispose();
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/Sources/Mailozaurr/Logging/LoggingConfigurator.cs
+++ b/Sources/Mailozaurr/Logging/LoggingConfigurator.cs
@@ -28,14 +28,14 @@ public class LoggingConfigurator {
     public string? LogClientPrefix { get; private set; }
     /// <summary>Indicates whether existing log files should be overwritten.</summary>
     public bool LogOverwrite { get; private set; }
-    /// <summary>The path of the log file.</summary>
+    /// <summary>The path of the log file or <see langword="null"/> when not logging to a file.</summary>
     public string? LogPath { get; private set; }
     internal ProtocolLogger? ProtocolLogger { get; set; }
 
     /// <summary>
     /// Configures protocol logging.
     /// </summary>
-    /// <param name="logPath">Path to the log file or <c>null</c> to disable file logging.</param>
+    /// <param name="logPath">Path to the log file or <see langword="null"/> to disable file logging.</param>
     /// <param name="logConsole">Enable console logging.</param>
     /// <param name="logObject">Capture log entries in memory for later use.</param>
     /// <param name="logTimestamps">Include timestamps in the log.</param>
@@ -44,7 +44,7 @@ public class LoggingConfigurator {
     /// <param name="logServerPrefix">Optional prefix for server messages.</param>
     /// <param name="logClientPrefix">Optional prefix for client messages.</param>
     /// <param name="logOverwrite">Overwrite existing log file if it exists.</param>
-    public void ConfigureLogging(string logPath, bool logConsole, bool logObject, bool logTimestamps, bool logSecrets, string? logTimestampsFormat = null, string? logServerPrefix = null, string? logClientPrefix = null, bool logOverwrite = false) {
+    public void ConfigureLogging(string? logPath, bool logConsole, bool logObject, bool logTimestamps, bool logSecrets, string? logTimestampsFormat = null, string? logServerPrefix = null, string? logClientPrefix = null, bool logOverwrite = false) {
         LogTimestamps = logTimestamps;
         LogSecrets = logSecrets;
         LogTimestampsFormat = logTimestampsFormat;

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -293,7 +293,7 @@ public class Smtp {
     public static SmtpConnectionInfo TestConnection(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false)
     {
         var logging = new LoggingConfigurator();
-        logging.ConfigureLogging(null!, false, true, false, false);
+        logging.ConfigureLogging(null, false, true, false, false);
 
         var smtp = new Smtp(logging);
         _ = smtp.Connect(server, port, secureSocketOptions, useSsl);


### PR DESCRIPTION
## Summary
- allow `LoggingConfigurator` to accept a nullable log path and update documentation
- remove null-forgiving operator from `Smtp.TestConnection`
- add unit tests covering null, empty and valid file paths

## Testing
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet build Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj`
- `dotnet build Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`
- `dotnet build Sources/Mailozaurr.Examples/Mailozaurr.Examples.csproj`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c53503418c832e8412cd4275f069d7