### PR TITLE
Add provider-specific pending message senders

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/GmailPendingMessageSenderTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/GmailPendingMessageSenderTests.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using MimeKit;
+
+namespace Mailozaurr.Tests.SentMessages;
+
+public sealed class GmailPendingMessageSenderTests {
+    private sealed class TestHandler : HttpMessageHandler {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler;
+
+        public TestHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) {
+            this.handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            handler(request, cancellationToken);
+    }
+
+    [Fact]
+    public async Task SendAsync_UsesAccessTokenAndUserId() {
+        Uri? requestUri = null;
+        string? authorization = null;
+        var handler = new TestHandler((request, _) => {
+            requestUri = request.RequestUri;
+            authorization = request.Headers.Authorization?.ToString();
+            var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("{\"id\":\"msg\",\"threadId\":\"msg\"}", Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        });
+        using var httpClient = new HttpClient(handler) {
+            BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/")
+        };
+
+        var sender = new GmailPendingMessageSender(credential => {
+            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", credential.AccessToken);
+            return new GmailApiClient(httpClient);
+        });
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+        message.Subject = "queued";
+        message.Body = new TextPart("plain") { Text = "body" };
+        using var ms = new MemoryStream();
+        await message.WriteToAsync(ms);
+
+        var record = new PendingMessageRecord {
+            MimeMessage = Convert.ToBase64String(ms.ToArray())
+        };
+        record.ProviderData[GmailPendingMessageSender.UserIdKey] = "me";
+        record.ProviderData[GmailPendingMessageSender.AccessTokenKey] = "token";
+        record.ProviderData[GmailPendingMessageSender.UserNameKey] = "me@example.com";
+        record.ProviderData[GmailPendingMessageSender.ExpiresOnKey] = DateTimeOffset.UtcNow.ToString("o", CultureInfo.InvariantCulture);
+
+        await sender.SendAsync(record, CancellationToken.None);
+
+        Assert.Equal("Bearer token", authorization);
+        Assert.Equal(new Uri("https://gmail.googleapis.com/gmail/v1/users/me/messages/send"), requestUri);
+    }
+}

--- a/Sources/Mailozaurr.Tests/SentMessages/MailgunPendingMessageSenderTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/MailgunPendingMessageSenderTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using MimeKit;
+
+namespace Mailozaurr.Tests.SentMessages;
+
+public sealed class MailgunPendingMessageSenderTests {
+    private sealed class TestHandler : HttpMessageHandler {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler;
+
+        public TestHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) {
+            if (handler == null) {
+                throw new ArgumentNullException(nameof(handler));
+            }
+            this.handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            handler(request, cancellationToken);
+    }
+
+    [Fact]
+    public async Task SendAsync_PostsMimeMessageWithBasicAuth() {
+        Uri? requestUri = null;
+        string? authorization = null;
+        string? payload = null;
+        var handler = new TestHandler(async (request, _) => {
+            requestUri = request.RequestUri;
+            authorization = request.Headers.Authorization?.ToString();
+            payload = await request.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent(string.Empty)
+            };
+        });
+        using var httpClient = new HttpClient(handler);
+        var sender = new MailgunPendingMessageSender(httpClient);
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+        message.Subject = "queued";
+        message.Body = new TextPart("plain") { Text = "body" };
+        message.MessageId = "mailgun-message";
+        using var ms = new MemoryStream();
+        await message.WriteToAsync(ms);
+
+        var record = new PendingMessageRecord {
+            MessageId = message.MessageId ?? string.Empty,
+            MimeMessage = Convert.ToBase64String(ms.ToArray())
+        };
+        record.ProviderData[MailgunPendingMessageSender.DomainKey] = "example.com";
+        record.ProviderData[MailgunPendingMessageSender.ApiKeyKey] = "key";
+
+        await sender.SendAsync(record, CancellationToken.None);
+
+        Assert.Equal(new Uri("https://api.mailgun.net/v3/example.com/messages.mime"), requestUri);
+        var expectedAuth = "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes("api:key"));
+        Assert.Equal(expectedAuth, authorization);
+        Assert.Contains("mailgun-message", payload);
+        Assert.Contains("body", payload);
+    }
+}

--- a/Sources/Mailozaurr.Tests/SentMessages/SendGridPendingMessageSenderTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/SendGridPendingMessageSenderTests.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+namespace Mailozaurr.Tests.SentMessages;
+
+public sealed class SendGridPendingMessageSenderTests {
+    private sealed class TestHandler : HttpMessageHandler {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler;
+
+        public TestHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) {
+            this.handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            handler(request, cancellationToken);
+    }
+
+    [Fact]
+    public async Task SendAsync_PostsJsonPayloadWithBearerToken() {
+        Uri? requestUri = null;
+        string? authorization = null;
+        string? payload = null;
+        var handler = new TestHandler(async (request, _) => {
+            requestUri = request.RequestUri;
+            authorization = request.Headers.Authorization?.ToString();
+            payload = await request.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.Accepted) { Content = new StringContent(string.Empty) };
+        });
+        using var httpClient = new HttpClient(handler);
+        var sender = new SendGridPendingMessageSender(httpClient);
+
+        var json = "{\"personalizations\":[]}";
+        var record = new PendingMessageRecord();
+        record.ProviderData[SendGridPendingMessageSender.MessageJsonKey] = json;
+        record.ProviderData[SendGridPendingMessageSender.ApiKeyBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes("SG.API"));
+
+        await sender.SendAsync(record, CancellationToken.None);
+
+        Assert.Equal(new Uri("https://api.sendgrid.com/v3/mail/send"), requestUri);
+        Assert.Equal("Bearer SG.API", authorization);
+        Assert.Equal(json, payload);
+    }
+}

--- a/Sources/Mailozaurr.Tests/SentMessages/SesPendingMessageSenderTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/SesPendingMessageSenderTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using MimeKit;
+
+namespace Mailozaurr.Tests.SentMessages;
+
+public sealed class SesPendingMessageSenderTests {
+    private sealed class TestHandler : HttpMessageHandler {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler;
+
+        public TestHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) {
+            this.handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            handler(request, cancellationToken);
+    }
+
+    [Fact]
+    public async Task SendAsync_ComputesAwsSignature() {
+        string? actualAuth = null;
+        string? actualDate = null;
+        Uri? requestUri = null;
+        var handler = new TestHandler((request, _) => {
+            requestUri = request.RequestUri;
+            actualAuth = request.Headers.TryGetValues("Authorization", out var authValues)
+                ? authValues.Single()
+                : null;
+            actualDate = request.Headers.TryGetValues("x-amz-date", out var dateValues)
+                ? dateValues.Single()
+                : null;
+            var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("<SendRawEmailResponse/>")
+            };
+            return Task.FromResult(response);
+        });
+        using var httpClient = new HttpClient(handler);
+        var fixedTime = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var sender = new SesPendingMessageSender(httpClient, () => fixedTime);
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+        message.Subject = "queued";
+        message.Body = new TextPart("plain") { Text = "body" };
+        using var ms = new MemoryStream();
+        await message.WriteToAsync(ms);
+
+        var record = new PendingMessageRecord {
+            MimeMessage = Convert.ToBase64String(ms.ToArray())
+        };
+        const string accessKey = "AKIDEXAMPLE";
+        const string secretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        record.ProviderData[SesPendingMessageSender.AccessKeyIdKey] = accessKey;
+        record.ProviderData[SesPendingMessageSender.SecretAccessKeyKey] = secretKey;
+        record.ProviderData[SesPendingMessageSender.RegionKey] = "us-east-1";
+
+        await sender.SendAsync(record, CancellationToken.None);
+
+        using var expected = CreateExpectedRequest(accessKey, secretKey, "us-east-1", record.MimeMessage, fixedTime);
+        var expectedAuth = expected.Headers.GetValues("Authorization").Single();
+        Assert.Equal(expectedAuth, actualAuth);
+        var expectedDate = expected.Headers.GetValues("x-amz-date").Single();
+        Assert.Equal(expectedDate, actualDate);
+        Assert.Equal(new Uri("https://email.us-east-1.amazonaws.com/"), requestUri);
+    }
+
+    private static HttpRequestMessage CreateExpectedRequest(string accessKey, string secretKey, string region, string base64Mime, DateTime now) {
+        var type = typeof(SesPendingMessageSender);
+        var buildBody = type.GetMethod("BuildRequestBody", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var body = (string)buildBody.Invoke(null, new object[] { base64Mime })!;
+        var createRequest = type.GetMethod("CreateRequest", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var request = (HttpRequestMessage)createRequest.Invoke(null, new object[] { accessKey, secretKey, region, body, now })!;
+        request.Content = new StringContent(body, Encoding.UTF8, "application/x-www-form-urlencoded");
+        return request;
+    }
+}

--- a/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageSenderTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageSenderTests.cs
@@ -1,0 +1,63 @@
+using System.Text;
+using MailKit;
+using MailKit.Security;
+using MimeKit;
+
+namespace Mailozaurr.Tests.SentMessages;
+
+public sealed class SmtpPendingMessageSenderTests {
+    private sealed class RecordingClient : ClientSmtp {
+        public string? Host { get; private set; }
+        public int Port { get; private set; }
+        public SecureSocketOptions Options { get; private set; }
+        public MimeMessage? SentMessage { get; private set; }
+        public bool WasDisconnected { get; private set; }
+        public bool WasConnected { get; private set; }
+
+        public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {
+            Host = host;
+            Port = port;
+            Options = options;
+            WasConnected = true;
+            return Task.CompletedTask;
+        }
+
+        public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {
+            SentMessage = message;
+            return Task.FromResult(message.MessageId ?? string.Empty);
+        }
+
+        public override Task DisconnectAsync(bool quit, CancellationToken cancellationToken = default) {
+            WasDisconnected = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_UsesClientFactoryToSendMessage() {
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+        message.Subject = "queued";
+        message.Body = new TextPart("plain") { Text = "body" };
+        message.MessageId = "queued-message";
+        using var ms = new MemoryStream();
+        await message.WriteToAsync(ms);
+        var record = new PendingMessageRecord {
+            MimeMessage = Convert.ToBase64String(ms.ToArray()),
+            MessageId = message.MessageId ?? string.Empty,
+            Server = "smtp.example.com",
+            Port = 2525
+        };
+
+        var client = new RecordingClient();
+        var sender = new SmtpPendingMessageSender(() => client);
+        await sender.SendAsync(record, CancellationToken.None);
+
+        Assert.Equal("smtp.example.com", client.Host);
+        Assert.Equal(2525, client.Port);
+        Assert.Equal(SecureSocketOptions.Auto, client.Options);
+        Assert.NotNull(client.SentMessage);
+        Assert.Equal("queued", client.SentMessage!.Subject);
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/Senders/GmailPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/GmailPendingMessageSender.cs
@@ -1,0 +1,73 @@
+using System.Globalization;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Sends queued Gmail messages using <see cref="GmailApiClient"/>.
+/// </summary>
+public sealed class GmailPendingMessageSender : IPendingMessageSender {
+    internal const string UserIdKey = "UserId";
+    internal const string AccessTokenKey = "AccessToken";
+    internal const string UserNameKey = "UserName";
+    internal const string ExpiresOnKey = "ExpiresOn";
+    internal const string RefreshTokenKey = "RefreshToken";
+
+    private readonly Func<OAuthCredential, GmailApiClient> clientFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GmailPendingMessageSender"/> class.
+    /// </summary>
+    /// <param name="clientFactory">Factory used to create <see cref="GmailApiClient"/> instances.</param>
+    public GmailPendingMessageSender(Func<OAuthCredential, GmailApiClient>? clientFactory = null) {
+        this.clientFactory = clientFactory ?? (credential => new GmailApiClient(credential));
+    }
+
+    /// <inheritdoc />
+    public async Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+        if (record == null) {
+            throw new ArgumentNullException(nameof(record));
+        }
+        if (!record.ProviderData.TryGetValue(UserIdKey, out var userId) || string.IsNullOrWhiteSpace(userId)) {
+            throw new InvalidOperationException("Pending Gmail message is missing the user identifier.");
+        }
+        if (!record.ProviderData.TryGetValue(AccessTokenKey, out var accessToken) || string.IsNullOrWhiteSpace(accessToken)) {
+            throw new InvalidOperationException("Pending Gmail message is missing an access token.");
+        }
+
+        var message = await LoadMessageAsync(record, ct).ConfigureAwait(false);
+        var credential = BuildCredential(record.ProviderData, accessToken, userId);
+        using var client = clientFactory(credential);
+        _ = await client.SendAsync(userId, message, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<MimeMessage> LoadMessageAsync(PendingMessageRecord record, CancellationToken ct) {
+        if (string.IsNullOrWhiteSpace(record.MimeMessage)) {
+            throw new InvalidOperationException("Pending Gmail message does not contain MIME content.");
+        }
+        var bytes = Convert.FromBase64String(record.MimeMessage);
+        using var stream = new MemoryStream(bytes);
+        return await MimeMessage.LoadAsync(stream, ct).ConfigureAwait(false);
+    }
+
+    private static OAuthCredential BuildCredential(Dictionary<string, string> providerData, string accessToken, string userId) {
+        var credential = new OAuthCredential {
+            AccessToken = accessToken,
+            UserName = providerData.TryGetValue(UserNameKey, out var userName) && !string.IsNullOrWhiteSpace(userName)
+                ? userName
+                : userId,
+            ExpiresOn = ResolveExpiration(providerData),
+        };
+        if (providerData.TryGetValue(RefreshTokenKey, out var refreshToken) && !string.IsNullOrWhiteSpace(refreshToken)) {
+            credential.RefreshToken = refreshToken;
+        }
+        return credential;
+    }
+
+    private static DateTimeOffset ResolveExpiration(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(ExpiresOnKey, out var value) && !string.IsNullOrWhiteSpace(value) &&
+            DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed)) {
+            return parsed;
+        }
+        return DateTimeOffset.MaxValue;
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/Senders/MailgunPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/MailgunPendingMessageSender.cs
@@ -1,0 +1,80 @@
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Sends queued Mailgun messages using the REST API.
+/// </summary>
+public sealed class MailgunPendingMessageSender : IPendingMessageSender {
+    internal const string DomainKey = "Domain";
+    internal const string ApiKeyKey = "ApiKey";
+    internal const string ApiKeyBase64Key = "ApiKeyBase64";
+    internal const string EndpointKey = "Endpoint";
+
+    private readonly HttpClient httpClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MailgunPendingMessageSender"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client used to send requests.</param>
+    public MailgunPendingMessageSender(HttpClient? httpClient = null) {
+        this.httpClient = httpClient ?? Helpers.SharedHttpClient;
+    }
+
+    /// <inheritdoc />
+    public async Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+        if (record == null) {
+            throw new ArgumentNullException(nameof(record));
+        }
+        if (string.IsNullOrWhiteSpace(record.MimeMessage)) {
+            throw new InvalidOperationException("Pending Mailgun message does not contain MIME content.");
+        }
+        if (!record.ProviderData.TryGetValue(DomainKey, out var domain) || string.IsNullOrWhiteSpace(domain)) {
+            throw new InvalidOperationException("Pending Mailgun message is missing the Mailgun domain.");
+        }
+        var apiKey = ResolveApiKey(record.ProviderData);
+        var endpoint = ResolveEndpoint(record.ProviderData, domain);
+        var bytes = Convert.FromBase64String(record.MimeMessage);
+
+        using var content = new MultipartFormDataContent();
+        using var messageContent = new ByteArrayContent(bytes);
+        messageContent.Headers.ContentType = new MediaTypeHeaderValue("message/rfc822");
+        var fileName = string.IsNullOrWhiteSpace(record.MessageId) ? "message.eml" : $"{record.MessageId}.eml";
+        content.Add(messageContent, "message", fileName);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint) {
+            Content = content
+        };
+        var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"api:{apiKey}"));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+
+        using var response = await httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode) {
+#if NET5_0_OR_GREATER
+            var error = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+#else
+            var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+            throw new HttpRequestException($"Mailgun returned {(int)response.StatusCode} ({response.StatusCode}): {error}");
+        }
+    }
+
+    private static Uri ResolveEndpoint(Dictionary<string, string> providerData, string domain) {
+        if (providerData.TryGetValue(EndpointKey, out var value) && !string.IsNullOrWhiteSpace(value) && Uri.TryCreate(value, UriKind.Absolute, out var uri)) {
+            return uri;
+        }
+        return new Uri($"https://api.mailgun.net/v3/{domain}/messages.mime");
+    }
+
+    private static string ResolveApiKey(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(ApiKeyBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
+            var bytes = Convert.FromBase64String(encoded);
+            return Encoding.UTF8.GetString(bytes);
+        }
+        if (providerData.TryGetValue(ApiKeyKey, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            return value;
+        }
+        throw new InvalidOperationException("Pending Mailgun message is missing API key information.");
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/Senders/SendGridPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/SendGridPendingMessageSender.cs
@@ -1,0 +1,70 @@
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Sends queued SendGrid messages using the REST API.
+/// </summary>
+public sealed class SendGridPendingMessageSender : IPendingMessageSender {
+    internal const string MessageJsonKey = "MessageJson";
+    internal const string ApiKeyKey = "ApiKey";
+    internal const string ApiKeyBase64Key = "ApiKeyBase64";
+    internal const string EndpointKey = "Endpoint";
+
+    private static readonly Uri DefaultEndpoint = new("https://api.sendgrid.com/v3/mail/send");
+
+    private readonly HttpClient httpClient;
+    private readonly Uri endpoint;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SendGridPendingMessageSender"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client used to send requests.</param>
+    /// <param name="endpoint">Optional override for the SendGrid endpoint.</param>
+    public SendGridPendingMessageSender(HttpClient? httpClient = null, Uri? endpoint = null) {
+        this.httpClient = httpClient ?? Helpers.SharedHttpClient;
+        this.endpoint = endpoint ?? DefaultEndpoint;
+    }
+
+    /// <inheritdoc />
+    public async Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+        if (record == null) {
+            throw new ArgumentNullException(nameof(record));
+        }
+        if (!record.ProviderData.TryGetValue(MessageJsonKey, out var json) || string.IsNullOrWhiteSpace(json)) {
+            throw new InvalidOperationException("Pending SendGrid message is missing serialized payload.");
+        }
+        var apiKey = ResolveApiKey(record.ProviderData);
+        using var request = new HttpRequestMessage(HttpMethod.Post, ResolveEndpoint(record.ProviderData));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var response = await httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode) {
+#if NET5_0_OR_GREATER
+            var error = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+#else
+            var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+            throw new HttpRequestException($"SendGrid returned {(int)response.StatusCode} ({response.StatusCode}): {error}");
+        }
+    }
+
+    private static Uri ResolveEndpoint(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(EndpointKey, out var value) && !string.IsNullOrWhiteSpace(value) && Uri.TryCreate(value, UriKind.Absolute, out var uri)) {
+            return uri;
+        }
+        return DefaultEndpoint;
+    }
+
+    private static string ResolveApiKey(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(ApiKeyBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
+            var bytes = Convert.FromBase64String(encoded);
+            return Encoding.UTF8.GetString(bytes);
+        }
+        if (providerData.TryGetValue(ApiKeyKey, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            return value;
+        }
+        throw new InvalidOperationException("Pending SendGrid message is missing API key information.");
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/Senders/SesPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/SesPendingMessageSender.cs
@@ -1,0 +1,111 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Sends queued Amazon SES messages using the REST API.
+/// </summary>
+public sealed class SesPendingMessageSender : IPendingMessageSender {
+    internal const string AccessKeyIdKey = "AccessKeyId";
+    internal const string SecretAccessKeyKey = "SecretAccessKey";
+    internal const string RegionKey = "Region";
+
+    private readonly HttpClient httpClient;
+    private readonly Func<DateTime> utcNow;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SesPendingMessageSender"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client used to send requests.</param>
+    /// <param name="utcNow">Clock used for signing requests.</param>
+    public SesPendingMessageSender(HttpClient? httpClient = null, Func<DateTime>? utcNow = null) {
+        this.httpClient = httpClient ?? Helpers.SharedHttpClient;
+        this.utcNow = utcNow ?? (() => DateTime.UtcNow);
+    }
+
+    /// <inheritdoc />
+    public async Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+        if (record == null) {
+            throw new ArgumentNullException(nameof(record));
+        }
+        if (string.IsNullOrWhiteSpace(record.MimeMessage)) {
+            throw new InvalidOperationException("Pending SES message does not contain MIME content.");
+        }
+        if (!record.ProviderData.TryGetValue(AccessKeyIdKey, out var accessKey) || string.IsNullOrWhiteSpace(accessKey)) {
+            throw new InvalidOperationException("Pending SES message is missing the AWS access key identifier.");
+        }
+        if (!record.ProviderData.TryGetValue(SecretAccessKeyKey, out var secretKey) || string.IsNullOrWhiteSpace(secretKey)) {
+            throw new InvalidOperationException("Pending SES message is missing the AWS secret access key.");
+        }
+        var region = record.ProviderData.TryGetValue(RegionKey, out var regionValue) && !string.IsNullOrWhiteSpace(regionValue)
+            ? regionValue
+            : "us-east-1";
+
+        var body = BuildRequestBody(record.MimeMessage);
+        var request = CreateRequest(accessKey, secretKey, region, body, utcNow());
+        request.Content = new StringContent(body, Encoding.UTF8, "application/x-www-form-urlencoded");
+
+        using (request)
+        using (var response = await httpClient.SendAsync(request, ct).ConfigureAwait(false)) {
+            if (!response.IsSuccessStatusCode) {
+#if NET5_0_OR_GREATER
+                var error = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+#else
+                var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+                throw new HttpRequestException($"SES returned {(int)response.StatusCode} ({response.StatusCode}): {error}");
+            }
+        }
+    }
+
+    private static string BuildRequestBody(string mimeMessageBase64) {
+        return $"Action=SendRawEmail&RawMessage.Data={Uri.EscapeDataString(mimeMessageBase64)}&Version=2010-12-01";
+    }
+
+    private static HttpRequestMessage CreateRequest(string accessKey, string secretKey, string region, string content, DateTime nowUtc) {
+        var request = new HttpRequestMessage(HttpMethod.Post, new Uri($"https://email.{region}.amazonaws.com/"));
+        var amzDate = nowUtc.ToString("yyyyMMdd'T'HHmmss'Z'", CultureInfo.InvariantCulture);
+        var dateStamp = nowUtc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+        var canonicalHeaders = $"content-type:application/x-www-form-urlencoded\nhost:email.{region}.amazonaws.com\nx-amz-date:{amzDate}\n";
+        const string signedHeaders = "content-type;host;x-amz-date";
+        var payloadHash = Sha256Hex(content);
+        var canonicalRequest = $"POST\n/\n\n{canonicalHeaders}\n{signedHeaders}\n{payloadHash}";
+        var credentialScope = $"{dateStamp}/{region}/ses/aws4_request";
+        var stringToSign = $"AWS4-HMAC-SHA256\n{amzDate}\n{credentialScope}\n{Sha256Hex(canonicalRequest)}";
+        var signingKey = GetSignatureKey(secretKey, dateStamp, region, "ses");
+        var signature = ToHex(HmacSha256(signingKey, stringToSign));
+        var authorization = $"AWS4-HMAC-SHA256 Credential={accessKey}/{credentialScope}, SignedHeaders={signedHeaders}, Signature={signature}";
+
+        request.Headers.TryAddWithoutValidation("x-amz-date", amzDate);
+        request.Headers.TryAddWithoutValidation("Authorization", authorization);
+        return request;
+    }
+
+    private static byte[] GetSignatureKey(string key, string dateStamp, string regionName, string serviceName) {
+        var kDate = HmacSha256(Encoding.UTF8.GetBytes("AWS4" + key), dateStamp);
+        var kRegion = HmacSha256(kDate, regionName);
+        var kService = HmacSha256(kRegion, serviceName);
+        return HmacSha256(kService, "aws4_request");
+    }
+
+    private static byte[] HmacSha256(byte[] key, string data) {
+        using var hmac = new HMACSHA256(key);
+        return hmac.ComputeHash(Encoding.UTF8.GetBytes(data));
+    }
+
+    private static string Sha256Hex(string data) {
+        using var sha = SHA256.Create();
+        var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(data));
+        return ToHex(hash);
+    }
+
+    private static string ToHex(byte[] bytes) {
+        var builder = new StringBuilder(bytes.Length * 2);
+        for (var i = 0; i < bytes.Length; i++) {
+            builder.Append(bytes[i].ToString("x2", CultureInfo.InvariantCulture));
+        }
+        return builder.ToString();
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/Senders/SmtpPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/SmtpPendingMessageSender.cs
@@ -1,0 +1,151 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Sends queued SMTP messages using <see cref="ClientSmtp"/>.
+/// </summary>
+public sealed class SmtpPendingMessageSender : IPendingMessageSender {
+    private const string SecureSocketOptionsKey = "SecureSocketOptions";
+    private const string UseSslKey = "UseSsl";
+    private const string SkipCertificateValidationKey = "SkipCertificateValidation";
+    private const string CheckCertificateRevocationKey = "CheckCertificateRevocation";
+    private const string TimeoutKey = "TimeoutMilliseconds";
+
+    private readonly Func<ClientSmtp> clientFactory;
+    private readonly SecureSocketOptions defaultSecureSocketOptions;
+    private readonly bool defaultUseSsl;
+    private readonly bool defaultSkipCertificateValidation;
+    private readonly bool defaultCheckCertificateRevocation;
+    private readonly int? defaultTimeout;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmtpPendingMessageSender"/> class.
+    /// </summary>
+    /// <param name="clientFactory">Factory used to create <see cref="ClientSmtp"/> instances.</param>
+    /// <param name="secureSocketOptions">Default secure socket options.</param>
+    /// <param name="useSsl">Whether SSL should be forced when options are auto.</param>
+    /// <param name="skipCertificateValidation">Whether certificate validation should be skipped.</param>
+    /// <param name="checkCertificateRevocation">Whether certificate revocation should be checked.</param>
+    /// <param name="timeout">Optional operation timeout in milliseconds.</param>
+    public SmtpPendingMessageSender(
+        Func<ClientSmtp>? clientFactory = null,
+        SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto,
+        bool useSsl = false,
+        bool skipCertificateValidation = false,
+        bool checkCertificateRevocation = true,
+        int? timeout = null) {
+        this.clientFactory = clientFactory ?? (() => Smtp.ClientFactory(null));
+        defaultSecureSocketOptions = secureSocketOptions;
+        defaultUseSsl = useSsl;
+        defaultSkipCertificateValidation = skipCertificateValidation;
+        defaultCheckCertificateRevocation = checkCertificateRevocation;
+        defaultTimeout = timeout;
+    }
+
+    /// <inheritdoc />
+    public async Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+        if (record == null) {
+            throw new ArgumentNullException(nameof(record));
+        }
+        if (string.IsNullOrWhiteSpace(record.MimeMessage)) {
+            throw new InvalidOperationException("Pending message does not contain a MIME payload.");
+        }
+        if (string.IsNullOrWhiteSpace(record.Server)) {
+            throw new InvalidOperationException("Pending message is missing SMTP server information.");
+        }
+
+        var message = await LoadMessageAsync(record, ct).ConfigureAwait(false);
+        var secureSocketOptions = ResolveSecureSocketOptions(record.ProviderData);
+        var useSsl = ResolveBool(record.ProviderData, UseSslKey, defaultUseSsl);
+        if (useSsl && secureSocketOptions == SecureSocketOptions.Auto) {
+            secureSocketOptions = SecureSocketOptions.StartTls;
+        }
+        var skipValidation = ResolveBool(record.ProviderData, SkipCertificateValidationKey, defaultSkipCertificateValidation);
+        var checkRevocation = ResolveBool(record.ProviderData, CheckCertificateRevocationKey, defaultCheckCertificateRevocation);
+        var timeout = ResolveInt(record.ProviderData, TimeoutKey, defaultTimeout);
+
+        var port = record.Port ?? 25;
+        using var client = clientFactory();
+        if (timeout.HasValue) {
+            client.Timeout = timeout.Value;
+        }
+        if (skipValidation) {
+            client.ServerCertificateValidationCallback = (_, _, _, _) => true;
+        }
+        client.CheckCertificateRevocation = checkRevocation;
+
+        try {
+            await client.ConnectAsync(record.Server, port, secureSocketOptions, ct).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(record.UserName)) {
+                var password = DecodePassword(record.Password);
+                await client.AuthenticateAsync(record.UserName, password, ct).ConfigureAwait(false);
+            }
+            await client.SendAsync(message, ct).ConfigureAwait(false);
+        } finally {
+            try {
+                if (client.IsConnected) {
+                    await client.DisconnectAsync(true, ct).ConfigureAwait(false);
+                }
+            } catch {
+                // Ignored - disconnect best effort.
+            }
+        }
+    }
+
+    private static async Task<MimeMessage> LoadMessageAsync(PendingMessageRecord record, CancellationToken ct) {
+        var bytes = Convert.FromBase64String(record.MimeMessage);
+        using var stream = new MemoryStream(bytes);
+        return await MimeMessage.LoadAsync(stream, ct).ConfigureAwait(false);
+    }
+
+    private SecureSocketOptions ResolveSecureSocketOptions(Dictionary<string, string> providerData) {
+        if (providerData == null) {
+            return defaultSecureSocketOptions;
+        }
+        if (providerData.TryGetValue(SecureSocketOptionsKey, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            if (Enum.TryParse(value, ignoreCase: true, out SecureSocketOptions parsed)) {
+                return parsed;
+            }
+            if (int.TryParse(value, out var numeric) && Enum.IsDefined(typeof(SecureSocketOptions), numeric)) {
+                return (SecureSocketOptions)numeric;
+            }
+        }
+        return defaultSecureSocketOptions;
+    }
+
+    private static bool ResolveBool(Dictionary<string, string> providerData, string key, bool defaultValue) {
+        if (providerData != null && providerData.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            if (bool.TryParse(value, out var parsed)) {
+                return parsed;
+            }
+            if (int.TryParse(value, out var numeric)) {
+                return numeric != 0;
+            }
+        }
+        return defaultValue;
+    }
+
+    private static int? ResolveInt(Dictionary<string, string> providerData, string key, int? defaultValue) {
+        if (providerData != null && providerData.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)) {
+                return parsed;
+            }
+        }
+        return defaultValue;
+    }
+
+    private static string DecodePassword(string? password) {
+        if (string.IsNullOrEmpty(password)) {
+            return string.Empty;
+        }
+        byte[] data = Convert.FromBase64String(password);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            data = ProtectedData.Unprotect(data, null, DataProtectionScope.CurrentUser);
+        }
+        return Encoding.UTF8.GetString(data);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce SMTP, SendGrid, Gmail, Mailgun, and SES pending message senders that implement IPendingMessageSender
- wire provider-specific retry/send logic into the new sender classes using existing transport clients
- add unit tests that exercise each sender's request construction and integration points

## Testing
- dotnet test Mailozaurr/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68ca59396e30832ebf62dfa7d70195d3