### PR TITLE
Dispose resources in LoggingConfigurator

### DIFF
--- a/Sources/Mailozaurr.Tests/LoggingConfiguratorDisposeTests.cs
+++ b/Sources/Mailozaurr.Tests/LoggingConfiguratorDisposeTests.cs
@@ -1,0 +1,24 @@
+using System;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class LoggingConfiguratorDisposeTests
+{
+    [Fact]
+    public void Dispose_ReleasesResources()
+    {
+        var configurator = new LoggingConfigurator();
+        configurator.ConfigureLogging(string.Empty, false, true, false, false);
+
+        var stream = configurator.LogStream!;
+        var logger = configurator.ProtocolLogger!;
+
+        configurator.Dispose();
+
+        Assert.Null(configurator.LogStream);
+        Assert.Null(configurator.ProtocolLogger);
+        Assert.Throws<ObjectDisposedException>(() => stream.WriteByte(0));
+        Assert.Throws<ObjectDisposedException>(() => logger.LogClient(new byte[] { 0x41 }, 0, 1));
+    }
+}

--- a/Sources/Mailozaurr/Logging/LoggingConfigurator.cs
+++ b/Sources/Mailozaurr/Logging/LoggingConfigurator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 namespace Mailozaurr;
@@ -9,7 +10,7 @@ namespace Mailozaurr;
 /// Enables capturing protocol transcripts either in memory or on
 /// disk so that troubleshooting information can be reviewed.
 /// </remarks>
-public class LoggingConfigurator {
+public class LoggingConfigurator : IDisposable {
     /// <summary>Gets the in-memory log stream when logging to an object.</summary>
     public MemoryStream? LogStream { get; private set; }
     /// <summary>True when logging to the console is enabled.</summary>
@@ -31,6 +32,7 @@ public class LoggingConfigurator {
     /// <summary>The path of the log file.</summary>
     public string? LogPath { get; private set; }
     internal ProtocolLogger? ProtocolLogger { get; set; }
+    private bool _disposed;
 
     /// <summary>
     /// Configures protocol logging.
@@ -87,5 +89,27 @@ public class LoggingConfigurator {
             }
         }
         ProtocolLogger = protocolLogger;
+    }
+
+    ~LoggingConfigurator() => Dispose(false);
+
+    protected virtual void Dispose(bool disposing) {
+        if (_disposed) {
+            return;
+        }
+
+        if (disposing) {
+            ProtocolLogger?.Dispose();
+            ProtocolLogger = null;
+            LogStream?.Dispose();
+            LogStream = null;
+        }
+
+        _disposed = true;
+    }
+
+    public void Dispose() {
+        Dispose(true);
+        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
## Summary
- implement `IDisposable` pattern for `LoggingConfigurator`
- ensure protocol logging resources are properly released
- add unit test verifying disposal of logging resources

## Testing
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --filter LoggingConfiguratorDisposeTests`


------
https://chatgpt.com/codex/tasks/task_e_68c534dde050832e9af92766ad138f30