### PR TITLE
Skip non-SMTP pending records in Smtp pending message processor

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
@@ -72,6 +72,26 @@ public sealed class SmtpPendingMessageTests {
         field.SetValue(smtp, client);
     }
 
+    private static PendingMessageRecord CreatePendingRecord(string messageId, EmailProvider provider) {
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("a@b.com"));
+        message.To.Add(MailboxAddress.Parse("b@c.com"));
+        message.Subject = $"queued-{messageId}";
+        message.Body = new TextPart("plain") { Text = "body" };
+        message.MessageId = messageId;
+
+        using var ms = new MemoryStream();
+        message.WriteTo(ms);
+
+        return new PendingMessageRecord {
+            MessageId = messageId,
+            MimeMessage = Convert.ToBase64String(ms.ToArray()),
+            Timestamp = DateTimeOffset.UtcNow,
+            NextAttemptAt = DateTimeOffset.UtcNow,
+            Provider = provider
+        };
+    }
+
     [Fact]
     public void PendingMessagesPathCreatesRepository() {
         var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -274,6 +294,31 @@ public sealed class SmtpPendingMessageTests {
         Assert.Equal("msg-4", sent.Saved[0].MessageId);
         Assert.Single(pending.Removed);
         Assert.Equal("msg-4", pending.Removed[0]);
+    }
+
+    [Fact]
+    public async Task ProcessPendingMessages_SkipsRecordsForOtherProviders() {
+        var pending = new InMemoryPendingRepository();
+        var sent = new InMemorySentRepository();
+        var smtp = new Smtp { PendingMessageRepository = pending, SentMessageRepository = sent };
+        SetClient(smtp, new SuccessClient());
+
+        var smtpRecord = CreatePendingRecord("msg-smtp", EmailProvider.None);
+        var gmailRecord = CreatePendingRecord("msg-gmail", EmailProvider.Gmail);
+
+        await pending.SaveAsync(smtpRecord);
+        await pending.SaveAsync(gmailRecord);
+
+        var expectedNextAttempt = gmailRecord.NextAttemptAt;
+
+        await smtp.ProcessPendingMessagesAsync();
+
+        Assert.Single(pending.Removed);
+        Assert.Equal("msg-smtp", pending.Removed[0]);
+        Assert.DoesNotContain("msg-gmail", pending.Removed);
+        Assert.Equal(expectedNextAttempt, gmailRecord.NextAttemptAt);
+        var sentRecord = Assert.Single(sent.Saved);
+        Assert.Equal("msg-smtp", sentRecord.MessageId);
     }
 }
 

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -711,6 +711,10 @@ public class Smtp {
                 continue;
             }
 
+            if (record.Provider != EmailProvider.None) {
+                continue;
+            }
+
             MimeMessage message;
             try {
                 var bytes = Convert.FromBase64String(record.MimeMessage);


### PR DESCRIPTION
## Summary
- ensure `Smtp.ProcessPendingMessagesAsync` ignores pending messages queued for non-SMTP providers
- add a regression test that verifies Gmail pending records remain untouched while SMTP records are retried

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cc18a51fb4832eba8187a67a676a76