### PR TITLE
Queue API provider failures for pending processing

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -1,0 +1,283 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using MimeKit;
+using Xunit;
+
+namespace Mailozaurr.Tests.SentMessages;
+
+public sealed class ProviderPendingMessageTests {
+    private sealed class InMemoryPendingMessageRepository : IPendingMessageRepository {
+        private readonly Dictionary<string, PendingMessageRecord> records = new(StringComparer.OrdinalIgnoreCase);
+
+        public PendingMessageRecord? LastSaved { get; private set; }
+
+        public Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
+            if (record == null) {
+                throw new ArgumentNullException(nameof(record));
+            }
+
+            LastSaved = record;
+            var key = record.MessageId ?? throw new InvalidOperationException("Pending message requires an identifier.");
+            records[key] = record;
+            return Task.CompletedTask;
+        }
+
+        public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+            if (messageId == null) {
+                throw new ArgumentNullException(nameof(messageId));
+            }
+
+            records.TryGetValue(messageId, out var record);
+            return Task.FromResult<PendingMessageRecord?>(record);
+        }
+
+        public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            foreach (var record in records.Values.ToArray()) {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return record;
+                await Task.Yield();
+            }
+        }
+
+        public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+            if (messageId == null) {
+                throw new ArgumentNullException(nameof(messageId));
+            }
+
+            records.Remove(messageId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestHandler : HttpMessageHandler {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler;
+
+        public int CallCount { get; private set; }
+
+        public TestHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) {
+            this.handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            CallCount++;
+            return await handler(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    [Fact]
+    public async Task SendGridClientQueuesAndProcessesPendingMessage() {
+        using var client = new SendGridClient {
+            Credentials = new NetworkCredential("apikey", "SG.API"),
+            From = "sender@example.com",
+            To = new List<object> { "recipient@example.com" },
+            Subject = "queued",
+            Text = "hello"
+        };
+        client.CreateMessage();
+
+        var repository = new InMemoryPendingMessageRepository();
+        client.PendingMessageRepository = repository;
+
+        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError) {
+            Content = new StringContent("failure", Encoding.UTF8, "text/plain")
+        }));
+        var httpClientField = typeof(SendGridClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        httpClientField.SetValue(client, new HttpClient(failureHandler));
+
+        var result = await client.SendEmailAsync(CancellationToken.None);
+        Assert.False(result.Status);
+
+        var record = repository.LastSaved;
+        Assert.NotNull(record);
+        Assert.Equal(EmailProvider.SendGrid, record.Provider);
+        Assert.False(string.IsNullOrWhiteSpace(record.MessageId));
+        Assert.True(record.ProviderData.TryGetValue(SendGridPendingMessageSender.MessageJsonKey, out var json));
+        Assert.False(string.IsNullOrWhiteSpace(json));
+        Assert.True(record.ProviderData.TryGetValue(SendGridPendingMessageSender.ApiKeyBase64Key, out var apiKeyBase64));
+        var decodedApiKey = Encoding.UTF8.GetString(Convert.FromBase64String(apiKeyBase64!));
+        Assert.Equal("SG.API", decodedApiKey);
+
+        var successHandler = new TestHandler((request, _) => {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("Bearer SG.API", request.Headers.Authorization?.ToString());
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted));
+        });
+        var sender = new SendGridPendingMessageSender(new HttpClient(successHandler));
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.SendGrid, sender }
+        });
+        var processor = new PendingMessageProcessor(repository, factory);
+
+        await processor.ProcessAsync(CancellationToken.None);
+
+        Assert.Equal(1, successHandler.CallCount);
+        Assert.Null(await repository.GetByMessageIdAsync(record!.MessageId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task MailgunClientQueuesAndProcessesPendingMessage() {
+        var repository = new InMemoryPendingMessageRepository();
+        using var client = new MailgunClient {
+            PendingMessageRepository = repository,
+            Credentials = new NetworkCredential("user", "mailgun-api-key"),
+            From = "sender@example.com",
+            To = new List<object> { "recipient@example.com" },
+            Subject = "mailgun",
+            Text = "body"
+        };
+
+        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway) {
+            Content = new StringContent("error", Encoding.UTF8, "text/plain")
+        }));
+        var httpClientField = typeof(MailgunClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        httpClientField.SetValue(client, new HttpClient(failureHandler));
+
+        var result = await client.SendEmailAsync(CancellationToken.None);
+        Assert.False(result.Status);
+
+        var record = repository.LastSaved;
+        Assert.NotNull(record);
+        Assert.Equal(EmailProvider.Mailgun, record.Provider);
+        Assert.Equal("example.com", record.ProviderData[MailgunPendingMessageSender.DomainKey]);
+        var apiKey = Encoding.UTF8.GetString(Convert.FromBase64String(record.ProviderData[MailgunPendingMessageSender.ApiKeyBase64Key]!));
+        Assert.Equal("mailgun-api-key", apiKey);
+        var mime = await MimeMessage.LoadAsync(new MemoryStream(Convert.FromBase64String(record.MimeMessage)));
+        Assert.Equal("mailgun", mime.Subject);
+
+        var successHandler = new TestHandler((request, _) => {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Contains("messages.mime", request.RequestUri!.AbsoluteUri);
+            Assert.Equal("Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes("api:mailgun-api-key")), request.Headers.Authorization?.ToString());
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+        var sender = new MailgunPendingMessageSender(new HttpClient(successHandler));
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.Mailgun, sender }
+        });
+        var processor = new PendingMessageProcessor(repository, factory);
+
+        await processor.ProcessAsync(CancellationToken.None);
+
+        Assert.Equal(1, successHandler.CallCount);
+        Assert.Null(await repository.GetByMessageIdAsync(record!.MessageId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GmailClientQueuesAndProcessesPendingMessage() {
+        var credential = new OAuthCredential {
+            UserName = "user@example.com",
+            AccessToken = "access-token",
+            RefreshToken = "refresh-token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        var repository = new InMemoryPendingMessageRepository();
+        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError) {
+            Content = new StringContent("{\"error\":\"failed\"}", Encoding.UTF8, "application/json")
+        }));
+        using var failureClient = new HttpClient(failureHandler) {
+            BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/")
+        };
+        using var client = new GmailApiClient(failureClient, credential: credential) {
+            PendingMessageRepository = repository
+        };
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+        message.Subject = "gmail";
+        message.Body = new TextPart("plain") { Text = "body" };
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync("me", message, CancellationToken.None));
+
+        var record = repository.LastSaved;
+        Assert.NotNull(record);
+        Assert.Equal(EmailProvider.Gmail, record.Provider);
+        Assert.Equal("me", record.ProviderData[GmailPendingMessageSender.UserIdKey]);
+        Assert.Equal("user@example.com", record.ProviderData[GmailPendingMessageSender.UserNameKey]);
+        var storedAccess = Encoding.UTF8.GetString(Convert.FromBase64String(record.ProviderData[GmailPendingMessageSender.AccessTokenBase64Key]!));
+        Assert.Equal("access-token", storedAccess);
+        var storedRefresh = Encoding.UTF8.GetString(Convert.FromBase64String(record.ProviderData[GmailPendingMessageSender.RefreshTokenBase64Key]!));
+        Assert.Equal("refresh-token", storedRefresh);
+        var queuedMessage = await MimeMessage.LoadAsync(new MemoryStream(Convert.FromBase64String(record.MimeMessage)));
+        Assert.Equal("gmail", queuedMessage.Subject);
+
+        var successHandler = new TestHandler((request, _) => {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("Bearer access-token", request.Headers.Authorization?.ToString());
+            Assert.Equal(new Uri("https://gmail.googleapis.com/gmail/v1/users/me/messages/send"), request.RequestUri);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("{\"id\":\"msg\",\"threadId\":\"msg\"}", Encoding.UTF8, "application/json")
+            });
+        });
+        var successClient = new HttpClient(successHandler) {
+            BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/")
+        };
+        var sender = new GmailPendingMessageSender(c => new GmailApiClient(successClient, credential: c));
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.Gmail, sender }
+        });
+        var processor = new PendingMessageProcessor(repository, factory);
+
+        await processor.ProcessAsync(CancellationToken.None);
+
+        Assert.Equal(1, successHandler.CallCount);
+        Assert.Null(await repository.GetByMessageIdAsync(record!.MessageId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SesClientQueuesAndProcessesPendingMessage() {
+        var repository = new InMemoryPendingMessageRepository();
+        using var client = new SesClient {
+            PendingMessageRepository = repository,
+            Credentials = new NetworkCredential("AKIA123", "secret-key"),
+            Region = "us-east-1",
+            From = "sender@example.com",
+            To = new List<object> { "recipient@example.com" },
+            Subject = "ses",
+            Text = "body"
+        };
+
+        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) {
+            Content = new StringContent("failure", Encoding.UTF8, "text/plain")
+        }));
+        var httpClientField = typeof(SesClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        httpClientField.SetValue(client, new HttpClient(failureHandler));
+
+        var result = await client.SendEmailAsync(CancellationToken.None);
+        Assert.False(result.Status);
+
+        var record = repository.LastSaved;
+        Assert.NotNull(record);
+        Assert.Equal(EmailProvider.SES, record.Provider);
+        var accessKey = Encoding.UTF8.GetString(Convert.FromBase64String(record.ProviderData[SesPendingMessageSender.AccessKeyIdBase64Key]!));
+        var secretKey = Encoding.UTF8.GetString(Convert.FromBase64String(record.ProviderData[SesPendingMessageSender.SecretAccessKeyBase64Key]!));
+        Assert.Equal("AKIA123", accessKey);
+        Assert.Equal("secret-key", secretKey);
+        Assert.Equal("us-east-1", record.ProviderData[SesPendingMessageSender.RegionKey]);
+
+        var successHandler = new TestHandler((request, _) => {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal(new Uri("https://email.us-east-1.amazonaws.com/"), request.RequestUri);
+            Assert.Equal("application/x-www-form-urlencoded", request.Content!.Headers.ContentType!.MediaType);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+        var sender = new SesPendingMessageSender(new HttpClient(successHandler), () => new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.SES, sender }
+        });
+        var processor = new PendingMessageProcessor(repository, factory);
+
+        await processor.ProcessAsync(CancellationToken.None);
+
+        Assert.Equal(1, successHandler.CallCount);
+        Assert.Null(await repository.GetByMessageIdAsync(record!.MessageId, CancellationToken.None));
+    }
+}

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -69,6 +69,9 @@ public class SesClient : IDisposable {
     /// <summary>Collector used to store log entries.</summary>
     public LogCollector LogCollector { get; set; } = new();
 
+    /// <summary>Repository used to persist messages that require retrying.</summary>
+    public IPendingMessageRepository? PendingMessageRepository { get; set; }
+
     /// <summary>
     /// Gets the normalized sender email address.
     /// </summary>
@@ -168,7 +171,81 @@ public class SesClient : IDisposable {
         return request;
     }
 
-    private async Task<SmtpResult> SendSesRequestAsync(string body, CancellationToken cancellationToken)
+    private async Task QueuePendingMessageAsync(MimeMessage? message, string? mimeMessageBase64, CancellationToken cancellationToken)
+    {
+        if (PendingMessageRepository == null)
+        {
+            return;
+        }
+
+        if (Credentials is not NetworkCredential net)
+        {
+            LogCollector.LogWarning("Send-EmailMessage - Unable to queue SES message because credentials are not network credentials.");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(net.UserName) || string.IsNullOrEmpty(net.Password))
+        {
+            return;
+        }
+
+        var base64 = mimeMessageBase64;
+        string messageId;
+        if (message != null)
+        {
+            if (string.IsNullOrEmpty(message.MessageId))
+            {
+                message.MessageId = MimeKit.Utils.MimeUtils.GenerateMessageId();
+            }
+
+            if (string.IsNullOrEmpty(base64))
+            {
+                using var stream = new MemoryStream();
+                await message.WriteToAsync(stream, cancellationToken).ConfigureAwait(false);
+                base64 = Convert.ToBase64String(stream.ToArray());
+            }
+
+            messageId = message.MessageId;
+        }
+        else
+        {
+            if (string.IsNullOrEmpty(base64))
+            {
+                return;
+            }
+
+            messageId = Guid.NewGuid().ToString("N");
+        }
+
+        if (string.IsNullOrEmpty(base64))
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var record = new PendingMessageRecord
+        {
+            MessageId = messageId,
+            MimeMessage = base64,
+            Timestamp = now,
+            NextAttemptAt = now,
+            Provider = EmailProvider.SES
+        };
+        record.ProviderData[SesPendingMessageSender.AccessKeyIdBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(net.UserName));
+        record.ProviderData[SesPendingMessageSender.SecretAccessKeyBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(net.Password));
+        record.ProviderData[SesPendingMessageSender.RegionKey] = Region;
+
+        try
+        {
+            await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogCollector.LogWarning($"Send-EmailMessage - Failed to persist SES pending message: {ex.Message}");
+        }
+    }
+
+    private async Task<SmtpResult> SendSesRequestAsync(string body, CancellationToken cancellationToken, MimeMessage? message = null, string? mimeMessageBase64 = null)
     {
         int attempts = 0;
         Exception? lastException = null;
@@ -201,6 +278,7 @@ public class SesClient : IDisposable {
 
             if ((!Helpers.IsTransient(lastException) && !RetryAlways) || attempts >= RetryCount)
             {
+                await QueuePendingMessageAsync(message, mimeMessageBase64, cancellationToken).ConfigureAwait(false);
                 if (ErrorAction == ActionPreference.Stop && lastException != null)
                 {
                     throw lastException;
@@ -219,6 +297,7 @@ public class SesClient : IDisposable {
         }
         while (attempts <= RetryCount);
 
+        await QueuePendingMessageAsync(message, mimeMessageBase64, cancellationToken).ConfigureAwait(false);
         SmtpResult final = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message);
         await Helpers.PostWebhookAsync(WebhookUrl, final, cancellationToken, _client);
         return final;
@@ -239,7 +318,7 @@ public class SesClient : IDisposable {
         await message.WriteToAsync(stream, cancellationToken);
         string raw = Convert.ToBase64String(stream.ToArray());
         string body = $"Action=SendRawEmail&RawMessage.Data={Uri.EscapeDataString(raw)}&Version=2010-12-01";
-        return await SendSesRequestAsync(body, cancellationToken);
+        return await SendSesRequestAsync(body, cancellationToken, message, raw);
     }
 
     /// <summary>
@@ -270,7 +349,11 @@ public class SesClient : IDisposable {
         if (ReplyTo != null) sb.Append("&ReplyToAddresses.member.1=").Append(Uri.EscapeDataString(Helpers.GetEmailAddress(ReplyTo)));
         string json = TemplateData != null ? JsonSerializer.Serialize(TemplateData) : "{}";
         sb.Append("&TemplateData=").Append(Uri.EscapeDataString(json));
-        return await SendSesRequestAsync(sb.ToString(), cancellationToken);
+        MimeMessage message = BuildMessage();
+        using MemoryStream stream = new();
+        await message.WriteToAsync(stream, cancellationToken);
+        var raw = Convert.ToBase64String(stream.ToArray());
+        return await SendSesRequestAsync(sb.ToString(), cancellationToken, message, raw);
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -19,6 +20,7 @@ public sealed class GmailApiClient : IDisposable {
     private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
     private readonly HttpClient _client;
     private readonly Func<CancellationToken, Task<string>>? _refreshToken;
+    private readonly OAuthCredential? _credential;
     private bool _disposed;
 
     private void ThrowIfDisposed() {
@@ -31,6 +33,11 @@ public sealed class GmailApiClient : IDisposable {
     /// Initializes the client using the provided OAuth credential.
     /// </summary>
     public GmailApiClient(OAuthCredential credential, Func<CancellationToken, Task<string>>? refreshToken = null) {
+        if (credential == null) {
+            throw new ArgumentNullException(nameof(credential));
+        }
+
+        _credential = credential;
         _client = new HttpClient {
             BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/")
         };
@@ -38,10 +45,19 @@ public sealed class GmailApiClient : IDisposable {
         _refreshToken = refreshToken;
     }
 
-    internal GmailApiClient(HttpClient client, Func<CancellationToken, Task<string>>? refreshToken = null) {
-        _client = client;
+    internal GmailApiClient(HttpClient client, Func<CancellationToken, Task<string>>? refreshToken = null, OAuthCredential? credential = null) {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
         _refreshToken = refreshToken;
+        _credential = credential;
+        if (credential != null && !string.IsNullOrEmpty(credential.AccessToken) && _client.DefaultRequestHeaders.Authorization == null) {
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential.AccessToken);
+        }
     }
+
+    /// <summary>
+    /// Repository used to persist messages that require retrying.
+    /// </summary>
+    public IPendingMessageRepository? PendingMessageRepository { get; set; }
 
     /// <inheritdoc />
     public void Dispose() {
@@ -60,6 +76,9 @@ public sealed class GmailApiClient : IDisposable {
             if (_refreshToken != null) {
                 string token = await _refreshToken(cancellationToken).ConfigureAwait(false);
                 _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                if (_credential != null) {
+                    _credential.AccessToken = token;
+                }
             }
 #if NET5_0_OR_GREATER
             string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -70,11 +89,71 @@ public sealed class GmailApiClient : IDisposable {
         }
     }
 
+    private string? ResolveAccessToken() {
+        if (!string.IsNullOrEmpty(_credential?.AccessToken)) {
+            return _credential.AccessToken;
+        }
+
+        var authorization = _client.DefaultRequestHeaders.Authorization;
+        if (authorization != null && authorization.Scheme.Equals("Bearer", StringComparison.OrdinalIgnoreCase)) {
+            return authorization.Parameter;
+        }
+
+        return null;
+    }
+
+    private async Task QueuePendingMessageAsync(string userId, MimeMessage message, CancellationToken cancellationToken) {
+        if (PendingMessageRepository == null) {
+            return;
+        }
+
+        var accessToken = ResolveAccessToken();
+        if (string.IsNullOrEmpty(accessToken)) {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(message.MessageId)) {
+            message.MessageId = MimeKit.Utils.MimeUtils.GenerateMessageId();
+        }
+
+        using var stream = new MemoryStream();
+        await message.WriteToAsync(stream, cancellationToken).ConfigureAwait(false);
+
+        var now = DateTimeOffset.UtcNow;
+        var record = new PendingMessageRecord {
+            MessageId = message.MessageId,
+            MimeMessage = Convert.ToBase64String(stream.ToArray()),
+            Timestamp = now,
+            NextAttemptAt = now,
+            Provider = EmailProvider.Gmail
+        };
+
+        var credential = _credential;
+        var userName = !string.IsNullOrWhiteSpace(credential?.UserName) ? credential!.UserName : userId;
+        var expiresOn = credential?.ExpiresOn ?? DateTimeOffset.MaxValue;
+        record.ProviderData[GmailPendingMessageSender.UserIdKey] = userId;
+        record.ProviderData[GmailPendingMessageSender.UserNameKey] = userName;
+        record.ProviderData[GmailPendingMessageSender.ExpiresOnKey] = expiresOn.ToString("o", CultureInfo.InvariantCulture);
+        record.ProviderData[GmailPendingMessageSender.AccessTokenBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(accessToken));
+        if (!string.IsNullOrEmpty(credential?.RefreshToken)) {
+            record.ProviderData[GmailPendingMessageSender.RefreshTokenBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(credential.RefreshToken));
+        }
+
+        try {
+            await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+        } catch (Exception ex) {
+            LoggingMessages.Logger.WriteWarning($"Failed to persist Gmail pending message: {ex.Message}");
+        }
+    }
+
     /// <summary>
     /// Sends the specified MIME message via Gmail API.
     /// </summary>
     public async Task<GmailMessage> SendAsync(string userId, MimeMessage message, CancellationToken cancellationToken = default) {
         ThrowIfDisposed();
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
         using var ms = new MemoryStream();
         await message.WriteToAsync(ms, cancellationToken).ConfigureAwait(false);
         var raw = Convert.ToBase64String(ms.ToArray())
@@ -84,8 +163,38 @@ public sealed class GmailApiClient : IDisposable {
         var json = JsonSerializer.Serialize(new { raw }, s_jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _client.PostAsync($"users/{userId}/messages/send", content, cancellationToken).ConfigureAwait(false);
-        await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        var queued = false;
+        try {
+            await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) {
+#if NET5_0_OR_GREATER
+                var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+                var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+                await QueuePendingMessageAsync(userId, message, cancellationToken).ConfigureAwait(false);
+                queued = true;
+                throw new HttpRequestException($"Gmail returned {(int)response.StatusCode} ({response.StatusCode}): {error}");
+            }
+        } catch (GmailAuthenticationException) {
+            if (!queued) {
+                await QueuePendingMessageAsync(userId, message, cancellationToken).ConfigureAwait(false);
+                queued = true;
+            }
+            throw;
+        } catch (HttpRequestException) {
+            if (!queued) {
+                await QueuePendingMessageAsync(userId, message, cancellationToken).ConfigureAwait(false);
+                queued = true;
+            }
+            throw;
+        } catch (TaskCanceledException) {
+            if (!queued) {
+                await QueuePendingMessageAsync(userId, message, cancellationToken).ConfigureAwait(false);
+                queued = true;
+            }
+            throw;
+        }
 #if NET5_0_OR_GREATER
         var resultJson = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -83,6 +83,9 @@ public class MailgunClient : IDisposable {
     /// <summary>URL of the webhook called after sending.</summary>
     public string? WebhookUrl { get; set; }
 
+    /// <summary>Repository used to persist messages that need retrying.</summary>
+    public IPendingMessageRepository? PendingMessageRepository { get; set; }
+
     /// <summary>The normalized sender email address.</summary>
     public string SentFrom => Helpers.GetEmailAddress(From);
     /// <summary>Comma separated list of recipients.</summary>
@@ -182,6 +185,80 @@ public class MailgunClient : IDisposable {
         return content;
     }
 
+    private MimeMessage BuildMimeMessage() {
+        var smtp = new Smtp {
+            From = From,
+            To = To,
+            Cc = Cc,
+            Bcc = Bcc,
+            ReplyTo = ReplyTo,
+            Subject = Subject ?? string.Empty,
+            TextBody = Text,
+            HtmlBody = Html,
+            Headers = Headers
+        };
+        if (Attachment != null) {
+            smtp.Attachments = Attachment.Cast<object>().ToList();
+        }
+        if (InlineAttachment != null) {
+            smtp.InlineAttachments = InlineAttachment.Cast<object>().ToList();
+        }
+        smtp.CreateMessage();
+        return smtp.Message;
+    }
+
+    private async Task QueuePendingMessageAsync(CancellationToken cancellationToken) {
+        if (PendingMessageRepository == null) {
+            return;
+        }
+
+        string apiKey;
+        string domain;
+        try {
+            apiKey = ApiKey;
+            domain = EmailDomain;
+        } catch (Exception ex) {
+            LogCollector.LogWarning($"Send-EmailMessage - Failed to capture Mailgun credentials for retry: {ex.Message}");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(apiKey)) {
+            return;
+        }
+
+        MimeMessage message;
+        try {
+            message = BuildMimeMessage();
+        } catch (Exception ex) {
+            LogCollector.LogWarning($"Send-EmailMessage - Failed to serialize Mailgun message for retry: {ex.Message}");
+            return;
+        }
+
+        var messageId = string.IsNullOrEmpty(message.MessageId)
+            ? MimeKit.Utils.MimeUtils.GenerateMessageId(domain)
+            : message.MessageId;
+
+        using var stream = new MemoryStream();
+        await message.WriteToAsync(stream, cancellationToken).ConfigureAwait(false);
+
+        var now = DateTimeOffset.UtcNow;
+        var record = new PendingMessageRecord {
+            MessageId = messageId,
+            MimeMessage = Convert.ToBase64String(stream.ToArray()),
+            Timestamp = now,
+            NextAttemptAt = now,
+            Provider = EmailProvider.Mailgun
+        };
+        record.ProviderData[MailgunPendingMessageSender.DomainKey] = domain;
+        record.ProviderData[MailgunPendingMessageSender.ApiKeyBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(apiKey));
+
+        try {
+            await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+        } catch (Exception ex) {
+            LogCollector.LogWarning($"Send-EmailMessage - Failed to persist Mailgun pending message: {ex.Message}");
+        }
+    }
+
     /// <summary>
     /// Sends the email using the Mailgun REST API.
     /// </summary>
@@ -226,6 +303,7 @@ public class MailgunClient : IDisposable {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Mailgun: {ex.Message}");
                 if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
+                    await QueuePendingMessageAsync(cancellationToken).ConfigureAwait(false);
                     if (ErrorAction == ActionPreference.Stop) throw;
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", ex.Message);
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
@@ -236,6 +314,7 @@ public class MailgunClient : IDisposable {
             }
             attempts++;
         } while (attempts <= RetryCount);
+        await QueuePendingMessageAsync(cancellationToken).ConfigureAwait(false);
         var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", lastException?.Message);
         await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken).ConfigureAwait(false);
         return finalResult;

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -95,6 +95,11 @@ public sealed class SendGridClient : IDisposable {
     public ActionPreference? ErrorAction { get; set; }
 
     /// <summary>
+    /// Repository used to persist messages that require retrying.
+    /// </summary>
+    public IPendingMessageRepository? PendingMessageRepository { get; set; }
+
+    /// <summary>
     /// Number of times to retry sending the message when an error occurs.
     /// </summary>
     public int RetryCount { get; set; } = 0;
@@ -361,6 +366,7 @@ public sealed class SendGridClient : IDisposable {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - HTTP error during sending using SendGrid: {ex.Message}");
                 if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
+                    await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
                     if (ErrorAction == ActionPreference.Stop && lastException != null) {
                         throw lastException;
                     }
@@ -377,6 +383,7 @@ public sealed class SendGridClient : IDisposable {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Request canceled: {ex.Message}");
                 if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
+                    await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
                     if (ErrorAction == ActionPreference.Stop && lastException != null) {
                         throw lastException;
                     }
@@ -392,9 +399,40 @@ public sealed class SendGridClient : IDisposable {
             attempts++;
         } while (attempts <= RetryCount);
 
+        await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
         var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
         await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken).ConfigureAwait(false);
         return finalResult;
+    }
+
+    private async Task QueuePendingMessageAsync(string apiKey, CancellationToken cancellationToken) {
+        if (PendingMessageRepository == null) {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(MessageJson)) {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(apiKey)) {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var record = new PendingMessageRecord {
+            MessageId = Guid.NewGuid().ToString("N"),
+            Timestamp = now,
+            NextAttemptAt = now,
+            Provider = EmailProvider.SendGrid
+        };
+        record.ProviderData[SendGridPendingMessageSender.MessageJsonKey] = MessageJson;
+        record.ProviderData[SendGridPendingMessageSender.ApiKeyBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(apiKey));
+
+        try {
+            await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+        } catch (Exception ex) {
+            LogCollector.LogWarning($"Send-EmailMessage - Failed to persist SendGrid pending message: {ex.Message}");
+        }
     }
 
     private void ThrowIfDisposed() {

--- a/Sources/Mailozaurr/SentMessages/Senders/GmailPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/GmailPendingMessageSender.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 
 namespace Mailozaurr;
 
@@ -8,9 +9,11 @@ namespace Mailozaurr;
 public sealed class GmailPendingMessageSender : IPendingMessageSender {
     internal const string UserIdKey = "UserId";
     internal const string AccessTokenKey = "AccessToken";
+    internal const string AccessTokenBase64Key = "AccessTokenBase64";
     internal const string UserNameKey = "UserName";
     internal const string ExpiresOnKey = "ExpiresOn";
     internal const string RefreshTokenKey = "RefreshToken";
+    internal const string RefreshTokenBase64Key = "RefreshTokenBase64";
 
     private readonly Func<OAuthCredential, GmailApiClient> clientFactory;
 
@@ -30,11 +33,8 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
         if (!record.ProviderData.TryGetValue(UserIdKey, out var userId) || string.IsNullOrWhiteSpace(userId)) {
             throw new InvalidOperationException("Pending Gmail message is missing the user identifier.");
         }
-        if (!record.ProviderData.TryGetValue(AccessTokenKey, out var accessToken) || string.IsNullOrWhiteSpace(accessToken)) {
-            throw new InvalidOperationException("Pending Gmail message is missing an access token.");
-        }
-
         var message = await LoadMessageAsync(record, ct).ConfigureAwait(false);
+        var accessToken = ResolveAccessToken(record.ProviderData);
         var credential = BuildCredential(record.ProviderData, accessToken, userId);
         using var client = clientFactory(credential);
         _ = await client.SendAsync(userId, message, ct).ConfigureAwait(false);
@@ -57,10 +57,37 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
                 : userId,
             ExpiresOn = ResolveExpiration(providerData),
         };
-        if (providerData.TryGetValue(RefreshTokenKey, out var refreshToken) && !string.IsNullOrWhiteSpace(refreshToken)) {
+        var refreshToken = ResolveRefreshToken(providerData);
+        if (!string.IsNullOrEmpty(refreshToken)) {
             credential.RefreshToken = refreshToken;
         }
         return credential;
+    }
+
+    private static string ResolveAccessToken(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(AccessTokenBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
+            var bytes = Convert.FromBase64String(encoded);
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        if (providerData.TryGetValue(AccessTokenKey, out var token) && !string.IsNullOrWhiteSpace(token)) {
+            return token;
+        }
+
+        throw new InvalidOperationException("Pending Gmail message is missing an access token.");
+    }
+
+    private static string? ResolveRefreshToken(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(RefreshTokenBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
+            var bytes = Convert.FromBase64String(encoded);
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        if (providerData.TryGetValue(RefreshTokenKey, out var token) && !string.IsNullOrWhiteSpace(token)) {
+            return token;
+        }
+
+        return null;
     }
 
     private static DateTimeOffset ResolveExpiration(Dictionary<string, string> providerData) {

--- a/Sources/Mailozaurr/SentMessages/Senders/SesPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/SesPendingMessageSender.cs
@@ -10,6 +10,8 @@ namespace Mailozaurr;
 public sealed class SesPendingMessageSender : IPendingMessageSender {
     internal const string AccessKeyIdKey = "AccessKeyId";
     internal const string SecretAccessKeyKey = "SecretAccessKey";
+    internal const string AccessKeyIdBase64Key = "AccessKeyIdBase64";
+    internal const string SecretAccessKeyBase64Key = "SecretAccessKeyBase64";
     internal const string RegionKey = "Region";
 
     private readonly HttpClient httpClient;
@@ -33,12 +35,8 @@ public sealed class SesPendingMessageSender : IPendingMessageSender {
         if (string.IsNullOrWhiteSpace(record.MimeMessage)) {
             throw new InvalidOperationException("Pending SES message does not contain MIME content.");
         }
-        if (!record.ProviderData.TryGetValue(AccessKeyIdKey, out var accessKey) || string.IsNullOrWhiteSpace(accessKey)) {
-            throw new InvalidOperationException("Pending SES message is missing the AWS access key identifier.");
-        }
-        if (!record.ProviderData.TryGetValue(SecretAccessKeyKey, out var secretKey) || string.IsNullOrWhiteSpace(secretKey)) {
-            throw new InvalidOperationException("Pending SES message is missing the AWS secret access key.");
-        }
+        var accessKey = ResolveAccessKey(record.ProviderData);
+        var secretKey = ResolveSecretKey(record.ProviderData);
         var region = record.ProviderData.TryGetValue(RegionKey, out var regionValue) && !string.IsNullOrWhiteSpace(regionValue)
             ? regionValue
             : "us-east-1";
@@ -62,6 +60,32 @@ public sealed class SesPendingMessageSender : IPendingMessageSender {
 
     private static string BuildRequestBody(string mimeMessageBase64) {
         return $"Action=SendRawEmail&RawMessage.Data={Uri.EscapeDataString(mimeMessageBase64)}&Version=2010-12-01";
+    }
+
+    private static string ResolveAccessKey(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(AccessKeyIdBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
+            var bytes = Convert.FromBase64String(encoded);
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        if (providerData.TryGetValue(AccessKeyIdKey, out var accessKey) && !string.IsNullOrWhiteSpace(accessKey)) {
+            return accessKey;
+        }
+
+        throw new InvalidOperationException("Pending SES message is missing the AWS access key identifier.");
+    }
+
+    private static string ResolveSecretKey(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(SecretAccessKeyBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
+            var bytes = Convert.FromBase64String(encoded);
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        if (providerData.TryGetValue(SecretAccessKeyKey, out var secretKey) && !string.IsNullOrWhiteSpace(secretKey)) {
+            return secretKey;
+        }
+
+        throw new InvalidOperationException("Pending SES message is missing the AWS secret access key.");
     }
 
     private static HttpRequestMessage CreateRequest(string accessKey, string secretKey, string region, string content, DateTime nowUtc) {

--- a/Tests/Send-EmailPendingMessage.Tests.ps1
+++ b/Tests/Send-EmailPendingMessage.Tests.ps1
@@ -29,8 +29,14 @@ public sealed class FakePendingMessageSender : IPendingMessageSender {
 
 public static class FakePendingMessageSenderFactory {
     public static PendingMessageSenderFactory Create() {
-        var pair = new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.None, new FakePendingMessageSender());
-        return new PendingMessageSenderFactory(new[] { pair });
+        var entries = new [] {
+            new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.None, new FakePendingMessageSender()),
+            new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.SendGrid, new FakePendingMessageSender()),
+            new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.Mailgun, new FakePendingMessageSender()),
+            new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.SES, new FakePendingMessageSender()),
+            new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.Gmail, new FakePendingMessageSender()),
+        };
+        return new PendingMessageSenderFactory(entries);
     }
 }
 "@
@@ -115,6 +121,45 @@ public static class FakePendingMessageSenderFactory {
         $remaining = @(Get-EmailPendingMessage -PendingMessagesPath $path)
         $remaining.Count | Should -Be 1
         $remaining[0].Provider | Should -Be ([Mailozaurr.EmailProvider]::Gmail)
+    }
+
+    It 'Replays non-SMTP messages when filtered by provider' {
+        $path = Join-Path $TestDrive 'pending-api'
+        $options = [Mailozaurr.PendingMessageRepositoryOptions]::new()
+        $options.DirectoryPath = $path
+        $repo = [Mailozaurr.FilePendingMessageRepository]::new($options)
+
+        $message = [MimeKit.MimeMessage]::new()
+        $message.From.Add([MimeKit.MailboxAddress]::Parse('sender@example.com'))
+        $message.To.Add([MimeKit.MailboxAddress]::Parse('recipient@example.com'))
+        $message.Subject = 'queued'
+        $message.Body = [MimeKit.TextPart]::new('plain')
+        $buffer = [System.IO.MemoryStream]::new()
+        $message.WriteTo($buffer)
+        $payload = [Convert]::ToBase64String($buffer.ToArray())
+
+        $gmailRecord = [Mailozaurr.PendingMessageRecord]::new()
+        $gmailRecord.MessageId = [Guid]::NewGuid().ToString()
+        $gmailRecord.MimeMessage = $payload
+        $gmailRecord.Timestamp = [DateTimeOffset]::UtcNow
+        $gmailRecord.NextAttemptAt = [DateTimeOffset]::UtcNow
+        $gmailRecord.Provider = [Mailozaurr.EmailProvider]::Gmail
+        $repo.SaveAsync($gmailRecord).GetAwaiter().GetResult()
+
+        $sendGridRecord = [Mailozaurr.PendingMessageRecord]::new()
+        $sendGridRecord.MessageId = [Guid]::NewGuid().ToString()
+        $sendGridRecord.MimeMessage = $payload
+        $sendGridRecord.Timestamp = [DateTimeOffset]::UtcNow
+        $sendGridRecord.NextAttemptAt = [DateTimeOffset]::UtcNow
+        $sendGridRecord.Provider = [Mailozaurr.EmailProvider]::SendGrid
+        $repo.SaveAsync($sendGridRecord).GetAwaiter().GetResult()
+
+        Send-EmailPendingMessage -PendingMessagesPath $path -Provider ([Mailozaurr.EmailProvider]::Gmail)
+
+        [FakePendingMessageSender]::SendCount | Should -Be 1
+        $remaining = @(Get-EmailPendingMessage -PendingMessagesPath $path)
+        $remaining.Count | Should -Be 1
+        $remaining[0].Provider | Should -Be ([Mailozaurr.EmailProvider]::SendGrid)
     }
 
     It 'Honors schedule unless ProcessAll is specified' {


### PR DESCRIPTION
## Summary
- integrate pending message persistence into SendGrid, Mailgun, Gmail API, and SES senders so final failures are queued with provider metadata
- base64-encode provider secrets and update Gmail/SES pending senders to consume the new fields
- add provider replay unit tests plus a PowerShell scenario proving non-SMTP filtering in Send-EmailPendingMessage

## Testing
- `dotnet test Sources/Mailozaurr.sln`
- `pwsh -File Mailozaurr.Tests.ps1` *(fails: existing PowerShell suite still reports known environment-dependent failures such as POP3/SMTP mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68cac4b09a44832eade87a6a0bc55cc2