### PR TITLE
Add async stop support to ImapIdleListener

### DIFF
--- a/Sources/Mailozaurr.Tests/ImapIdleListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapIdleListenerTests.cs
@@ -1,4 +1,8 @@
+using System;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
 using MailKit.Net.Imap;
 using MailKit.Search;
 using Xunit;
@@ -18,4 +22,49 @@ public class ImapIdleListenerTests {
 
         Assert.Equal(query, field);
     }
+
+    [Fact]
+    public async Task StopAsync_CancelsIdleLoopGracefully() {
+        var listener = new ImapIdleListener(new ImapClient());
+        var cancellation = new CancellationTokenSource();
+        var idleCompletion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        SetPrivateField(listener, "_cancel", cancellation);
+        SetPrivateField(listener, "_idleTask", idleCompletion.Task);
+
+        var stopTask = listener.StopAsync();
+
+        Assert.True(cancellation.IsCancellationRequested);
+        Assert.False(stopTask.IsCompleted, "StopAsync completed before the idle loop finished.");
+
+        idleCompletion.SetResult(null);
+
+        await stopTask;
+
+        Assert.Null(GetPrivateField<CancellationTokenSource?>(listener, "_cancel"));
+        Assert.Null(GetPrivateField<Task?>(listener, "_idleTask"));
+    }
+
+    [Fact]
+    public async Task StopAsync_PropagatesExceptionsFromIdleLoop() {
+        var listener = new ImapIdleListener(new ImapClient());
+        var cancellation = new CancellationTokenSource();
+        var idleFailure = new InvalidOperationException("Idle loop faulted");
+
+        SetPrivateField(listener, "_cancel", cancellation);
+        SetPrivateField(listener, "_idleTask", Task.FromException(idleFailure));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => listener.StopAsync());
+
+        Assert.Same(idleFailure, exception);
+        Assert.True(cancellation.IsCancellationRequested);
+        Assert.Null(GetPrivateField<Task?>(listener, "_idleTask"));
+        Assert.Null(GetPrivateField<CancellationTokenSource?>(listener, "_cancel"));
+    }
+
+    private static void SetPrivateField<T>(ImapIdleListener listener, string name, T value) =>
+        typeof(ImapIdleListener).GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(listener, value);
+
+    private static T? GetPrivateField<T>(ImapIdleListener listener, string name) =>
+        (T?)typeof(ImapIdleListener).GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(listener);
 }

--- a/Sources/Mailozaurr/Receive/ImapIdleListener.cs
+++ b/Sources/Mailozaurr/Receive/ImapIdleListener.cs
@@ -1,11 +1,11 @@
-using MailKit;
-using MailKit.Net.Imap;
-using MailKit.Search;
-using MimeKit;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Search;
+using MimeKit;
 
 namespace Mailozaurr;
 
@@ -16,7 +16,7 @@ namespace Mailozaurr;
 /// An internal cache of <see cref="IMessageSummary"/> objects is maintained
 /// to ensure each message is reported only once per session.
 /// </remarks>
-public class ImapIdleListener : IDisposable {
+public class ImapIdleListener : IDisposable, IAsyncDisposable {
     private readonly ImapClient _client;
     private readonly string? _folderName;
     private readonly List<IMessageSummary> _summaries = new();
@@ -27,6 +27,8 @@ public class ImapIdleListener : IDisposable {
     private CancellationTokenSource? _cancel;
     private CancellationTokenSource? _done;
     private bool _messagesArrived;
+    private Task? _idleTask;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ImapIdleListener"/> class.
@@ -54,6 +56,10 @@ public class ImapIdleListener : IDisposable {
     /// Starts listening for new messages.
     /// </summary>
     public async Task StartAsync(CancellationToken cancellationToken = default) {
+        if (_disposed) {
+            throw new ObjectDisposedException(nameof(ImapIdleListener));
+        }
+
         if (_cancel != null) {
             throw new InvalidOperationException("Listener already started.");
         }
@@ -74,7 +80,7 @@ public class ImapIdleListener : IDisposable {
         _folder.CountChanged += OnCountChanged;
         _folder.MessageExpunged += OnMessageExpunged;
 
-        _ = IdleLoopAsync();
+        _idleTask = IdleLoopAsync();
     }
 
     /// <summary>
@@ -82,21 +88,48 @@ public class ImapIdleListener : IDisposable {
     /// </summary>
     public void Stop() => _cancel?.Cancel();
 
-    private async Task IdleLoopAsync() {
-        while (!_cancel!.IsCancellationRequested) {
-            try {
-                await WaitForNewMessagesAsync().ConfigureAwait(false);
+    /// <summary>
+    /// Stops listening for new messages and waits for the listener loop to finish.
+    /// </summary>
+    public async Task StopAsync() {
+        var idleTask = _idleTask;
 
-                if (_messagesArrived) {
-                    await FetchNewMessagesAsync().ConfigureAwait(false);
-                    _messagesArrived = false;
-                }
-            } catch (OperationCanceledException) when (_cancel.IsCancellationRequested) {
-                break;
-            } catch (Exception ex) {
-                IdleError?.Invoke(this, ex);
-                await Task.Delay(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+        Stop();
+
+        if (idleTask == null) {
+            Cleanup();
+            return;
+        }
+
+        try {
+            await idleTask.ConfigureAwait(false);
+        } finally {
+            Cleanup();
+            if (ReferenceEquals(_idleTask, idleTask)) {
+                _idleTask = null;
             }
+        }
+    }
+
+    private async Task IdleLoopAsync() {
+        try {
+            while (!_cancel!.IsCancellationRequested) {
+                try {
+                    await WaitForNewMessagesAsync().ConfigureAwait(false);
+
+                    if (_messagesArrived) {
+                        await FetchNewMessagesAsync().ConfigureAwait(false);
+                        _messagesArrived = false;
+                    }
+                } catch (OperationCanceledException) when (_cancel.IsCancellationRequested) {
+                    break;
+                } catch (Exception ex) {
+                    IdleError?.Invoke(this, ex);
+                    await Task.Delay(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+                }
+            }
+        } finally {
+            Cleanup();
         }
     }
 
@@ -153,10 +186,55 @@ public class ImapIdleListener : IDisposable {
 
     /// <inheritdoc />
     public void Dispose() {
-        Stop();
+        if (_disposed) {
+            return;
+        }
+
+        _disposed = true;
+
+        try {
+            Stop();
+
+            var idleTask = _idleTask;
+            if (idleTask != null) {
+                idleTask.GetAwaiter().GetResult();
+            }
+        } finally {
+            Cleanup();
+            _idleTask = null;
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync() {
+        if (_disposed) {
+            return;
+        }
+
+        _disposed = true;
+
+        try {
+            await StopAsync().ConfigureAwait(false);
+        } finally {
+            _idleTask = null;
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    private void Cleanup() {
         if (_folder != null) {
             _folder.CountChanged -= OnCountChanged;
             _folder.MessageExpunged -= OnMessageExpunged;
+            _folder = null;
         }
+
+        _done?.Dispose();
+        _done = null;
+
+        _cancel?.Dispose();
+        _cancel = null;
+
+        _messagesArrived = false;
     }
 }


### PR DESCRIPTION
## Summary
- track the idle loop task so callers can await `StopAsync`
- implement `IAsyncDisposable` and centralize cleanup of cancellation sources and event subscriptions
- add tests that exercise graceful shutdown and exception propagation through `StopAsync`

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68cd24b2329c832ebe0f7a9feb3ec52f