### PR TITLE
Add async message save support

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using MailKit;
 using MimeKit;
 
@@ -319,6 +320,66 @@ public sealed class SmtpPendingMessageTests {
         Assert.Equal(expectedNextAttempt, gmailRecord.NextAttemptAt);
         var sentRecord = Assert.Single(sent.Saved);
         Assert.Equal("msg-smtp", sentRecord.MessageId);
+    }
+
+    [Fact]
+    public async Task SaveMessageAsync_WritesMessageToFile() {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(tempDir, "message.eml");
+        var smtp = new Smtp();
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("async@from.com"));
+        message.To.Add(MailboxAddress.Parse("async@to.com"));
+        message.Subject = "async-save";
+        message.Body = new TextPart("plain") { Text = "body" };
+        message.MessageId = $"async-{Guid.NewGuid():N}";
+        smtp.Message = message;
+
+        try {
+            await smtp.SaveMessageAsync(path);
+
+            Assert.True(File.Exists(path));
+            using var stream = File.OpenRead(path);
+            var loaded = await MimeMessage.LoadAsync(stream);
+            Assert.Equal(message.MessageId, loaded.MessageId);
+            var body = Assert.IsType<TextPart>(loaded.Body);
+            Assert.Equal("body", body.Text.TrimEnd('\r', '\n'));
+        } finally {
+            if (Directory.Exists(tempDir)) {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SaveMessageAsync_RespectsCancellation() {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(tempDir, "message.eml");
+        var smtp = new Smtp();
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("async@from.com"));
+        message.To.Add(MailboxAddress.Parse("async@to.com"));
+        message.Subject = "async-cancel";
+        message.Body = new TextPart("plain") { Text = "body" };
+        smtp.Message = message;
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        try {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => smtp.SaveMessageAsync(path, cts.Token));
+
+            if (File.Exists(path)) {
+                var info = new FileInfo(path);
+                Assert.Equal(0, info.Length);
+            }
+        } finally {
+            if (Directory.Exists(tempDir)) {
+                Directory.Delete(tempDir, true);
+            }
+        }
     }
 }
 

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using System.Threading.Tasks;
 using MimeKit.Utils;
 
 namespace Mailozaurr;
@@ -267,6 +268,22 @@ public partial class ClientSmtp : SmtpClient {
             Directory.CreateDirectory(directory);
         }
         Message.WriteTo(path);
+    }
+
+    /// <summary>
+    /// Asynchronously saves the constructed message to the specified file path.
+    /// </summary>
+    /// <param name="path">Destination file path.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task SaveMessageAsync(string path, CancellationToken cancellationToken = default) {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true);
+        await Message.WriteToAsync(stream, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private IEnumerable<MailboxAddress> ConvertToMailboxAddressesUnique(IEnumerable<object>? inputs, HashSet<string> seen) {

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -379,6 +379,19 @@ public class Smtp {
     }
 
     /// <summary>
+    /// Asynchronously saves the constructed message to the specified path.
+    /// </summary>
+    /// <param name="path">Destination file path.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public Task SaveMessageAsync(string path, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return Task.CompletedTask;
+        }
+
+        return Client.SaveMessageAsync(path, cancellationToken);
+    }
+
+    /// <summary>
     /// Connect to the SMTP server using the provided server and port.
     /// </summary>
     /// <param name="server"></param>


### PR DESCRIPTION
## Summary
- add ClientSmtp.SaveMessageAsync and wire it through Smtp
- ensure async save writes to disk and honors cancellation via new tests

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68cdb5da32ac832eb9da76c490dd3689