### PR TITLE
Support Gmail service account token minting

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/GmailPendingMessageSenderTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/GmailPendingMessageSenderTests.cs
@@ -2,8 +2,15 @@ using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
+using System.Runtime.CompilerServices;
+using System.IO;
 using MimeKit;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Pkcs;
+using Org.BouncyCastle.Security;
 
 namespace Mailozaurr.Tests.SentMessages;
 
@@ -133,6 +140,189 @@ public sealed class GmailPendingMessageSenderTests {
             Assert.True(storedExpiry > DateTimeOffset.UtcNow);
         } finally {
             Helpers.SharedHttpClient = new HttpClient();
+        }
+    }
+
+    [Fact]
+    public async Task ProcessAsync_MintsServiceAccountTokenAndSendsMessage() {
+        var mintedToken = "service-access-token";
+        var tokenRequestCount = 0;
+        var tokenHandler = new TestHandler(async (request, cancellationToken) => {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal(new Uri("https://oauth2.googleapis.com/token"), request.RequestUri);
+#if NET5_0_OR_GREATER
+            var payload = await request.Content!.ReadAsStringAsync(cancellationToken);
+#else
+            var payload = await request.Content!.ReadAsStringAsync();
+#endif
+            Assert.Contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer", payload);
+            Assert.Contains("assertion=", payload);
+            Interlocked.Increment(ref tokenRequestCount);
+            var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("{\"access_token\":\"service-access-token\",\"expires_in\":3600}", Encoding.UTF8, "application/json")
+            };
+            return response;
+        });
+
+        string? authorization = null;
+        var gmailCallCount = 0;
+        var gmailHandler = new TestHandler((request, _) => {
+            authorization = request.Headers.Authorization?.ToString();
+            Interlocked.Increment(ref gmailCallCount);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("{\"id\":\"msg\",\"threadId\":\"msg\"}", Encoding.UTF8, "application/json")
+            });
+        });
+
+        using var gmailClient = new HttpClient(gmailHandler) { BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/") };
+        var sender = new GmailPendingMessageSender((credential, refresher) => new GmailApiClient(gmailClient, refresher, credential));
+
+        var serviceAccountJson = CreateServiceAccountJson();
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+        message.Subject = "queued";
+        message.Body = new TextPart("plain") { Text = "body" };
+        using var ms = new MemoryStream();
+        await message.WriteToAsync(ms);
+
+        var now = DateTimeOffset.UtcNow;
+        var record = new PendingMessageRecord {
+            MessageId = Guid.NewGuid().ToString("N"),
+            MimeMessage = Convert.ToBase64String(ms.ToArray()),
+            Provider = EmailProvider.Gmail,
+            Timestamp = now.AddMinutes(-10),
+            NextAttemptAt = now.AddMinutes(-1)
+        };
+        var subject = "impersonated@example.com";
+        record.ProviderData[GmailPendingMessageSender.UserIdKey] = subject;
+        record.ProviderData[GmailPendingMessageSender.UserNameKey] = subject;
+        record.ProviderData[GmailPendingMessageSender.AccessTokenProtectedKey] = CredentialProtection.Default.Protect("expired-token");
+        record.ProviderData[GmailPendingMessageSender.ExpiresOnKey] = now.AddMinutes(-5).ToString("o", CultureInfo.InvariantCulture);
+        record.ProviderData[GmailPendingMessageSender.ServiceAccountJsonProtectedKey] = CredentialProtection.Default.Protect(serviceAccountJson);
+        record.ProviderData[GmailPendingMessageSender.ServiceAccountSubjectKey] = subject;
+
+        var repository = new SingleRecordRepository(record);
+        var observer = new ProcessorObserver();
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.Gmail, sender }
+        });
+
+        Helpers.SharedHttpClient = new HttpClient(tokenHandler);
+
+        try {
+            var processor = new PendingMessageProcessor(
+                repository,
+                factory,
+                retryDelaySelector: _ => TimeSpan.FromMinutes(1),
+                clock: () => now,
+                observer: observer,
+                processingLeaseDuration: TimeSpan.Zero);
+
+            await processor.ProcessAsync();
+        } finally {
+            Helpers.SharedHttpClient = new HttpClient();
+        }
+
+        Assert.Equal(1, tokenRequestCount);
+        Assert.Equal(1, gmailCallCount);
+        Assert.Equal("Bearer service-access-token", authorization);
+        Assert.True(repository.IsEmpty);
+        Assert.Equal(1, observer.SentCount);
+        Assert.Equal(0, observer.FailedCount);
+        Assert.Equal(0, observer.DroppedCount);
+
+        var storedAccess = CredentialProtection.UnprotectWithFallback(record.ProviderData[GmailPendingMessageSender.AccessTokenProtectedKey]);
+        Assert.Equal(mintedToken, storedAccess);
+        var storedExpiry = DateTimeOffset.Parse(record.ProviderData[GmailPendingMessageSender.ExpiresOnKey], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+        Assert.True(storedExpiry > now);
+    }
+
+    private static string CreateServiceAccountJson() {
+        var generator = new RsaKeyPairGenerator();
+        generator.Init(new KeyGenerationParameters(new SecureRandom(), 2048));
+        AsymmetricCipherKeyPair keyPair = generator.GenerateKeyPair();
+        var privateKeyInfo = PrivateKeyInfoFactory.CreatePrivateKeyInfo(keyPair.Private);
+        var builder = new StringBuilder();
+        builder.AppendLine("-----BEGIN PRIVATE KEY-----");
+        builder.AppendLine(Convert.ToBase64String(privateKeyInfo.GetEncoded(), Base64FormattingOptions.InsertLineBreaks));
+        builder.AppendLine("-----END PRIVATE KEY-----");
+
+        var payload = new Dictionary<string, object> {
+            { "type", "service_account" },
+            { "project_id", "test-project" },
+            { "private_key_id", "test-key" },
+            { "private_key", builder.ToString() },
+            { "client_email", "mailer@test-project.iam.gserviceaccount.com" },
+            { "client_id", "1234567890" },
+            { "token_uri", "https://oauth2.googleapis.com/token" }
+        };
+
+        return JsonSerializer.Serialize(payload);
+    }
+
+    private sealed class SingleRecordRepository : IPendingMessageRepository {
+        private PendingMessageRecord? record;
+
+        public SingleRecordRepository(PendingMessageRecord record) {
+            this.record = record ?? throw new ArgumentNullException(nameof(record));
+        }
+
+        public bool IsEmpty => record == null;
+
+        public Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
+            this.record = record;
+            return Task.CompletedTask;
+        }
+
+        public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(record);
+
+        public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            var current = record;
+            if (current != null) {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return current;
+            }
+            await Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+            var current = record;
+            if (current != null && string.Equals(current.MessageId, messageId, StringComparison.Ordinal)) {
+                record = null;
+            }
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ProcessorObserver : IPendingMessageProcessorObserver {
+        public int SentCount { get; private set; }
+        public int FailedCount { get; private set; }
+        public int DroppedCount { get; private set; }
+
+        public void MessageSkipped(PendingMessageRecord record, PendingMessageSkipReason reason) {
+        }
+
+        public void MessageAttemptStarted(PendingMessageRecord record, int attempt) {
+        }
+
+        public void MessageSent(PendingMessageRecord record, int attempt, TimeSpan duration) {
+            SentCount++;
+        }
+
+        public void MessageFailed(
+            PendingMessageRecord record,
+            int attempt,
+            Exception exception,
+            TimeSpan duration,
+            bool willRetry,
+            TimeSpan? retryDelay) {
+            FailedCount++;
+        }
+
+        public void MessageDropped(PendingMessageRecord record, int attempt, PendingMessageDropReason reason, Exception? exception) {
+            DroppedCount++;
         }
     }
 }

--- a/Sources/Mailozaurr/SentMessages/Senders/GmailPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/GmailPendingMessageSender.cs
@@ -1,12 +1,20 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Net.Http;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using MimeKit;
+using Org.BouncyCastle.Asn1.Pkcs;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.OpenSsl;
+using Org.BouncyCastle.Pkcs;
+using Org.BouncyCastle.Security;
 
 namespace Mailozaurr;
 
@@ -29,6 +37,7 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
     internal const string ServiceAccountSubjectKey = "ServiceAccountSubject";
 
     private const string TokenEndpoint = "https://oauth2.googleapis.com/token";
+    private const string GmailSendScope = "https://www.googleapis.com/auth/gmail.send";
 
     private readonly Func<OAuthCredential, Func<CancellationToken, Task<string>>?, GmailApiClient> clientFactory;
     private readonly ICredentialProtector credentialProtector;
@@ -193,17 +202,20 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
     }
 
     private GmailRefreshContext? BuildRefreshContext(Dictionary<string, string> providerData, OAuthCredential credential) {
-        var refreshToken = credential.RefreshToken;
-        if (string.IsNullOrEmpty(refreshToken)) {
-            return null;
-        }
-
         credential.ClientId ??= ResolveClientId(providerData);
         credential.ClientSecret ??= ResolveProtectedString(providerData, ClientSecretProtectedKey);
         credential.ServiceAccountJson ??= ResolveProtectedString(providerData, ServiceAccountJsonProtectedKey);
         credential.ServiceAccountSubject ??= ResolveServiceAccountSubject(providerData);
 
-        if (string.IsNullOrEmpty(credential.ClientId) && string.IsNullOrEmpty(credential.ServiceAccountJson)) {
+        var refreshToken = credential.RefreshToken;
+        var hasRefreshToken = !string.IsNullOrEmpty(refreshToken);
+        var hasServiceAccount = !string.IsNullOrEmpty(credential.ServiceAccountJson);
+
+        if (!hasRefreshToken && !hasServiceAccount) {
+            return null;
+        }
+
+        if (!hasServiceAccount && string.IsNullOrEmpty(credential.ClientId)) {
             return null;
         }
 
@@ -242,8 +254,9 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
     private static bool ShouldRefreshToken(DateTimeOffset expiresOn) => expiresOn <= DateTimeOffset.UtcNow.AddMinutes(1);
 
     private async Task<string> RefreshAccessTokenAsync(OAuthCredential credential, GmailRefreshContext context, CancellationToken cancellationToken) {
-        if (context.HasClientSecret) {
-            var refreshed = await ExchangeRefreshTokenAsync(context.ClientId!, context.ClientSecret!, context.RefreshToken, cancellationToken)
+        if (context.HasClientSecret && context.HasRefreshToken) {
+            var refreshToken = context.RefreshToken!;
+            var refreshed = await ExchangeRefreshTokenAsync(context.ClientId!, context.ClientSecret!, refreshToken, cancellationToken)
                 .ConfigureAwait(false);
             credential.AccessToken = refreshed.AccessToken;
             if (!string.IsNullOrEmpty(refreshed.RefreshToken)) {
@@ -261,7 +274,12 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
         }
 
         if (context.HasServiceAccount) {
-            throw new InvalidOperationException("Service account refresh is not supported for pending Gmail messages.");
+            var refreshed = await ExchangeServiceAccountTokenAsync(context, cancellationToken).ConfigureAwait(false);
+            credential.AccessToken = refreshed.AccessToken;
+            credential.RefreshToken = null;
+            credential.ExpiresOn = refreshed.ExpiresOn ?? DateTimeOffset.UtcNow.AddHours(1);
+            context.UpdateStoredCredential(credential);
+            return credential.AccessToken;
         }
 
         throw new InvalidOperationException("Pending Gmail message is missing OAuth client context required to refresh the access token.");
@@ -313,20 +331,156 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
         return (accessToken, newRefresh, expiresOn);
     }
 
+    private async Task<(string AccessToken, DateTimeOffset? ExpiresOn)> ExchangeServiceAccountTokenAsync(
+        GmailRefreshContext context,
+        CancellationToken cancellationToken) {
+        var serviceAccountJson = context.ServiceAccountJson;
+        if (string.IsNullOrEmpty(serviceAccountJson)) {
+            throw new InvalidOperationException("Pending Gmail message is missing service account credentials required to mint a new access token.");
+        }
+
+        using var document = JsonDocument.Parse(serviceAccountJson);
+        var root = document.RootElement;
+        if (!root.TryGetProperty("client_email", out var emailProperty)) {
+            throw new InvalidOperationException("Service account JSON does not contain the client_email field.");
+        }
+
+        var clientEmail = emailProperty.GetString();
+        if (string.IsNullOrWhiteSpace(clientEmail)) {
+            throw new InvalidOperationException("Service account client_email value is empty.");
+        }
+        var clientEmailValue = clientEmail!;
+
+        if (!root.TryGetProperty("private_key", out var keyProperty)) {
+            throw new InvalidOperationException("Service account JSON does not contain the private_key field.");
+        }
+
+        var privateKey = keyProperty.GetString();
+        if (string.IsNullOrWhiteSpace(privateKey)) {
+            throw new InvalidOperationException("Service account private key is empty.");
+        }
+
+        privateKey = privateKey.Replace("\\n", "\n").Trim();
+        var assertion = CreateServiceAccountAssertion(clientEmailValue, privateKey, context.ServiceAccountSubject);
+
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string> {
+            { "grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer" },
+            { "assertion", assertion }
+        });
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, TokenEndpoint) { Content = content };
+        using var response = await Helpers.SharedHttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var payload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!response.IsSuccessStatusCode) {
+            throw new InvalidOperationException($"Failed to mint Gmail service account access token: {payload}");
+        }
+
+        using var tokenDocument = JsonDocument.Parse(payload);
+        if (!tokenDocument.RootElement.TryGetProperty("access_token", out var tokenProperty)) {
+            throw new InvalidOperationException("Gmail service account response did not include an access token.");
+        }
+
+        var accessToken = tokenProperty.GetString();
+        if (string.IsNullOrEmpty(accessToken)) {
+            throw new InvalidOperationException("Gmail service account response contained an empty access token.");
+        }
+        var accessTokenValue = accessToken!;
+
+        DateTimeOffset? expiresOn = null;
+        if (tokenDocument.RootElement.TryGetProperty("expires_in", out var expiresProperty) &&
+            expiresProperty.TryGetInt64(out var seconds) && seconds > 0) {
+            expiresOn = DateTimeOffset.UtcNow.AddSeconds(seconds);
+        }
+
+        return (accessTokenValue, expiresOn);
+    }
+
+    private static string CreateServiceAccountAssertion(string clientEmail, string privateKeyPem, string? subject) {
+        var now = DateTimeOffset.UtcNow;
+        var headerJson = JsonSerializer.Serialize(new Dictionary<string, object> {
+            { "alg", "RS256" },
+            { "typ", "JWT" }
+        });
+
+        var payload = new Dictionary<string, object> {
+            { "iss", clientEmail },
+            { "scope", GmailSendScope },
+            { "aud", TokenEndpoint },
+            { "iat", now.ToUnixTimeSeconds() },
+            { "exp", now.AddHours(1).ToUnixTimeSeconds() }
+        };
+
+        if (!string.IsNullOrEmpty(subject)) {
+            payload["sub"] = subject;
+        }
+
+        var payloadJson = JsonSerializer.Serialize(payload);
+        var header = Base64UrlEncode(Encoding.UTF8.GetBytes(headerJson));
+        var body = Base64UrlEncode(Encoding.UTF8.GetBytes(payloadJson));
+        var unsignedToken = string.Concat(header, '.', body);
+
+        using var rsa = CreateRsaFromPrivateKey(privateKeyPem);
+        var signature = rsa.SignData(Encoding.UTF8.GetBytes(unsignedToken), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var signatureSegment = Base64UrlEncode(signature);
+        return string.Concat(unsignedToken, '.', signatureSegment);
+    }
+
+    private static RSA CreateRsaFromPrivateKey(string privateKeyPem) {
+        using var reader = new StringReader(privateKeyPem);
+        var pemReader = new PemReader(reader);
+        object? keyObject = pemReader.ReadObject();
+        if (keyObject == null) {
+            throw new InvalidOperationException("Service account private key is invalid.");
+        }
+
+        RsaPrivateCrtKeyParameters? rsaParameters = null;
+        switch (keyObject) {
+            case AsymmetricCipherKeyPair pair:
+                rsaParameters = pair.Private as RsaPrivateCrtKeyParameters;
+                break;
+            case RsaPrivateCrtKeyParameters parameters:
+                rsaParameters = parameters;
+                break;
+            case PrivateKeyInfo privateKeyInfo:
+                rsaParameters = PrivateKeyFactory.CreateKey(privateKeyInfo) as RsaPrivateCrtKeyParameters;
+                break;
+            case AsymmetricKeyParameter keyParameter when keyParameter.IsPrivate:
+                rsaParameters = keyParameter as RsaPrivateCrtKeyParameters;
+                break;
+        }
+
+        if (rsaParameters == null) {
+            throw new InvalidOperationException("Service account private key format is not supported.");
+        }
+
+        var rsa = RSA.Create();
+        rsa.ImportParameters(DotNetUtilities.ToRSAParameters(rsaParameters));
+        return rsa;
+    }
+
+    private static string Base64UrlEncode(byte[] data) {
+        var base64 = Convert.ToBase64String(data);
+        return base64.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
     private sealed class GmailRefreshContext {
         private readonly Dictionary<string, string> providerData;
         private readonly ICredentialProtector protector;
 
         internal GmailRefreshContext(
             Dictionary<string, string> providerData,
-            string refreshToken,
+            string? refreshToken,
             string? clientId,
             string? clientSecret,
             string? serviceAccountJson,
             string? serviceAccountSubject,
             ICredentialProtector protector) {
             this.providerData = providerData ?? throw new ArgumentNullException(nameof(providerData));
-            RefreshToken = refreshToken ?? throw new ArgumentNullException(nameof(refreshToken));
+            RefreshToken = refreshToken;
             ClientId = clientId;
             ClientSecret = clientSecret;
             ServiceAccountJson = serviceAccountJson;
@@ -334,7 +488,7 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
             this.protector = protector ?? throw new ArgumentNullException(nameof(protector));
         }
 
-        internal string RefreshToken { get; private set; }
+        internal string? RefreshToken { get; private set; }
         internal string? ClientId { get; }
         internal string? ClientSecret { get; }
         internal string? ServiceAccountJson { get; }
@@ -342,6 +496,7 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
 
         internal bool HasClientSecret => !string.IsNullOrEmpty(ClientId) && !string.IsNullOrEmpty(ClientSecret);
         internal bool HasServiceAccount => !string.IsNullOrEmpty(ServiceAccountJson);
+        internal bool HasRefreshToken => !string.IsNullOrEmpty(RefreshToken);
 
         internal void UpdateStoredCredential(OAuthCredential credential) {
             providerData[GmailPendingMessageSender.AccessTokenProtectedKey] = protector.Protect(credential.AccessToken);
@@ -353,6 +508,11 @@ public sealed class GmailPendingMessageSender : IPendingMessageSender {
                 providerData.Remove(GmailPendingMessageSender.RefreshTokenBase64Key);
                 providerData.Remove(GmailPendingMessageSender.RefreshTokenKey);
                 RefreshToken = credential.RefreshToken!;
+            } else {
+                providerData.Remove(GmailPendingMessageSender.RefreshTokenProtectedKey);
+                providerData.Remove(GmailPendingMessageSender.RefreshTokenBase64Key);
+                providerData.Remove(GmailPendingMessageSender.RefreshTokenKey);
+                RefreshToken = null;
             }
 
             providerData[GmailPendingMessageSender.ExpiresOnKey] = credential.ExpiresOn.ToString("o", CultureInfo.InvariantCulture);


### PR DESCRIPTION
## Summary
- enable GmailPendingMessageSender to mint service account access tokens when protected JSON is available
- update refresh logic to persist refreshed credentials, regardless of whether a refresh token is present
- add tests covering service account minting within the pending message processor

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cbe609a2ec832eb447710f84294d0c