### PR TITLE
Support Gmail token refresh for pending messages

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/GmailPendingMessageSenderTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/GmailPendingMessageSenderTests.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using MimeKit;
 
 namespace Mailozaurr.Tests.SentMessages;
@@ -34,10 +35,7 @@ public sealed class GmailPendingMessageSenderTests {
             BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/")
         };
 
-        var sender = new GmailPendingMessageSender(credential => {
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", credential.AccessToken);
-            return new GmailApiClient(httpClient);
-        });
+        var sender = new GmailPendingMessageSender((credential, refresher) => new GmailApiClient(httpClient, refresher, credential));
 
         var message = new MimeMessage();
         message.From.Add(MailboxAddress.Parse("sender@example.com"));
@@ -51,13 +49,90 @@ public sealed class GmailPendingMessageSenderTests {
             MimeMessage = Convert.ToBase64String(ms.ToArray())
         };
         record.ProviderData[GmailPendingMessageSender.UserIdKey] = "me";
-        record.ProviderData[GmailPendingMessageSender.AccessTokenKey] = "token";
+        record.ProviderData[GmailPendingMessageSender.AccessTokenProtectedKey] = CredentialProtection.Default.Protect("token");
         record.ProviderData[GmailPendingMessageSender.UserNameKey] = "me@example.com";
-        record.ProviderData[GmailPendingMessageSender.ExpiresOnKey] = DateTimeOffset.UtcNow.ToString("o", CultureInfo.InvariantCulture);
+        record.ProviderData[GmailPendingMessageSender.ExpiresOnKey] = DateTimeOffset.UtcNow.AddHours(1).ToString("o", CultureInfo.InvariantCulture);
 
         await sender.SendAsync(record, CancellationToken.None);
 
         Assert.Equal("Bearer token", authorization);
         Assert.Equal(new Uri("https://gmail.googleapis.com/gmail/v1/users/me/messages/send"), requestUri);
+    }
+
+    [Fact]
+    public async Task SendAsync_RefreshesExpiredTokenAndSendsMessage() {
+        var refreshCallCount = 0;
+        var refreshHandler = new TestHandler(async (request, cancellationToken) => {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal(new Uri("https://oauth2.googleapis.com/token"), request.RequestUri);
+#if NET5_0_OR_GREATER
+            var payload = await request.Content!.ReadAsStringAsync(cancellationToken);
+#else
+            var payload = await request.Content!.ReadAsStringAsync();
+#endif
+            Assert.Contains("client_id=client-123", payload);
+            Assert.Contains("client_secret=client-secret", payload);
+            Assert.Contains("refresh_token=refresh-token", payload);
+            Interlocked.Increment(ref refreshCallCount);
+            return new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent(
+                    "{\"access_token\":\"new-access-token\",\"expires_in\":3600,\"refresh_token\":\"updated-refresh\"}",
+                    Encoding.UTF8,
+                    "application/json")
+            };
+        });
+
+        var refreshClient = new HttpClient(refreshHandler);
+        Helpers.SharedHttpClient = refreshClient;
+
+        try {
+            string? authorization = null;
+            var sendCallCount = 0;
+            var gmailHandler = new TestHandler((request, _) => {
+                authorization = request.Headers.Authorization?.ToString();
+                Interlocked.Increment(ref sendCallCount);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent("{\"id\":\"msg\",\"threadId\":\"msg\"}", Encoding.UTF8, "application/json")
+                });
+            });
+            using var gmailClient = new HttpClient(gmailHandler) {
+                BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/")
+            };
+            var sender = new GmailPendingMessageSender((credential, refresher) => new GmailApiClient(gmailClient, refresher, credential));
+
+            var message = new MimeMessage();
+            message.From.Add(MailboxAddress.Parse("sender@example.com"));
+            message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+            message.Subject = "queued";
+            message.Body = new TextPart("plain") { Text = "body" };
+            using var ms = new MemoryStream();
+            await message.WriteToAsync(ms);
+
+            var record = new PendingMessageRecord {
+                MimeMessage = Convert.ToBase64String(ms.ToArray())
+            };
+            record.ProviderData[GmailPendingMessageSender.UserIdKey] = "me";
+            record.ProviderData[GmailPendingMessageSender.UserNameKey] = "user@example.com";
+            record.ProviderData[GmailPendingMessageSender.ExpiresOnKey] = DateTimeOffset.UtcNow.AddMinutes(-5).ToString("o", CultureInfo.InvariantCulture);
+            record.ProviderData[GmailPendingMessageSender.AccessTokenProtectedKey] = CredentialProtection.Default.Protect("expired-token");
+            record.ProviderData[GmailPendingMessageSender.RefreshTokenProtectedKey] = CredentialProtection.Default.Protect("refresh-token");
+            record.ProviderData[GmailPendingMessageSender.ClientIdKey] = "client-123";
+            record.ProviderData[GmailPendingMessageSender.ClientSecretProtectedKey] = CredentialProtection.Default.Protect("client-secret");
+
+            await sender.SendAsync(record, CancellationToken.None);
+
+            Assert.Equal(1, refreshCallCount);
+            Assert.Equal(1, sendCallCount);
+            Assert.Equal("Bearer new-access-token", authorization);
+
+            var storedAccess = CredentialProtection.UnprotectWithFallback(record.ProviderData[GmailPendingMessageSender.AccessTokenProtectedKey]);
+            Assert.Equal("new-access-token", storedAccess);
+            var storedRefresh = CredentialProtection.UnprotectWithFallback(record.ProviderData[GmailPendingMessageSender.RefreshTokenProtectedKey]);
+            Assert.Equal("updated-refresh", storedRefresh);
+            var storedExpiry = DateTimeOffset.Parse(record.ProviderData[GmailPendingMessageSender.ExpiresOnKey], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            Assert.True(storedExpiry > DateTimeOffset.UtcNow);
+        } finally {
+            Helpers.SharedHttpClient = new HttpClient();
+        }
     }
 }

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -176,7 +176,9 @@ public sealed class ProviderPendingMessageTests {
             UserName = "user@example.com",
             AccessToken = "access-token",
             RefreshToken = "refresh-token",
-            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1),
+            ClientId = "client-123",
+            ClientSecret = "client-secret"
         };
         var repository = new InMemoryPendingMessageRepository();
         var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError) {
@@ -202,10 +204,13 @@ public sealed class ProviderPendingMessageTests {
         Assert.Equal(EmailProvider.Gmail, record.Provider);
         Assert.Equal("me", record.ProviderData[GmailPendingMessageSender.UserIdKey]);
         Assert.Equal("user@example.com", record.ProviderData[GmailPendingMessageSender.UserNameKey]);
-        var storedAccess = Encoding.UTF8.GetString(Convert.FromBase64String(record.ProviderData[GmailPendingMessageSender.AccessTokenBase64Key]!));
+        var storedAccess = CredentialProtection.UnprotectWithFallback(record.ProviderData[GmailPendingMessageSender.AccessTokenProtectedKey]);
         Assert.Equal("access-token", storedAccess);
-        var storedRefresh = Encoding.UTF8.GetString(Convert.FromBase64String(record.ProviderData[GmailPendingMessageSender.RefreshTokenBase64Key]!));
+        var storedRefresh = CredentialProtection.UnprotectWithFallback(record.ProviderData[GmailPendingMessageSender.RefreshTokenProtectedKey]);
         Assert.Equal("refresh-token", storedRefresh);
+        Assert.Equal("client-123", record.ProviderData[GmailPendingMessageSender.ClientIdKey]);
+        var storedSecret = CredentialProtection.UnprotectWithFallback(record.ProviderData[GmailPendingMessageSender.ClientSecretProtectedKey]);
+        Assert.Equal("client-secret", storedSecret);
         var queuedMessage = await MimeMessage.LoadAsync(new MemoryStream(Convert.FromBase64String(record.MimeMessage)));
         Assert.Equal("gmail", queuedMessage.Subject);
 
@@ -220,7 +225,7 @@ public sealed class ProviderPendingMessageTests {
         var successClient = new HttpClient(successHandler) {
             BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/")
         };
-        var sender = new GmailPendingMessageSender(c => new GmailApiClient(successClient, credential: c));
+        var sender = new GmailPendingMessageSender((c, refresher) => new GmailApiClient(successClient, refresher, credential: c));
         var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
             { EmailProvider.Gmail, sender }
         });

--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -137,7 +137,9 @@ public static class OAuthHelpers {
             UserName = credential.UserId,
             AccessToken = credential.Token.AccessToken,
             RefreshToken = credential.Token.RefreshToken,
-            ExpiresOn = credential.Token.IssuedUtc + TimeSpan.FromSeconds(credential.Token.ExpiresInSeconds ?? 0)
+            ExpiresOn = credential.Token.IssuedUtc + TimeSpan.FromSeconds(credential.Token.ExpiresInSeconds ?? 0),
+            ClientId = clientId,
+            ClientSecret = clientSecret
         };
         await OAuthTokenCache.SetAsync($"google:{cred.UserName}", cred);
         return cred;
@@ -184,6 +186,10 @@ public static class OAuthHelpers {
         IEnumerable<string> scopes) {
         var cacheKey = $"google:{gmailAccount}";
         var cached = await OAuthTokenCache.GetAsync(cacheKey);
+        if (cached != null) {
+            cached.ClientId ??= clientId;
+            cached.ClientSecret ??= clientSecret;
+        }
         if (cached != null && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
             return cached;
         }
@@ -203,7 +209,9 @@ public static class OAuthHelpers {
                     UserName = gmailAccount,
                     AccessToken = userCred.Token.AccessToken,
                     RefreshToken = userCred.Token.RefreshToken,
-                    ExpiresOn = userCred.Token.IssuedUtc + TimeSpan.FromSeconds(userCred.Token.ExpiresInSeconds ?? 0)
+                    ExpiresOn = userCred.Token.IssuedUtc + TimeSpan.FromSeconds(userCred.Token.ExpiresInSeconds ?? 0),
+                    ClientId = clientId,
+                    ClientSecret = clientSecret
                 };
                 await OAuthTokenCache.SetAsync(cacheKey, newCred);
                 return newCred;

--- a/Sources/Mailozaurr/Definitions/OAuthCredential.cs
+++ b/Sources/Mailozaurr/Definitions/OAuthCredential.cs
@@ -26,4 +26,24 @@ public class OAuthCredential {
     /// The refresh token, if available.
     /// </summary>
     public string? RefreshToken { get; set; }
+
+    /// <summary>
+    /// Identifier of the OAuth client used to acquire the token.
+    /// </summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>
+    /// Secret associated with the OAuth client used to acquire the token.
+    /// </summary>
+    public string? ClientSecret { get; set; }
+
+    /// <summary>
+    /// Raw JSON payload containing service account credentials used for delegated access.
+    /// </summary>
+    public string? ServiceAccountJson { get; set; }
+
+    /// <summary>
+    /// Optional subject impersonated when using service account credentials.
+    /// </summary>
+    public string? ServiceAccountSubject { get; set; }
 }

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -134,9 +134,31 @@ public sealed class GmailApiClient : IDisposable {
         record.ProviderData[GmailPendingMessageSender.UserIdKey] = userId;
         record.ProviderData[GmailPendingMessageSender.UserNameKey] = userName;
         record.ProviderData[GmailPendingMessageSender.ExpiresOnKey] = expiresOn.ToString("o", CultureInfo.InvariantCulture);
-        record.ProviderData[GmailPendingMessageSender.AccessTokenBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(accessToken));
+
+        var protector = CredentialProtection.Default;
+        record.ProviderData[GmailPendingMessageSender.AccessTokenProtectedKey] = protector.Protect(accessToken);
+        record.ProviderData.Remove(GmailPendingMessageSender.AccessTokenKey);
+        record.ProviderData.Remove(GmailPendingMessageSender.AccessTokenBase64Key);
         if (!string.IsNullOrEmpty(credential?.RefreshToken)) {
-            record.ProviderData[GmailPendingMessageSender.RefreshTokenBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(credential.RefreshToken));
+            record.ProviderData[GmailPendingMessageSender.RefreshTokenProtectedKey] = protector.Protect(credential.RefreshToken);
+        }
+        record.ProviderData.Remove(GmailPendingMessageSender.RefreshTokenKey);
+        record.ProviderData.Remove(GmailPendingMessageSender.RefreshTokenBase64Key);
+
+        if (!string.IsNullOrEmpty(credential?.ClientId)) {
+            record.ProviderData[GmailPendingMessageSender.ClientIdKey] = credential.ClientId;
+        }
+
+        if (!string.IsNullOrEmpty(credential?.ClientSecret)) {
+            record.ProviderData[GmailPendingMessageSender.ClientSecretProtectedKey] = protector.Protect(credential.ClientSecret);
+        }
+
+        if (!string.IsNullOrEmpty(credential?.ServiceAccountJson)) {
+            record.ProviderData[GmailPendingMessageSender.ServiceAccountJsonProtectedKey] = protector.Protect(credential.ServiceAccountJson);
+        }
+
+        if (!string.IsNullOrEmpty(credential?.ServiceAccountSubject)) {
+            record.ProviderData[GmailPendingMessageSender.ServiceAccountSubjectKey] = credential.ServiceAccountSubject;
         }
 
         try {

--- a/Sources/Mailozaurr/SentMessages/Senders/GmailPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/GmailPendingMessageSender.cs
@@ -1,5 +1,12 @@
+using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Net.Http;
 using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MimeKit;
 
 namespace Mailozaurr;
 
@@ -10,19 +17,44 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
     internal const string UserIdKey = "UserId";
     internal const string AccessTokenKey = "AccessToken";
     internal const string AccessTokenBase64Key = "AccessTokenBase64";
+    internal const string AccessTokenProtectedKey = "AccessTokenProtected";
     internal const string UserNameKey = "UserName";
     internal const string ExpiresOnKey = "ExpiresOn";
     internal const string RefreshTokenKey = "RefreshToken";
     internal const string RefreshTokenBase64Key = "RefreshTokenBase64";
+    internal const string RefreshTokenProtectedKey = "RefreshTokenProtected";
+    internal const string ClientIdKey = "ClientId";
+    internal const string ClientSecretProtectedKey = "ClientSecretProtected";
+    internal const string ServiceAccountJsonProtectedKey = "ServiceAccountJsonProtected";
+    internal const string ServiceAccountSubjectKey = "ServiceAccountSubject";
 
-    private readonly Func<OAuthCredential, GmailApiClient> clientFactory;
+    private const string TokenEndpoint = "https://oauth2.googleapis.com/token";
+
+    private readonly Func<OAuthCredential, Func<CancellationToken, Task<string>>?, GmailApiClient> clientFactory;
+    private readonly ICredentialProtector credentialProtector;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GmailPendingMessageSender"/> class.
     /// </summary>
     /// <param name="clientFactory">Factory used to create <see cref="GmailApiClient"/> instances.</param>
-    public GmailPendingMessageSender(Func<OAuthCredential, GmailApiClient>? clientFactory = null) {
-        this.clientFactory = clientFactory ?? (credential => new GmailApiClient(credential));
+    /// <param name="credentialProtector">Protector used to decrypt stored secrets.</param>
+    public GmailPendingMessageSender(
+        Func<OAuthCredential, Func<CancellationToken, Task<string>>?, GmailApiClient>? clientFactory = null,
+        ICredentialProtector? credentialProtector = null) {
+        this.clientFactory = clientFactory ?? ((credential, refresher) => new GmailApiClient(credential, refresher));
+        this.credentialProtector = credentialProtector ?? CredentialProtection.Default;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GmailPendingMessageSender"/> class.
+    /// </summary>
+    /// <param name="clientFactory">Factory used to create <see cref="GmailApiClient"/> instances.</param>
+    [Obsolete("Use the overload accepting a refresh-aware factory.")]
+    public GmailPendingMessageSender(Func<OAuthCredential, GmailApiClient> clientFactory)
+        : this(
+            (credential, refresher) => refresher != null
+                ? new GmailApiClient(credential, refresher)
+                : (clientFactory ?? throw new ArgumentNullException(nameof(clientFactory)))(credential)) {
     }
 
     /// <inheritdoc />
@@ -33,11 +65,37 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
         if (!record.ProviderData.TryGetValue(UserIdKey, out var userId) || string.IsNullOrWhiteSpace(userId)) {
             throw new InvalidOperationException("Pending Gmail message is missing the user identifier.");
         }
+
         var message = await LoadMessageAsync(record, ct).ConfigureAwait(false);
         var accessToken = ResolveAccessToken(record.ProviderData);
         var credential = BuildCredential(record.ProviderData, accessToken, userId);
-        using var client = clientFactory(credential);
-        _ = await client.SendAsync(userId, message, ct).ConfigureAwait(false);
+
+        var refreshContext = BuildRefreshContext(record.ProviderData, credential);
+        Func<CancellationToken, Task<string>>? refresher = null;
+        if (refreshContext != null) {
+            refresher = cancellationToken => RefreshAccessTokenAsync(credential, refreshContext, cancellationToken);
+            if (ShouldRefreshToken(credential.ExpiresOn)) {
+                await refresher(ct).ConfigureAwait(false);
+            }
+        } else if (ShouldRefreshToken(credential.ExpiresOn)) {
+            throw new InvalidOperationException(
+                "Pending Gmail message cannot be sent because the access token has expired and refresh data is unavailable.");
+        }
+
+        using var client = clientFactory(credential, refresher);
+        var retryAttempted = false;
+        while (true) {
+            try {
+                _ = await client.SendAsync(userId, message, ct).ConfigureAwait(false);
+                break;
+            } catch (GmailAuthenticationException ex) when (refresher == null) {
+                throw new InvalidOperationException(
+                    "Pending Gmail message could not be authenticated and no refresh data is available.", ex);
+            } catch (GmailAuthenticationException) when (!retryAttempted && refresher != null) {
+                retryAttempted = true;
+                continue;
+            }
+        }
     }
 
     private static async Task<MimeMessage> LoadMessageAsync(PendingMessageRecord record, CancellationToken ct) {
@@ -57,14 +115,43 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
                 : userId,
             ExpiresOn = ResolveExpiration(providerData),
         };
+
         var refreshToken = ResolveRefreshToken(providerData);
         if (!string.IsNullOrEmpty(refreshToken)) {
             credential.RefreshToken = refreshToken;
         }
+
+        var clientId = ResolveClientId(providerData);
+        if (!string.IsNullOrEmpty(clientId)) {
+            credential.ClientId = clientId;
+        }
+
+        var clientSecret = ResolveProtectedString(providerData, ClientSecretProtectedKey);
+        if (!string.IsNullOrEmpty(clientSecret)) {
+            credential.ClientSecret = clientSecret;
+        }
+
+        var serviceAccountJson = ResolveProtectedString(providerData, ServiceAccountJsonProtectedKey);
+        if (!string.IsNullOrEmpty(serviceAccountJson)) {
+            credential.ServiceAccountJson = serviceAccountJson;
+        }
+
+        var subject = ResolveServiceAccountSubject(providerData);
+        if (!string.IsNullOrEmpty(subject)) {
+            credential.ServiceAccountSubject = subject;
+        }
+
         return credential;
     }
 
     private static string ResolveAccessToken(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(AccessTokenProtectedKey, out var protectedValue) && !string.IsNullOrWhiteSpace(protectedValue)) {
+            var decrypted = CredentialProtection.UnprotectWithFallback(protectedValue);
+            if (!string.IsNullOrEmpty(decrypted)) {
+                return decrypted;
+            }
+        }
+
         if (providerData.TryGetValue(AccessTokenBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
             var bytes = Convert.FromBase64String(encoded);
             return Encoding.UTF8.GetString(bytes);
@@ -78,6 +165,13 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
     }
 
     private static string? ResolveRefreshToken(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(RefreshTokenProtectedKey, out var protectedValue) && !string.IsNullOrWhiteSpace(protectedValue)) {
+            var decrypted = CredentialProtection.UnprotectWithFallback(protectedValue);
+            if (!string.IsNullOrEmpty(decrypted)) {
+                return decrypted;
+            }
+        }
+
         if (providerData.TryGetValue(RefreshTokenBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
             var bytes = Convert.FromBase64String(encoded);
             return Encoding.UTF8.GetString(bytes);
@@ -96,5 +190,188 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
             return parsed;
         }
         return DateTimeOffset.MaxValue;
+    }
+
+    private GmailRefreshContext? BuildRefreshContext(Dictionary<string, string> providerData, OAuthCredential credential) {
+        var refreshToken = credential.RefreshToken;
+        if (string.IsNullOrEmpty(refreshToken)) {
+            return null;
+        }
+
+        credential.ClientId ??= ResolveClientId(providerData);
+        credential.ClientSecret ??= ResolveProtectedString(providerData, ClientSecretProtectedKey);
+        credential.ServiceAccountJson ??= ResolveProtectedString(providerData, ServiceAccountJsonProtectedKey);
+        credential.ServiceAccountSubject ??= ResolveServiceAccountSubject(providerData);
+
+        if (string.IsNullOrEmpty(credential.ClientId) && string.IsNullOrEmpty(credential.ServiceAccountJson)) {
+            return null;
+        }
+
+        return new GmailRefreshContext(
+            providerData,
+            refreshToken,
+            credential.ClientId,
+            credential.ClientSecret,
+            credential.ServiceAccountJson,
+            credential.ServiceAccountSubject,
+            credentialProtector);
+    }
+
+    private static string? ResolveClientId(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(ClientIdKey, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            return value;
+        }
+        return null;
+    }
+
+    private static string? ResolveProtectedString(Dictionary<string, string> providerData, string key) {
+        if (providerData.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            var decrypted = CredentialProtection.UnprotectWithFallback(value);
+            return string.IsNullOrEmpty(decrypted) ? null : decrypted;
+        }
+        return null;
+    }
+
+    private static string? ResolveServiceAccountSubject(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(ServiceAccountSubjectKey, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            return value;
+        }
+        return null;
+    }
+
+    private static bool ShouldRefreshToken(DateTimeOffset expiresOn) => expiresOn <= DateTimeOffset.UtcNow.AddMinutes(1);
+
+    private async Task<string> RefreshAccessTokenAsync(OAuthCredential credential, GmailRefreshContext context, CancellationToken cancellationToken) {
+        if (context.HasClientSecret) {
+            var refreshed = await ExchangeRefreshTokenAsync(context.ClientId!, context.ClientSecret!, context.RefreshToken, cancellationToken)
+                .ConfigureAwait(false);
+            credential.AccessToken = refreshed.AccessToken;
+            if (!string.IsNullOrEmpty(refreshed.RefreshToken)) {
+                credential.RefreshToken = refreshed.RefreshToken;
+            }
+
+            if (refreshed.ExpiresOn.HasValue) {
+                credential.ExpiresOn = refreshed.ExpiresOn.Value;
+            } else if (credential.ExpiresOn <= DateTimeOffset.UtcNow) {
+                credential.ExpiresOn = DateTimeOffset.UtcNow.AddHours(1);
+            }
+
+            context.UpdateStoredCredential(credential);
+            return credential.AccessToken;
+        }
+
+        if (context.HasServiceAccount) {
+            throw new InvalidOperationException("Service account refresh is not supported for pending Gmail messages.");
+        }
+
+        throw new InvalidOperationException("Pending Gmail message is missing OAuth client context required to refresh the access token.");
+    }
+
+    private static async Task<(string AccessToken, string? RefreshToken, DateTimeOffset? ExpiresOn)> ExchangeRefreshTokenAsync(
+        string clientId,
+        string clientSecret,
+        string refreshToken,
+        CancellationToken cancellationToken) {
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string> {
+            { "client_id", clientId },
+            { "client_secret", clientSecret },
+            { "refresh_token", refreshToken },
+            { "grant_type", "refresh_token" }
+        });
+        using var request = new HttpRequestMessage(HttpMethod.Post, TokenEndpoint) { Content = content };
+        using var response = await Helpers.SharedHttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var payload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!response.IsSuccessStatusCode) {
+            throw new InvalidOperationException($"Failed to refresh Gmail access token: {payload}");
+        }
+
+        using var document = JsonDocument.Parse(payload);
+        if (!document.RootElement.TryGetProperty("access_token", out var tokenProperty)) {
+            throw new InvalidOperationException("Gmail token refresh response did not include an access token.");
+        }
+
+        var accessToken = tokenProperty.GetString();
+        if (string.IsNullOrEmpty(accessToken)) {
+            throw new InvalidOperationException("Gmail token refresh response contained an empty access token.");
+        }
+
+        string? newRefresh = null;
+        if (document.RootElement.TryGetProperty("refresh_token", out var refreshProperty)) {
+            newRefresh = refreshProperty.GetString();
+        }
+
+        DateTimeOffset? expiresOn = null;
+        if (document.RootElement.TryGetProperty("expires_in", out var expiresProperty) &&
+            expiresProperty.TryGetInt64(out var seconds) && seconds > 0) {
+            expiresOn = DateTimeOffset.UtcNow.AddSeconds(seconds);
+        }
+
+        return (accessToken, newRefresh, expiresOn);
+    }
+
+    private sealed class GmailRefreshContext {
+        private readonly Dictionary<string, string> providerData;
+        private readonly ICredentialProtector protector;
+
+        internal GmailRefreshContext(
+            Dictionary<string, string> providerData,
+            string refreshToken,
+            string? clientId,
+            string? clientSecret,
+            string? serviceAccountJson,
+            string? serviceAccountSubject,
+            ICredentialProtector protector) {
+            this.providerData = providerData ?? throw new ArgumentNullException(nameof(providerData));
+            RefreshToken = refreshToken ?? throw new ArgumentNullException(nameof(refreshToken));
+            ClientId = clientId;
+            ClientSecret = clientSecret;
+            ServiceAccountJson = serviceAccountJson;
+            ServiceAccountSubject = serviceAccountSubject;
+            this.protector = protector ?? throw new ArgumentNullException(nameof(protector));
+        }
+
+        internal string RefreshToken { get; private set; }
+        internal string? ClientId { get; }
+        internal string? ClientSecret { get; }
+        internal string? ServiceAccountJson { get; }
+        internal string? ServiceAccountSubject { get; }
+
+        internal bool HasClientSecret => !string.IsNullOrEmpty(ClientId) && !string.IsNullOrEmpty(ClientSecret);
+        internal bool HasServiceAccount => !string.IsNullOrEmpty(ServiceAccountJson);
+
+        internal void UpdateStoredCredential(OAuthCredential credential) {
+            providerData[GmailPendingMessageSender.AccessTokenProtectedKey] = protector.Protect(credential.AccessToken);
+            providerData.Remove(GmailPendingMessageSender.AccessTokenBase64Key);
+            providerData.Remove(GmailPendingMessageSender.AccessTokenKey);
+
+            if (!string.IsNullOrEmpty(credential.RefreshToken)) {
+                providerData[GmailPendingMessageSender.RefreshTokenProtectedKey] = protector.Protect(credential.RefreshToken);
+                providerData.Remove(GmailPendingMessageSender.RefreshTokenBase64Key);
+                providerData.Remove(GmailPendingMessageSender.RefreshTokenKey);
+                RefreshToken = credential.RefreshToken!;
+            }
+
+            providerData[GmailPendingMessageSender.ExpiresOnKey] = credential.ExpiresOn.ToString("o", CultureInfo.InvariantCulture);
+
+            if (!string.IsNullOrEmpty(credential.ClientId)) {
+                providerData[GmailPendingMessageSender.ClientIdKey] = credential.ClientId!;
+            }
+
+            if (!string.IsNullOrEmpty(credential.ClientSecret)) {
+                providerData[GmailPendingMessageSender.ClientSecretProtectedKey] = protector.Protect(credential.ClientSecret!);
+            }
+
+            if (!string.IsNullOrEmpty(credential.ServiceAccountJson)) {
+                providerData[GmailPendingMessageSender.ServiceAccountJsonProtectedKey] = protector.Protect(credential.ServiceAccountJson!);
+            }
+
+            if (!string.IsNullOrEmpty(credential.ServiceAccountSubject)) {
+                providerData[GmailPendingMessageSender.ServiceAccountSubjectKey] = credential.ServiceAccountSubject!;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend OAuth credential storage with client metadata and propagate Google helper caching
- persist encrypted Gmail OAuth state and client context when queuing pending messages
- refresh Gmail access tokens when processing pending messages and mark missing refresh data as permanent failures
- cover Gmail pending message encryption and refresh flows with new tests

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68cbc57f50a0832eb66d14169af5485a