### PR TITLE
Protect provider secrets in pending messages

### DIFF
--- a/Examples/Example-EmailPendingMessages.ps1
+++ b/Examples/Example-EmailPendingMessages.ps1
@@ -1,5 +1,9 @@
 $pending = Join-Path $PSScriptRoot 'pending'
 
+# Existing pending queues created prior to credential protection will still replay,
+# and the entries will be re-encrypted with the new protector the next time they are
+# saved by the module (for example, after another delivery attempt).
+
 # Review queued messages
 Get-EmailPendingMessage -PendingMessagesPath $pending
 

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -101,9 +101,10 @@ public sealed class ProviderPendingMessageTests {
         Assert.False(string.IsNullOrWhiteSpace(record.MessageId));
         Assert.True(record.ProviderData.TryGetValue(SendGridPendingMessageSender.MessageJsonKey, out var json));
         Assert.False(string.IsNullOrWhiteSpace(json));
-        Assert.True(record.ProviderData.TryGetValue(SendGridPendingMessageSender.ApiKeyBase64Key, out var apiKeyBase64));
-        var decodedApiKey = Encoding.UTF8.GetString(Convert.FromBase64String(apiKeyBase64!));
-        Assert.Equal("SG.API", decodedApiKey);
+        Assert.True(record.ProviderData.TryGetValue(SendGridPendingMessageSender.ApiKeyProtectedKey, out var apiKeyProtected));
+        Assert.False(string.IsNullOrWhiteSpace(apiKeyProtected));
+        Assert.Equal("SG.API", CredentialProtection.UnprotectWithFallback(apiKeyProtected));
+        Assert.DoesNotContain(SendGridPendingMessageSender.ApiKeyBase64Key, record.ProviderData.Keys);
 
         var successHandler = new TestHandler((request, _) => {
             Assert.Equal(HttpMethod.Post, request.Method);
@@ -147,8 +148,10 @@ public sealed class ProviderPendingMessageTests {
         Assert.NotNull(record);
         Assert.Equal(EmailProvider.Mailgun, record.Provider);
         Assert.Equal("example.com", record.ProviderData[MailgunPendingMessageSender.DomainKey]);
-        var apiKey = Encoding.UTF8.GetString(Convert.FromBase64String(record.ProviderData[MailgunPendingMessageSender.ApiKeyBase64Key]!));
-        Assert.Equal("mailgun-api-key", apiKey);
+        Assert.True(record.ProviderData.TryGetValue(MailgunPendingMessageSender.ApiKeyProtectedKey, out var mailgunProtected));
+        Assert.False(string.IsNullOrWhiteSpace(mailgunProtected));
+        Assert.Equal("mailgun-api-key", CredentialProtection.UnprotectWithFallback(mailgunProtected));
+        Assert.DoesNotContain(MailgunPendingMessageSender.ApiKeyBase64Key, record.ProviderData.Keys);
         var mime = await MimeMessage.LoadAsync(new MemoryStream(Convert.FromBase64String(record.MimeMessage)));
         Assert.Equal("mailgun", mime.Subject);
 
@@ -262,10 +265,12 @@ public sealed class ProviderPendingMessageTests {
         var record = repository.LastSaved;
         Assert.NotNull(record);
         Assert.Equal(EmailProvider.SES, record.Provider);
-        var accessKey = Encoding.UTF8.GetString(Convert.FromBase64String(record.ProviderData[SesPendingMessageSender.AccessKeyIdBase64Key]!));
-        var secretKey = Encoding.UTF8.GetString(Convert.FromBase64String(record.ProviderData[SesPendingMessageSender.SecretAccessKeyBase64Key]!));
-        Assert.Equal("AKIA123", accessKey);
-        Assert.Equal("secret-key", secretKey);
+        Assert.True(record.ProviderData.TryGetValue(SesPendingMessageSender.AccessKeyIdProtectedKey, out var sesAccessProtected));
+        Assert.True(record.ProviderData.TryGetValue(SesPendingMessageSender.SecretAccessKeyProtectedKey, out var sesSecretProtected));
+        Assert.Equal("AKIA123", CredentialProtection.UnprotectWithFallback(sesAccessProtected));
+        Assert.Equal("secret-key", CredentialProtection.UnprotectWithFallback(sesSecretProtected));
+        Assert.DoesNotContain(SesPendingMessageSender.AccessKeyIdBase64Key, record.ProviderData.Keys);
+        Assert.DoesNotContain(SesPendingMessageSender.SecretAccessKeyBase64Key, record.ProviderData.Keys);
         Assert.Equal("us-east-1", record.ProviderData[SesPendingMessageSender.RegionKey]);
 
         var successHandler = new TestHandler((request, _) => {

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -231,8 +231,13 @@ public class SesClient : IDisposable {
             NextAttemptAt = now,
             Provider = EmailProvider.SES
         };
-        record.ProviderData[SesPendingMessageSender.AccessKeyIdBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(net.UserName));
-        record.ProviderData[SesPendingMessageSender.SecretAccessKeyBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(net.Password));
+        var protector = CredentialProtection.Default;
+        record.ProviderData[SesPendingMessageSender.AccessKeyIdProtectedKey] = protector.Protect(net.UserName);
+        record.ProviderData[SesPendingMessageSender.SecretAccessKeyProtectedKey] = protector.Protect(net.Password);
+        record.ProviderData.Remove(SesPendingMessageSender.AccessKeyIdKey);
+        record.ProviderData.Remove(SesPendingMessageSender.AccessKeyIdBase64Key);
+        record.ProviderData.Remove(SesPendingMessageSender.SecretAccessKeyKey);
+        record.ProviderData.Remove(SesPendingMessageSender.SecretAccessKeyBase64Key);
         record.ProviderData[SesPendingMessageSender.RegionKey] = Region;
 
         try

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -250,7 +250,10 @@ public class MailgunClient : IDisposable {
             Provider = EmailProvider.Mailgun
         };
         record.ProviderData[MailgunPendingMessageSender.DomainKey] = domain;
-        record.ProviderData[MailgunPendingMessageSender.ApiKeyBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(apiKey));
+        var protector = CredentialProtection.Default;
+        record.ProviderData[MailgunPendingMessageSender.ApiKeyProtectedKey] = protector.Protect(apiKey);
+        record.ProviderData.Remove(MailgunPendingMessageSender.ApiKeyKey);
+        record.ProviderData.Remove(MailgunPendingMessageSender.ApiKeyBase64Key);
 
         try {
             await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -426,7 +426,10 @@ public sealed class SendGridClient : IDisposable {
             Provider = EmailProvider.SendGrid
         };
         record.ProviderData[SendGridPendingMessageSender.MessageJsonKey] = MessageJson;
-        record.ProviderData[SendGridPendingMessageSender.ApiKeyBase64Key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(apiKey));
+        var protector = CredentialProtection.Default;
+        record.ProviderData[SendGridPendingMessageSender.ApiKeyProtectedKey] = protector.Protect(apiKey);
+        record.ProviderData.Remove(SendGridPendingMessageSender.ApiKeyKey);
+        record.ProviderData.Remove(SendGridPendingMessageSender.ApiKeyBase64Key);
 
         try {
             await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);

--- a/Sources/Mailozaurr/SentMessages/Senders/MailgunPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/MailgunPendingMessageSender.cs
@@ -10,6 +10,7 @@ public sealed class MailgunPendingMessageSender : IPendingMessageSender {
     internal const string DomainKey = "Domain";
     internal const string ApiKeyKey = "ApiKey";
     internal const string ApiKeyBase64Key = "ApiKeyBase64";
+    internal const string ApiKeyProtectedKey = "ApiKeyProtected";
     internal const string EndpointKey = "Endpoint";
 
     private readonly HttpClient httpClient;
@@ -68,6 +69,13 @@ public sealed class MailgunPendingMessageSender : IPendingMessageSender {
     }
 
     private static string ResolveApiKey(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(ApiKeyProtectedKey, out var protectedValue) && !string.IsNullOrWhiteSpace(protectedValue)) {
+            var decrypted = CredentialProtection.UnprotectWithFallback(protectedValue);
+            if (!string.IsNullOrEmpty(decrypted)) {
+                return decrypted;
+            }
+        }
+
         if (providerData.TryGetValue(ApiKeyBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
             var bytes = Convert.FromBase64String(encoded);
             return Encoding.UTF8.GetString(bytes);

--- a/Sources/Mailozaurr/SentMessages/Senders/SendGridPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/SendGridPendingMessageSender.cs
@@ -10,6 +10,7 @@ public sealed class SendGridPendingMessageSender : IPendingMessageSender {
     internal const string MessageJsonKey = "MessageJson";
     internal const string ApiKeyKey = "ApiKey";
     internal const string ApiKeyBase64Key = "ApiKeyBase64";
+    internal const string ApiKeyProtectedKey = "ApiKeyProtected";
     internal const string EndpointKey = "Endpoint";
 
     private static readonly Uri DefaultEndpoint = new("https://api.sendgrid.com/v3/mail/send");
@@ -58,6 +59,13 @@ public sealed class SendGridPendingMessageSender : IPendingMessageSender {
     }
 
     private static string ResolveApiKey(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(ApiKeyProtectedKey, out var protectedValue) && !string.IsNullOrWhiteSpace(protectedValue)) {
+            var decrypted = CredentialProtection.UnprotectWithFallback(protectedValue);
+            if (!string.IsNullOrEmpty(decrypted)) {
+                return decrypted;
+            }
+        }
+
         if (providerData.TryGetValue(ApiKeyBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
             var bytes = Convert.FromBase64String(encoded);
             return Encoding.UTF8.GetString(bytes);

--- a/Sources/Mailozaurr/SentMessages/Senders/SesPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/SesPendingMessageSender.cs
@@ -12,6 +12,8 @@ public sealed class SesPendingMessageSender : IPendingMessageSender {
     internal const string SecretAccessKeyKey = "SecretAccessKey";
     internal const string AccessKeyIdBase64Key = "AccessKeyIdBase64";
     internal const string SecretAccessKeyBase64Key = "SecretAccessKeyBase64";
+    internal const string AccessKeyIdProtectedKey = "AccessKeyIdProtected";
+    internal const string SecretAccessKeyProtectedKey = "SecretAccessKeyProtected";
     internal const string RegionKey = "Region";
 
     private readonly HttpClient httpClient;
@@ -63,6 +65,13 @@ public sealed class SesPendingMessageSender : IPendingMessageSender {
     }
 
     private static string ResolveAccessKey(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(AccessKeyIdProtectedKey, out var protectedValue) && !string.IsNullOrWhiteSpace(protectedValue)) {
+            var decrypted = CredentialProtection.UnprotectWithFallback(protectedValue);
+            if (!string.IsNullOrEmpty(decrypted)) {
+                return decrypted;
+            }
+        }
+
         if (providerData.TryGetValue(AccessKeyIdBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
             var bytes = Convert.FromBase64String(encoded);
             return Encoding.UTF8.GetString(bytes);
@@ -76,6 +85,13 @@ public sealed class SesPendingMessageSender : IPendingMessageSender {
     }
 
     private static string ResolveSecretKey(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(SecretAccessKeyProtectedKey, out var protectedValue) && !string.IsNullOrWhiteSpace(protectedValue)) {
+            var decrypted = CredentialProtection.UnprotectWithFallback(protectedValue);
+            if (!string.IsNullOrEmpty(decrypted)) {
+                return decrypted;
+            }
+        }
+
         if (providerData.TryGetValue(SecretAccessKeyBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
             var bytes = Convert.FromBase64String(encoded);
             return Encoding.UTF8.GetString(bytes);


### PR DESCRIPTION
## Summary
- update SendGrid, Mailgun, and SES queueing to protect provider secrets instead of saving raw Base64 copies
- teach the SendGrid, Mailgun, and SES pending-message senders to decrypt protected credentials while retaining legacy fallbacks
- refresh provider pending-message regression tests and examples to cover the new encryption flow and migration expectations

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cbd9be8c2c832e9510b09051b5b2e0