### PR TITLE
Validate plain text credentials and add tests

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -60,6 +60,26 @@ public class HelpersTests {
     }
 
     [Fact]
+    public void ConvertFromPlainText_ThrowsArgumentNullException_WhenUserNameIsNull() {
+        Assert.Throws<ArgumentNullException>(() => Mailozaurr.Helpers.ConvertFromPlainText(null!, "secret"));
+    }
+
+    [Fact]
+    public void ConvertFromPlainText_ThrowsArgumentNullException_WhenPasswordIsNull() {
+        Assert.Throws<ArgumentNullException>(() => Mailozaurr.Helpers.ConvertFromPlainText("user", null!));
+    }
+
+    [Fact]
+    public void ConvertFromPlainText_ThrowsArgumentException_WhenUserNameIsEmpty() {
+        Assert.Throws<ArgumentException>(() => Mailozaurr.Helpers.ConvertFromPlainText(string.Empty, "secret"));
+    }
+
+    [Fact]
+    public void ConvertFromPlainText_ThrowsArgumentException_WhenPasswordIsEmpty() {
+        Assert.Throws<ArgumentException>(() => Mailozaurr.Helpers.ConvertFromPlainText("user", string.Empty));
+    }
+
+    [Fact]
     public void CredentialToApiKey_ReturnsPassword_WhenNetworkCredential() {
         var cred = new NetworkCredential("apikey", "theKey");
 

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -33,7 +33,29 @@ public static class Helpers {
     /// <param name="userName">The user name.</param>
     /// <param name="password">The password.</param>
     /// <returns>The resulting credential.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="userName"/> or <paramref name="password"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="userName"/> or <paramref name="password"/> is empty.
+    /// </exception>
     public static NetworkCredential ConvertFromPlainText(string userName, string password) {
+        if (userName is null) {
+            throw new ArgumentNullException(nameof(userName));
+        }
+
+        if (userName.Length == 0) {
+            throw new ArgumentException("Value cannot be empty.", nameof(userName));
+        }
+
+        if (password is null) {
+            throw new ArgumentNullException(nameof(password));
+        }
+
+        if (password.Length == 0) {
+            throw new ArgumentException("Value cannot be empty.", nameof(password));
+        }
+
         var secStringPassword = new SecureString();
         foreach (char c in password) {
             secStringPassword.AppendChar(c);


### PR DESCRIPTION
## Summary
- validate user name and password inputs in `ConvertFromPlainText`
- document null and empty behavior via XML comments
- cover valid and invalid inputs with unit tests

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c534ee9184832eaa7c7d8f444229dd