### PR TITLE
Use IndexOf for email domain extraction and add tests

### DIFF
--- a/Sources/Mailozaurr.Tests/IsDisposableEmailTests.cs
+++ b/Sources/Mailozaurr.Tests/IsDisposableEmailTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class IsDisposableEmailTests
+{
+    private static readonly MethodInfo Method = typeof(Validator).GetMethod("IsDisposableEmail", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    [Fact]
+    public void IsDisposableEmail_ValidEmail_ReturnsTrue()
+    {
+        var result = (bool)Method.Invoke(null, new object[] { "user@example.com" })!;
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsDisposableEmail_MissingAt_ReturnsFalse()
+    {
+        var result = (bool)Method.Invoke(null, new object[] { "invalidemail.com" })!;
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsDisposableEmail_MultipleAt_ReturnsFalse()
+    {
+        var result = (bool)Method.Invoke(null, new object[] { "user@@example.com" })!;
+        Assert.False(result);
+    }
+}
+

--- a/Sources/Mailozaurr/Validator.cs
+++ b/Sources/Mailozaurr/Validator.cs
@@ -36,8 +36,12 @@ public static class Validator {
         return set;
     }
     private static bool IsDisposableEmail(string email) {
-        var domain = email.Split('@').Last();
-        return IsDisposableDomain(domain);
+        var atIndex = email.IndexOf('@');
+        if (atIndex < 0 || atIndex == email.Length - 1) {
+            return false;
+        }
+        var domain = email.AsSpan(atIndex + 1);
+        return IsDisposableDomain(domain.ToString());
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- use `IndexOf` to extract email domain without `Split`
- guard against missing `@` when checking disposable domains
- add unit tests for valid, missing, and multiple `@` cases

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c53c760248832eadeb9c8cb2aaca26