### PR TITLE
Include Exchange NDR subjects and verify search queries

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailNonDeliveryReportsTests.cs
@@ -29,6 +29,7 @@ public class GmailNonDeliveryReportsTests {
     public async Task SearchNonDeliveryReportsAsync_GmailApi_ReturnsReports() {
         var now = DateTimeOffset.UtcNow;
         var ndr = CreateNdr("user@example.com", "<id1>", now);
+        ndr.Subject = "Undeliverable: Delivery has failed";
         var normal = new MimeMessage();
         normal.Subject = "hello";
         var listJson = "{\"messages\":[{\"id\":\"1\"},{\"id\":\"2\"}]}";
@@ -42,6 +43,20 @@ public class GmailNonDeliveryReportsTests {
         var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
         field.SetValue(client, new HttpClient(handler) { BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/") });
         var reports = await MailboxSearcher.SearchNonDeliveryReportsAsync(client, "me", parallelDownloadLimit: 1, cancellationToken: CancellationToken.None);
+        Assert.NotEmpty(handler.Requests);
+        var listRequest = handler.Requests[0];
+        var uri = listRequest.RequestUri!;
+        string? queryParam = null;
+        var query = uri.Query.TrimStart('?').Split(new[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var part in query) {
+            var kvp = part.Split(new[] { '=' }, 2);
+            if (kvp.Length == 2 && kvp[0] == "q") {
+                queryParam = Uri.UnescapeDataString(kvp[1]);
+                break;
+            }
+        }
+        Assert.NotNull(queryParam);
+        Assert.Contains("subject:\"Undeliverable:\"", queryParam, StringComparison.Ordinal);
         Assert.Single(reports);
         Assert.Equal("id1", reports[0].OriginalMessageId);
     }

--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -295,8 +295,10 @@ public class SearchNonDeliveryReportsTests {
             Assert.Equal(1, handler.MimeFetches);
             Assert.NotNull(handler.Filter);
             foreach (var pattern in NonDeliveryReportSubjectPatterns.Values) {
-                Assert.Contains(pattern, handler.Filter!);
+                var expectedPattern = pattern.Replace("'", "''");
+                Assert.Contains(expectedPattern, handler.Filter!, StringComparison.Ordinal);
             }
+            Assert.Contains("contains(subject,'Undeliverable:')", handler.Filter!, StringComparison.Ordinal);
         } finally {
             handlerField.SetValue(client, original);
         }
@@ -330,7 +332,7 @@ public class SearchNonDeliveryReportsTests {
 
             if (uri.AbsolutePath.Contains("/messages/") && uri.AbsolutePath.EndsWith("/$value")) {
                 MimeFetches++;
-                const string raw = "Date: Mon, 1 Jan 2024 00:00:00 +0000\r\nSubject: Mail Delivery Subsystem\r\n\r\nbody";
+                const string raw = "Date: Mon, 1 Jan 2024 00:00:00 +0000\r\nSubject: Undeliverable: Delivery has failed\r\n\r\nbody";
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(raw) });
             }
 

--- a/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportSubjectPatterns.cs
+++ b/Sources/Mailozaurr/NonDeliveryReports/NonDeliveryReportSubjectPatterns.cs
@@ -8,6 +8,11 @@ internal static class NonDeliveryReportSubjectPatterns {
         "Mail Delivery Subsystem",
         "Failure Notice",
         "Delivery failure",
+        "Undeliverable:",
+        "Delivery has failed to these recipients or groups",
+        "Undeliverable message",
+        "Undeliverable mail",
+        "Your message couldn't be delivered",
     };
 }
 


### PR DESCRIPTION
## Summary
- extend non-delivery subject patterns with common Exchange variants such as "Undeliverable:"
- ensure the Graph subject filter escapes apostrophes and includes the new pattern
- update Gmail and Graph NDR tests to validate queries return Undeliverable-prefixed reports

## Testing
- DOTNET_CLI_USE_TERMINAL_LOGGER=0 dotnet test Sources/Mailozaurr.sln --logger "console;verbosity=minimal"


------
https://chatgpt.com/codex/tasks/task_e_68cbe0dd2a74832e8cc4bed92ff2a667