### PR TITLE
Add pending message sender factory

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageSenderFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageSenderFactoryTests.cs
@@ -1,0 +1,86 @@
+using System;
+
+using System.Collections.Generic;
+
+using System.Threading;
+
+using System.Threading.Tasks;
+
+
+
+namespace Mailozaurr.Tests;
+
+
+
+public sealed class PendingMessageSenderFactoryTests {
+
+    private sealed class TestSender : IPendingMessageSender {
+
+        public Task SendAsync(PendingMessageRecord record, CancellationToken ct) => Task.CompletedTask;
+
+    }
+
+
+
+    [Fact]
+
+    public void GetSender_ReturnsRegisteredSender() {
+
+        var sender = new TestSender();
+
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+
+            { EmailProvider.SendGrid, sender }
+
+        });
+
+
+
+        var record = new PendingMessageRecord { Provider = EmailProvider.SendGrid };
+
+
+
+        var result = factory.GetSender(record);
+
+
+
+        Assert.Same(sender, result);
+
+    }
+
+
+
+    [Fact]
+
+    public void GetSender_ReturnsNoopWhenProviderMissing() {
+
+        var factory = new PendingMessageSenderFactory();
+
+        var record = new PendingMessageRecord { Provider = EmailProvider.Mailgun };
+
+
+
+        var result = factory.GetSender(record);
+
+
+
+        Assert.IsType<NoopPendingMessageSender>(result);
+
+    }
+
+
+
+    [Fact]
+
+    public void GetSender_ThrowsWhenRecordIsNull() {
+
+        var factory = new PendingMessageSenderFactory();
+
+
+
+        Assert.Throws<ArgumentNullException>(() => factory.GetSender(null!));
+
+    }
+
+}
+

--- a/Sources/Mailozaurr/SentMessages/IPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/IPendingMessageSender.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+
+using System.Threading.Tasks;
+
+
+
+namespace Mailozaurr;
+
+
+
+/// <summary>
+
+/// Provides a mechanism to send pending messages using provider-specific transports.
+
+/// </summary>
+
+public interface IPendingMessageSender {
+
+    /// <summary>Sends the pending message.</summary>
+
+    /// <param name="record">The pending message metadata.</param>
+
+    /// <param name="ct">Token used to observe cancellation requests.</param>
+
+    Task SendAsync(PendingMessageRecord record, CancellationToken ct);
+
+}
+

--- a/Sources/Mailozaurr/SentMessages/NoopPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/NoopPendingMessageSender.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+
+using System.Threading.Tasks;
+
+
+
+namespace Mailozaurr;
+
+
+
+/// <summary>
+
+/// Provides a no-operation implementation for queued messages without a provider.
+
+/// </summary>
+
+internal sealed class NoopPendingMessageSender : IPendingMessageSender {
+
+    internal static NoopPendingMessageSender Instance { get; } = new();
+
+
+
+    private NoopPendingMessageSender() {
+
+    }
+
+
+
+    public Task SendAsync(PendingMessageRecord record, CancellationToken ct) => Task.CompletedTask;
+
+}
+

--- a/Sources/Mailozaurr/SentMessages/PendingMessageSenderFactory.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageSenderFactory.cs
@@ -1,0 +1,120 @@
+using System;
+
+using System.Collections.Generic;
+
+
+
+namespace Mailozaurr;
+
+
+
+/// <summary>
+
+/// Creates provider specific <see cref="IPendingMessageSender"/> instances for queued messages.
+
+/// </summary>
+
+public sealed class PendingMessageSenderFactory {
+
+    private readonly IReadOnlyDictionary<EmailProvider, IPendingMessageSender> senders;
+
+    private readonly IPendingMessageSender fallbackSender;
+
+
+
+    /// <summary>
+
+    /// Initializes a new instance of the <see cref="PendingMessageSenderFactory"/> class.
+
+    /// </summary>
+
+    /// <param name="senders">Known provider specific senders.</param>
+
+    /// <param name="fallbackSender">The sender used when no provider specific sender is registered.</param>
+
+    public PendingMessageSenderFactory(
+
+        IEnumerable<KeyValuePair<EmailProvider, IPendingMessageSender>>? senders = null,
+
+        IPendingMessageSender? fallbackSender = null) {
+
+        this.senders = CreateMap(senders);
+
+        this.fallbackSender = fallbackSender ?? NoopPendingMessageSender.Instance;
+
+    }
+
+
+
+    /// <summary>
+
+    /// Gets the sender appropriate for the supplied <paramref name="record"/>.
+
+    /// </summary>
+
+    /// <param name="record">Pending message metadata used to select the sender.</param>
+
+    /// <returns>The sender registered for the provider or a fallback instance.</returns>
+
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="record"/> is <c>null</c>.</exception>
+
+    public IPendingMessageSender GetSender(PendingMessageRecord record) {
+
+        if (record == null) {
+
+            throw new ArgumentNullException(nameof(record));
+
+        }
+
+
+
+        if (senders.TryGetValue(record.Provider, out var sender)) {
+
+            return sender;
+
+        }
+
+
+
+        return fallbackSender;
+
+    }
+
+
+
+    private static IReadOnlyDictionary<EmailProvider, IPendingMessageSender> CreateMap(
+
+        IEnumerable<KeyValuePair<EmailProvider, IPendingMessageSender>>? entries) {
+
+        if (entries == null) {
+
+            return new Dictionary<EmailProvider, IPendingMessageSender>();
+
+        }
+
+
+
+        var map = new Dictionary<EmailProvider, IPendingMessageSender>();
+
+        foreach (var entry in entries) {
+
+            if (entry.Value == null) {
+
+                throw new ArgumentException("Sender value cannot be null.", nameof(entries));
+
+            }
+
+
+
+            map[entry.Key] = entry.Value;
+
+        }
+
+
+
+        return map;
+
+    }
+
+}
+


### PR DESCRIPTION
## Summary
- add the IPendingMessageSender abstraction for processing queued emails
- introduce a PendingMessageSenderFactory with a no-op fallback sender
- cover the selection logic with unit tests

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68c96e9c50f4832ea7690304869b8378