### PR TITLE
Cache POP3 UIDs during polling

### DIFF
--- a/Sources/Mailozaurr.Tests/Pop3PollListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/Pop3PollListenerTests.cs
@@ -1,7 +1,10 @@
 using MailKit.Net.Pop3;
+using MimeKit;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -18,5 +21,143 @@ public class Pop3PollListenerTests {
 
         Assert.Null(field.GetValue(listener));
         Assert.Throws<ObjectDisposedException>(() => _ = cts.Token.WaitHandle);
+    }
+
+    [Fact]
+    public async Task StartAsync_RaisesEventsForNewUidsOnly() {
+        var listener = new TestPop3PollListener();
+        listener.SetMessages(
+            new TestPop3PollListener.TestMessage("uid1", CreateMessage("Initial")));
+        var receivedSubjects = new List<string>();
+        listener.MessageArrived += (_, message) => receivedSubjects.Add(message.Message.Subject ?? string.Empty);
+
+        await listener.StartAsync();
+
+        await listener.WaitForDelayAsync();
+        listener.SetMessages(
+            new TestPop3PollListener.TestMessage("uid1", CreateMessage("Initial")),
+            new TestPop3PollListener.TestMessage("uid2", CreateMessage("New")));
+        listener.ReleaseNextDelay();
+
+        await listener.WaitForDelayAsync();
+
+        listener.Stop();
+
+        Assert.Single(receivedSubjects);
+        Assert.Equal("New", receivedSubjects[0]);
+    }
+
+    [Fact]
+    public async Task PollLoop_HandlesDeletionsAndReorderedIndexes() {
+        var listener = new TestPop3PollListener();
+        listener.SetMessages(
+            new TestPop3PollListener.TestMessage("uid1", CreateMessage("First")),
+            new TestPop3PollListener.TestMessage("uid2", CreateMessage("Second")));
+        var receivedSubjects = new List<string>();
+        listener.MessageArrived += (_, message) => receivedSubjects.Add(message.Message.Subject ?? string.Empty);
+
+        await listener.StartAsync();
+
+        await listener.WaitForDelayAsync();
+        listener.SetMessages(new TestPop3PollListener.TestMessage("uid2", CreateMessage("Second")));
+        listener.ReleaseNextDelay();
+
+        await listener.WaitForDelayAsync();
+        listener.SetMessages(
+            new TestPop3PollListener.TestMessage("uid2", CreateMessage("Second")),
+            new TestPop3PollListener.TestMessage("uid3", CreateMessage("Third")));
+        listener.ReleaseNextDelay();
+
+        await listener.WaitForDelayAsync();
+
+        listener.Stop();
+
+        Assert.Single(receivedSubjects);
+        Assert.Equal("Third", receivedSubjects[0]);
+    }
+
+    private static MimeMessage CreateMessage(string subject) {
+        var message = new MimeMessage();
+        message.Subject = subject;
+        return message;
+    }
+
+    private sealed class TestPop3PollListener : Pop3PollListener {
+        private readonly object _syncRoot = new object();
+        private readonly List<TestMessage> _messages = new List<TestMessage>();
+        private readonly Queue<TaskCompletionSource<bool>> _pendingDelays = new Queue<TaskCompletionSource<bool>>();
+        private readonly SemaphoreSlim _delayScheduled = new SemaphoreSlim(0);
+
+        public TestPop3PollListener()
+            : base(new Pop3Client(), TimeSpan.Zero) {
+        }
+
+        public void SetMessages(params TestMessage[] messages) {
+            lock (_syncRoot) {
+                _messages.Clear();
+                if (messages != null && messages.Length > 0) {
+                    _messages.AddRange(messages);
+                }
+            }
+        }
+
+        public Task WaitForDelayAsync() => _delayScheduled.WaitAsync();
+
+        public void ReleaseNextDelay() {
+            TaskCompletionSource<bool>? pending = null;
+            lock (_syncRoot) {
+                if (_pendingDelays.Count > 0) {
+                    pending = _pendingDelays.Dequeue();
+                }
+            }
+
+            pending?.TrySetResult(true);
+        }
+
+        protected override int GetMessageCount() {
+            lock (_syncRoot) {
+                return _messages.Count;
+            }
+        }
+
+        protected override Task<string> GetMessageUidAsync(int index, CancellationToken cancellationToken) {
+            lock (_syncRoot) {
+                return Task.FromResult(_messages[index].Uid);
+            }
+        }
+
+        protected override Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken) {
+            lock (_syncRoot) {
+                return Task.FromResult(_messages[index].Message);
+            }
+        }
+
+        protected override Task NoOpAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        protected override Task DelayAsync(TimeSpan interval, CancellationToken cancellationToken) {
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (cancellationToken.CanBeCanceled) {
+                cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+            }
+
+            lock (_syncRoot) {
+                _pendingDelays.Enqueue(tcs);
+            }
+
+            _delayScheduled.Release();
+
+            return tcs.Task;
+        }
+
+        public readonly struct TestMessage {
+            public TestMessage(string uid, MimeMessage message) {
+                Uid = uid;
+                Message = message;
+            }
+
+            public string Uid { get; }
+
+            public MimeMessage Message { get; }
+        }
     }
 }

--- a/Sources/Mailozaurr/Receive/Pop3PollListener.cs
+++ b/Sources/Mailozaurr/Receive/Pop3PollListener.cs
@@ -16,7 +16,7 @@ namespace Mailozaurr;
 /// </remarks>
 public class Pop3PollListener : IDisposable {
     private readonly Pop3Client _client;
-    private int _seenCount;
+    private readonly HashSet<string> _knownUids = new HashSet<string>(StringComparer.Ordinal);
     private CancellationTokenSource? _cancel;
     private readonly TimeSpan _interval;
 
@@ -43,15 +43,21 @@ public class Pop3PollListener : IDisposable {
     /// <summary>
     /// Starts listening for new messages.
     /// </summary>
-    public Task StartAsync(CancellationToken cancellationToken = default) {
+    public async Task StartAsync(CancellationToken cancellationToken = default) {
         if (_cancel != null) {
             throw new InvalidOperationException("Listener already started.");
         }
 
         _cancel = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _seenCount = _client.Count;
+        _knownUids.Clear();
+        var count = GetMessageCount();
+        for (var i = 0; i < count; i++) {
+            var uid = await GetMessageUidAsync(i, _cancel.Token).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(uid)) {
+                _knownUids.Add(uid);
+            }
+        }
         _ = PollLoopAsync();
-        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -62,24 +68,77 @@ public class Pop3PollListener : IDisposable {
     private async Task PollLoopAsync() {
         while (!_cancel!.IsCancellationRequested) {
             try {
-                await Task.Delay(_interval, _cancel.Token).ConfigureAwait(false);
-                await _client.NoOpAsync(_cancel.Token).ConfigureAwait(false);
-                var count = _client.Count;
-                if (count > _seenCount) {
-                    for (var i = _seenCount; i < count; i++) {
-                        var message = await _client.GetMessageAsync(i, _cancel.Token).ConfigureAwait(false);
-                        MessageArrived?.Invoke(this, new Pop3EmailMessage(i, message));
+                await DelayAsync(_interval, _cancel.Token).ConfigureAwait(false);
+                await NoOpAsync(_cancel.Token).ConfigureAwait(false);
+                var count = GetMessageCount();
+                var currentUids = new HashSet<string>(StringComparer.Ordinal);
+                for (var i = 0; i < count; i++) {
+                    var uid = await GetMessageUidAsync(i, _cancel.Token).ConfigureAwait(false);
+                    if (string.IsNullOrEmpty(uid)) {
+                        continue;
                     }
-                    _seenCount = count;
+
+                    currentUids.Add(uid);
+
+                    if (_knownUids.Contains(uid)) {
+                        continue;
+                    }
+
+                    var message = await GetMessageAsync(i, _cancel.Token).ConfigureAwait(false);
+                    MessageArrived?.Invoke(this, new Pop3EmailMessage(i, message));
+                    _knownUids.Add(uid);
                 }
+
+                _knownUids.IntersectWith(currentUids);
             } catch (OperationCanceledException) when (_cancel.IsCancellationRequested) {
                 break;
             } catch (Exception ex) {
                 PollError?.Invoke(this, ex);
-                await Task.Delay(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+                await DelayAsync(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
             }
         }
     }
+
+    /// <summary>
+    /// Retrieves the total number of messages in the current mailbox.
+    /// </summary>
+    /// <returns>The number of messages available.</returns>
+    protected virtual int GetMessageCount() => _client.Count;
+
+    /// <summary>
+    /// Retrieves a message UID by index.
+    /// </summary>
+    /// <param name="index">Message index.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The message UID.</returns>
+    protected virtual Task<string> GetMessageUidAsync(int index, CancellationToken cancellationToken) =>
+        _client.GetMessageUidAsync(index, cancellationToken);
+
+    /// <summary>
+    /// Retrieves a message by index.
+    /// </summary>
+    /// <param name="index">Message index.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The message.</returns>
+    protected virtual Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken) =>
+        _client.GetMessageAsync(index, cancellationToken);
+
+    /// <summary>
+    /// Sends a NOOP command to keep the POP3 connection alive.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    protected virtual Task NoOpAsync(CancellationToken cancellationToken) =>
+        _client.NoOpAsync(cancellationToken);
+
+    /// <summary>
+    /// Delays the polling loop execution.
+    /// </summary>
+    /// <param name="interval">Delay interval.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    protected virtual Task DelayAsync(TimeSpan interval, CancellationToken cancellationToken) =>
+        Task.Delay(interval, cancellationToken);
 
     /// <inheritdoc />
     public void Dispose() {


### PR DESCRIPTION
## Summary
- cache POP3 message UIDs to track seen messages and eliminate the index counter
- update the polling loop to detect new messages by UID and remove deleted entries
- add unit tests covering new message detection, deletions, and index reordering

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cdb5be0c50832ea26a507ed5a7974e