### PR TITLE
Handle invalid Gmail API JSON responses

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -232,6 +232,27 @@ public class GmailApiClientTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task SendAsync_InvalidJson_ThrowsGmailApiException() {
+        var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("not json") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        var message = new MimeKit.MimeMessage();
+        var ex = await Assert.ThrowsAsync<GmailApiException>(() => client.SendAsync("me", message));
+        Assert.Equal("not json", ex.ResponseContent);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetAsync_InvalidJson_ThrowsGmailApiException() {
+        var handler = new RecordingHandler(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new System.Net.Http.StringContent("not json") });
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+        var ex = await Assert.ThrowsAsync<GmailApiException>(() => client.GetAsync("me", "id"));
+        Assert.Equal("not json", ex.ResponseContent);
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task ListThreadsAsync_PaginatesUntilTokenNull() {
         var page1 = "{\"threads\":[{\"id\":\"1\"}],\"nextPageToken\":\"tok\"}";
         var page2 = "{\"threads\":[{\"id\":\"2\"}]}";

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -84,7 +84,12 @@ public sealed class GmailApiClient : IDisposable {
 #else
         var resultJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
-        var result = JsonSerializer.Deserialize<GmailMessage>(resultJson, s_jsonOptions);
+        GmailMessage? result;
+        try {
+            result = JsonSerializer.Deserialize<GmailMessage>(resultJson, s_jsonOptions);
+        } catch (JsonException ex) {
+            throw new GmailApiException("Failed to parse Gmail API send response.", resultJson, ex);
+        }
         if (result is null) {
             throw new InvalidDataException("Gmail API returned an invalid send response.");
         }
@@ -115,7 +120,12 @@ public sealed class GmailApiClient : IDisposable {
 #else
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
-            var list = JsonSerializer.Deserialize<GmailListResponse>(json, s_jsonOptions);
+            GmailListResponse? list;
+            try {
+                list = JsonSerializer.Deserialize<GmailListResponse>(json, s_jsonOptions);
+            } catch (JsonException ex) {
+                throw new GmailApiException("Failed to parse Gmail API list response.", json, ex);
+            }
             if (list?.Messages != null) {
                 messages.AddRange(list.Messages);
             }
@@ -146,7 +156,12 @@ public sealed class GmailApiClient : IDisposable {
 #else
         var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
-        var message = JsonSerializer.Deserialize<GmailMessage>(json, s_jsonOptions);
+        GmailMessage? message;
+        try {
+            message = JsonSerializer.Deserialize<GmailMessage>(json, s_jsonOptions);
+        } catch (JsonException ex) {
+            throw new GmailApiException("Failed to parse Gmail API message response.", json, ex);
+        }
         if (message is null) {
             throw new InvalidDataException("Gmail API returned an invalid message response.");
         }
@@ -165,7 +180,12 @@ public sealed class GmailApiClient : IDisposable {
 #else
         var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
-        var msg = JsonSerializer.Deserialize<GmailMessage>(json, s_jsonOptions);
+        GmailMessage? msg;
+        try {
+            msg = JsonSerializer.Deserialize<GmailMessage>(json, s_jsonOptions);
+        } catch (JsonException ex) {
+            throw new GmailApiException("Failed to parse Gmail API message response.", json, ex);
+        }
         if (string.IsNullOrEmpty(msg?.Raw)) {
             throw new InvalidDataException("Gmail API returned an invalid message response.");
         }
@@ -209,7 +229,12 @@ public sealed class GmailApiClient : IDisposable {
 #else
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
-            var list = JsonSerializer.Deserialize<GmailThreadListResponse>(json, s_jsonOptions);
+            GmailThreadListResponse? list;
+            try {
+                list = JsonSerializer.Deserialize<GmailThreadListResponse>(json, s_jsonOptions);
+            } catch (JsonException ex) {
+                throw new GmailApiException("Failed to parse Gmail API thread list response.", json, ex);
+            }
             if (list?.Threads != null) {
                 threads.AddRange(list.Threads);
             }
@@ -231,7 +256,12 @@ public sealed class GmailApiClient : IDisposable {
 #else
         var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
-        var thread = JsonSerializer.Deserialize<GmailThread>(json, s_jsonOptions);
+        GmailThread? thread;
+        try {
+            thread = JsonSerializer.Deserialize<GmailThread>(json, s_jsonOptions);
+        } catch (JsonException ex) {
+            throw new GmailApiException("Failed to parse Gmail API thread response.", json, ex);
+        }
         if (thread is null) {
             throw new InvalidDataException("Gmail API returned an invalid thread response.");
         }
@@ -270,7 +300,12 @@ public sealed class GmailApiClient : IDisposable {
 #else
         var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
-        var result = JsonSerializer.Deserialize<AttachmentResponse>(json, s_jsonOptions);
+        AttachmentResponse? result;
+        try {
+            result = JsonSerializer.Deserialize<AttachmentResponse>(json, s_jsonOptions);
+        } catch (JsonException ex) {
+            throw new GmailApiException("Failed to parse Gmail API attachment response.", json, ex);
+        }
         if (string.IsNullOrEmpty(result?.Data)) {
             return Array.Empty<byte>();
         }

--- a/Sources/Mailozaurr/Gmail/GmailApiException.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiException.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Exception thrown when Gmail API returns an unexpected response.
+/// </summary>
+public class GmailApiException : Exception {
+    /// <summary>
+    /// Raw response content returned by the Gmail API.
+    /// </summary>
+    public string ResponseContent { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GmailApiException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="responseContent">Raw response content from the server.</param>
+    /// <param name="innerException">The original exception.</param>
+    public GmailApiException(string message, string responseContent, Exception innerException)
+        : base(message, innerException) {
+        ResponseContent = responseContent;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `GmailApiException` to surface response body when JSON parsing fails
- wrap Gmail API deserialization in try/catch and throw `GmailApiException`
- test Gmail API client against invalid JSON responses

## Testing
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c53c9e3678832e908bff99d8bf4747