### PR TITLE
Preserve SMTP TLS settings for pending retries

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageProcessorIntegrationTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageProcessorIntegrationTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Security;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Security;
+using MimeKit;
+using Xunit;
+
+namespace Mailozaurr.Tests.SentMessages;
+
+public sealed class SmtpPendingMessageProcessorIntegrationTests {
+    [Fact]
+    public async Task QueuedRecordReplaysStoredSecuritySettingsAsync() {
+        var repository = new RecordingPendingMessageRepository();
+        var originalFactory = Smtp.ClientFactory;
+        var failingClient = new FailingClient();
+        Smtp.ClientFactory = _ => failingClient;
+
+        Smtp? smtp = null;
+        try {
+            smtp = new Smtp();
+            smtp.PendingMessageRepository = repository;
+            smtp.SkipCertificateValidation = true;
+            smtp.CheckCertificateRevocation = false;
+            smtp.Timeout = 12345;
+
+            await smtp.ConnectAsync("smtp.integration.test", 587, SecureSocketOptions.Auto, useSsl: true);
+
+            var message = new MimeMessage();
+            message.From.Add(MailboxAddress.Parse("sender@example.com"));
+            message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+            message.Subject = "queued";
+            message.Body = new TextPart("plain") { Text = "body" };
+            message.MessageId = MimeKit.Utils.MimeUtils.GenerateMessageId();
+            smtp.Message = message;
+
+            var sendResult = await smtp.SendAsync(CancellationToken.None);
+            Assert.False(sendResult.Status);
+
+            var record = Assert.Single(repository.Records);
+            Assert.Equal("smtp.integration.test", record.Server);
+            Assert.Equal(587, record.Port);
+            Assert.Equal(SecureSocketOptions.StartTls.ToString(), record.ProviderData["SecureSocketOptions"]);
+            Assert.Equal(bool.TrueString, record.ProviderData["UseSsl"]);
+            Assert.Equal(bool.TrueString, record.ProviderData["SkipCertificateValidation"]);
+            Assert.Equal(bool.FalseString, record.ProviderData["CheckCertificateRevocation"]);
+            Assert.Equal("12345", record.ProviderData["TimeoutMilliseconds"]);
+
+            var captureClient = new CapturingClient();
+            var sender = new SmtpPendingMessageSender(
+                () => captureClient,
+                secureSocketOptions: SecureSocketOptions.SslOnConnect,
+                useSsl: false,
+                skipCertificateValidation: false,
+                checkCertificateRevocation: true,
+                timeout: 9876);
+
+            var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+                { EmailProvider.None, sender }
+            });
+
+            var processor = new PendingMessageProcessor(
+                repository,
+                factory,
+                clock: () => DateTimeOffset.UtcNow.AddMinutes(1),
+                processingLeaseDuration: TimeSpan.Zero);
+
+            await processor.ProcessAsync();
+
+            Assert.Equal("smtp.integration.test", captureClient.Host);
+            Assert.Equal(587, captureClient.Port);
+            Assert.Equal(SecureSocketOptions.StartTls, captureClient.Options);
+            Assert.Equal(12345, captureClient.Timeout);
+            Assert.False(captureClient.CheckCertificateRevocation);
+
+            var callback = captureClient.ServerCertificateValidationCallback;
+            Assert.NotNull(callback);
+            Assert.True(callback!(new object(), null!, null!, SslPolicyErrors.None));
+
+            Assert.Empty(repository.Records);
+        } finally {
+            smtp?.Dispose();
+            Smtp.ClientFactory = originalFactory;
+        }
+    }
+
+    private sealed class FailingClient : ClientSmtp {
+        public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken = default, ITransferProgress? progress = null) =>
+            throw new InvalidOperationException("Simulated failure");
+    }
+
+    private sealed class CapturingClient : ClientSmtp {
+        public string? Host { get; private set; }
+        public int Port { get; private set; }
+        public SecureSocketOptions Options { get; private set; }
+
+        public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {
+            Host = host;
+            Port = port;
+            Options = options;
+            return Task.CompletedTask;
+        }
+
+        public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken = default, ITransferProgress? progress = null) =>
+            Task.FromResult(message.MessageId ?? string.Empty);
+    }
+
+    private sealed class RecordingPendingMessageRepository : IPendingMessageRepository {
+        private readonly List<PendingMessageRecord> records = new();
+
+        public IReadOnlyList<PendingMessageRecord> Records => records;
+
+        public Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
+            records.RemoveAll(r => string.Equals(r.MessageId, record.MessageId, StringComparison.Ordinal));
+            records.Add(record);
+            return Task.CompletedTask;
+        }
+
+        public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+            var record = records.FirstOrDefault(r => string.Equals(r.MessageId, messageId, StringComparison.Ordinal));
+            return Task.FromResult(record);
+        }
+
+        public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            foreach (var record in records.ToList()) {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return record;
+                await Task.Yield();
+            }
+        }
+
+        public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+            records.RemoveAll(r => string.Equals(r.MessageId, messageId, StringComparison.Ordinal));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageSenderTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageSenderTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Security;
 using System.Text;
 using MailKit;
 using MailKit.Security;
@@ -59,5 +60,51 @@ public sealed class SmtpPendingMessageSenderTests {
         Assert.Equal(SecureSocketOptions.Auto, client.Options);
         Assert.NotNull(client.SentMessage);
         Assert.Equal("queued", client.SentMessage!.Subject);
+    }
+
+    [Fact]
+    public async Task SendAsync_ReplaysStoredSecuritySettings() {
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+        message.Subject = "queued";
+        message.Body = new TextPart("plain") { Text = "body" };
+        message.MessageId = "queued-message-security";
+        using var ms = new MemoryStream();
+        await message.WriteToAsync(ms);
+
+        var record = new PendingMessageRecord {
+            MimeMessage = Convert.ToBase64String(ms.ToArray()),
+            MessageId = message.MessageId ?? string.Empty,
+            Server = "smtp.secure.example.com",
+            Port = 465
+        };
+
+        record.ProviderData["SecureSocketOptions"] = SecureSocketOptions.Auto.ToString();
+        record.ProviderData["UseSsl"] = bool.TrueString;
+        record.ProviderData["SkipCertificateValidation"] = bool.TrueString;
+        record.ProviderData["CheckCertificateRevocation"] = bool.FalseString;
+        record.ProviderData["TimeoutMilliseconds"] = "12345";
+
+        var client = new RecordingClient();
+        var sender = new SmtpPendingMessageSender(
+            () => client,
+            secureSocketOptions: SecureSocketOptions.SslOnConnect,
+            useSsl: false,
+            skipCertificateValidation: false,
+            checkCertificateRevocation: true,
+            timeout: 54321);
+
+        await sender.SendAsync(record, CancellationToken.None);
+
+        Assert.Equal("smtp.secure.example.com", client.Host);
+        Assert.Equal(465, client.Port);
+        Assert.Equal(SecureSocketOptions.StartTls, client.Options);
+        Assert.Equal(12345, client.Timeout);
+        Assert.False(client.CheckCertificateRevocation);
+
+        var callback = client.ServerCertificateValidationCallback;
+        Assert.NotNull(callback);
+        Assert.True(callback!(new object(), null!, null!, SslPolicyErrors.None));
     }
 }

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 using System.Net;
 using System.Net.Security;
 using System.Runtime.InteropServices;
@@ -37,6 +38,12 @@ public class Smtp {
     /// <summary>Repository used to persist pending messages for later retry.</summary>
     public IPendingMessageRepository? PendingMessageRepository { get; set; }
 
+    private const string ProviderDataSecureSocketOptionsKey = "SecureSocketOptions";
+    private const string ProviderDataUseSslKey = "UseSsl";
+    private const string ProviderDataSkipCertificateValidationKey = "SkipCertificateValidation";
+    private const string ProviderDataCheckCertificateRevocationKey = "CheckCertificateRevocation";
+    private const string ProviderDataTimeoutKey = "TimeoutMilliseconds";
+
     private string? _pendingMessagesPath;
     /// <summary>Directory path for storing pending messages.</summary>
     public string? PendingMessagesPath {
@@ -56,6 +63,9 @@ public class Smtp {
 
     /// <summary>Underlying SMTP client used to send messages.</summary>
     public ClientSmtp Client { get; private set; }
+
+    private SecureSocketOptions _activeSecureSocketOptions = SecureSocketOptions.Auto;
+    private bool _activeUseSsl;
 
     /// <summary>Credentials used during authentication.</summary>
     public NetworkCredential? Credential { get; private set; }
@@ -403,22 +413,25 @@ public class Smtp {
         {
             Client = pooled;
         }
+        var effectiveOptions = secureSocketOptions;
+        if (useSsl && effectiveOptions == SecureSocketOptions.Auto) {
+            // Maintain backwards compatibility with Send-MailMessage by
+            // defaulting to StartTls when the UseSsl flag is supplied and
+            // no explicit option was provided.
+            effectiveOptions = SecureSocketOptions.StartTls;
+        }
+        _activeUseSsl = useSsl;
+        _activeSecureSocketOptions = effectiveOptions;
         try {
             if (!Client.IsConnected)
             {
-                if (useSsl && secureSocketOptions == SecureSocketOptions.Auto) {
-                    // Maintain backwards compatibility with Send-MailMessage by
-                    // defaulting to StartTls when the UseSsl flag is supplied and
-                    // no explicit option was provided.
-                    secureSocketOptions = SecureSocketOptions.StartTls;
-                }
-                Client.Connect(server, port, secureSocketOptions);
+                Client.Connect(server, port, effectiveOptions);
             }
-            LogVerbose($"Connected to {server} on {port} port using SSL: {secureSocketOptions}");
+            LogVerbose($"Connected to {server} on {port} port using SSL: {effectiveOptions}");
             return new SmtpResult(true, EmailAction.Connect, SentTo, SentFrom, server, port, Stopwatch.Elapsed, "");
         } catch (Exception ex) {
             LogWarning($"Send-EmailMessage - Error during connect: {ex.Message}");
-            LogWarning($"Send-EmailMessage - Possible issue: Port? ({port} was used), Using SSL? ({secureSocketOptions}, was used). You can also try 'SkipCertificateValidation' or 'SkipCertificateRevocation'.");
+            LogWarning($"Send-EmailMessage - Possible issue: Port? ({port} was used), Using SSL? ({effectiveOptions}, was used). You can also try 'SkipCertificateValidation' or 'SkipCertificateRevocation'.");
             if (ErrorAction == ActionPreference.Stop) {
                 throw;
             }
@@ -461,22 +474,25 @@ public class Smtp {
         {
             Client = pooled;
         }
+        var effectiveOptions = secureSocketOptions;
+        if (useSsl && effectiveOptions == SecureSocketOptions.Auto) {
+            // Maintain backwards compatibility with Send-MailMessage by
+            // defaulting to StartTls when the UseSsl flag is supplied and
+            // no explicit option was provided.
+            effectiveOptions = SecureSocketOptions.StartTls;
+        }
+        _activeUseSsl = useSsl;
+        _activeSecureSocketOptions = effectiveOptions;
         try {
             if (!Client.IsConnected)
             {
-                if (useSsl && secureSocketOptions == SecureSocketOptions.Auto) {
-                    // Maintain backwards compatibility with Send-MailMessage by
-                    // defaulting to StartTls when the UseSsl flag is supplied and
-                    // no explicit option was provided.
-                    secureSocketOptions = SecureSocketOptions.StartTls;
-                }
-                await Client.ConnectAsync(server, port, secureSocketOptions);
+                await Client.ConnectAsync(server, port, effectiveOptions);
             }
-            LogVerbose($"Connected to {server} on {port} port using SSL: {secureSocketOptions}");
+            LogVerbose($"Connected to {server} on {port} port using SSL: {effectiveOptions}");
             return new SmtpResult(true, EmailAction.Connect, SentTo, SentFrom, server, port, Stopwatch.Elapsed, "");
         } catch (Exception ex) {
             LogWarning($"Send-EmailMessage - Error during connect: {ex.Message}");
-            LogWarning($"Send-EmailMessage - Possible issue: Port? ({port} was used), Using SSL? ({secureSocketOptions}, was used). You can also try 'SkipCertificateValidation' or 'SkipCertificateRevocation'.");
+            LogWarning($"Send-EmailMessage - Possible issue: Port? ({port} was used), Using SSL? ({effectiveOptions}, was used). You can also try 'SkipCertificateValidation' or 'SkipCertificateRevocation'.");
             if (ErrorAction == ActionPreference.Stop) {
                 throw;
             }
@@ -761,6 +777,18 @@ public class Smtp {
         }
     }
 
+    private Dictionary<string, string> CreateProviderDataSnapshot() {
+        var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+            [ProviderDataSecureSocketOptionsKey] = _activeSecureSocketOptions.ToString(),
+            [ProviderDataUseSslKey] = _activeUseSsl.ToString(CultureInfo.InvariantCulture),
+            [ProviderDataSkipCertificateValidationKey] = _skipCertificateValidation.ToString(CultureInfo.InvariantCulture),
+            [ProviderDataCheckCertificateRevocationKey] = Client.CheckCertificateRevocation.ToString(CultureInfo.InvariantCulture),
+            [ProviderDataTimeoutKey] = Client.Timeout.ToString(CultureInfo.InvariantCulture)
+        };
+
+        return data;
+    }
+
     private async Task<SmtpResult> SendCoreAsync(CancellationToken cancellationToken = default) {
         int attempts = 0;
         Exception? lastException = null;
@@ -812,7 +840,8 @@ public class Smtp {
                             UserName = Credential?.UserName,
                             Password = string.IsNullOrEmpty(Credential?.Password)
                                 ? null
-                                : credentialProtector.Protect(Credential!.Password)
+                                : credentialProtector.Protect(Credential!.Password),
+                            ProviderData = CreateProviderDataSnapshot()
                         };
                         await PendingMessageRepository.SaveAsync(record, cancellationToken);
                     }
@@ -849,7 +878,8 @@ public class Smtp {
                 UserName = Credential?.UserName,
                 Password = string.IsNullOrEmpty(Credential?.Password)
                     ? null
-                    : credentialProtector.Protect(Credential!.Password)
+                    : credentialProtector.Protect(Credential!.Password),
+                ProviderData = CreateProviderDataSnapshot()
             };
             await PendingMessageRepository.SaveAsync(record, cancellationToken);
         }


### PR DESCRIPTION
## Summary
- capture the active SMTP TLS, SSL, validation, and timeout settings whenever a message is queued for retry
- teach the SMTP sender tests to verify replaying stored TLS options and add an integration test that exercises PendingMessageProcessor with customized SSL

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68caff1e349c832eab249b758d8afd2a