### PR TITLE
Ensure pending message saves replace existing entries

### DIFF
--- a/Sources/Mailozaurr.Tests/FilePendingMessageRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/FilePendingMessageRepositoryTests.cs
@@ -75,4 +75,72 @@ public sealed class FilePendingMessageRepositoryTests {
         Assert.Contains("FileNamingScheme", ex.Message);
         Assert.IsType<InvalidOperationException>(ex.InnerException);
     }
+
+    [Fact]
+    public async Task SaveAsync_ReplacesExistingMessageWithSameId() {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var options = new PendingMessageRepositoryOptions { DirectoryPath = dir, FileNamingScheme = () => "pending.log" };
+        var filePath = Path.Combine(dir, "pending.log");
+        Directory.CreateDirectory(dir);
+
+        try {
+            var repo = new FilePendingMessageRepository(options);
+            var messageId = Guid.NewGuid().ToString("N");
+            var initial = new PendingMessageRecord {
+                MessageId = messageId,
+                Timestamp = DateTimeOffset.UtcNow,
+                NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+                Provider = EmailProvider.SendGrid,
+                AttemptCount = 1
+            };
+
+            await repo.SaveAsync(initial);
+
+            var updated = new PendingMessageRecord {
+                MessageId = messageId,
+                Timestamp = initial.Timestamp.AddMinutes(1),
+                NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(10),
+                Provider = EmailProvider.Mailgun,
+                AttemptCount = 3
+            };
+
+            await repo.SaveAsync(updated);
+
+            var loaded = await repo.GetByMessageIdAsync(messageId);
+            Assert.NotNull(loaded);
+            Assert.Equal(updated.AttemptCount, loaded!.AttemptCount);
+            Assert.Equal(updated.Provider, loaded.Provider);
+            Assert.Equal(updated.NextAttemptAt, loaded.NextAttemptAt);
+
+            var nonEmptyLines = 0;
+            foreach (var line in File.ReadAllLines(filePath)) {
+                if (!string.IsNullOrWhiteSpace(line)) {
+                    nonEmptyLines++;
+                }
+            }
+
+            Assert.Equal(1, nonEmptyLines);
+
+            var records = await ReadAllAsync(repo);
+            Assert.Single(records);
+            Assert.Equal(messageId, records[0].MessageId);
+            Assert.Equal(updated.AttemptCount, records[0].AttemptCount);
+        } finally {
+            if (File.Exists(filePath)) {
+                File.Delete(filePath);
+            }
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
+    private static async Task<List<PendingMessageRecord>> ReadAllAsync(IPendingMessageRepository repository) {
+        var records = new List<PendingMessageRecord>();
+        await foreach (var record in repository.GetAllAsync()) {
+            records.Add(record);
+        }
+
+        return records;
+    }
 }

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorFileRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorFileRepositoryTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,6 +48,118 @@ public sealed class PendingMessageProcessorFileRepositoryTests {
             if (Directory.Exists(directory)) {
                 Directory.Delete(directory, true);
             }
+        }
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RetriesRespectDelaysAndRetryLimit() {
+        var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var options = new PendingMessageRepositoryOptions {
+            DirectoryPath = directory,
+            FileNamingScheme = () => "pending.log"
+        };
+        Directory.CreateDirectory(directory);
+        var repository = new FilePendingMessageRepository(options);
+        var filePath = Path.Combine(directory, "pending.log");
+
+        try {
+            var baseTime = DateTimeOffset.Parse("2024-06-01T10:00:00Z");
+            var currentTime = baseTime;
+            var retryDelay = TimeSpan.FromMinutes(10);
+            var leaseDuration = TimeSpan.FromMinutes(1);
+            const int maxAttempts = 3;
+
+            var record = new PendingMessageRecord {
+                MessageId = Guid.NewGuid().ToString("N"),
+                Timestamp = baseTime,
+                NextAttemptAt = baseTime,
+                Provider = EmailProvider.None
+            };
+            await repository.SaveAsync(record);
+
+            var sender = new FailingPendingMessageSender();
+            var pair = new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.None, sender);
+            var factory = new PendingMessageSenderFactory(new[] { pair });
+            var processor = new PendingMessageProcessor(
+                repository,
+                factory,
+                retryDelaySelector: _ => retryDelay,
+                clock: () => currentTime,
+                maxRetryAttempts: maxAttempts,
+                processingLeaseDuration: leaseDuration);
+
+            await processor.ProcessAsync();
+
+            Assert.Equal(1, sender.Attempts);
+            var pending = await repository.GetByMessageIdAsync(record.MessageId);
+            Assert.NotNull(pending);
+            Assert.Equal(1, pending!.AttemptCount);
+            Assert.Equal(baseTime + retryDelay, pending.NextAttemptAt);
+            Assert.Equal(1, CountNonEmptyLines(filePath));
+
+            currentTime = baseTime.AddMinutes(5);
+            await processor.ProcessAsync();
+            pending = await repository.GetByMessageIdAsync(record.MessageId);
+            Assert.NotNull(pending);
+            Assert.Equal(1, pending!.AttemptCount);
+            Assert.Equal(baseTime + retryDelay, pending.NextAttemptAt);
+            Assert.Equal(1, sender.Attempts);
+
+            currentTime = baseTime + retryDelay + TimeSpan.FromMinutes(1);
+            await processor.ProcessAsync();
+            pending = await repository.GetByMessageIdAsync(record.MessageId);
+            Assert.NotNull(pending);
+            Assert.Equal(2, pending!.AttemptCount);
+            var expectedNextAttempt = currentTime + retryDelay;
+            Assert.Equal(expectedNextAttempt, pending.NextAttemptAt);
+            Assert.Equal(2, sender.Attempts);
+            Assert.Equal(1, CountNonEmptyLines(filePath));
+
+            currentTime = expectedNextAttempt.AddMinutes(-2);
+            await processor.ProcessAsync();
+            pending = await repository.GetByMessageIdAsync(record.MessageId);
+            Assert.NotNull(pending);
+            Assert.Equal(2, pending!.AttemptCount);
+            Assert.Equal(expectedNextAttempt, pending.NextAttemptAt);
+            Assert.Equal(2, sender.Attempts);
+
+            currentTime = expectedNextAttempt.AddMinutes(1);
+            await processor.ProcessAsync();
+            pending = await repository.GetByMessageIdAsync(record.MessageId);
+            Assert.Null(pending);
+            Assert.Equal(maxAttempts, sender.Attempts);
+            Assert.Equal(0, CountNonEmptyLines(filePath));
+        } finally {
+            if (File.Exists(filePath)) {
+                File.Delete(filePath);
+            }
+            if (Directory.Exists(directory)) {
+                Directory.Delete(directory, true);
+            }
+        }
+    }
+
+    private static int CountNonEmptyLines(string path) {
+        if (!File.Exists(path)) {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var line in File.ReadAllLines(path)) {
+            if (!string.IsNullOrWhiteSpace(line)) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private sealed class FailingPendingMessageSender : IPendingMessageSender {
+        public int Attempts { get; private set; }
+
+        public Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+            Attempts++;
+            throw new HttpRequestException("Simulated failure");
         }
     }
 

--- a/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
@@ -82,14 +82,75 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
 
             _ = record.ProviderData;
             var payload = JsonSerializer.SerializeToUtf8Bytes(record, SerializerOptions);
+            var hasExistingRecord = File.Exists(filePath) && index.ContainsKey(record.MessageId);
 
-            using var write = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
-            var offset = write.Position;
-            await write.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
-            await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken).ConfigureAwait(false);
-            await write.FlushAsync(cancellationToken).ConfigureAwait(false);
+            if (!hasExistingRecord) {
+                using var write = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+                var offset = write.Position;
+                await write.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
+                await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken).ConfigureAwait(false);
+                await write.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-            index[record.MessageId] = offset;
+                index[record.MessageId] = offset;
+                return;
+            }
+
+            var temp = filePath + ".tmp";
+            if (File.Exists(temp)) {
+                File.Delete(temp);
+            }
+
+            var newIndex = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+
+            try {
+                using (var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None))
+                using (var write = new FileStream(temp, FileMode.Create, FileAccess.Write, FileShare.None)) {
+                    using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
+                    long position = 0;
+                    string? line;
+                    while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null) {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        if (string.IsNullOrWhiteSpace(line)) {
+                            continue;
+                        }
+
+                        var existingRecord = DeserializeRecord(line);
+                        if (existingRecord == null || string.IsNullOrWhiteSpace(existingRecord.MessageId)) {
+                            continue;
+                        }
+
+                        if (string.Equals(existingRecord.MessageId, record.MessageId, StringComparison.OrdinalIgnoreCase)) {
+                            continue;
+                        }
+
+                        var bytes = Encoding.UTF8.GetBytes(line);
+                        await write.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+                        await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken).ConfigureAwait(false);
+                        newIndex[existingRecord.MessageId] = position;
+                        position += bytes.Length + newlineBytes.Length;
+                    }
+
+                    newIndex[record.MessageId] = position;
+                    await write.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
+                    await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken).ConfigureAwait(false);
+                    await write.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+                File.Move(temp, filePath);
+
+                index.Clear();
+                foreach (var pair in newIndex) {
+                    index[pair.Key] = pair.Value;
+                }
+            } finally {
+                if (File.Exists(temp)) {
+                    File.Delete(temp);
+                }
+            }
         } finally {
             gate.Release();
         }
@@ -131,6 +192,8 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
 
         await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
+            var orderedIds = new List<string>();
+            var recordsById = new Dictionary<string, PendingMessageRecord>(StringComparer.OrdinalIgnoreCase);
             using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
             string? line;
@@ -141,7 +204,19 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
                 }
 
                 var record = DeserializeRecord(line);
-                if (record != null) {
+                if (record == null || string.IsNullOrWhiteSpace(record.MessageId)) {
+                    continue;
+                }
+
+                if (!recordsById.ContainsKey(record.MessageId)) {
+                    orderedIds.Add(record.MessageId);
+                }
+
+                recordsById[record.MessageId] = record;
+            }
+
+            foreach (var id in orderedIds) {
+                if (recordsById.TryGetValue(id, out var record)) {
                     snapshot.Add(record);
                 }
             }


### PR DESCRIPTION
## Summary
- update `FilePendingMessageRepository` so saving an existing message ID rewrites the log and ensures `GetAllAsync` only returns the most recent version
- add unit coverage that verifies duplicate saves are pruned
- add a regression test around the file-backed processor to confirm retries respect delays and stop at the retry limit

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68caee3f8dcc832eb4183009ba66b4ba