### PR TITLE
Add provider mapping to pending message sender factory

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageSenderFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageSenderFactoryTests.cs
@@ -1,86 +1,78 @@
 using System;
-
 using System.Collections.Generic;
-
 using System.Threading;
-
 using System.Threading.Tasks;
-
-
 
 namespace Mailozaurr.Tests;
 
-
-
 public sealed class PendingMessageSenderFactoryTests {
-
     private sealed class TestSender : IPendingMessageSender {
-
         public Task SendAsync(PendingMessageRecord record, CancellationToken ct) => Task.CompletedTask;
-
     }
 
-
-
     [Fact]
-
     public void GetSender_ReturnsRegisteredSender() {
-
         var sender = new TestSender();
-
         var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
-
             { EmailProvider.SendGrid, sender }
-
         });
-
-
 
         var record = new PendingMessageRecord { Provider = EmailProvider.SendGrid };
 
-
-
         var result = factory.GetSender(record);
-
-
 
         Assert.Same(sender, result);
-
     }
 
-
-
     [Fact]
-
-    public void GetSender_ReturnsNoopWhenProviderMissing() {
-
+    public void GetSender_ReturnsNoopWhenProviderUnknown() {
         var factory = new PendingMessageSenderFactory();
-
-        var record = new PendingMessageRecord { Provider = EmailProvider.Mailgun };
-
-
+        var record = new PendingMessageRecord { Provider = (EmailProvider)int.MaxValue };
 
         var result = factory.GetSender(record);
 
-
-
-        Assert.IsType<NoopPendingMessageSender>(result);
-
+        Assert.Same(NoopPendingMessageSender.Instance, result);
     }
-
-
 
     [Fact]
-
     public void GetSender_ThrowsWhenRecordIsNull() {
-
         var factory = new PendingMessageSenderFactory();
 
-
-
         Assert.Throws<ArgumentNullException>(() => factory.GetSender(null!));
-
     }
 
-}
+    [Fact]
+    public void Resolve_ReturnsRegisteredSender() {
+        var sender = new TestSender();
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.Mailgun, sender }
+        });
 
+        var result = factory.Resolve(EmailProvider.Mailgun);
+
+        Assert.Same(sender, result);
+    }
+
+    [Theory]
+    [InlineData(EmailProvider.None, typeof(SmtpPendingMessageSender))]
+    [InlineData(EmailProvider.SendGrid, typeof(SendGridPendingMessageSender))]
+    [InlineData(EmailProvider.Mailgun, typeof(MailgunPendingMessageSender))]
+    [InlineData(EmailProvider.SES, typeof(SesPendingMessageSender))]
+    [InlineData(EmailProvider.Gmail, typeof(GmailPendingMessageSender))]
+    public void Resolve_ReturnsDefaultSenderForKnownProviders(EmailProvider provider, Type expectedType) {
+        var factory = new PendingMessageSenderFactory();
+
+        var result = factory.Resolve(provider);
+
+        Assert.IsType(expectedType, result);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsFallbackForUnknownProvider() {
+        var factory = new PendingMessageSenderFactory();
+
+        var result = factory.Resolve((EmailProvider)int.MaxValue);
+
+        Assert.Same(NoopPendingMessageSender.Instance, result);
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/PendingMessageSenderFactory.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageSenderFactory.cs
@@ -1,120 +1,80 @@
 using System;
-
 using System.Collections.Generic;
-
-
 
 namespace Mailozaurr;
 
-
-
 /// <summary>
-
 /// Creates provider specific <see cref="IPendingMessageSender"/> instances for queued messages.
-
 /// </summary>
-
 public sealed class PendingMessageSenderFactory {
-
     private readonly IReadOnlyDictionary<EmailProvider, IPendingMessageSender> senders;
-
     private readonly IPendingMessageSender fallbackSender;
 
-
-
     /// <summary>
-
     /// Initializes a new instance of the <see cref="PendingMessageSenderFactory"/> class.
-
     /// </summary>
-
     /// <param name="senders">Known provider specific senders.</param>
-
     /// <param name="fallbackSender">The sender used when no provider specific sender is registered.</param>
-
     public PendingMessageSenderFactory(
-
         IEnumerable<KeyValuePair<EmailProvider, IPendingMessageSender>>? senders = null,
-
         IPendingMessageSender? fallbackSender = null) {
-
         this.senders = CreateMap(senders);
-
         this.fallbackSender = fallbackSender ?? NoopPendingMessageSender.Instance;
-
     }
 
+    /// <summary>
+    /// Gets the sender appropriate for the supplied <paramref name="record"/>.
+    /// </summary>
+    /// <param name="record">Pending message metadata used to select the sender.</param>
+    /// <returns>The sender registered for the provider or a fallback instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="record"/> is <c>null</c>.</exception>
+    public IPendingMessageSender GetSender(PendingMessageRecord record) {
+        if (record == null) {
+            throw new ArgumentNullException(nameof(record));
+        }
 
+        return Resolve(record.Provider);
+    }
 
     /// <summary>
-
-    /// Gets the sender appropriate for the supplied <paramref name="record"/>.
-
+    /// Resolves the sender registered for <paramref name="provider"/>.
     /// </summary>
-
-    /// <param name="record">Pending message metadata used to select the sender.</param>
-
+    /// <param name="provider">The provider whose sender should be returned.</param>
     /// <returns>The sender registered for the provider or a fallback instance.</returns>
-
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="record"/> is <c>null</c>.</exception>
-
-    public IPendingMessageSender GetSender(PendingMessageRecord record) {
-
-        if (record == null) {
-
-            throw new ArgumentNullException(nameof(record));
-
-        }
-
-
-
-        if (senders.TryGetValue(record.Provider, out var sender)) {
-
+    public IPendingMessageSender Resolve(EmailProvider provider) {
+        if (senders.TryGetValue(provider, out var sender)) {
             return sender;
-
         }
-
-
 
         return fallbackSender;
-
     }
-
-
 
     private static IReadOnlyDictionary<EmailProvider, IPendingMessageSender> CreateMap(
-
         IEnumerable<KeyValuePair<EmailProvider, IPendingMessageSender>>? entries) {
-
-        if (entries == null) {
-
-            return new Dictionary<EmailProvider, IPendingMessageSender>();
-
-        }
-
-
-
         var map = new Dictionary<EmailProvider, IPendingMessageSender>();
 
-        foreach (var entry in entries) {
-
-            if (entry.Value == null) {
-
-                throw new ArgumentException("Sender value cannot be null.", nameof(entries));
-
-            }
-
-
-
-            map[entry.Key] = entry.Value;
-
+        foreach (var defaultEntry in CreateDefaultSenders()) {
+            map[defaultEntry.Key] = defaultEntry.Value;
         }
 
+        if (entries != null) {
+            foreach (var entry in entries) {
+                if (entry.Value == null) {
+                    throw new ArgumentException("Sender value cannot be null.", nameof(entries));
+                }
 
+                map[entry.Key] = entry.Value;
+            }
+        }
 
         return map;
-
     }
 
+    private static IEnumerable<KeyValuePair<EmailProvider, IPendingMessageSender>> CreateDefaultSenders() {
+        yield return new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.None, new SmtpPendingMessageSender());
+        yield return new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.SendGrid, new SendGridPendingMessageSender());
+        yield return new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.Mailgun, new MailgunPendingMessageSender());
+        yield return new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.SES, new SesPendingMessageSender());
+        yield return new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.Gmail, new GmailPendingMessageSender());
+    }
 }
-


### PR DESCRIPTION
## Summary
- add default provider registry in `PendingMessageSenderFactory`
- expose `Resolve` helper to fetch sender by `EmailProvider`
- expand unit tests to cover default mapping and fallback behaviour

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68ca61565530832e8082b61c62e3b28f