### PR TITLE
Add async stop for GraphMessageListener

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -8,110 +8,111 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Mailozaurr.Tests;
+namespace Mailozaurr.Tests
+{
+    [Collection("GraphCollection")]
+    public class GraphMessageListenerTests {
+        private class QueueHandler : HttpMessageHandler {
+            private readonly Queue<HttpResponseMessage> _responses;
 
-[Collection("GraphCollection")]
-public class GraphMessageListenerTests {
-    private class QueueHandler : HttpMessageHandler {
-        private readonly Queue<HttpResponseMessage> _responses;
-
-        public QueueHandler(IEnumerable<HttpResponseMessage> responses) {
-            _responses = new Queue<HttpResponseMessage>(responses);
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
-            if (_responses.Count > 0) {
-                return Task.FromResult(_responses.Dequeue());
+            public QueueHandler(IEnumerable<HttpResponseMessage> responses) {
+                _responses = new Queue<HttpResponseMessage>(responses);
             }
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
-                Content = new StringContent("{\"value\":[]}")
-            });
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                if (_responses.Count > 0) {
+                    return Task.FromResult(_responses.Dequeue());
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent("{\"value\":[]}")
+                });
+            }
         }
-    }
 
-    private static FieldInfo GetHandlerField() =>
-        typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.NonPublic | BindingFlags.Instance) ??
-        typeof(HttpMessageInvoker).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance) ??
-        throw new InvalidOperationException("HttpClient handler field not found");
+        private static FieldInfo GetHandlerField() =>
+            typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.NonPublic | BindingFlags.Instance) ??
+            typeof(HttpMessageInvoker).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance) ??
+            throw new InvalidOperationException("HttpClient handler field not found");
 
-    [Fact]
-    public async Task Listener_StartStopMultipleTimes_DoesNotLeakResources() {
-        var responses = new[] {
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"access_token\":\"token\",\"token_type\":\"Bearer\"}") },
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") },
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"access_token\":\"token\",\"token_type\":\"Bearer\"}") },
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") }
-        };
-        var handler = new QueueHandler(responses);
-        var clientField = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var client = (HttpClient)clientField.GetValue(null)!;
-        var handlerField = GetHandlerField();
-        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
-        handlerField.SetValue(client, handler);
-        var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var cache = (ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
-        cache.Clear();
-        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
-        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
-        oauthField?.SetValue(null, null);
-        string cachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
-        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
-        try {
+        [Fact]
+        public async Task Listener_StartStopMultipleTimes_DoesNotLeakResources() {
+            var responses = new[] {
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"access_token\":\"token\",\"token_type\":\"Bearer\"}") },
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") },
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"access_token\":\"token\",\"token_type\":\"Bearer\"}") },
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") }
+            };
+            var handler = new QueueHandler(responses);
+            var clientField = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var client = (HttpClient)clientField.GetValue(null)!;
+            var handlerField = GetHandlerField();
+            var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+            handlerField.SetValue(client, handler);
+            var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var cache = (ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
+            cache.Clear();
+            var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
+            var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+            oauthField?.SetValue(null, null);
+            string cachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
+            if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+            try {
+                var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+                var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
+                var cancelField = typeof(GraphMessageListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+                var pollField = typeof(GraphMessageListener).GetField("_pollTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+                await listener.StartAsync();
+                var first = cancelField.GetValue(listener);
+                var firstPoll = pollField.GetValue(listener);
+                await listener.StopAsync(CancellationToken.None);
+                Assert.Null(cancelField.GetValue(listener));
+                Assert.Null(pollField.GetValue(listener));
+
+                await listener.StartAsync();
+                var second = cancelField.GetValue(listener);
+                var secondPoll = pollField.GetValue(listener);
+                listener.Dispose();
+                Assert.Null(cancelField.GetValue(listener));
+                Assert.Null(pollField.GetValue(listener));
+
+                Assert.NotNull(first);
+                Assert.NotNull(second);
+                Assert.NotSame(first, second);
+                Assert.NotNull(firstPoll);
+                Assert.NotNull(secondPoll);
+                Assert.NotSame(firstPoll, secondPoll);
+            } finally {
+                handlerField.SetValue(client, original);
+            }
+        }
+
+        [Fact]
+        public async Task StopAsync_WhenPollingTaskFaults_PropagatesException() {
             var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
             var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
+
             var cancelField = typeof(GraphMessageListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
             var pollField = typeof(GraphMessageListener).GetField("_pollTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
 
-            await listener.StartAsync();
-            var first = cancelField.GetValue(listener);
-            var firstPoll = pollField.GetValue(listener);
-            await listener.StopAsync(CancellationToken.None);
-            Assert.Null(cancelField.GetValue(listener));
-            Assert.Null(pollField.GetValue(listener));
+            var cts = new CancellationTokenSource();
+            cancelField.SetValue(listener, cts);
+            var exception = new InvalidOperationException("boom");
+            pollField.SetValue(listener, Task.FromException(exception));
 
-            await listener.StartAsync();
-            var second = cancelField.GetValue(listener);
-            var secondPoll = pollField.GetValue(listener);
-            listener.Dispose();
-            Assert.Null(cancelField.GetValue(listener));
-            Assert.Null(pollField.GetValue(listener));
-
-            Assert.NotNull(first);
-            Assert.NotNull(second);
-            Assert.NotSame(first, second);
-            Assert.NotNull(firstPoll);
-            Assert.NotNull(secondPoll);
-            Assert.NotSame(firstPoll, secondPoll);
-        } finally {
-            handlerField.SetValue(client, original);
+            var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => listener.StopAsync(CancellationToken.None));
+            Assert.Same(exception, thrown);
         }
-    }
 
-    [Fact]
-    public async Task StopAsync_WhenPollingTaskFaults_PropagatesException() {
-        var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
-        var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
+        [Fact]
+        public async Task StopAsync_AfterDispose_ThrowsObjectDisposedException() {
+            var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
 
-        var cancelField = typeof(GraphMessageListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var pollField = typeof(GraphMessageListener).GetField("_pollTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            await listener.DisposeAsync();
 
-        var cts = new CancellationTokenSource();
-        cancelField.SetValue(listener, cts);
-        var exception = new InvalidOperationException("boom");
-        pollField.SetValue(listener, Task.FromException(exception));
-
-        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => listener.StopAsync(CancellationToken.None));
-        Assert.Same(exception, thrown);
-    }
-
-    [Fact]
-    public async Task StopAsync_AfterDispose_ThrowsObjectDisposedException() {
-        var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
-        var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
-
-        await listener.DisposeAsync();
-
-        await Assert.ThrowsAsync<ObjectDisposedException>(() => listener.StopAsync(CancellationToken.None));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => listener.StopAsync(CancellationToken.None));
+        }
     }
 }
 }

--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -65,7 +65,6 @@ public class GraphMessageListenerTests {
             await listener.StartAsync();
             var first = cancelField.GetValue(listener);
             var firstPoll = pollField.GetValue(listener);
-            await Task.Delay(20);
             await listener.StopAsync(CancellationToken.None);
             Assert.Null(cancelField.GetValue(listener));
             Assert.Null(pollField.GetValue(listener));
@@ -73,7 +72,6 @@ public class GraphMessageListenerTests {
             await listener.StartAsync();
             var second = cancelField.GetValue(listener);
             var secondPoll = pollField.GetValue(listener);
-            await Task.Delay(20);
             listener.Dispose();
             Assert.Null(cancelField.GetValue(listener));
             Assert.Null(pollField.GetValue(listener));
@@ -104,6 +102,16 @@ public class GraphMessageListenerTests {
 
         var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => listener.StopAsync(CancellationToken.None));
         Assert.Same(exception, thrown);
+    }
+
+    [Fact]
+    public async Task StopAsync_AfterDispose_ThrowsObjectDisposedException() {
+        var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+        var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
+
+        await listener.DisposeAsync();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => listener.StopAsync(CancellationToken.None));
     }
 }
 }

--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -105,6 +105,25 @@ namespace Mailozaurr.Tests
         }
 
         [Fact]
+        public async Task StopAsync_WhenWaitIsCancelled_ThrowsOperationCanceledException() {
+            var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
+
+            var cancelField = typeof(GraphMessageListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var pollField = typeof(GraphMessageListener).GetField("_pollTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+            var listenerCts = new CancellationTokenSource();
+            cancelField.SetValue(listener, listenerCts);
+            var pollTcs = new TaskCompletionSource<object?>();
+            pollField.SetValue(listener, pollTcs.Task);
+
+            using var externalCts = new CancellationTokenSource();
+            externalCts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => listener.StopAsync(externalCts.Token));
+        }
+
+        [Fact]
         public async Task StopAsync_AfterDispose_ThrowsObjectDisposedException() {
             var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
             var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
@@ -112,6 +131,23 @@ namespace Mailozaurr.Tests
             await listener.DisposeAsync();
 
             await Assert.ThrowsAsync<ObjectDisposedException>(() => listener.StopAsync(CancellationToken.None));
+        }
+
+        [Fact]
+        public void GetNextErrorDelay_ResetsAndCapsAsExpected() {
+            var type = typeof(GraphMessageListener);
+            var initial = (TimeSpan)type.GetField("ErrorDelayInitial", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+            var maximum = (TimeSpan)type.GetField("ErrorDelayMaximum", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+            var method = type.GetMethod("GetNextErrorDelay", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            var doubled = (TimeSpan)method.Invoke(null, new object[] { initial })!;
+            Assert.Equal(initial + initial, doubled);
+
+            var capped = (TimeSpan)method.Invoke(null, new object[] { maximum })!;
+            Assert.Equal(maximum, capped);
+
+            var reset = (TimeSpan)method.Invoke(null, new object[] { TimeSpan.Zero })!;
+            Assert.Equal(initial, reset);
         }
     }
 }

--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -66,7 +66,7 @@ public class GraphMessageListenerTests {
             var first = cancelField.GetValue(listener);
             var firstPoll = pollField.GetValue(listener);
             await Task.Delay(20);
-            listener.Dispose();
+            await listener.StopAsync(CancellationToken.None);
             Assert.Null(cancelField.GetValue(listener));
             Assert.Null(pollField.GetValue(listener));
 
@@ -87,4 +87,23 @@ public class GraphMessageListenerTests {
         } finally {
             handlerField.SetValue(client, original);
         }
-    }}
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenPollingTaskFaults_PropagatesException() {
+        var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+        var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
+
+        var cancelField = typeof(GraphMessageListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var pollField = typeof(GraphMessageListener).GetField("_pollTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        var cts = new CancellationTokenSource();
+        cancelField.SetValue(listener, cts);
+        var exception = new InvalidOperationException("boom");
+        pollField.SetValue(listener, Task.FromException(exception));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => listener.StopAsync(CancellationToken.None));
+        Assert.Same(exception, thrown);
+    }
+}
+}

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -12,7 +12,7 @@ namespace Mailozaurr;
 /// The listener keeps track of message IDs to avoid raising duplicate
 /// notifications during polling.
 /// </remarks>
-public class GraphMessageListener : IDisposable {
+public class GraphMessageListener : IDisposable, IAsyncDisposable {
     private readonly GraphCredential _credential;
     private readonly string _userPrincipalName;
     private readonly HashSet<string> _seenIds = new();
@@ -66,20 +66,35 @@ public class GraphMessageListener : IDisposable {
     /// Stops listening for new messages.
     /// </summary>
     public void Stop() {
-        if (_cancel == null) {
+        StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Stops listening for new messages.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel waiting for the polling loop to complete.</param>
+    public async Task StopAsync(CancellationToken cancellationToken) {
+        var cancel = _cancel;
+        if (cancel == null) {
             return;
         }
 
-        _cancel.Cancel();
-        try {
-            _pollTask?.GetAwaiter().GetResult();
-        } catch (OperationCanceledException) {
-            // ignored
-        }
+        Task? pollTask = _pollTask;
+        cancel.Cancel();
 
-        _cancel.Dispose();
-        _cancel = null;
-        _pollTask = null;
+        try {
+            if (pollTask != null) {
+                try {
+                    await WaitWithCancellationAsync(pollTask, cancellationToken).ConfigureAwait(false);
+                } catch (OperationCanceledException) when (cancel.IsCancellationRequested && !cancellationToken.IsCancellationRequested) {
+                    // Expected cancellation from the listener itself.
+                }
+            }
+        } finally {
+            cancel.Dispose();
+            _cancel = null;
+            _pollTask = null;
+        }
     }
 
     private async Task PollLoopAsync() {
@@ -104,8 +119,33 @@ public class GraphMessageListener : IDisposable {
 
     /// <inheritdoc />
     public void Dispose() {
-        Stop();
-        _cancel?.Dispose();
-        _cancel = null;
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync() {
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
+
+    private static async Task WaitWithCancellationAsync(Task task, CancellationToken cancellationToken) {
+        if (!cancellationToken.CanBeCanceled) {
+            await task.ConfigureAwait(false);
+            return;
+        }
+
+        if (task.IsCompleted) {
+            await task.ConfigureAwait(false);
+            return;
+        }
+
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (cancellationToken.Register(static state => ((TaskCompletionSource<object?>)state!).TrySetResult(null), tcs)) {
+            if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false)) {
+                throw new OperationCanceledException(cancellationToken);
+            }
+        }
+
+        await task.ConfigureAwait(false);
     }
 }

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -74,14 +74,14 @@ public class GraphMessageListener : IDisposable, IAsyncDisposable {
     /// Stops listening for new messages.
     /// </summary>
     public void Stop() {
-        StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+        StopAsync().GetAwaiter().GetResult();
     }
 
     /// <summary>
     /// Stops listening for new messages.
     /// </summary>
     /// <param name="cancellationToken">Token used to cancel waiting for the polling loop to complete.</param>
-    public async Task StopAsync(CancellationToken cancellationToken) {
+    public async Task StopAsync(CancellationToken cancellationToken = default) {
         var disposeTask = Volatile.Read(ref _disposeTask);
         if (disposeTask != null) {
             await WaitWithCancellationAsync(disposeTask, cancellationToken).ConfigureAwait(false);

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -21,6 +21,8 @@ public class GraphMessageListener : IDisposable, IAsyncDisposable {
     private readonly TimeSpan _interval;
     private Task? _disposeTask;
     private int _disposeState;
+    private static readonly TimeSpan ErrorDelayInitial = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan ErrorDelayMaximum = TimeSpan.FromMinutes(2);
 
     private const int DisposeStateActive = 0;
     private const int DisposeStateDisposing = 1;
@@ -95,6 +97,8 @@ public class GraphMessageListener : IDisposable, IAsyncDisposable {
     }
 
     private async Task PollLoopAsync() {
+        var currentErrorDelay = ErrorDelayInitial;
+
         while (!_cancel!.IsCancellationRequested) {
             try {
                 await Task.Delay(_interval, _cancel.Token).ConfigureAwait(false);
@@ -105,11 +109,14 @@ public class GraphMessageListener : IDisposable, IAsyncDisposable {
                         MessageArrived?.Invoke(this, msg);
                     }
                 }
+                currentErrorDelay = ErrorDelayInitial;
             } catch (OperationCanceledException) when (_cancel.IsCancellationRequested) {
                 break;
             } catch (Exception ex) {
                 PollError?.Invoke(this, ex);
-                await Task.Delay(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+                var delay = currentErrorDelay;
+                currentErrorDelay = GetNextErrorDelay(currentErrorDelay);
+                await Task.Delay(delay, _cancel.Token).ConfigureAwait(false);
             }
         }
     }
@@ -198,5 +205,25 @@ public class GraphMessageListener : IDisposable, IAsyncDisposable {
         }
 
         await task.ConfigureAwait(false);
+    }
+
+    private static TimeSpan GetNextErrorDelay(TimeSpan current)
+    {
+        if (current <= TimeSpan.Zero) {
+            return ErrorDelayInitial;
+        }
+
+        long doubledTicks;
+        try {
+            doubledTicks = checked(current.Ticks * 2);
+        } catch (OverflowException) {
+            return ErrorDelayMaximum;
+        }
+
+        if (doubledTicks > ErrorDelayMaximum.Ticks) {
+            return ErrorDelayMaximum;
+        }
+
+        return TimeSpan.FromTicks(doubledTicks);
     }
 }

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -19,6 +19,12 @@ public class GraphMessageListener : IDisposable, IAsyncDisposable {
     private CancellationTokenSource? _cancel;
     private Task? _pollTask;
     private readonly TimeSpan _interval;
+    private Task? _disposeTask;
+    private int _disposeState;
+
+    private const int DisposeStateActive = 0;
+    private const int DisposeStateDisposing = 1;
+    private const int DisposeStateDisposed = 2;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GraphMessageListener"/> class.
@@ -46,6 +52,8 @@ public class GraphMessageListener : IDisposable, IAsyncDisposable {
     /// Starts listening for new messages.
     /// </summary>
     public async Task StartAsync(CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+
         if (_cancel != null) {
             throw new InvalidOperationException("Listener already started.");
         }
@@ -74,27 +82,16 @@ public class GraphMessageListener : IDisposable, IAsyncDisposable {
     /// </summary>
     /// <param name="cancellationToken">Token used to cancel waiting for the polling loop to complete.</param>
     public async Task StopAsync(CancellationToken cancellationToken) {
-        var cancel = _cancel;
-        if (cancel == null) {
+        var disposeTask = Volatile.Read(ref _disposeTask);
+        if (disposeTask != null) {
+            await WaitWithCancellationAsync(disposeTask, cancellationToken).ConfigureAwait(false);
+            ThrowIfDisposed();
             return;
         }
 
-        Task? pollTask = _pollTask;
-        cancel.Cancel();
+        ThrowIfDisposed();
 
-        try {
-            if (pollTask != null) {
-                try {
-                    await WaitWithCancellationAsync(pollTask, cancellationToken).ConfigureAwait(false);
-                } catch (OperationCanceledException) when (cancel.IsCancellationRequested && !cancellationToken.IsCancellationRequested) {
-                    // Expected cancellation from the listener itself.
-                }
-            }
-        } finally {
-            cancel.Dispose();
-            _cancel = null;
-            _pollTask = null;
-        }
+        await StopAsyncCore(cancellationToken).ConfigureAwait(false);
     }
 
     private async Task PollLoopAsync() {
@@ -123,9 +120,63 @@ public class GraphMessageListener : IDisposable, IAsyncDisposable {
     }
 
     /// <inheritdoc />
-    public async ValueTask DisposeAsync() {
-        await StopAsync(CancellationToken.None).ConfigureAwait(false);
-        GC.SuppressFinalize(this);
+    public ValueTask DisposeAsync() => new ValueTask(EnsureDisposeTask());
+
+    private Task EnsureDisposeTask() {
+        while (true) {
+            var existing = Volatile.Read(ref _disposeTask);
+            if (existing != null) {
+                return existing;
+            }
+
+            var created = DisposeAsyncCore();
+            if (Interlocked.CompareExchange(ref _disposeTask, created, null) == null) {
+                return created;
+            }
+        }
+    }
+
+    private async Task DisposeAsyncCore() {
+        if (Interlocked.CompareExchange(ref _disposeState, DisposeStateDisposing, DisposeStateActive) != DisposeStateActive) {
+            return;
+        }
+
+        try {
+            await StopAsyncCore(CancellationToken.None).ConfigureAwait(false);
+        } finally {
+            Volatile.Write(ref _disposeState, DisposeStateDisposed);
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    private async Task StopAsyncCore(CancellationToken cancellationToken) {
+        var cancel = _cancel;
+        if (cancel == null) {
+            return;
+        }
+
+        Task? pollTask = _pollTask;
+        cancel.Cancel();
+
+        try {
+            if (pollTask != null) {
+                try {
+                    await WaitWithCancellationAsync(pollTask, cancellationToken).ConfigureAwait(false);
+                } catch (OperationCanceledException) when (cancel.IsCancellationRequested && !cancellationToken.IsCancellationRequested) {
+                    // Expected cancellation from the listener itself.
+                }
+            }
+        } finally {
+            cancel.Dispose();
+            _cancel = null;
+            _pollTask = null;
+        }
+    }
+
+    private void ThrowIfDisposed() {
+        if (Volatile.Read(ref _disposeState) == DisposeStateDisposed) {
+            throw new ObjectDisposedException(nameof(GraphMessageListener));
+        }
     }
 
     private static async Task WaitWithCancellationAsync(Task task, CancellationToken cancellationToken) {


### PR DESCRIPTION
## Summary
- add an asynchronous StopAsync workflow for GraphMessageListener and wire Dispose through DisposeAsync
- ensure StopAsync cancels the polling loop safely and expose helper to wait with cancellation support
- extend GraphMessageListener tests to cover async stop usage and exception propagation

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68cdb5b348a0832ebf8a5a8ddd63756c