### PR TITLE
Handle concurrent AES credential key creation

### DIFF
--- a/Sources/Mailozaurr.Tests/Cryptography/AesCredentialProtectorTests.cs
+++ b/Sources/Mailozaurr.Tests/Cryptography/AesCredentialProtectorTests.cs
@@ -63,7 +63,9 @@ public sealed class AesCredentialProtectorTests {
     }
 
     private sealed class KeyDirectoryScope : IDisposable {
-        private static readonly string[] VariableNames = new[] {
+        private const string OverrideVariable = "MAILOZAURR_KEY_DIRECTORY";
+
+        private static readonly string[] BasePathVariables = new[] {
             "LOCALAPPDATA",
             "APPDATA",
             "HOME",
@@ -78,9 +80,10 @@ public sealed class AesCredentialProtectorTests {
             root = Path.Combine(Path.GetTempPath(), "Mailozaurr", "KeyTests", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(root);
 
-            foreach (var variable in VariableNames) {
-                previousValues[variable] = Environment.GetEnvironmentVariable(variable);
-                Environment.SetEnvironmentVariable(variable, root);
+            SetVariable(OverrideVariable, Path.Combine(root, "keys"));
+
+            foreach (var variable in BasePathVariables) {
+                SetVariable(variable, root);
             }
         }
 
@@ -96,6 +99,11 @@ public sealed class AesCredentialProtectorTests {
             } catch {
                 // Best-effort cleanup.
             }
+        }
+
+        private void SetVariable(string name, string value) {
+            previousValues[name] = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
         }
     }
 }

--- a/Sources/Mailozaurr.Tests/Cryptography/AesCredentialProtectorTests.cs
+++ b/Sources/Mailozaurr.Tests/Cryptography/AesCredentialProtectorTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Mailozaurr;
+
+namespace Mailozaurr.Tests.Cryptography;
+
+public sealed class AesCredentialProtectorTests {
+    [Fact]
+    public async Task ConcurrentInstancesShareKeyMaterial() {
+        using var scope = new KeyDirectoryScope();
+
+        var keyDirectory = CredentialProtectionPaths.ResolveKeyDirectory();
+        if (Directory.Exists(keyDirectory)) {
+            Directory.Delete(keyDirectory, true);
+        }
+
+        var startEvent = new ManualResetEventSlim(false);
+        var concurrencyLevel = Math.Max(4, Environment.ProcessorCount);
+        var tasks = new List<Task<(byte[] Key, string CipherText, string PlainText)>>(concurrencyLevel);
+
+        for (var i = 0; i < concurrencyLevel; i++) {
+            var secret = $"secret-{i}";
+            tasks.Add(Task.Run(() => {
+                startEvent.Wait();
+                var protector = new AesCredentialProtector();
+                var cipher = protector.Protect(secret);
+                var keyMaterial = GetKeyMaterial(protector);
+                return (keyMaterial, cipher, secret);
+            }));
+        }
+
+        startEvent.Set();
+
+        var results = await Task.WhenAll(tasks);
+
+        var verifier = new AesCredentialProtector();
+        foreach (var (_, cipher, plain) in results) {
+            var roundtrip = verifier.Unprotect(cipher);
+            Assert.Equal(plain, roundtrip);
+        }
+
+        var keyPath = Path.Combine(keyDirectory, "credential.key");
+        Assert.True(File.Exists(keyPath));
+        var keyBytes = File.ReadAllBytes(keyPath);
+        Assert.Equal(32, keyBytes.Length);
+
+        foreach (var (key, _, _) in results) {
+            Assert.Equal(keyBytes, key);
+        }
+    }
+
+    private static byte[] GetKeyMaterial(AesCredentialProtector protector) {
+        var field = typeof(AesCredentialProtector).GetField("key", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        var value = field!.GetValue(protector) as byte[];
+        Assert.NotNull(value);
+        return ((byte[])value!).ToArray();
+    }
+
+    private sealed class KeyDirectoryScope : IDisposable {
+        private static readonly string[] VariableNames = new[] {
+            "LOCALAPPDATA",
+            "APPDATA",
+            "HOME",
+            "USERPROFILE",
+            "XDG_DATA_HOME"
+        };
+
+        private readonly Dictionary<string, string?> previousValues = new();
+        private readonly string root;
+
+        public KeyDirectoryScope() {
+            root = Path.Combine(Path.GetTempPath(), "Mailozaurr", "KeyTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+
+            foreach (var variable in VariableNames) {
+                previousValues[variable] = Environment.GetEnvironmentVariable(variable);
+                Environment.SetEnvironmentVariable(variable, root);
+            }
+        }
+
+        public void Dispose() {
+            foreach (var pair in previousValues) {
+                Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+            }
+
+            try {
+                if (Directory.Exists(root)) {
+                    Directory.Delete(root, true);
+                }
+            } catch {
+                // Best-effort cleanup.
+            }
+        }
+    }
+}

--- a/Sources/Mailozaurr/Cryptography/AesCredentialProtector.cs
+++ b/Sources/Mailozaurr/Cryptography/AesCredentialProtector.cs
@@ -208,17 +208,22 @@ internal sealed class AesCredentialProtector : ICredentialProtector {
     }
 
     private static bool IsSharingViolation(Exception ex) {
-        const int ERROR_SHARING_VIOLATION = unchecked((int)0x80070020);
-        const int ERROR_LOCK_VIOLATION = unchecked((int)0x80070021);
-        const int ERROR_FILE_EXISTS = unchecked((int)0x80070050);
-        const int ERROR_ALREADY_EXISTS = unchecked((int)0x800700B7);
-        const int ERROR_ACCESS_DENIED = unchecked((int)0x80070005);
+        const int ERROR_SHARING_VIOLATION = 32;
+        const int ERROR_LOCK_VIOLATION = 33;
+        const int ERROR_FILE_EXISTS = 80;
+        const int ERROR_ALREADY_EXISTS = 183;
+        const int ERROR_ACCESS_DENIED = 5;
+        const int EACCES = 13;
+        const int EAGAIN = 11;
 
-        var hresult = ex.HResult;
-        return hresult == ERROR_SHARING_VIOLATION
-            || hresult == ERROR_LOCK_VIOLATION
-            || hresult == ERROR_FILE_EXISTS
-            || hresult == ERROR_ALREADY_EXISTS
-            || hresult == ERROR_ACCESS_DENIED;
+        var code = (int)((uint)ex.HResult & 0xFFFF);
+
+        return code == ERROR_SHARING_VIOLATION
+            || code == ERROR_LOCK_VIOLATION
+            || code == ERROR_FILE_EXISTS
+            || code == ERROR_ALREADY_EXISTS
+            || code == ERROR_ACCESS_DENIED
+            || code == EACCES
+            || code == EAGAIN;
     }
 }

--- a/Sources/Mailozaurr/Cryptography/AesCredentialProtector.cs
+++ b/Sources/Mailozaurr/Cryptography/AesCredentialProtector.cs
@@ -218,12 +218,26 @@ internal sealed class AesCredentialProtector : ICredentialProtector {
 
         var code = (int)((uint)ex.HResult & 0xFFFF);
 
-        return code == ERROR_SHARING_VIOLATION
+        if (code == ERROR_SHARING_VIOLATION
             || code == ERROR_LOCK_VIOLATION
             || code == ERROR_FILE_EXISTS
             || code == ERROR_ALREADY_EXISTS
             || code == ERROR_ACCESS_DENIED
             || code == EACCES
-            || code == EAGAIN;
+            || code == EAGAIN) {
+            return true;
+        }
+
+        if (ex is IOException ioEx) {
+            var message = ioEx.Message;
+            if (!string.IsNullOrEmpty(message)) {
+                if (message.IndexOf("sharing violation", StringComparison.OrdinalIgnoreCase) >= 0
+                    || message.IndexOf("used by another process", StringComparison.OrdinalIgnoreCase) >= 0) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/Sources/Mailozaurr/Cryptography/AesCredentialProtector.cs
+++ b/Sources/Mailozaurr/Cryptography/AesCredentialProtector.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 
 namespace Mailozaurr;
 
@@ -62,23 +63,162 @@ internal sealed class AesCredentialProtector : ICredentialProtector {
         return Encoding.UTF8.GetString(plaintextBytes);
     }
 
+    private static readonly TimeSpan[] RetryDelays = new[] {
+        TimeSpan.Zero,
+        TimeSpan.FromMilliseconds(20),
+        TimeSpan.FromMilliseconds(50),
+        TimeSpan.FromMilliseconds(100),
+        TimeSpan.FromMilliseconds(200),
+        TimeSpan.FromMilliseconds(400)
+    };
+
     private static byte[] LoadOrCreateKey() {
         var directory = CredentialProtectionPaths.ResolveKeyDirectory();
         Directory.CreateDirectory(directory);
         var keyPath = Path.Combine(directory, KeyFileName);
 
-        if (File.Exists(keyPath)) {
-            var existingKey = File.ReadAllBytes(keyPath);
-            if (existingKey.Length == KeySizeBytes) {
+        var requiresCleanup = false;
+
+        for (var attempt = 0; attempt < RetryDelays.Length; attempt++) {
+            var delay = RetryDelays[attempt];
+            if (delay > TimeSpan.Zero) {
+                Thread.Sleep(delay);
+            }
+
+            if (requiresCleanup) {
+                if (!TryDeleteInvalidKeyFile(keyPath)) {
+                    continue;
+                }
+
+                requiresCleanup = false;
+            }
+
+            if (TryReadExistingKey(keyPath, out var existingKey, out var invalidLength)) {
                 return existingKey;
+            }
+
+            if (invalidLength) {
+                requiresCleanup = true;
+                continue;
+            }
+
+            if (TryCreateKeyFile(keyPath, out var newKey)) {
+                return newKey;
             }
         }
 
-        var newKey = new byte[KeySizeBytes];
-        using (var rng = RandomNumberGenerator.Create()) {
-            rng.GetBytes(newKey);
+        if (TryReadExistingKey(keyPath, out var fallbackKey, out _)) {
+            return fallbackKey;
         }
-        File.WriteAllBytes(keyPath, newKey);
-        return newKey;
+
+        throw new IOException($"Failed to create or load credential key at '{keyPath}'.");
+    }
+
+    private static bool TryReadExistingKey(string keyPath, out byte[] key, out bool invalidLength) {
+        key = Array.Empty<byte>();
+        invalidLength = false;
+
+        if (!File.Exists(keyPath)) {
+            return false;
+        }
+
+        try {
+            using var stream = new FileStream(keyPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            if (stream.Length != KeySizeBytes) {
+                invalidLength = true;
+                return false;
+            }
+
+            var buffer = new byte[KeySizeBytes];
+            var offset = 0;
+            while (offset < buffer.Length) {
+                var bytesRead = stream.Read(buffer, offset, buffer.Length - offset);
+                if (bytesRead == 0) {
+                    invalidLength = true;
+                    return false;
+                }
+
+                offset += bytesRead;
+            }
+
+            key = buffer;
+            return true;
+        } catch (IOException ex) {
+            if (IsSharingViolation(ex)) {
+                return false;
+            }
+
+            throw;
+        } catch (UnauthorizedAccessException ex) {
+            if (IsSharingViolation(ex)) {
+                return false;
+            }
+
+            throw;
+        }
+    }
+
+    private static bool TryCreateKeyFile(string keyPath, out byte[] key) {
+        key = new byte[KeySizeBytes];
+        using (var rng = RandomNumberGenerator.Create()) {
+            rng.GetBytes(key);
+        }
+
+        try {
+            using var stream = new FileStream(keyPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            stream.Write(key, 0, key.Length);
+            stream.Flush(true);
+            return true;
+        } catch (IOException ex) {
+            if (IsSharingViolation(ex) || File.Exists(keyPath)) {
+                return false;
+            }
+
+            throw;
+        } catch (UnauthorizedAccessException ex) {
+            if (IsSharingViolation(ex)) {
+                return false;
+            }
+
+            throw;
+        }
+    }
+
+    private static bool TryDeleteInvalidKeyFile(string keyPath) {
+        try {
+            if (!File.Exists(keyPath)) {
+                return true;
+            }
+
+            File.Delete(keyPath);
+            return true;
+        } catch (IOException ex) {
+            if (IsSharingViolation(ex)) {
+                return false;
+            }
+
+            throw;
+        } catch (UnauthorizedAccessException ex) {
+            if (IsSharingViolation(ex)) {
+                return false;
+            }
+
+            throw;
+        }
+    }
+
+    private static bool IsSharingViolation(Exception ex) {
+        const int ERROR_SHARING_VIOLATION = unchecked((int)0x80070020);
+        const int ERROR_LOCK_VIOLATION = unchecked((int)0x80070021);
+        const int ERROR_FILE_EXISTS = unchecked((int)0x80070050);
+        const int ERROR_ALREADY_EXISTS = unchecked((int)0x800700B7);
+        const int ERROR_ACCESS_DENIED = unchecked((int)0x80070005);
+
+        var hresult = ex.HResult;
+        return hresult == ERROR_SHARING_VIOLATION
+            || hresult == ERROR_LOCK_VIOLATION
+            || hresult == ERROR_FILE_EXISTS
+            || hresult == ERROR_ALREADY_EXISTS
+            || hresult == ERROR_ACCESS_DENIED;
     }
 }

--- a/Sources/Mailozaurr/Cryptography/CredentialProtectionPaths.cs
+++ b/Sources/Mailozaurr/Cryptography/CredentialProtectionPaths.cs
@@ -6,8 +6,14 @@ namespace Mailozaurr;
 internal static class CredentialProtectionPaths {
     private const string RootDirectoryName = "Mailozaurr";
     private const string SubDirectoryName = "DataProtection";
+    private const string OverrideDirectoryVariable = "MAILOZAURR_KEY_DIRECTORY";
 
     public static string ResolveKeyDirectory() {
+        var overrideDirectory = Environment.GetEnvironmentVariable(OverrideDirectoryVariable);
+        if (!string.IsNullOrWhiteSpace(overrideDirectory)) {
+            return Path.GetFullPath(overrideDirectory);
+        }
+
         var baseDirectory = GetBaseDirectory();
         return Path.Combine(baseDirectory, RootDirectoryName, SubDirectoryName);
     }


### PR DESCRIPTION
## Summary
- harden AES credential key management with retry/backoff and exclusive file creation that honors existing material
- add a concurrent creation test to ensure all protectors observe the same key and can decrypt shared ciphertext

## Testing
- `dotnet build Sources/Mailozaurr.sln`
- `dotnet test Sources/Mailozaurr.sln`


------
https://chatgpt.com/codex/tasks/task_e_68caff2aa2e0832eb1a6b705fe79f2b2