### PR TITLE
Dispose shared HttpClient safely

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -214,7 +214,6 @@ public class HelpersTests {
 
     [Fact]
     public async Task PostWebhookAsync_UsesSharedClient_WhenClientNotProvided() {
-        var original = Mailozaurr.Helpers.SharedHttpClient;
         var handler = new CountingHandler();
         var client = new HttpClient(handler);
         Mailozaurr.Helpers.SharedHttpClient = client;
@@ -225,8 +224,41 @@ public class HelpersTests {
             await Mailozaurr.Helpers.PostWebhookAsync("http://localhost", result);
             Assert.Equal(2, handler.Calls);
         } finally {
-            Mailozaurr.Helpers.SharedHttpClient = original;
-            client.Dispose();
+            Mailozaurr.Helpers.SharedHttpClient = new HttpClient();
         }
+    }
+
+    private class DisposeTrackingHandler : HttpMessageHandler {
+        public bool Disposed;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+
+        protected override void Dispose(bool disposing) {
+            if (disposing) {
+                Disposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    [Fact]
+    public async Task SharedHttpClient_ReplacesAndDisposesPreviousClient() {
+        var handler1 = new DisposeTrackingHandler();
+        var client1 = new HttpClient(handler1);
+        Mailozaurr.Helpers.SharedHttpClient = client1;
+
+        var handler2 = new CountingHandler();
+        var client2 = new HttpClient(handler2);
+        Mailozaurr.Helpers.SharedHttpClient = client2;
+
+        Assert.True(handler1.Disposed);
+
+        using var response = await Mailozaurr.Helpers.SharedHttpClient.GetAsync("http://localhost");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, handler2.Calls);
+
+        Mailozaurr.Helpers.SharedHttpClient = new HttpClient();
     }
 }

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -16,8 +16,17 @@ public static class Helpers {
     private static HttpClient s_sharedHttpClient = new HttpClient();
 
     internal static HttpClient SharedHttpClient {
-        get => s_sharedHttpClient;
-        set => s_sharedHttpClient = value ?? throw new ArgumentNullException(nameof(value));
+        get => Volatile.Read(ref s_sharedHttpClient);
+        set {
+            if (value is null) {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var old = Interlocked.Exchange(ref s_sharedHttpClient, value);
+            if (!ReferenceEquals(old, value)) {
+                old.Dispose();
+            }
+        }
     }
     /// <summary>Converts a credential into an OAuth token tuple.</summary>
     /// <param name="credential">The credential containing the token.</param>


### PR DESCRIPTION
## Summary
- dispose previous SharedHttpClient instance when replaced
- ensure thread-safe client swapping
- test SharedHttpClient disposal and PostWebhook behavior

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --filter "HelpersTests"`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net472 --filter "HelpersTests"`


------
https://chatgpt.com/codex/tasks/task_e_68c534e4e070832eb3c8bed6d4b0b386