### PR TITLE
Add tests for pending message dispatch and PowerShell filter coverage

### DIFF
--- a/Examples/Example-SendEmailPendingMessage-ScheduleAndNotify.ps1
+++ b/Examples/Example-SendEmailPendingMessage-ScheduleAndNotify.ps1
@@ -1,0 +1,57 @@
+$pending = Join-Path $PSScriptRoot 'pending'
+$adminRecipient = 'admin@example.com'
+$notificationSender = 'mailer@example.com'
+$smtpServer = 'smtp.office365.com'
+$notificationSubject = 'Mailozaurr pending message queue failure'
+
+if (-not $NotificationCredential) {
+    $NotificationCredential = Get-Credential -Message 'Provide SMTP credentials used for failure notifications'
+}
+
+$notificationParameters = @{
+    From       = $notificationSender
+    To         = $adminRecipient
+    Subject    = $notificationSubject
+    SmtpServer = $smtpServer
+    Credential = $NotificationCredential
+    UseSsl     = $true
+    Port       = 587
+}
+
+try {
+    Send-EmailPendingMessage -PendingMessagesPath $pending -ProcessAll
+} catch {
+    $timestamp = Get-Date -Format o
+    $body = @"
+Processing of the pending message queue failed at $timestamp.
+
+$($_.Exception.Message)
+"@
+    Send-EmailMessage @notificationParameters -Body $body
+    throw
+}
+
+# To automatically process the queue, register a scheduled job that reuses the
+# same notification block. The example below runs every 15 minutes and alerts the
+# administrator when a failure occurs.
+#
+# $trigger = New-JobTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 15) -RepetitionDuration ([TimeSpan]::MaxValue)
+# Register-ScheduledJob -Name 'Mailozaurr-PendingMessages' -ScriptBlock {
+#     param(
+#         [string]$PendingMessagesPath,
+#         [hashtable]$NotificationParameters
+#     )
+#
+#     try {
+#         Send-EmailPendingMessage -PendingMessagesPath $PendingMessagesPath -ProcessAll
+#     } catch {
+#         $errorTimestamp = Get-Date -Format o
+#         $errorBody = @"
+# Processing of the pending message queue failed at $errorTimestamp.
+#
+# $($_.Exception.Message)
+# "@
+#         Send-EmailMessage @NotificationParameters -Body $errorBody
+#         throw
+#     }
+# } -ArgumentList $pending, $notificationParameters -Trigger $trigger -ScheduledJobOption (New-ScheduledJobOption -RunElevated)

--- a/Examples/Example-SendEmailPendingMessage-ScheduleAndNotify.ps1
+++ b/Examples/Example-SendEmailPendingMessage-ScheduleAndNotify.ps1
@@ -4,8 +4,15 @@ $notificationSender = 'mailer@example.com'
 $smtpServer = 'smtp.office365.com'
 $notificationSubject = 'Mailozaurr pending message queue failure'
 
+if ($NotificationCredential -and $NotificationCredential -isnot [pscredential]) {
+    throw 'NotificationCredential must be a PSCredential instance.'
+}
+
 if (-not $NotificationCredential) {
     $NotificationCredential = Get-Credential -Message 'Provide SMTP credentials used for failure notifications'
+    if (-not $NotificationCredential) {
+        throw 'SMTP credentials are required for failure notifications'
+    }
 }
 
 $notificationParameters = @{
@@ -22,10 +29,12 @@ try {
     Send-EmailPendingMessage -PendingMessagesPath $pending -ProcessAll
 } catch {
     $timestamp = Get-Date -Format o
+    $rawMessage = if ($_.Exception) { $_.Exception.ToString() } else { $_ | Out-String }
+    $sanitizedMessage = $rawMessage -replace '(?i)(password|token|key|secret)=\S+', '$1=***'
     $body = @"
 Processing of the pending message queue failed at $timestamp.
 
-$($_.Exception.Message)
+$sanitizedMessage
 "@
     Send-EmailMessage @notificationParameters -Body $body
     throw

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
@@ -152,6 +152,14 @@ public sealed class PendingMessageProcessorTests {
         }
     }
 
+    private static readonly EmailProvider[] ProvidersUnderTest = new[] {
+        EmailProvider.None,
+        EmailProvider.SendGrid,
+        EmailProvider.Mailgun,
+        EmailProvider.SES,
+        EmailProvider.Gmail
+    };
+
     private static PendingMessageRecord CreateRecord(DateTimeOffset nextAttempt, string? messageId = null) => new() {
         MessageId = messageId ?? Guid.NewGuid().ToString("N"),
         Timestamp = nextAttempt,
@@ -476,5 +484,112 @@ public sealed class PendingMessageProcessorTests {
         var failure = Assert.Single(observer.Failed);
         Assert.True(failure.RetryDelay.HasValue);
         Assert.Equal(TimeSpan.Zero, failure.RetryDelay.Value);
+    }
+
+    public static IEnumerable<object[]> ProviderDispatchData() {
+        foreach (var provider in ProvidersUnderTest) {
+            yield return new object[] { provider };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ProviderDispatchData))]
+    public async Task ProcessAsync_DispatchesToRegisteredProviderSender(EmailProvider provider) {
+        var currentTime = DateTimeOffset.Parse("2024-06-11T08:00:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime.AddMinutes(-1));
+        record.Provider = provider;
+        repository.Add(record);
+        var senders = new Dictionary<EmailProvider, RecordingPendingMessageSender>();
+        var entries = new List<KeyValuePair<EmailProvider, IPendingMessageSender>>();
+        foreach (var providerUnderTest in ProvidersUnderTest) {
+            var stub = new RecordingPendingMessageSender();
+            senders[providerUnderTest] = stub;
+            entries.Add(new KeyValuePair<EmailProvider, IPendingMessageSender>(providerUnderTest, stub));
+        }
+
+        var factory = new PendingMessageSenderFactory(entries);
+        var processor = new PendingMessageProcessor(
+            repository,
+            factory,
+            clock: () => currentTime,
+            processingLeaseDuration: TimeSpan.Zero);
+
+        await processor.ProcessAsync();
+
+        Assert.False(repository.Contains(record.MessageId));
+        Assert.Single(senders[provider].SentRecords);
+        Assert.Equal(provider, senders[provider].SentRecords[0].Provider);
+        foreach (var pair in senders) {
+            if (pair.Key == provider) {
+                continue;
+            }
+
+            Assert.Empty(pair.Value.SentRecords);
+        }
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RetriesUsingDelaySelectorPerAttempt() {
+        var currentTime = DateTimeOffset.Parse("2024-06-12T07:30:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime.AddMinutes(-2));
+        record.Provider = EmailProvider.Mailgun;
+        repository.Add(record);
+        var sender = new RecordingPendingMessageSender {
+            ShouldThrow = true,
+            ExceptionToThrow = new Exception("Transient provider failure")
+        };
+        var attempts = new List<int>();
+        var delays = new Dictionary<int, TimeSpan> {
+            { 1, TimeSpan.FromMinutes(5) },
+            { 2, TimeSpan.FromMinutes(10) }
+        };
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.Mailgun, sender }
+        });
+        var processor = new PendingMessageProcessor(
+            repository,
+            factory,
+            retryDelaySelector: attempt => {
+                attempts.Add(attempt);
+                if (delays.TryGetValue(attempt, out var delay)) {
+                    return delay;
+                }
+
+                return TimeSpan.FromMinutes(15);
+            },
+            clock: () => currentTime,
+            maxRetryAttempts: 4);
+
+        await processor.ProcessAsync();
+
+        var storedAfterFirstAttempt = await repository.GetByMessageIdAsync(record.MessageId);
+        Assert.NotNull(storedAfterFirstAttempt);
+        Assert.Equal(1, storedAfterFirstAttempt!.AttemptCount);
+        Assert.Equal(currentTime + delays[1], storedAfterFirstAttempt.NextAttemptAt);
+        Assert.Equal(new[] { 1 }, attempts);
+
+        currentTime = storedAfterFirstAttempt.NextAttemptAt.AddMinutes(1);
+
+        await processor.ProcessAsync();
+
+        var storedAfterSecondAttempt = await repository.GetByMessageIdAsync(record.MessageId);
+        Assert.NotNull(storedAfterSecondAttempt);
+        Assert.Equal(2, storedAfterSecondAttempt!.AttemptCount);
+        Assert.Equal(currentTime + delays[2], storedAfterSecondAttempt.NextAttemptAt);
+        Assert.Equal(new[] { 1, 2 }, attempts);
+
+        currentTime = storedAfterSecondAttempt.NextAttemptAt.AddMinutes(1);
+        sender.ShouldThrow = false;
+
+        await processor.ProcessAsync();
+
+        Assert.False(repository.Contains(record.MessageId));
+        Assert.Equal(3, sender.SentRecords.Count);
+        var lastRecord = sender.SentRecords[sender.SentRecords.Count - 1];
+        Assert.Equal(3, lastRecord.AttemptCount);
+        Assert.Equal(EmailProvider.Mailgun, lastRecord.Provider);
+        Assert.Equal(new[] { 1, 2 }, attempts);
     }
 }

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -9,7 +10,7 @@ namespace Mailozaurr.Tests;
 
 public sealed class PendingMessageProcessorTests {
     private sealed class InMemoryPendingMessageRepository : IPendingMessageRepository {
-        private readonly Dictionary<string, PendingMessageRecord> records = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, PendingMessageRecord> records = new(StringComparer.OrdinalIgnoreCase);
 
         public void Add(PendingMessageRecord record) {
             records[record.MessageId] = record;
@@ -22,13 +23,12 @@ public sealed class PendingMessageProcessorTests {
 
         public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
             records.TryGetValue(messageId, out var record);
-            PendingMessageRecord? result = record;
-            return Task.FromResult<PendingMessageRecord?>(result);
+            return Task.FromResult(record);
         }
 
         public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync(
             [EnumeratorCancellation] CancellationToken cancellationToken = default) {
-            foreach (var record in records.Values.ToList()) {
+            foreach (var record in records.Values) {
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return record;
                 await Task.Yield();
@@ -36,7 +36,7 @@ public sealed class PendingMessageProcessorTests {
         }
 
         public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
-            records.Remove(messageId);
+            records.TryRemove(messageId, out _);
             return Task.CompletedTask;
         }
 

--- a/Tests/Mailozaurr.Pester/Send-EmailPendingMessage.Filters.Tests.ps1
+++ b/Tests/Mailozaurr.Pester/Send-EmailPendingMessage.Filters.Tests.ps1
@@ -1,0 +1,175 @@
+function global:New-PendingRecord {
+    param(
+        [Mailozaurr.EmailProvider]$Provider,
+        [string]$MessageId = ([Guid]::NewGuid().ToString())
+    )
+
+    $message = [MimeKit.MimeMessage]::new()
+    $message.From.Add([MimeKit.MailboxAddress]::Parse('sender@example.com'))
+    $message.To.Add([MimeKit.MailboxAddress]::Parse('recipient@example.com'))
+    $message.Subject = 'Queue item'
+    $message.Body = [MimeKit.TextPart]::new('plain', 'body')
+    $buffer = [System.IO.MemoryStream]::new()
+    $message.WriteTo($buffer)
+    $payload = [Convert]::ToBase64String($buffer.ToArray())
+
+    $record = [Mailozaurr.PendingMessageRecord]::new()
+    $record.MessageId = $MessageId
+    $record.MimeMessage = $payload
+    $record.Timestamp = [DateTimeOffset]::UtcNow
+    $record.NextAttemptAt = [DateTimeOffset]::UtcNow
+    $record.Provider = $Provider
+    if ($Provider -eq [Mailozaurr.EmailProvider]::None) {
+        $record.Server = 'smtp.server'
+        $record.Port = 25
+    }
+
+    return $record
+}
+
+Describe 'Send-EmailPendingMessage provider and message filters' {
+    BeforeAll {
+        $moduleRoot = Join-Path (Join-Path $PSScriptRoot '..') '..'
+        $modulePath = Join-Path $moduleRoot 'Mailozaurr.psd1'
+        if (-not (Get-Module -Name Mailozaurr)) {
+            Import-Module $modulePath -Force
+        }
+
+        if (-not ('FilterRecordingPendingMessageSender' -as [type])) {
+            $sharedRoot = Join-Path ([Environment]::GetFolderPath('UserProfile')) '.dotnet/shared/Microsoft.NETCore.App'
+            $runtimeVersion = Get-ChildItem -Path $sharedRoot -Directory | Sort-Object Name -Descending | Select-Object -First 1
+            if (-not $runtimeVersion) {
+                throw 'Unable to locate .NET runtime assemblies required for Add-Type.'
+            }
+
+            $runtimePath = $runtimeVersion.FullName
+            $assemblies = @(
+                [Mailozaurr.PendingMessageRecord].Assembly.Location,
+                (Join-Path $runtimePath 'System.Private.CoreLib.dll'),
+                (Join-Path $runtimePath 'System.Runtime.dll'),
+                (Join-Path $runtimePath 'System.Collections.dll')
+            )
+
+            Add-Type -ReferencedAssemblies $assemblies -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Mailozaurr;
+
+public sealed class FilterRecordingPendingMessageSender : IPendingMessageSender {
+    private readonly EmailProvider provider;
+    private static readonly Hashtable Processed = new();
+
+    public FilterRecordingPendingMessageSender(EmailProvider provider) {
+        this.provider = provider;
+    }
+
+    public static void Reset() => Processed.Clear();
+
+    public static string[] GetProcessedMessageIds(EmailProvider provider) {
+        if (Processed[provider] is ArrayList list) {
+            var result = new string[list.Count];
+            list.CopyTo(result, 0);
+            return result;
+        }
+
+        return Array.Empty<string>();
+    }
+
+    public Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+        if (Processed[provider] is not ArrayList list) {
+            list = new ArrayList();
+            Processed[provider] = list;
+        }
+
+        list.Add(record.MessageId ?? string.Empty);
+
+        return Task.CompletedTask;
+    }
+}
+
+public static class FilterPendingMessageSenderFactory {
+    private static readonly EmailProvider[] Providers = new[] {
+        EmailProvider.None,
+        EmailProvider.SendGrid,
+        EmailProvider.Mailgun,
+        EmailProvider.SES,
+        EmailProvider.Gmail
+    };
+
+    public static PendingMessageSenderFactory Create() {
+        var entries = new KeyValuePair<EmailProvider, IPendingMessageSender>[Providers.Length];
+        for (var i = 0; i < Providers.Length; i++) {
+            var provider = Providers[i];
+            entries[i] = new KeyValuePair<EmailProvider, IPendingMessageSender>(provider, new FilterRecordingPendingMessageSender(provider));
+        }
+
+        return new PendingMessageSenderFactory(entries);
+    }
+}
+"@
+        }
+    }
+
+    BeforeEach {
+        [FilterRecordingPendingMessageSender]::Reset()
+        $delegate = [System.Delegate]::CreateDelegate(
+            [System.Func[Mailozaurr.PendingMessageSenderFactory]],
+            [FilterPendingMessageSenderFactory],
+            'Create')
+        [Mailozaurr.PowerShell.CmdletSendEmailPendingMessage]::SenderFactoryProvider = $delegate
+    }
+
+    AfterEach {
+        [Mailozaurr.PowerShell.CmdletSendEmailPendingMessage]::SenderFactoryProvider = $null
+    }
+
+    It 'Processes only messages for the requested provider' {
+        $path = Join-Path $TestDrive 'filters-provider'
+        $options = [Mailozaurr.PendingMessageRepositoryOptions]::new()
+        $options.DirectoryPath = $path
+        $repo = [Mailozaurr.FilePendingMessageRepository]::new($options)
+
+        $smtpRecord = New-PendingRecord -Provider ([Mailozaurr.EmailProvider]::None)
+        $repo.SaveAsync($smtpRecord).GetAwaiter().GetResult()
+        $sesRecord = New-PendingRecord -Provider ([Mailozaurr.EmailProvider]::SES)
+        $repo.SaveAsync($sesRecord).GetAwaiter().GetResult()
+
+        Send-EmailPendingMessage -PendingMessagesPath $path -Provider ([Mailozaurr.EmailProvider]::SES)
+
+        [FilterRecordingPendingMessageSender]::GetProcessedMessageIds([Mailozaurr.EmailProvider]::SES).Count | Should -Be 1
+        [FilterRecordingPendingMessageSender]::GetProcessedMessageIds([Mailozaurr.EmailProvider]::None).Count | Should -Be 0
+
+        $remaining = @(Get-EmailPendingMessage -PendingMessagesPath $path)
+        $remaining.Count | Should -Be 1
+        $remaining[0].MessageId | Should -Be $smtpRecord.MessageId
+    }
+
+    It 'Processes only the message matching both provider and message id filters' {
+        $path = Join-Path $TestDrive 'filters-combined'
+        $options = [Mailozaurr.PendingMessageRepositoryOptions]::new()
+        $options.DirectoryPath = $path
+        $repo = [Mailozaurr.FilePendingMessageRepository]::new($options)
+
+        $target = New-PendingRecord -Provider ([Mailozaurr.EmailProvider]::SendGrid)
+        $repo.SaveAsync($target).GetAwaiter().GetResult()
+        $other = New-PendingRecord -Provider ([Mailozaurr.EmailProvider]::SendGrid)
+        $repo.SaveAsync($other).GetAwaiter().GetResult()
+        $mailgun = New-PendingRecord -Provider ([Mailozaurr.EmailProvider]::Mailgun)
+        $repo.SaveAsync($mailgun).GetAwaiter().GetResult()
+
+        Send-EmailPendingMessage -PendingMessagesPath $path -Provider ([Mailozaurr.EmailProvider]::SendGrid) -MessageId $target.MessageId
+
+        $processed = [FilterRecordingPendingMessageSender]::GetProcessedMessageIds([Mailozaurr.EmailProvider]::SendGrid)
+        $processed | Should -Contain $target.MessageId
+        $processed.Count | Should -Be 1
+        [FilterRecordingPendingMessageSender]::GetProcessedMessageIds([Mailozaurr.EmailProvider]::Mailgun).Count | Should -Be 0
+
+        $pending = @(Get-EmailPendingMessage -PendingMessagesPath $path)
+        $pending.Count | Should -Be 2
+        $pending.MessageId | Should -Contain $other.MessageId
+        $pending.MessageId | Should -Contain $mailgun.MessageId
+    }
+}

--- a/Tests/Mailozaurr.Pester/Send-EmailPendingMessage.Filters.Tests.ps1
+++ b/Tests/Mailozaurr.Pester/Send-EmailPendingMessage.Filters.Tests.ps1
@@ -1,3 +1,26 @@
+$script:FilterSenderReferencedAssemblies = $null
+
+function Get-FilterSenderReferencedAssemblies {
+    if ($null -eq $script:FilterSenderReferencedAssemblies) {
+        $sharedRoot = Join-Path ([Environment]::GetFolderPath('UserProfile')) '.dotnet/shared/Microsoft.NETCore.App'
+        $runtimeVersion = Get-ChildItem -Path $sharedRoot -Directory | Sort-Object Name -Descending | Select-Object -First 1
+        if (-not $runtimeVersion) {
+            throw 'Unable to locate .NET runtime assemblies required for Add-Type.'
+        }
+
+        $runtimePath = $runtimeVersion.FullName
+        $script:FilterSenderReferencedAssemblies = @(
+            [Mailozaurr.PendingMessageRecord].Assembly.Location,
+            (Join-Path $runtimePath 'System.Private.CoreLib.dll'),
+            (Join-Path $runtimePath 'System.Runtime.dll'),
+            (Join-Path $runtimePath 'System.Collections.dll'),
+            (Join-Path $runtimePath 'System.Collections.Concurrent.dll')
+        )
+    }
+
+    return $script:FilterSenderReferencedAssemblies
+}
+
 function global:New-PendingRecord {
     param(
         [Mailozaurr.EmailProvider]$Provider,
@@ -36,31 +59,19 @@ Describe 'Send-EmailPendingMessage provider and message filters' {
         }
 
         if (-not ('FilterRecordingPendingMessageSender' -as [type])) {
-            $sharedRoot = Join-Path ([Environment]::GetFolderPath('UserProfile')) '.dotnet/shared/Microsoft.NETCore.App'
-            $runtimeVersion = Get-ChildItem -Path $sharedRoot -Directory | Sort-Object Name -Descending | Select-Object -First 1
-            if (-not $runtimeVersion) {
-                throw 'Unable to locate .NET runtime assemblies required for Add-Type.'
-            }
-
-            $runtimePath = $runtimeVersion.FullName
-            $assemblies = @(
-                [Mailozaurr.PendingMessageRecord].Assembly.Location,
-                (Join-Path $runtimePath 'System.Private.CoreLib.dll'),
-                (Join-Path $runtimePath 'System.Runtime.dll'),
-                (Join-Path $runtimePath 'System.Collections.dll')
-            )
+            $assemblies = Get-FilterSenderReferencedAssemblies
 
             Add-Type -ReferencedAssemblies $assemblies -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Mailozaurr;
 
 public sealed class FilterRecordingPendingMessageSender : IPendingMessageSender {
     private readonly EmailProvider provider;
-    private static readonly Hashtable Processed = new();
+    private static readonly ConcurrentDictionary<EmailProvider, ConcurrentBag<string>> Processed = new();
 
     public FilterRecordingPendingMessageSender(EmailProvider provider) {
         this.provider = provider;
@@ -69,22 +80,16 @@ public sealed class FilterRecordingPendingMessageSender : IPendingMessageSender 
     public static void Reset() => Processed.Clear();
 
     public static string[] GetProcessedMessageIds(EmailProvider provider) {
-        if (Processed[provider] is ArrayList list) {
-            var result = new string[list.Count];
-            list.CopyTo(result, 0);
-            return result;
+        if (Processed.TryGetValue(provider, out var records)) {
+            return records.ToArray();
         }
 
         return Array.Empty<string>();
     }
 
     public Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
-        if (Processed[provider] is not ArrayList list) {
-            list = new ArrayList();
-            Processed[provider] = list;
-        }
-
-        list.Add(record.MessageId ?? string.Empty);
+        var messages = Processed.GetOrAdd(provider, _ => new ConcurrentBag<string>());
+        messages.Add(record.MessageId ?? string.Empty);
 
         return Task.CompletedTask;
     }


### PR DESCRIPTION
## Summary
- add dispatch coverage for each pending message provider and exercise retry delay tracking in `PendingMessageProcessorTests`
- add dedicated Pester coverage that exercises `Send-EmailPendingMessage` provider and message id filters via lightweight C# stubs
- provide a sample script demonstrating scheduled queue processing with administrative notification on failure

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `Invoke-Pester -Script Tests/Mailozaurr.Pester/Send-EmailPendingMessage.Filters.Tests.ps1` *(hangs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca90c27d74832eb5e08f66f9ec0e8b