### PR TITLE
Fix file repository gating deadlock and add integration tests

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorFileRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorFileRepositoryTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.Tests;
+
+public sealed class PendingMessageProcessorFileRepositoryTests {
+    [Fact]
+    public async Task ProcessAsync_CompletesAgainstFileRepository() {
+        var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var options = new PendingMessageRepositoryOptions {
+            DirectoryPath = directory,
+            FileNamingScheme = () => "pending.log"
+        };
+        Directory.CreateDirectory(directory);
+        var repository = new FilePendingMessageRepository(options);
+
+        try {
+            var record = new PendingMessageRecord {
+                MessageId = Guid.NewGuid().ToString("N"),
+                Timestamp = DateTimeOffset.UtcNow,
+                NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+                Provider = EmailProvider.None,
+                MimeMessage = Convert.ToBase64String(Encoding.UTF8.GetBytes("payload"))
+            };
+            await repository.SaveAsync(record);
+
+            var sender = new RecordingPendingMessageSender();
+            var pair = new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.None, sender);
+            var factory = new PendingMessageSenderFactory(new[] { pair });
+            var processor = new PendingMessageProcessor(repository, factory, clock: () => DateTimeOffset.UtcNow);
+
+            await processor.ProcessAsync();
+
+            Assert.Single(sender.SentRecords);
+            Assert.Equal(record.MessageId, sender.SentRecords[0].MessageId);
+
+            var remaining = await repository.GetByMessageIdAsync(record.MessageId);
+            Assert.Null(remaining);
+        } finally {
+            if (File.Exists(Path.Combine(directory, "pending.log"))) {
+                File.Delete(Path.Combine(directory, "pending.log"));
+            }
+            if (Directory.Exists(directory)) {
+                Directory.Delete(directory, true);
+            }
+        }
+    }
+
+    private sealed class RecordingPendingMessageSender : IPendingMessageSender {
+        public List<PendingMessageRecord> SentRecords { get; } = new();
+
+        public Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+            SentRecords.Add(record);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
@@ -69,20 +69,26 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
 
     /// <summary>Saves a pending message to the repository.</summary>
     public async Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
-        await gate.WaitAsync(cancellationToken);
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
             var directory = Path.GetDirectoryName(filePath);
             if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
                 Directory.CreateDirectory(directory);
             }
+
             if (record.NextAttemptAt == default) {
                 record.NextAttemptAt = DateTimeOffset.UtcNow;
             }
+
+            _ = record.ProviderData;
+            var payload = JsonSerializer.SerializeToUtf8Bytes(record, SerializerOptions);
+
             using var write = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
             var offset = write.Position;
-            _ = record.ProviderData;
-            await JsonSerializer.SerializeAsync(write, record, SerializerOptions, cancellationToken);
-            await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
+            await write.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
+            await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken).ConfigureAwait(false);
+            await write.FlushAsync(cancellationToken).ConfigureAwait(false);
+
             index[record.MessageId] = offset;
         } finally {
             gate.Release();
@@ -94,7 +100,7 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
         if (!File.Exists(filePath)) {
             return null;
         }
-        await gate.WaitAsync(cancellationToken);
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
             if (!index.TryGetValue(messageId, out var offset)) {
                 return null;
@@ -102,7 +108,7 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
             using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             read.Seek(offset, SeekOrigin.Begin);
             using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
-            string? line = await reader.ReadLineAsync();
+            string? line = await reader.ReadLineAsync().ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(line)) {
                 return null;
             }
@@ -121,23 +127,31 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
         if (!File.Exists(filePath)) {
             yield break;
         }
-        await gate.WaitAsync(cancellationToken);
+        var snapshot = new List<PendingMessageRecord>();
+
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
             using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
             string? line;
-            while ((line = await reader.ReadLineAsync()) != null) {
+            while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (string.IsNullOrWhiteSpace(line)) {
                     continue;
                 }
+
                 var record = DeserializeRecord(line);
                 if (record != null) {
-                    yield return record;
+                    snapshot.Add(record);
                 }
             }
         } finally {
             gate.Release();
+        }
+
+        foreach (var record in snapshot) {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return record;
         }
     }
 
@@ -146,21 +160,21 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
         if (!File.Exists(filePath)) {
             return;
         }
-        await gate.WaitAsync(cancellationToken);
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
             if (!index.ContainsKey(messageId)) {
                 return;
             }
             var temp = filePath + ".tmp";
+            var newIndex = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
             using (var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None))
             using (var write = new FileStream(temp, FileMode.Create, FileAccess.Write, FileShare.None)) {
                 using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
                 long position = 0;
                 string? line;
-                index.Clear();
-                while ((line = await reader.ReadLineAsync()) != null) {
+                while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null) {
                     if (string.IsNullOrWhiteSpace(line)) {
-                        await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
+                        await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken).ConfigureAwait(false);
                         position += newlineBytes.Length;
                         continue;
                     }
@@ -169,14 +183,19 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
                         continue;
                     }
                     var bytes = Encoding.UTF8.GetBytes(line);
-                    await write.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
-                    await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
-                    index[record.MessageId] = position;
+                    await write.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+                    await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken).ConfigureAwait(false);
+                    newIndex[record.MessageId] = position;
                     position += bytes.Length + newlineBytes.Length;
                 }
+                await write.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
             File.Delete(filePath);
             File.Move(temp, filePath);
+            index.Clear();
+            foreach (var pair in newIndex) {
+                index[pair.Key] = pair.Value;
+            }
         } finally {
             gate.Release();
         }

--- a/Tests/Send-EmailPendingMessage.Tests.ps1
+++ b/Tests/Send-EmailPendingMessage.Tests.ps1
@@ -151,5 +151,36 @@ public static class FakePendingMessageSenderFactory {
         [FakePendingMessageSender]::SendCount | Should -Be 1
         (Get-EmailPendingMessage -PendingMessagesPath $path | Measure-Object).Count | Should -Be 0
     }
+
+    It 'Processes due messages without hanging when using the file repository' {
+        $path = Join-Path $TestDrive 'pending-hang-check'
+        $options = [Mailozaurr.PendingMessageRepositoryOptions]::new()
+        $options.DirectoryPath = $path
+        $repo = [Mailozaurr.FilePendingMessageRepository]::new($options)
+
+        $message = [MimeKit.MimeMessage]::new()
+        $message.From.Add([MimeKit.MailboxAddress]::Parse('a@example.com'))
+        $message.To.Add([MimeKit.MailboxAddress]::Parse('b@example.com'))
+        $message.Subject = 'Immediate delivery'
+        $message.Body = [MimeKit.TextPart]::new('plain')
+        $data = [System.IO.MemoryStream]::new()
+        $message.WriteTo($data)
+
+        $record = [Mailozaurr.PendingMessageRecord]::new()
+        $record.MessageId = $message.MessageId
+        $record.MimeMessage = [Convert]::ToBase64String($data.ToArray())
+        $record.Timestamp = [DateTimeOffset]::UtcNow
+        $record.NextAttemptAt = [DateTimeOffset]::UtcNow.AddMinutes(-1)
+        $record.Provider = [Mailozaurr.EmailProvider]::None
+        $repo.SaveAsync($record).GetAwaiter().GetResult()
+
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        Send-EmailPendingMessage -PendingMessagesPath $path
+        $stopwatch.Stop()
+
+        [FakePendingMessageSender]::SendCount | Should -Be 1
+        (Get-EmailPendingMessage -PendingMessagesPath $path | Measure-Object).Count | Should -Be 0
+        $stopwatch.Elapsed.TotalSeconds | Should -BeLessThan 5
+    }
 }
 


### PR DESCRIPTION
## Summary
- refactor FilePendingMessageRepository to snapshot reads under the gate and keep write operations atomic
- add integration coverage for PendingMessageProcessor against the file-based repository to guard against hangs
- extend PowerShell Send-EmailPendingMessage Pester tests with a due-message scenario to validate the real repository path

## Testing
- dotnet build Sources/Mailozaurr.sln
- dotnet test Sources/Mailozaurr.sln
- pwsh -NoLogo -NoProfile -Command "Import-Module ./Mailozaurr.psd1 -Force; Invoke-Pester -Script ./Tests/Send-EmailPendingMessage.Tests.ps1 -PassThru"

------
https://chatgpt.com/codex/tasks/task_e_68cab4133c24832e924c06d4f56de6ef