### PR TITLE
Add cancellation support to connection retry logic

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -3,6 +3,7 @@ using MailKit.Security;
 using Mailozaurr;
 using System.Security;
 using System.Security.Authentication;
+using System.Threading;
 
 namespace Mailozaurr.PowerShell;
 
@@ -141,7 +142,7 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
     /// Use the returned object with <c>Disconnect-IMAP</c>, <c>Get-IMAPFolder</c>, or <c>Get-IMAPMessage</c> for further operations.
     /// </remarks>
     protected override async Task ProcessRecordAsync() {
-        async Task Authenticate(ImapClient c) {
+        async Task Authenticate(ImapClient c, CancellationToken ct) {
             if (ParameterSetName == "OAuth2" && OAuth2.IsPresent) {
                 if (Credential == null) {
                     throw new System.Security.Authentication.AuthenticationException("Credential is required for OAuth2 authentication.");
@@ -149,13 +150,13 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
                 var username = Credential.UserName;
                 var token = new System.Net.NetworkCredential(string.Empty, Credential.Password).Password;
                 var sasl = new MailKit.Security.SaslMechanismOAuth2(username, token);
-                await c.AuthenticateAsync(sasl);
+                await c.AuthenticateAsync(sasl, ct);
             } else if (ParameterSetName == "ClearText" && !string.IsNullOrWhiteSpace(UserName) && !string.IsNullOrWhiteSpace(Password)) {
-                await c.AuthenticateAsync(UserName, Password);
+                await c.AuthenticateAsync(UserName, Password, ct);
             } else if (Credential != null) {
                 var username = Credential.UserName;
                 var password = Credential.Password is SecureString ss ? new System.Net.NetworkCredential(string.Empty, ss).Password : Credential.GetNetworkCredential().Password;
-                await c.AuthenticateAsync(username, password);
+                await c.AuthenticateAsync(username, password, ct);
             } else {
                 throw new System.Security.Authentication.AuthenticationException("No valid authentication method provided.");
             }
@@ -173,7 +174,8 @@ public sealed class CmdletConnectIMAP : AsyncPSCmdlet {
                 Authenticate,
                 RetryCount,
                 RetryDelayMilliseconds,
-                RetryDelayBackoff);
+                RetryDelayBackoff,
+                CancelToken);
         } catch (Exception ex) {
             WriteWarning($"Connect-IMAP - {ex.Message}");
             return;

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -2,6 +2,7 @@ using MailKit.Net.Pop3;
 using MailKit.Security;
 using System.Security;
 using System.Security.Authentication;
+using System.Threading;
 
 namespace Mailozaurr.PowerShell;
 
@@ -147,7 +148,7 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
     /// Use the returned object with <c>Disconnect-POP3</c> or <c>Get-POP3Message</c> for further operations.
     /// </remarks>
     protected override async Task ProcessRecordAsync() {
-        async Task Authenticate(Pop3Client c) {
+        async Task Authenticate(Pop3Client c, CancellationToken ct) {
             if (ParameterSetName == "OAuth2" && OAuth2.IsPresent) {
                 if (Credential == null) {
                     throw new System.Security.Authentication.AuthenticationException("Credential is required for OAuth2 authentication.");
@@ -155,13 +156,13 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
                 var username = Credential.UserName;
                 var token = new System.Net.NetworkCredential(string.Empty, Credential.Password).Password;
                 var sasl = new MailKit.Security.SaslMechanismOAuth2(username, token);
-                await c.AuthenticateAsync(sasl);
+                await c.AuthenticateAsync(sasl, ct);
             } else if (ParameterSetName == "ClearText" && !string.IsNullOrWhiteSpace(UserName) && !string.IsNullOrWhiteSpace(Password)) {
-                await c.AuthenticateAsync(UserName, Password);
+                await c.AuthenticateAsync(UserName, Password, ct);
             } else if (Credential != null) {
                 var username = Credential.UserName;
                 var password = Credential.Password is SecureString ss ? new System.Net.NetworkCredential(string.Empty, ss).Password : Credential.GetNetworkCredential().Password;
-                await c.AuthenticateAsync(username, password);
+                await c.AuthenticateAsync(username, password, ct);
             } else {
                 throw new System.Security.Authentication.AuthenticationException("No valid authentication method provided.");
             }
@@ -183,7 +184,8 @@ public sealed class CmdletConnectPOP3 : AsyncPSCmdlet {
                 Authenticate,
                 RetryCount,
                 RetryDelayMilliseconds,
-                RetryDelayBackoff);
+                RetryDelayBackoff,
+                CancelToken);
         } catch (Exception ex) {
             WriteWarning($"Connect-POP3 - {ex.Message}");
             return;

--- a/Sources/Mailozaurr.Tests/ConnectorTests.cs
+++ b/Sources/Mailozaurr.Tests/ConnectorTests.cs
@@ -96,10 +96,10 @@ public class ConnectorTests
         var fake = new FakeImapClient { FailuresBeforeSuccess = 2 };
         var delays = new List<int>();
         ImapConnector.ClientFactory = () => fake;
-        ImapConnector.DelayAsync = d => { delays.Add(d); return Task.CompletedTask; };
+        ImapConnector.DelayAsync = (d, ct) => { delays.Add(d); return Task.CompletedTask; };
         var client = await ImapConnector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            c => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
+            (c, ct) => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
             3, 10, 2);
         ImapConnector.ClientFactory = () => new ImapClient();
         ImapConnector.DelayAsync = null;
@@ -114,10 +114,10 @@ public class ConnectorTests
         var fake = new FakeImapClient { FailuresBeforeSuccess = 5 };
         var delays = new List<int>();
         ImapConnector.ClientFactory = () => fake;
-        ImapConnector.DelayAsync = d => { delays.Add(d); return Task.CompletedTask; };
+        ImapConnector.DelayAsync = (d, ct) => { delays.Add(d); return Task.CompletedTask; };
         await Assert.ThrowsAsync<HttpRequestException>(() => ImapConnector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            c => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
+            (c, ct) => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
             2, 10, 2));
         ImapConnector.ClientFactory = () => new ImapClient();
         ImapConnector.DelayAsync = null;
@@ -131,10 +131,10 @@ public class ConnectorTests
         var fake = new FakePop3Client { FailuresBeforeSuccess = 1 };
         var delays = new List<int>();
         Pop3Connector.ClientFactory = () => fake;
-        Pop3Connector.DelayAsync = d => { delays.Add(d); return Task.CompletedTask; };
+        Pop3Connector.DelayAsync = (d, ct) => { delays.Add(d); return Task.CompletedTask; };
         var client = await Pop3Connector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            c => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
+            (c, ct) => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
             2, 10, 2);
         Pop3Connector.ClientFactory = () => new Pop3Client();
         Pop3Connector.DelayAsync = null;
@@ -149,10 +149,10 @@ public class ConnectorTests
         var fake = new FakePop3Client { FailuresBeforeSuccess = 4 };
         var delays = new List<int>();
         Pop3Connector.ClientFactory = () => fake;
-        Pop3Connector.DelayAsync = d => { delays.Add(d); return Task.CompletedTask; };
+        Pop3Connector.DelayAsync = (d, ct) => { delays.Add(d); return Task.CompletedTask; };
         await Assert.ThrowsAsync<HttpRequestException>(() => Pop3Connector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            c => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
+            (c, ct) => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
             2, 10, 2));
         Pop3Connector.ClientFactory = () => new Pop3Client();
         Pop3Connector.DelayAsync = null;
@@ -167,7 +167,7 @@ public class ConnectorTests
         ImapConnector.ClientFactory = () => fake;
         await Assert.ThrowsAsync<HttpRequestException>(() => ImapConnector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            c => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
+            (c, ct) => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
             0, 10, 2));
         ImapConnector.ClientFactory = () => new ImapClient();
         Assert.Equal(1, fake.ConnectCalls);
@@ -180,9 +180,41 @@ public class ConnectorTests
         Pop3Connector.ClientFactory = () => fake;
         await Assert.ThrowsAsync<HttpRequestException>(() => Pop3Connector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            c => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
+            (c, ct) => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
             0, 10, 2));
         Pop3Connector.ClientFactory = () => new Pop3Client();
+        Assert.Equal(1, fake.ConnectCalls);
+    }
+
+    [Fact]
+    public async Task ImapConnector_CancellationStopsRetries()
+    {
+        var fake = new FakeImapClient { FailuresBeforeSuccess = 5 };
+        var cts = new CancellationTokenSource();
+        ImapConnector.ClientFactory = () => fake;
+        ImapConnector.DelayAsync = (d, ct) => { cts.Cancel(); return Task.Delay(d, ct); };
+        await Assert.ThrowsAsync<TaskCanceledException>(() => ImapConnector.ConnectAsync(
+            "s", 1, SecureSocketOptions.Auto, 0, false, false,
+            (c, ct) => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
+            3, 10, 2, cts.Token));
+        ImapConnector.ClientFactory = () => new ImapClient();
+        ImapConnector.DelayAsync = null;
+        Assert.Equal(1, fake.ConnectCalls);
+    }
+
+    [Fact]
+    public async Task Pop3Connector_CancellationStopsRetries()
+    {
+        var fake = new FakePop3Client { FailuresBeforeSuccess = 5 };
+        var cts = new CancellationTokenSource();
+        Pop3Connector.ClientFactory = () => fake;
+        Pop3Connector.DelayAsync = (d, ct) => { cts.Cancel(); return Task.Delay(d, ct); };
+        await Assert.ThrowsAsync<TaskCanceledException>(() => Pop3Connector.ConnectAsync(
+            "s", 1, SecureSocketOptions.Auto, 0, false, false,
+            (c, ct) => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
+            3, 10, 2, cts.Token));
+        Pop3Connector.ClientFactory = () => new Pop3Client();
+        Pop3Connector.DelayAsync = null;
         Assert.Equal(1, fake.ConnectCalls);
     }
 
@@ -197,7 +229,7 @@ public class ConnectorTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => ImapConnector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            _ => throw new InvalidOperationException("auth"),
+            (_, _) => throw new InvalidOperationException("auth"),
             0, 0, 1));
 
         LoggingMessages.Logger.OnWarningMessage -= Handler;
@@ -223,7 +255,7 @@ public class ConnectorTests
         };
         var client = await ImapConnector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            c => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
+            (c, ct) => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
             1, 0, 1);
         ImapConnector.ClientFactory = () => new ImapClient();
         Assert.Same(second, client);
@@ -236,7 +268,7 @@ public class ConnectorTests
         ImapConnector.ClientFactory = () => fake;
         await Assert.ThrowsAsync<HttpRequestException>(() => ImapConnector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            c => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
+            (c, ct) => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; },
             0, 0, 1));
         ImapConnector.ClientFactory = () => new ImapClient();
         Assert.True(fake.Disposed);
@@ -253,7 +285,7 @@ public class ConnectorTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => Pop3Connector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            _ => throw new InvalidOperationException("auth"),
+            (_, _) => throw new InvalidOperationException("auth"),
             0, 0, 1));
 
         LoggingMessages.Logger.OnWarningMessage -= Handler;
@@ -279,7 +311,7 @@ public class ConnectorTests
         };
         var client = await Pop3Connector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            c => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
+            (c, ct) => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
             1, 0, 1);
         Pop3Connector.ClientFactory = () => new Pop3Client();
         Assert.Same(second, client);
@@ -292,7 +324,7 @@ public class ConnectorTests
         Pop3Connector.ClientFactory = () => fake;
         await Assert.ThrowsAsync<HttpRequestException>(() => Pop3Connector.ConnectAsync(
             "s", 1, SecureSocketOptions.Auto, 0, false, false,
-            c => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
+            (c, ct) => { ((FakePop3Client)c).Authenticated = true; return Task.CompletedTask; },
             0, 0, 1));
         Pop3Connector.ClientFactory = () => new Pop3Client();
         Assert.True(fake.Disposed);

--- a/Sources/Mailozaurr/Connections/ConnectionRetrier.cs
+++ b/Sources/Mailozaurr/Connections/ConnectionRetrier.cs
@@ -1,6 +1,7 @@
 using MailKit;
 using MailKit.Security;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Mailozaurr;
@@ -26,6 +27,7 @@ internal static class ConnectionRetrier {
     /// <param name="retryDelayMilliseconds">Initial delay between retries.</param>
     /// <param name="retryDelayBackoff">Multiplier for delay backoff.</param>
     /// <param name="delayAsync">Delegate used to introduce delay between retries.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>Authenticated client instance.</returns>
     internal static async Task<TClient> ConnectAsync<TClient>(
         Func<TClient> clientFactory,
@@ -36,18 +38,19 @@ internal static class ConnectionRetrier {
         int timeout,
         bool skipCertificateRevocation,
         bool skipCertificateValidation,
-        Func<TClient, Task> authenticateAsync,
+        Func<TClient, CancellationToken, Task> authenticateAsync,
         int retryCount,
         int retryDelayMilliseconds,
         double retryDelayBackoff,
-        Func<int, Task>? delayAsync)
+        Func<int, CancellationToken, Task>? delayAsync,
+        CancellationToken cancellationToken = default)
         where TClient : MailService {
         int attempts = 0;
         Exception? lastException = null;
         do {
             var client = clientFactory();
             try {
-                await client.ConnectAsync(server, port, options).ConfigureAwait(false);
+                await client.ConnectAsync(server, port, options, cancellationToken).ConfigureAwait(false);
                 if (skipCertificateRevocation) {
                     client.CheckCertificateRevocation = false;
                 }
@@ -57,7 +60,7 @@ internal static class ConnectionRetrier {
                 if (client.Timeout != timeout) {
                     client.Timeout = timeout;
                 }
-                await authenticateAsync(client).ConfigureAwait(false);
+                await authenticateAsync(client, cancellationToken).ConfigureAwait(false);
                 if (!client.IsAuthenticated) {
                     throw new InvalidOperationException("Authentication failed.");
                 }
@@ -67,7 +70,7 @@ internal static class ConnectionRetrier {
                 LoggingMessages.Logger.WriteWarning($"Connect-{protocolName} - {ex.Message}");
                 try {
                     if (client.IsConnected) {
-                        await client.DisconnectAsync(true).ConfigureAwait(false);
+                        await client.DisconnectAsync(true, cancellationToken).ConfigureAwait(false);
                     }
                 } catch (Exception ex2) {
                     LoggingMessages.Logger.WriteWarning($"Connect-{protocolName} - {ex2.Message}");
@@ -80,9 +83,9 @@ internal static class ConnectionRetrier {
                 var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
                 if (delay > 0) {
                     if (delayAsync != null) {
-                        await delayAsync(delay).ConfigureAwait(false);
+                        await delayAsync(delay, cancellationToken).ConfigureAwait(false);
                     } else {
-                        await Task.Delay(delay).ConfigureAwait(false);
+                        await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }

--- a/Sources/Mailozaurr/Connections/ImapConnector.cs
+++ b/Sources/Mailozaurr/Connections/ImapConnector.cs
@@ -1,6 +1,7 @@
 using MailKit.Net.Imap;
 using MailKit.Security;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Mailozaurr;
@@ -17,7 +18,7 @@ public static class ImapConnector {
     /// <summary>
     /// Delegate used to introduce a delay between connection retries.
     /// </summary>
-    public static Func<int, Task>? DelayAsync { get; set; }
+    public static Func<int, CancellationToken, Task>? DelayAsync { get; set; }
 
     /// <summary>
     /// Connects and authenticates to an IMAP server with retry support.
@@ -40,10 +41,11 @@ public static class ImapConnector {
         int timeout,
         bool skipCertificateRevocation,
         bool skipCertificateValidation,
-        Func<ImapClient, Task> authenticateAsync,
+        Func<ImapClient, CancellationToken, Task> authenticateAsync,
         int retryCount,
         int retryDelayMilliseconds,
-        double retryDelayBackoff) =>
+        double retryDelayBackoff,
+        CancellationToken cancellationToken = default) =>
         ConnectionRetrier.ConnectAsync(
             ClientFactory,
             "IMAP",
@@ -57,5 +59,6 @@ public static class ImapConnector {
             retryCount,
             retryDelayMilliseconds,
             retryDelayBackoff,
-            DelayAsync);
+            DelayAsync,
+            cancellationToken);
 }

--- a/Sources/Mailozaurr/Connections/Pop3Connector.cs
+++ b/Sources/Mailozaurr/Connections/Pop3Connector.cs
@@ -1,6 +1,7 @@
 using MailKit.Net.Pop3;
 using MailKit.Security;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Mailozaurr;
@@ -17,7 +18,7 @@ public static class Pop3Connector {
     /// <summary>
     /// Delegate used to delay between connection retries.
     /// </summary>
-    public static Func<int, Task>? DelayAsync { get; set; }
+    public static Func<int, CancellationToken, Task>? DelayAsync { get; set; }
     /// <summary>
     /// Connects and authenticates to a POP3 server with retry support.
     /// </summary>
@@ -39,10 +40,11 @@ public static class Pop3Connector {
         int timeout,
         bool skipCertificateRevocation,
         bool skipCertificateValidation,
-        Func<Pop3Client, Task> authenticateAsync,
+        Func<Pop3Client, CancellationToken, Task> authenticateAsync,
         int retryCount,
         int retryDelayMilliseconds,
-        double retryDelayBackoff) =>
+        double retryDelayBackoff,
+        CancellationToken cancellationToken = default) =>
         ConnectionRetrier.ConnectAsync(
             ClientFactory,
             "POP3",
@@ -56,5 +58,6 @@ public static class Pop3Connector {
             retryCount,
             retryDelayMilliseconds,
             retryDelayBackoff,
-            DelayAsync);
+            DelayAsync,
+            cancellationToken);
 }


### PR DESCRIPTION
## Summary
- allow passing `CancellationToken` to connection retry logic
- propagate cancellation through IMAP/POP3 connectors and cmdlets
- add tests verifying cancellation halts retries

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net472`


------
https://chatgpt.com/codex/tasks/task_e_68c534f896e0832ebed384e0ac77bd2e