### PR TITLE
Use precompiled regex for image src detection

### DIFF
--- a/Sources/Mailozaurr.Tests/HtmlUtilsTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlUtilsTests.cs
@@ -127,5 +127,49 @@ public class HtmlUtilsTests
             handlerField.SetValue(client, original);
         }
     }
+
+    [Fact]
+    public async Task DownloadRemoteImagesAsync_DetectsMultipleImagesRegardlessOfCaseAsync()
+    {
+        const string url1 = "https://example.com/img.png";
+        const string url2 = "HTTPS://example.com/photo.jpg";
+        var html = $"<IMG SRC=\"{url1}\"><img SRC=\"{url2}\"><p>{url1}</p>";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 1 })
+                {
+                    Headers = { ContentType = new MediaTypeHeaderValue("image/png") }
+                }
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 2 })
+                {
+                    Headers = { ContentType = new MediaTypeHeaderValue("image/jpeg") }
+                }
+            });
+        var client = HtmlUtils.HttpClient;
+        var handlerField = typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? typeof(HttpMessageInvoker).GetField("handler", BindingFlags.Instance | BindingFlags.NonPublic);
+        var original = (HttpMessageHandler)handlerField!.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        try
+        {
+            var (result, images) = await HtmlUtils.DownloadRemoteImagesAsync(html);
+
+            Assert.Contains("cid:img.png", result);
+            Assert.Contains("cid:photo.jpg", result);
+            Assert.Contains($"<p>{url1}</p>", result);
+            Assert.Equal(2, images.Count);
+            Assert.Contains(images, i => i.MediaType == "image/png");
+            Assert.Contains(images, i => i.MediaType == "image/jpeg");
+            Assert.Equal(2, handler.Requests.Count);
+        }
+        finally
+        {
+            handlerField.SetValue(client, original);
+        }
+    }
 }
 

--- a/Sources/Mailozaurr/Helpers/HtmlUtils.cs
+++ b/Sources/Mailozaurr/Helpers/HtmlUtils.cs
@@ -70,8 +70,7 @@ public static class HtmlUtils {
         var images = new List<RemoteImage>();
         if (string.IsNullOrWhiteSpace(html)) return (html, images);
 
-        string pattern = "(?<=<img[^>]+src=['\"])([^'\"]+)(?=['\"])";
-        var matches = Regex.Matches(html, pattern, RegexOptions.IgnoreCase);
+        var matches = ImageSrcRegex.Matches(html);
         var replacements = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (Match match in matches) {
@@ -97,7 +96,7 @@ public static class HtmlUtils {
             }
         }
 
-        html = Regex.Replace(html, pattern, m => replacements.TryGetValue(m.Value, out var value) ? value : m.Value, RegexOptions.IgnoreCase);
+        html = ImageSrcRegex.Replace(html, m => replacements.TryGetValue(m.Value, out var value) ? value : m.Value);
 
         return (html, images);
     }


### PR DESCRIPTION
## Summary
- use the shared `ImageSrcRegex` when parsing image tags in `DownloadRemoteImagesAsync`
- test remote image parsing with multiple, case-insensitive tags

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c53c88a548832e925af9f641b1542f