### PR TITLE
Add pending message processor for queued emails

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -57,6 +58,86 @@ public sealed class PendingMessageProcessorTests {
         }
     }
 
+    private sealed class RecordingObserver : IPendingMessageProcessorObserver {
+        public List<(PendingMessageRecord Record, PendingMessageSkipReason Reason)> Skipped { get; } = new();
+        public List<(PendingMessageRecord Record, int Attempt)> Started { get; } = new();
+        public List<(PendingMessageRecord Record, int Attempt, TimeSpan Duration)> Sent { get; } = new();
+        public List<MessageFailureEvent> Failed { get; } = new();
+        public List<MessageDropEvent> Dropped { get; } = new();
+
+        public void MessageSkipped(PendingMessageRecord record, PendingMessageSkipReason reason) {
+            Skipped.Add((record, reason));
+        }
+
+        public void MessageAttemptStarted(PendingMessageRecord record, int attempt) {
+            Started.Add((record, attempt));
+        }
+
+        public void MessageSent(PendingMessageRecord record, int attempt, TimeSpan duration) {
+            Sent.Add((record, attempt, duration));
+        }
+
+        public void MessageFailed(
+            PendingMessageRecord record,
+            int attempt,
+            Exception exception,
+            TimeSpan duration,
+            bool willRetry,
+            TimeSpan? retryDelay) {
+            Failed.Add(new MessageFailureEvent(record, attempt, exception, duration, willRetry, retryDelay));
+        }
+
+        public void MessageDropped(
+            PendingMessageRecord record,
+            int attempt,
+            PendingMessageDropReason reason,
+            Exception? exception) {
+            Dropped.Add(new MessageDropEvent(record, attempt, reason, exception));
+        }
+
+        public sealed class MessageFailureEvent {
+            public MessageFailureEvent(
+                PendingMessageRecord record,
+                int attempt,
+                Exception exception,
+                TimeSpan duration,
+                bool willRetry,
+                TimeSpan? retryDelay) {
+                Record = record;
+                Attempt = attempt;
+                Exception = exception;
+                Duration = duration;
+                WillRetry = willRetry;
+                RetryDelay = retryDelay;
+            }
+
+            public PendingMessageRecord Record { get; }
+            public int Attempt { get; }
+            public Exception Exception { get; }
+            public TimeSpan Duration { get; }
+            public bool WillRetry { get; }
+            public TimeSpan? RetryDelay { get; }
+        }
+
+        public sealed class MessageDropEvent {
+            public MessageDropEvent(
+                PendingMessageRecord record,
+                int attempt,
+                PendingMessageDropReason reason,
+                Exception? exception) {
+                Record = record;
+                Attempt = attempt;
+                Reason = reason;
+                Exception = exception;
+            }
+
+            public PendingMessageRecord Record { get; }
+            public int Attempt { get; }
+            public PendingMessageDropReason Reason { get; }
+            public Exception? Exception { get; }
+        }
+    }
+
     private static PendingMessageRecord CreateRecord(DateTimeOffset nextAttempt, string? messageId = null) => new() {
         MessageId = messageId ?? Guid.NewGuid().ToString("N"),
         Timestamp = nextAttempt,
@@ -71,6 +152,7 @@ public sealed class PendingMessageProcessorTests {
         var record = CreateRecord(currentTime.AddMinutes(-5));
         repository.Add(record);
         var sender = new RecordingPendingMessageSender();
+        var observer = new RecordingObserver();
         var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
             { EmailProvider.None, sender }
         });
@@ -78,13 +160,19 @@ public sealed class PendingMessageProcessorTests {
             repository,
             factory,
             retryDelaySelector: _ => TimeSpan.FromMinutes(1),
-            clock: () => currentTime);
+            clock: () => currentTime,
+            observer: observer);
 
         await processor.ProcessAsync();
 
         Assert.False(repository.Contains(record.MessageId));
         Assert.Single(sender.SentRecords);
         Assert.Equal(1, sender.SentRecords[0].AttemptCount);
+        Assert.Single(observer.Started);
+        Assert.Single(observer.Sent);
+        Assert.Empty(observer.Failed);
+        Assert.Equal(1, observer.Started[0].Attempt);
+        Assert.True(observer.Sent[0].Duration >= TimeSpan.Zero);
     }
 
     [Fact]
@@ -98,6 +186,7 @@ public sealed class PendingMessageProcessorTests {
             ExceptionToThrow = new Exception("Send failure")
         };
         var delay = TimeSpan.FromMinutes(15);
+        var observer = new RecordingObserver();
         var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
             { EmailProvider.None, sender }
         });
@@ -105,7 +194,8 @@ public sealed class PendingMessageProcessorTests {
             repository,
             factory,
             retryDelaySelector: _ => delay,
-            clock: () => currentTime);
+            clock: () => currentTime,
+            observer: observer);
 
         await processor.ProcessAsync();
 
@@ -114,6 +204,10 @@ public sealed class PendingMessageProcessorTests {
         Assert.True(repository.Contains(record.MessageId));
         Assert.Equal(1, stored!.AttemptCount);
         Assert.Equal(currentTime + delay, stored.NextAttemptAt);
+        var failure = Assert.Single(observer.Failed);
+        Assert.True(failure.WillRetry);
+        Assert.True(failure.RetryDelay.HasValue);
+        Assert.Equal(delay, failure.RetryDelay.Value);
     }
 
     [Fact]
@@ -123,6 +217,7 @@ public sealed class PendingMessageProcessorTests {
         var record = CreateRecord(currentTime.AddMinutes(10));
         repository.Add(record);
         var sender = new RecordingPendingMessageSender();
+        var observer = new RecordingObserver();
         var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
             { EmailProvider.None, sender }
         });
@@ -130,7 +225,8 @@ public sealed class PendingMessageProcessorTests {
             repository,
             factory,
             retryDelaySelector: _ => TimeSpan.FromMinutes(5),
-            clock: () => currentTime);
+            clock: () => currentTime,
+            observer: observer);
 
         await processor.ProcessAsync();
 
@@ -140,6 +236,8 @@ public sealed class PendingMessageProcessorTests {
         Assert.Equal(0, stored!.AttemptCount);
         Assert.Empty(sender.SentRecords);
         Assert.Equal(record.NextAttemptAt, stored.NextAttemptAt);
+        Assert.Single(observer.Skipped);
+        Assert.Equal(PendingMessageSkipReason.NotDue, observer.Skipped[0].Reason);
     }
 
     [Fact]
@@ -151,10 +249,11 @@ public sealed class PendingMessageProcessorTests {
         repository.Add(invalid);
         repository.Add(valid);
         var sender = new RecordingPendingMessageSender();
+        var observer = new RecordingObserver();
         var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
             { EmailProvider.None, sender }
         });
-        var processor = new PendingMessageProcessor(repository, factory, clock: () => currentTime);
+        var processor = new PendingMessageProcessor(repository, factory, clock: () => currentTime, observer: observer);
 
         await processor.ProcessAsync();
 
@@ -162,6 +261,8 @@ public sealed class PendingMessageProcessorTests {
         Assert.False(repository.Contains(valid.MessageId));
         Assert.Single(sender.SentRecords);
         Assert.Equal(valid.MessageId, sender.SentRecords[0].MessageId);
+        Assert.Single(observer.Skipped);
+        Assert.Equal(PendingMessageSkipReason.MissingMessageId, observer.Skipped[0].Reason);
     }
 
     [Fact]
@@ -174,15 +275,21 @@ public sealed class PendingMessageProcessorTests {
             ShouldThrow = true,
             ExceptionToThrow = new InvalidOperationException("Permanent failure")
         };
+        var observer = new RecordingObserver();
         var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
             { EmailProvider.None, sender }
         });
-        var processor = new PendingMessageProcessor(repository, factory, clock: () => currentTime);
+        var processor = new PendingMessageProcessor(repository, factory, clock: () => currentTime, observer: observer);
 
         await processor.ProcessAsync();
 
         Assert.False(repository.Contains(record.MessageId));
         Assert.Single(sender.SentRecords);
+        var failure = Assert.Single(observer.Failed);
+        Assert.False(failure.WillRetry);
+        Assert.Null(failure.RetryDelay);
+        var drop = Assert.Single(observer.Dropped);
+        Assert.Equal(PendingMessageDropReason.PermanentFailure, drop.Reason);
     }
 
     [Fact]
@@ -218,16 +325,20 @@ public sealed class PendingMessageProcessorTests {
         record.AttemptCount = 5;
         repository.Add(record);
         var sender = new RecordingPendingMessageSender();
+        var observer = new RecordingObserver();
         var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
             { EmailProvider.None, sender }
         });
-        var processor = new PendingMessageProcessor(repository, factory, clock: () => currentTime, maxRetryAttempts: 5);
+        var processor = new PendingMessageProcessor(repository, factory, clock: () => currentTime, maxRetryAttempts: 5, observer: observer);
 
         await processor.ProcessAsync();
 
         Assert.False(repository.Contains(record.MessageId));
         Assert.Empty(sender.SentRecords);
         Assert.Equal(5, record.AttemptCount);
+        Assert.Single(observer.Dropped);
+        Assert.Equal(PendingMessageDropReason.RetryLimitReached, observer.Dropped[0].Reason);
+        Assert.Equal(5, observer.Dropped[0].Attempt);
     }
 
     [Fact]
@@ -241,6 +352,7 @@ public sealed class PendingMessageProcessorTests {
             ShouldThrow = true,
             ExceptionToThrow = new Exception("Transient failure")
         };
+        var observer = new RecordingObserver();
         var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
             { EmailProvider.None, sender }
         });
@@ -249,12 +361,82 @@ public sealed class PendingMessageProcessorTests {
             factory,
             retryDelaySelector: _ => TimeSpan.FromMinutes(5),
             clock: () => currentTime,
-            maxRetryAttempts: 5);
+            maxRetryAttempts: 5,
+            observer: observer);
 
         await processor.ProcessAsync();
 
         Assert.False(repository.Contains(record.MessageId));
         Assert.Single(sender.SentRecords);
         Assert.Equal(5, record.AttemptCount);
+        var failure = Assert.Single(observer.Failed);
+        Assert.False(failure.WillRetry);
+        Assert.Null(failure.RetryDelay);
+        var drop = Assert.Single(observer.Dropped);
+        Assert.Equal(PendingMessageDropReason.RetryLimitReached, drop.Reason);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UsesCustomPermanentFailureDetector() {
+        var currentTime = DateTimeOffset.Parse("2024-06-09T12:00:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime.AddMinutes(-1));
+        repository.Add(record);
+        var sender = new RecordingPendingMessageSender {
+            ShouldThrow = true,
+            ExceptionToThrow = new HttpRequestException("Unrecoverable remote error")
+        };
+        var observer = new RecordingObserver();
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(
+            repository,
+            factory,
+            clock: () => currentTime,
+            observer: observer,
+            permanentFailureDetector: ex => ex is HttpRequestException);
+
+        await processor.ProcessAsync();
+
+        Assert.False(repository.Contains(record.MessageId));
+        var failure = Assert.Single(observer.Failed);
+        Assert.False(failure.WillRetry);
+        Assert.Null(failure.RetryDelay);
+        var drop = Assert.Single(observer.Dropped);
+        Assert.Equal(PendingMessageDropReason.PermanentFailure, drop.Reason);
+        Assert.IsType<HttpRequestException>(drop.Exception);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NormalizesNegativeRetryDelayToZero() {
+        var currentTime = DateTimeOffset.Parse("2024-06-10T10:15:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime.AddMinutes(-1));
+        repository.Add(record);
+        var sender = new RecordingPendingMessageSender {
+            ShouldThrow = true,
+            ExceptionToThrow = new Exception("Transient")
+        };
+        var observer = new RecordingObserver();
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(
+            repository,
+            factory,
+            retryDelaySelector: _ => TimeSpan.FromMinutes(-5),
+            clock: () => currentTime,
+            observer: observer,
+            maxRetryAttempts: 3);
+
+        await processor.ProcessAsync();
+
+        var stored = await repository.GetByMessageIdAsync(record.MessageId);
+        Assert.NotNull(stored);
+        Assert.Equal(currentTime, stored!.NextAttemptAt);
+        var failure = Assert.Single(observer.Failed);
+        Assert.True(failure.RetryDelay.HasValue);
+        Assert.Equal(TimeSpan.Zero, failure.RetryDelay.Value);
     }
 }

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
@@ -58,6 +58,20 @@ public sealed class PendingMessageProcessorTests {
         }
     }
 
+    private sealed class CancellingPendingMessageSender : IPendingMessageSender {
+        private readonly CancellationTokenSource cts;
+
+        public CancellingPendingMessageSender(CancellationTokenSource cts) {
+            this.cts = cts;
+        }
+
+        public Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+            cts.Cancel();
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed class RecordingObserver : IPendingMessageProcessorObserver {
         public List<(PendingMessageRecord Record, PendingMessageSkipReason Reason)> Skipped { get; } = new();
         public List<(PendingMessageRecord Record, int Attempt)> Started { get; } = new();
@@ -156,18 +170,21 @@ public sealed class PendingMessageProcessorTests {
         var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
             { EmailProvider.None, sender }
         });
+        var lease = TimeSpan.FromMinutes(2);
         var processor = new PendingMessageProcessor(
             repository,
             factory,
             retryDelaySelector: _ => TimeSpan.FromMinutes(1),
             clock: () => currentTime,
-            observer: observer);
+            observer: observer,
+            processingLeaseDuration: lease);
 
         await processor.ProcessAsync();
 
         Assert.False(repository.Contains(record.MessageId));
         Assert.Single(sender.SentRecords);
         Assert.Equal(1, sender.SentRecords[0].AttemptCount);
+        Assert.Equal(currentTime + lease, sender.SentRecords[0].NextAttemptAt);
         Assert.Single(observer.Started);
         Assert.Single(observer.Sent);
         Assert.Empty(observer.Failed);
@@ -208,6 +225,27 @@ public sealed class PendingMessageProcessorTests {
         Assert.True(failure.WillRetry);
         Assert.True(failure.RetryDelay.HasValue);
         Assert.Equal(delay, failure.RetryDelay.Value);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ReleasesLeaseWhenCancelled() {
+        var currentTime = DateTimeOffset.Parse("2024-07-01T09:00:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime.AddMinutes(-1));
+        repository.Add(record);
+        using var cts = new CancellationTokenSource();
+        var sender = new CancellingPendingMessageSender(cts);
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(repository, factory, clock: () => currentTime);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => processor.ProcessAsync(cts.Token));
+
+        var stored = await repository.GetByMessageIdAsync(record.MessageId);
+        Assert.NotNull(stored);
+        Assert.Equal(0, stored!.AttemptCount);
+        Assert.Equal(currentTime, stored.NextAttemptAt);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.Tests;
+
+public sealed class PendingMessageProcessorTests {
+    private sealed class InMemoryPendingMessageRepository : IPendingMessageRepository {
+        private readonly Dictionary<string, PendingMessageRecord> records = new(StringComparer.OrdinalIgnoreCase);
+
+        public void Add(PendingMessageRecord record) {
+            records[record.MessageId] = record;
+        }
+
+        public Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
+            records[record.MessageId] = record;
+            return Task.CompletedTask;
+        }
+
+        public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+            records.TryGetValue(messageId, out var record);
+            PendingMessageRecord? result = record;
+            return Task.FromResult(result);
+        }
+
+        public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            foreach (var record in records.Values.ToList()) {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return record;
+                await Task.Yield();
+            }
+        }
+
+        public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+            records.Remove(messageId);
+            return Task.CompletedTask;
+        }
+
+        public bool Contains(string messageId) => records.ContainsKey(messageId);
+    }
+
+    private sealed class RecordingPendingMessageSender : IPendingMessageSender {
+        public List<PendingMessageRecord> SentRecords { get; } = new();
+        public bool ShouldThrow { get; set; }
+        public Exception ExceptionToThrow { get; set; } = new InvalidOperationException("Send failure");
+
+        public Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+            SentRecords.Add(record);
+            if (ShouldThrow) {
+                throw ExceptionToThrow;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private static PendingMessageRecord CreateRecord(DateTimeOffset nextAttempt) => new() {
+        MessageId = Guid.NewGuid().ToString("N"),
+        Timestamp = nextAttempt,
+        NextAttemptAt = nextAttempt,
+        Provider = EmailProvider.None
+    };
+
+    [Fact]
+    public async Task ProcessAsync_SendsDueMessagesAndRemovesThem() {
+        var currentTime = DateTimeOffset.Parse("2024-06-01T12:00:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime.AddMinutes(-5));
+        repository.Add(record);
+        var sender = new RecordingPendingMessageSender();
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(
+            repository,
+            factory,
+            retryDelaySelector: _ => TimeSpan.FromMinutes(1),
+            clock: () => currentTime);
+
+        await processor.ProcessAsync();
+
+        Assert.False(repository.Contains(record.MessageId));
+        Assert.Single(sender.SentRecords);
+        Assert.Equal(1, sender.SentRecords[0].AttemptCount);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_OnFailureSchedulesNextAttemptAndPersistsRecord() {
+        var currentTime = DateTimeOffset.Parse("2024-06-02T08:30:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime);
+        repository.Add(record);
+        var sender = new RecordingPendingMessageSender { ShouldThrow = true };
+        var delay = TimeSpan.FromMinutes(15);
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(
+            repository,
+            factory,
+            retryDelaySelector: _ => delay,
+            clock: () => currentTime);
+
+        await processor.ProcessAsync();
+
+        var stored = await repository.GetByMessageIdAsync(record.MessageId);
+        Assert.NotNull(stored);
+        Assert.True(repository.Contains(record.MessageId));
+        Assert.Equal(1, stored!.AttemptCount);
+        Assert.Equal(currentTime + delay, stored.NextAttemptAt);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SkipsRecordsNotYetDue() {
+        var currentTime = DateTimeOffset.Parse("2024-06-03T09:00:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime.AddMinutes(10));
+        repository.Add(record);
+        var sender = new RecordingPendingMessageSender();
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(
+            repository,
+            factory,
+            retryDelaySelector: _ => TimeSpan.FromMinutes(5),
+            clock: () => currentTime);
+
+        await processor.ProcessAsync();
+
+        var stored = await repository.GetByMessageIdAsync(record.MessageId);
+        Assert.NotNull(stored);
+        Assert.True(repository.Contains(record.MessageId));
+        Assert.Equal(0, stored!.AttemptCount);
+        Assert.Empty(sender.SentRecords);
+        Assert.Equal(record.NextAttemptAt, stored.NextAttemptAt);
+    }
+}

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
@@ -22,7 +22,7 @@ public sealed class PendingMessageProcessorTests {
         public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
             records.TryGetValue(messageId, out var record);
             PendingMessageRecord? result = record;
-            return Task.FromResult(result);
+            return Task.FromResult<PendingMessageRecord?>(result);
         }
 
         public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync(
@@ -57,8 +57,8 @@ public sealed class PendingMessageProcessorTests {
         }
     }
 
-    private static PendingMessageRecord CreateRecord(DateTimeOffset nextAttempt) => new() {
-        MessageId = Guid.NewGuid().ToString("N"),
+    private static PendingMessageRecord CreateRecord(DateTimeOffset nextAttempt, string? messageId = null) => new() {
+        MessageId = messageId ?? Guid.NewGuid().ToString("N"),
         Timestamp = nextAttempt,
         NextAttemptAt = nextAttempt,
         Provider = EmailProvider.None
@@ -93,7 +93,10 @@ public sealed class PendingMessageProcessorTests {
         var repository = new InMemoryPendingMessageRepository();
         var record = CreateRecord(currentTime);
         repository.Add(record);
-        var sender = new RecordingPendingMessageSender { ShouldThrow = true };
+        var sender = new RecordingPendingMessageSender {
+            ShouldThrow = true,
+            ExceptionToThrow = new Exception("Send failure")
+        };
         var delay = TimeSpan.FromMinutes(15);
         var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
             { EmailProvider.None, sender }
@@ -137,5 +140,121 @@ public sealed class PendingMessageProcessorTests {
         Assert.Equal(0, stored!.AttemptCount);
         Assert.Empty(sender.SentRecords);
         Assert.Equal(record.NextAttemptAt, stored.NextAttemptAt);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SkipsRecordsWithMissingMessageId() {
+        var currentTime = DateTimeOffset.Parse("2024-06-04T10:00:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var invalid = CreateRecord(currentTime.AddMinutes(-2), string.Empty);
+        var valid = CreateRecord(currentTime.AddMinutes(-2));
+        repository.Add(invalid);
+        repository.Add(valid);
+        var sender = new RecordingPendingMessageSender();
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(repository, factory, clock: () => currentTime);
+
+        await processor.ProcessAsync();
+
+        Assert.True(repository.Contains(string.Empty));
+        Assert.False(repository.Contains(valid.MessageId));
+        Assert.Single(sender.SentRecords);
+        Assert.Equal(valid.MessageId, sender.SentRecords[0].MessageId);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RemovesRecordWhenPermanentFailureOccurs() {
+        var currentTime = DateTimeOffset.Parse("2024-06-05T09:30:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime.AddMinutes(-1));
+        repository.Add(record);
+        var sender = new RecordingPendingMessageSender {
+            ShouldThrow = true,
+            ExceptionToThrow = new InvalidOperationException("Permanent failure")
+        };
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(repository, factory, clock: () => currentTime);
+
+        await processor.ProcessAsync();
+
+        Assert.False(repository.Contains(record.MessageId));
+        Assert.Single(sender.SentRecords);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_StopsAfterCancellation() {
+        var currentTime = DateTimeOffset.Parse("2024-06-06T07:15:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var first = CreateRecord(currentTime.AddMinutes(-1));
+        var second = CreateRecord(currentTime.AddMinutes(-1));
+        repository.Add(first);
+        repository.Add(second);
+        var sender = new RecordingPendingMessageSender();
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(repository, factory, clock: () => currentTime);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => processor.ProcessAsync(cts.Token));
+
+        Assert.Empty(sender.SentRecords);
+        Assert.True(repository.Contains(first.MessageId));
+        Assert.True(repository.Contains(second.MessageId));
+        Assert.Equal(0, first.AttemptCount);
+        Assert.Equal(0, second.AttemptCount);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RemovesRecordsThatExceededRetryLimit() {
+        var currentTime = DateTimeOffset.Parse("2024-06-07T11:00:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime.AddMinutes(-1));
+        record.AttemptCount = 5;
+        repository.Add(record);
+        var sender = new RecordingPendingMessageSender();
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(repository, factory, clock: () => currentTime, maxRetryAttempts: 5);
+
+        await processor.ProcessAsync();
+
+        Assert.False(repository.Contains(record.MessageId));
+        Assert.Empty(sender.SentRecords);
+        Assert.Equal(5, record.AttemptCount);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RemovesRecordAfterFinalFailedAttempt() {
+        var currentTime = DateTimeOffset.Parse("2024-06-08T14:45:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime.AddMinutes(-1));
+        record.AttemptCount = 4;
+        repository.Add(record);
+        var sender = new RecordingPendingMessageSender {
+            ShouldThrow = true,
+            ExceptionToThrow = new Exception("Transient failure")
+        };
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(
+            repository,
+            factory,
+            retryDelaySelector: _ => TimeSpan.FromMinutes(5),
+            clock: () => currentTime,
+            maxRetryAttempts: 5);
+
+        await processor.ProcessAsync();
+
+        Assert.False(repository.Contains(record.MessageId));
+        Assert.Single(sender.SentRecords);
+        Assert.Equal(5, record.AttemptCount);
     }
 }

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageRecordSerializationTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageRecordSerializationTests.cs
@@ -51,6 +51,7 @@ public sealed class PendingMessageRecordSerializationTests {
             MessageId = $"message-{provider}",
             Timestamp = DateTimeOffset.Parse("2024-01-01T00:00:00Z"),
             NextAttemptAt = DateTimeOffset.Parse("2024-01-01T01:00:00Z"),
+            AttemptCount = 3,
             MimeMessage = Convert.ToBase64String(Encoding.UTF8.GetBytes($"Message body for {provider}")),
             Provider = provider
         };
@@ -65,6 +66,7 @@ public sealed class PendingMessageRecordSerializationTests {
         Assert.Equal(provider, restored!.Provider);
         Assert.Equal(record.ProviderData, restored.ProviderData);
         Assert.Equal(record.MessageId, restored.MessageId);
+        Assert.Equal(record.AttemptCount, restored.AttemptCount);
     }
 
     [Fact]
@@ -76,6 +78,7 @@ public sealed class PendingMessageRecordSerializationTests {
         Assert.NotNull(record);
         Assert.Equal(EmailProvider.None, record!.Provider);
         Assert.Empty(record.ProviderData);
+        Assert.Equal(0, record.AttemptCount);
     }
 
     [Fact]
@@ -87,5 +90,6 @@ public sealed class PendingMessageRecordSerializationTests {
         Assert.NotNull(record);
         Assert.Equal(EmailProvider.SES, record!.Provider);
         Assert.Empty(record.ProviderData);
+        Assert.Equal(0, record.AttemptCount);
     }
 }

--- a/Sources/Mailozaurr/SentMessages/IPendingMessageProcessorObserver.cs
+++ b/Sources/Mailozaurr/SentMessages/IPendingMessageProcessorObserver.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Provides telemetry hooks for <see cref="PendingMessageProcessor"/> operations.
+/// </summary>
+public interface IPendingMessageProcessorObserver {
+    /// <summary>Called when a pending message is skipped before attempting delivery.</summary>
+    void MessageSkipped(PendingMessageRecord record, PendingMessageSkipReason reason);
+
+    /// <summary>Called immediately before a delivery attempt is made.</summary>
+    void MessageAttemptStarted(PendingMessageRecord record, int attempt);
+
+    /// <summary>Called when a message is successfully sent.</summary>
+    void MessageSent(PendingMessageRecord record, int attempt, TimeSpan duration);
+
+    /// <summary>
+    /// Called when a delivery attempt fails.
+    /// </summary>
+    /// <param name="record">The record that was processed.</param>
+    /// <param name="attempt">The attempt number that failed.</param>
+    /// <param name="exception">The exception describing the failure.</param>
+    /// <param name="duration">How long the attempt took.</param>
+    /// <param name="willRetry">Indicates whether another attempt will be scheduled.</param>
+    /// <param name="retryDelay">Delay until the next attempt if <paramref name="willRetry"/> is <see langword="true"/>.</param>
+    void MessageFailed(
+        PendingMessageRecord record,
+        int attempt,
+        Exception exception,
+        TimeSpan duration,
+        bool willRetry,
+        TimeSpan? retryDelay);
+
+    /// <summary>Called when a message is removed from the pending queue without being sent.</summary>
+    void MessageDropped(
+        PendingMessageRecord record,
+        int attempt,
+        PendingMessageDropReason reason,
+        Exception? exception);
+}
+
+/// <summary>
+/// Indicates why a pending message was skipped.
+/// </summary>
+public enum PendingMessageSkipReason {
+    /// <summary>The record does not specify a valid message identifier.</summary>
+    MissingMessageId,
+
+    /// <summary>The record is scheduled for a future attempt.</summary>
+    NotDue
+}
+
+/// <summary>
+/// Indicates why a pending message was removed from the queue.
+/// </summary>
+public enum PendingMessageDropReason {
+    /// <summary>The message exceeded the configured retry limit.</summary>
+    RetryLimitReached,
+
+    /// <summary>The sender reported a permanent failure.</summary>
+    PermanentFailure
+}

--- a/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
@@ -94,6 +94,7 @@ public sealed class PendingMessageProcessor {
 
             await AcquireProcessingLeaseAsync(record, now, cancellationToken).ConfigureAwait(false);
 
+            var originalAttemptCount = record.AttemptCount;
             var attempt = record.IncrementAttemptCount();
             observer.MessageAttemptStarted(record, attempt);
             var stopwatch = Stopwatch.StartNew();
@@ -106,9 +107,9 @@ public sealed class PendingMessageProcessor {
                 await repository.RemoveAsync(record.MessageId, cancellationToken).ConfigureAwait(false);
             } catch (OperationCanceledException ex) {
                 stopwatch.Stop();
-                observer.MessageFailed(record, attempt, ex, stopwatch.Elapsed, willRetry: false, retryDelay: null);
-                record.AttemptCount = attempt - 1;
+                record.ExchangeAttemptCount(originalAttemptCount);
                 record.NextAttemptAt = ApplyDelay(clock(), TimeSpan.Zero);
+                observer.MessageFailed(record, attempt, ex, stopwatch.Elapsed, willRetry: false, retryDelay: null);
                 try {
                     await repository.SaveAsync(record, CancellationToken.None).ConfigureAwait(false);
                 } catch (Exception saveEx) {

--- a/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
@@ -12,6 +12,8 @@ public sealed class PendingMessageProcessor {
     private readonly PendingMessageSenderFactory senderFactory;
     private readonly Func<int, TimeSpan> retryDelaySelector;
     private readonly Func<DateTimeOffset> clock;
+    private readonly int maxRetryAttempts;
+    private readonly InternalLogger? logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PendingMessageProcessor"/> class.
@@ -20,15 +22,25 @@ public sealed class PendingMessageProcessor {
     /// <param name="senderFactory">Factory used to resolve the correct sender for each record.</param>
     /// <param name="retryDelaySelector">Provides the delay applied before the next retry attempt.</param>
     /// <param name="clock">Supplies the current time used for scheduling retries.</param>
+    /// <param name="maxRetryAttempts">Maximum number of delivery attempts performed before giving up on a message.</param>
+    /// <param name="logger">Optional logger used to record processing diagnostics.</param>
     public PendingMessageProcessor(
         IPendingMessageRepository repository,
         PendingMessageSenderFactory? senderFactory = null,
         Func<int, TimeSpan>? retryDelaySelector = null,
-        Func<DateTimeOffset>? clock = null) {
+        Func<DateTimeOffset>? clock = null,
+        int maxRetryAttempts = 5,
+        InternalLogger? logger = null) {
         this.repository = repository ?? throw new ArgumentNullException(nameof(repository));
         this.senderFactory = senderFactory ?? new PendingMessageSenderFactory();
         this.retryDelaySelector = retryDelaySelector ?? DefaultRetryDelaySelector;
         this.clock = clock ?? (() => DateTimeOffset.UtcNow);
+        if (maxRetryAttempts <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxRetryAttempts), "Maximum retry attempts must be greater than zero.");
+        }
+
+        this.maxRetryAttempts = maxRetryAttempts;
+        this.logger = logger;
     }
 
     /// <summary>
@@ -36,9 +48,11 @@ public sealed class PendingMessageProcessor {
     /// </summary>
     /// <param name="cancellationToken">Token used to observe cancellation requests.</param>
     public async Task ProcessAsync(CancellationToken cancellationToken = default) {
-        await foreach (var record in repository.GetAllAsync(cancellationToken)) {
+        await using var enumerator = repository.GetAllAsync(cancellationToken).GetAsyncEnumerator(cancellationToken);
+        while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
             cancellationToken.ThrowIfCancellationRequested();
-            if (record == null || string.IsNullOrEmpty(record.MessageId)) {
+            var record = enumerator.Current;
+            if (record == null || string.IsNullOrWhiteSpace(record.MessageId)) {
                 continue;
             }
 
@@ -47,22 +61,35 @@ public sealed class PendingMessageProcessor {
                 continue;
             }
 
+            if (record.AttemptCount >= maxRetryAttempts) {
+                logger?.WriteWarning($"Removing message {record.MessageId} after reaching the retry limit ({record.AttemptCount}).");
+                await repository.RemoveAsync(record.MessageId, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
             var sender = senderFactory.GetSender(record);
-            record.AttemptCount++;
+            var attempt = record.IncrementAttemptCount();
 
             try {
                 await sender.SendAsync(record, cancellationToken).ConfigureAwait(false);
                 await repository.RemoveAsync(record.MessageId, cancellationToken).ConfigureAwait(false);
             } catch (OperationCanceledException) {
+                record.AttemptCount = attempt - 1;
                 throw;
-            } catch (Exception) {
-                var delay = retryDelaySelector(record.AttemptCount);
+            } catch (Exception ex) {
+                if (IsPermanentFailure(ex) || attempt >= maxRetryAttempts) {
+                    logger?.WriteWarning($"Dropping message {record.MessageId} due to {(IsPermanentFailure(ex) ? "permanent failure" : "exceeding retry attempts")}: {ex.Message}");
+                    await repository.RemoveAsync(record.MessageId, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                var delay = retryDelaySelector(attempt);
                 if (delay < TimeSpan.Zero) {
                     delay = TimeSpan.Zero;
                 }
 
-                var scheduledAt = clock();
-                record.NextAttemptAt = scheduledAt + delay;
+                record.NextAttemptAt = now + delay;
+                logger?.WriteWarning($"Failed to send message {record.MessageId}. Scheduling retry #{attempt + 1} at {record.NextAttemptAt:O}. Error: {ex.Message}");
                 await repository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
             }
         }
@@ -74,4 +101,7 @@ public sealed class PendingMessageProcessor {
         var capped = Math.Min(60, minutes);
         return TimeSpan.FromMinutes(capped);
     }
+
+    private static bool IsPermanentFailure(Exception exception) =>
+        exception is InvalidOperationException or ArgumentException;
 }

--- a/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,6 +15,8 @@ public sealed class PendingMessageProcessor {
     private readonly Func<DateTimeOffset> clock;
     private readonly int maxRetryAttempts;
     private readonly InternalLogger? logger;
+    private readonly IPendingMessageProcessorObserver observer;
+    private readonly Func<Exception, bool> permanentFailureDetector;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PendingMessageProcessor"/> class.
@@ -24,13 +27,17 @@ public sealed class PendingMessageProcessor {
     /// <param name="clock">Supplies the current time used for scheduling retries.</param>
     /// <param name="maxRetryAttempts">Maximum number of delivery attempts performed before giving up on a message.</param>
     /// <param name="logger">Optional logger used to record processing diagnostics.</param>
+    /// <param name="observer">Optional observer used to emit telemetry about processing outcomes.</param>
+    /// <param name="permanentFailureDetector">Optional delegate that classifies whether a failure should skip retries.</param>
     public PendingMessageProcessor(
         IPendingMessageRepository repository,
         PendingMessageSenderFactory? senderFactory = null,
         Func<int, TimeSpan>? retryDelaySelector = null,
         Func<DateTimeOffset>? clock = null,
         int maxRetryAttempts = 5,
-        InternalLogger? logger = null) {
+        InternalLogger? logger = null,
+        IPendingMessageProcessorObserver? observer = null,
+        Func<Exception, bool>? permanentFailureDetector = null) {
         this.repository = repository ?? throw new ArgumentNullException(nameof(repository));
         this.senderFactory = senderFactory ?? new PendingMessageSenderFactory();
         this.retryDelaySelector = retryDelaySelector ?? DefaultRetryDelaySelector;
@@ -41,6 +48,8 @@ public sealed class PendingMessageProcessor {
 
         this.maxRetryAttempts = maxRetryAttempts;
         this.logger = logger;
+        this.observer = observer ?? NullPendingMessageProcessorObserver.Instance;
+        this.permanentFailureDetector = permanentFailureDetector ?? DefaultPermanentFailureDetector;
     }
 
     /// <summary>
@@ -52,43 +61,62 @@ public sealed class PendingMessageProcessor {
         while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
             cancellationToken.ThrowIfCancellationRequested();
             var record = enumerator.Current;
-            if (record == null || string.IsNullOrWhiteSpace(record.MessageId)) {
+            if (record == null) {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(record.MessageId)) {
+                observer.MessageSkipped(record, PendingMessageSkipReason.MissingMessageId);
                 continue;
             }
 
             var now = clock();
             if (record.NextAttemptAt > now) {
+                observer.MessageSkipped(record, PendingMessageSkipReason.NotDue);
                 continue;
             }
 
             if (record.AttemptCount >= maxRetryAttempts) {
                 logger?.WriteWarning($"Removing message {record.MessageId} after reaching the retry limit ({record.AttemptCount}).");
+                observer.MessageDropped(record, record.AttemptCount, PendingMessageDropReason.RetryLimitReached, null);
                 await repository.RemoveAsync(record.MessageId, cancellationToken).ConfigureAwait(false);
                 continue;
             }
 
             var sender = senderFactory.GetSender(record);
             var attempt = record.IncrementAttemptCount();
+            observer.MessageAttemptStarted(record, attempt);
+            var stopwatch = Stopwatch.StartNew();
 
             try {
                 await sender.SendAsync(record, cancellationToken).ConfigureAwait(false);
+                stopwatch.Stop();
+                observer.MessageSent(record, attempt, stopwatch.Elapsed);
                 await repository.RemoveAsync(record.MessageId, cancellationToken).ConfigureAwait(false);
-            } catch (OperationCanceledException) {
+            } catch (OperationCanceledException ex) {
+                stopwatch.Stop();
+                observer.MessageFailed(record, attempt, ex, stopwatch.Elapsed, willRetry: false, retryDelay: null);
                 record.AttemptCount = attempt - 1;
                 throw;
             } catch (Exception ex) {
-                if (IsPermanentFailure(ex) || attempt >= maxRetryAttempts) {
-                    logger?.WriteWarning($"Dropping message {record.MessageId} due to {(IsPermanentFailure(ex) ? "permanent failure" : "exceeding retry attempts")}: {ex.Message}");
+                stopwatch.Stop();
+                var permanentFailure = permanentFailureDetector(ex);
+                var willRetry = !permanentFailure && attempt < maxRetryAttempts;
+                TimeSpan? delay = null;
+                if (willRetry) {
+                    delay = NormalizeDelay(retryDelaySelector(attempt));
+                    record.NextAttemptAt = now + delay.Value;
+                }
+
+                observer.MessageFailed(record, attempt, ex, stopwatch.Elapsed, willRetry, delay);
+
+                if (!willRetry) {
+                    logger?.WriteWarning($"Dropping message {record.MessageId} due to {(permanentFailure ? "permanent failure" : "exceeding retry attempts")}: {ex.Message}");
+                    observer.MessageDropped(record, attempt, permanentFailure ? PendingMessageDropReason.PermanentFailure : PendingMessageDropReason.RetryLimitReached, ex);
                     await repository.RemoveAsync(record.MessageId, cancellationToken).ConfigureAwait(false);
                     continue;
                 }
 
-                var delay = retryDelaySelector(attempt);
-                if (delay < TimeSpan.Zero) {
-                    delay = TimeSpan.Zero;
-                }
-
-                record.NextAttemptAt = now + delay;
                 logger?.WriteWarning($"Failed to send message {record.MessageId}. Scheduling retry #{attempt + 1} at {record.NextAttemptAt:O}. Error: {ex.Message}");
                 await repository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
             }
@@ -102,6 +130,46 @@ public sealed class PendingMessageProcessor {
         return TimeSpan.FromMinutes(capped);
     }
 
-    private static bool IsPermanentFailure(Exception exception) =>
+    private static TimeSpan NormalizeDelay(TimeSpan delay) {
+        if (delay <= TimeSpan.Zero || delay == TimeSpan.MinValue) {
+            return TimeSpan.Zero;
+        }
+
+        return delay;
+    }
+
+    private static bool DefaultPermanentFailureDetector(Exception exception) =>
         exception is InvalidOperationException or ArgumentException;
+
+    private sealed class NullPendingMessageProcessorObserver : IPendingMessageProcessorObserver {
+        internal static NullPendingMessageProcessorObserver Instance { get; } = new();
+
+        private NullPendingMessageProcessorObserver() {
+        }
+
+        public void MessageSkipped(PendingMessageRecord record, PendingMessageSkipReason reason) {
+        }
+
+        public void MessageAttemptStarted(PendingMessageRecord record, int attempt) {
+        }
+
+        public void MessageSent(PendingMessageRecord record, int attempt, TimeSpan duration) {
+        }
+
+        public void MessageFailed(
+            PendingMessageRecord record,
+            int attempt,
+            Exception exception,
+            TimeSpan duration,
+            bool willRetry,
+            TimeSpan? retryDelay) {
+        }
+
+        public void MessageDropped(
+            PendingMessageRecord record,
+            int attempt,
+            PendingMessageDropReason reason,
+            Exception? exception) {
+        }
+    }
 }

--- a/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Processes pending messages by dispatching them through provider specific senders.
+/// </summary>
+public sealed class PendingMessageProcessor {
+    private readonly IPendingMessageRepository repository;
+    private readonly PendingMessageSenderFactory senderFactory;
+    private readonly Func<int, TimeSpan> retryDelaySelector;
+    private readonly Func<DateTimeOffset> clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PendingMessageProcessor"/> class.
+    /// </summary>
+    /// <param name="repository">Repository used to load and persist pending messages.</param>
+    /// <param name="senderFactory">Factory used to resolve the correct sender for each record.</param>
+    /// <param name="retryDelaySelector">Provides the delay applied before the next retry attempt.</param>
+    /// <param name="clock">Supplies the current time used for scheduling retries.</param>
+    public PendingMessageProcessor(
+        IPendingMessageRepository repository,
+        PendingMessageSenderFactory? senderFactory = null,
+        Func<int, TimeSpan>? retryDelaySelector = null,
+        Func<DateTimeOffset>? clock = null) {
+        this.repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        this.senderFactory = senderFactory ?? new PendingMessageSenderFactory();
+        this.retryDelaySelector = retryDelaySelector ?? DefaultRetryDelaySelector;
+        this.clock = clock ?? (() => DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>
+    /// Attempts to send all pending messages that are due for processing.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to observe cancellation requests.</param>
+    public async Task ProcessAsync(CancellationToken cancellationToken = default) {
+        await foreach (var record in repository.GetAllAsync(cancellationToken)) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (record == null || string.IsNullOrEmpty(record.MessageId)) {
+                continue;
+            }
+
+            var now = clock();
+            if (record.NextAttemptAt > now) {
+                continue;
+            }
+
+            var sender = senderFactory.GetSender(record);
+            record.AttemptCount++;
+
+            try {
+                await sender.SendAsync(record, cancellationToken).ConfigureAwait(false);
+                await repository.RemoveAsync(record.MessageId, cancellationToken).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception) {
+                var delay = retryDelaySelector(record.AttemptCount);
+                if (delay < TimeSpan.Zero) {
+                    delay = TimeSpan.Zero;
+                }
+
+                var scheduledAt = clock();
+                record.NextAttemptAt = scheduledAt + delay;
+                await repository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static TimeSpan DefaultRetryDelaySelector(int attempt) {
+        var exponent = Math.Max(0, attempt - 1);
+        var minutes = Math.Pow(2, exponent);
+        var capped = Math.Min(60, minutes);
+        return TimeSpan.FromMinutes(capped);
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
@@ -17,6 +17,7 @@ public sealed class PendingMessageProcessor {
     private readonly InternalLogger? logger;
     private readonly IPendingMessageProcessorObserver observer;
     private readonly Func<Exception, bool> permanentFailureDetector;
+    private readonly TimeSpan processingLeaseDuration;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PendingMessageProcessor"/> class.
@@ -29,6 +30,7 @@ public sealed class PendingMessageProcessor {
     /// <param name="logger">Optional logger used to record processing diagnostics.</param>
     /// <param name="observer">Optional observer used to emit telemetry about processing outcomes.</param>
     /// <param name="permanentFailureDetector">Optional delegate that classifies whether a failure should skip retries.</param>
+    /// <param name="processingLeaseDuration">Optional duration used to lease records while they are being processed to avoid concurrent handling.</param>
     public PendingMessageProcessor(
         IPendingMessageRepository repository,
         PendingMessageSenderFactory? senderFactory = null,
@@ -37,7 +39,8 @@ public sealed class PendingMessageProcessor {
         int maxRetryAttempts = 5,
         InternalLogger? logger = null,
         IPendingMessageProcessorObserver? observer = null,
-        Func<Exception, bool>? permanentFailureDetector = null) {
+        Func<Exception, bool>? permanentFailureDetector = null,
+        TimeSpan? processingLeaseDuration = null) {
         this.repository = repository ?? throw new ArgumentNullException(nameof(repository));
         this.senderFactory = senderFactory ?? new PendingMessageSenderFactory();
         this.retryDelaySelector = retryDelaySelector ?? DefaultRetryDelaySelector;
@@ -50,6 +53,12 @@ public sealed class PendingMessageProcessor {
         this.logger = logger;
         this.observer = observer ?? NullPendingMessageProcessorObserver.Instance;
         this.permanentFailureDetector = permanentFailureDetector ?? DefaultPermanentFailureDetector;
+        processingLeaseDuration ??= TimeSpan.FromMinutes(1);
+        if (processingLeaseDuration < TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException(nameof(processingLeaseDuration), "Processing lease duration cannot be negative.");
+        }
+
+        this.processingLeaseDuration = processingLeaseDuration.Value;
     }
 
     /// <summary>
@@ -83,12 +92,14 @@ public sealed class PendingMessageProcessor {
                 continue;
             }
 
-            var sender = senderFactory.GetSender(record);
+            await AcquireProcessingLeaseAsync(record, now, cancellationToken).ConfigureAwait(false);
+
             var attempt = record.IncrementAttemptCount();
             observer.MessageAttemptStarted(record, attempt);
             var stopwatch = Stopwatch.StartNew();
 
             try {
+                var sender = senderFactory.GetSender(record);
                 await sender.SendAsync(record, cancellationToken).ConfigureAwait(false);
                 stopwatch.Stop();
                 observer.MessageSent(record, attempt, stopwatch.Elapsed);
@@ -97,6 +108,12 @@ public sealed class PendingMessageProcessor {
                 stopwatch.Stop();
                 observer.MessageFailed(record, attempt, ex, stopwatch.Elapsed, willRetry: false, retryDelay: null);
                 record.AttemptCount = attempt - 1;
+                record.NextAttemptAt = ApplyDelay(clock(), TimeSpan.Zero);
+                try {
+                    await repository.SaveAsync(record, CancellationToken.None).ConfigureAwait(false);
+                } catch (Exception saveEx) {
+                    logger?.WriteWarning($"Failed to release processing lease for message {record.MessageId} after cancellation: {saveEx.Message}");
+                }
                 throw;
             } catch (Exception ex) {
                 stopwatch.Stop();
@@ -105,7 +122,8 @@ public sealed class PendingMessageProcessor {
                 TimeSpan? delay = null;
                 if (willRetry) {
                     delay = NormalizeDelay(retryDelaySelector(attempt));
-                    record.NextAttemptAt = now + delay.Value;
+                    var failureTime = clock();
+                    record.NextAttemptAt = ApplyDelay(failureTime, delay.Value);
                 }
 
                 observer.MessageFailed(record, attempt, ex, stopwatch.Elapsed, willRetry, delay);
@@ -121,6 +139,15 @@ public sealed class PendingMessageProcessor {
                 await repository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
             }
         }
+    }
+
+    private async Task AcquireProcessingLeaseAsync(PendingMessageRecord record, DateTimeOffset now, CancellationToken cancellationToken) {
+        if (processingLeaseDuration == TimeSpan.Zero) {
+            return;
+        }
+
+        record.NextAttemptAt = ApplyDelay(now, processingLeaseDuration);
+        await repository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
     }
 
     private static TimeSpan DefaultRetryDelaySelector(int attempt) {
@@ -140,6 +167,19 @@ public sealed class PendingMessageProcessor {
 
     private static bool DefaultPermanentFailureDetector(Exception exception) =>
         exception is InvalidOperationException or ArgumentException;
+
+    private static DateTimeOffset ApplyDelay(DateTimeOffset reference, TimeSpan delay) {
+        if (delay <= TimeSpan.Zero) {
+            return reference;
+        }
+
+        var maxIncrement = DateTimeOffset.MaxValue - reference;
+        if (delay > maxIncrement) {
+            return DateTimeOffset.MaxValue;
+        }
+
+        return reference + delay;
+    }
 
     private sealed class NullPendingMessageProcessorObserver : IPendingMessageProcessorObserver {
         internal static NullPendingMessageProcessorObserver Instance { get; } = new();

--- a/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
@@ -15,6 +15,9 @@ public sealed class PendingMessageRecord {
     /// <summary>Time when the next send attempt should occur.</summary>
     public DateTimeOffset NextAttemptAt { get; set; }
 
+    /// <summary>Number of times delivery has been attempted.</summary>
+    public int AttemptCount { get; set; }
+
     /// <summary>Base64-encoded MIME message.</summary>
     public string MimeMessage { get; set; } = string.Empty;
 

--- a/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Mailozaurr;
 
@@ -6,6 +7,8 @@ namespace Mailozaurr;
 /// Represents a message pending to be sent.
 /// </summary>
 public sealed class PendingMessageRecord {
+    private int attemptCount;
+
     /// <summary>Identifier of the message.</summary>
     public string MessageId { get; set; } = string.Empty;
 
@@ -16,7 +19,10 @@ public sealed class PendingMessageRecord {
     public DateTimeOffset NextAttemptAt { get; set; }
 
     /// <summary>Number of times delivery has been attempted.</summary>
-    public int AttemptCount { get; set; }
+    public int AttemptCount {
+        get => Volatile.Read(ref attemptCount);
+        set => Volatile.Write(ref attemptCount, value);
+    }
 
     /// <summary>Base64-encoded MIME message.</summary>
     public string MimeMessage { get; set; } = string.Empty;
@@ -49,4 +55,9 @@ public sealed class PendingMessageRecord {
         get => providerData ??= new Dictionary<string, string>();
         set => providerData = value ?? new Dictionary<string, string>();
     }
+
+    /// <summary>
+    /// Atomically increments <see cref="AttemptCount"/> and returns the updated value.
+    /// </summary>
+    public int IncrementAttemptCount() => Interlocked.Increment(ref attemptCount);
 }

--- a/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
@@ -60,4 +60,11 @@ public sealed class PendingMessageRecord {
     /// Atomically increments <see cref="AttemptCount"/> and returns the updated value.
     /// </summary>
     public int IncrementAttemptCount() => Interlocked.Increment(ref attemptCount);
+
+    /// <summary>
+    /// Atomically sets <see cref="AttemptCount"/> to the specified value.
+    /// </summary>
+    /// <param name="value">Value assigned to the attempt counter.</param>
+    /// <returns>The previous value stored in the attempt counter.</returns>
+    public int ExchangeAttemptCount(int value) => Interlocked.Exchange(ref attemptCount, value);
 }


### PR DESCRIPTION
## Summary
- add a pending message processor that dispatches due queued messages through provider-specific senders and reschedules failures
- track attempt counts on pending records so retry scheduling can account for prior attempts
- cover the new processor and serialization changes with focused unit tests

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68ca668269f0832e97edd6dc176d44c7