### PR TITLE
Handle null tracking set in UniqueAddresses

### DIFF
--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -149,6 +149,36 @@ public class HelpersTests {
         Assert.Same(first, result[0]);
     }
 
+    [Fact]
+    public void UniqueAddresses_DefaultsToNewSet_WhenSeenIsNull() {
+        var addresses = new object[] { "a@example.com", "a@example.com", "b@example.com" };
+
+        var result = Mailozaurr.Helpers
+            .UniqueAddresses(addresses, null)
+            .Select(Mailozaurr.Helpers.GetEmailAddress)
+            .ToArray();
+
+        Assert.Equal(new[] { "a@example.com", "b@example.com" }, result);
+    }
+
+    [Fact]
+    public void UniqueAddresses_UsesProvidedSetAcrossCalls() {
+        var seen = new HashSet<string>();
+        var first = new object[] { "a@example.com" };
+        var second = new object[] { "a@example.com", "b@example.com" };
+
+        Mailozaurr.Helpers
+            .UniqueAddresses(first, seen)
+            .ToArray();
+
+        var result = Mailozaurr.Helpers
+            .UniqueAddresses(second, seen)
+            .Select(Mailozaurr.Helpers.GetEmailAddress)
+            .ToArray();
+
+        Assert.Equal(new[] { "b@example.com" }, result);
+    }
+
     private class CancelHandler : HttpMessageHandler {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => Task.FromCanceled<HttpResponseMessage>(cancellationToken);

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -98,13 +98,15 @@ public static class Helpers {
     }
 
     /// <summary>
-    /// Enumerates unique address objects based on email value using the provided hash set to track seen addresses.
+    /// Enumerates unique address objects based on email value using a hash set to track already yielded addresses.
     /// </summary>
     /// <param name="addresses">Collection of address objects.</param>
-    /// <param name="seen">Hash set tracking emails that were already yielded.</param>
+    /// <param name="seen">Optional hash set tracking emails that were already yielded. If <see langword="null"/> a new set is created.</param>
     /// <returns>Unique address objects.</returns>
-    public static IEnumerable<object> UniqueAddresses(IEnumerable<object>? addresses, HashSet<string> seen) {
+    public static IEnumerable<object> UniqueAddresses(IEnumerable<object>? addresses, HashSet<string>? seen) {
         if (addresses == null) yield break;
+
+        seen ??= new HashSet<string>();
 
         foreach (var address in addresses) {
             var email = GetEmailAddress(address);


### PR DESCRIPTION
## Summary
- handle null `seen` in `Helpers.UniqueAddresses` by creating a new set
- document optional tracking set in XML comments
- test null and reusable tracking sets in `HelpersTests`

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test --no-build -f net8.0 Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c53c7e4f34832e9da9926d781576c3