### PR TITLE
Add async ClientSmtp message creation and tests

### DIFF
--- a/Sources/Mailozaurr.Tests/ClientSmtpTests.cs
+++ b/Sources/Mailozaurr.Tests/ClientSmtpTests.cs
@@ -1,7 +1,12 @@
-using System;
-using System.Reflection;
 using System.Collections.Generic;
+using System;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using MimeKit;
 using Xunit;
 using Mailozaurr;
@@ -48,5 +53,151 @@ public class ClientSmtpTests
         LoggingMessages.Logger.OnWarningMessage -= Handler;
         Assert.Empty(result);
         Assert.Contains(messages, static m => m.Contains("invalid@"));
+    }
+
+    [Fact]
+    public async Task CreateMessage_SyncAndAsyncProduceEquivalentMessages()
+    {
+        const string url = "https://example.com/img.png";
+        var html = $"<img src=\"{url}\">";
+        var imageContent = new byte[] { 1, 2, 3 };
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(imageContent)
+                {
+                    Headers = { ContentType = new MediaTypeHeaderValue("image/png") }
+                }
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(imageContent)
+                {
+                    Headers = { ContentType = new MediaTypeHeaderValue("image/png") }
+                }
+            });
+
+        var client = HtmlUtils.HttpClient;
+        var handlerField = typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? typeof(HttpMessageInvoker).GetField("handler", BindingFlags.Instance | BindingFlags.NonPublic);
+        var original = (HttpMessageHandler)handlerField!.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+
+        try
+        {
+            var syncClient = CreateClientForTest(html);
+            syncClient.CreateMessage();
+
+            var asyncClient = CreateClientForTest(html);
+            await asyncClient.CreateMessageAsync();
+
+            Assert.Equal(syncClient.Message.HtmlBody, asyncClient.Message.HtmlBody);
+            Assert.Equal(syncClient.Message.TextBody, asyncClient.Message.TextBody);
+            Assert.Contains("cid:", syncClient.Message.HtmlBody);
+
+            var syncInline = GetInlineAttachments(syncClient.Message).OrderBy(p => p.ContentId).ToList();
+            var asyncInline = GetInlineAttachments(asyncClient.Message).OrderBy(p => p.ContentId).ToList();
+
+            Assert.Equal(syncInline.Count, asyncInline.Count);
+            for (var i = 0; i < syncInline.Count; i++)
+            {
+                Assert.Equal(syncInline[i].ContentId, asyncInline[i].ContentId);
+                Assert.Equal(syncInline[i].MediaType, asyncInline[i].MediaType);
+            }
+        }
+        finally
+        {
+            handlerField.SetValue(client, original);
+        }
+    }
+
+    [Fact]
+    public async Task CreateMessage_CancellationPropagatesToBothOverloads()
+    {
+        const string url = "https://example.com/slow.png";
+        var html = $"<img src=\"{url}\">";
+        var client = HtmlUtils.HttpClient;
+        var handlerField = typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? typeof(HttpMessageInvoker).GetField("handler", BindingFlags.Instance | BindingFlags.NonPublic);
+        var original = (HttpMessageHandler)handlerField!.GetValue(client)!;
+
+        try
+        {
+            handlerField.SetValue(client, new DelayedHandler());
+            var asyncClient = CreateClientForTest(html);
+            using (var asyncCts = new CancellationTokenSource())
+            {
+                var asyncOperation = asyncClient.CreateMessageAsync(asyncCts.Token);
+                asyncCts.CancelAfter(TimeSpan.FromMilliseconds(100));
+                await Assert.ThrowsAsync<OperationCanceledException>(async () => await asyncOperation);
+            }
+
+            handlerField.SetValue(client, new DelayedHandler());
+            var syncClient = CreateClientForTest(html);
+            using var syncCts = new CancellationTokenSource();
+            var syncTask = Task.Run(() => syncClient.CreateMessage(syncCts.Token));
+            syncCts.CancelAfter(TimeSpan.FromMilliseconds(100));
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await syncTask);
+        }
+        finally
+        {
+            handlerField.SetValue(client, original);
+        }
+    }
+
+    private static ClientSmtp CreateClientForTest(string html)
+    {
+        return new ClientSmtp
+        {
+            AutoEmbedRemoteImages = true,
+            HtmlBody = html,
+            Subject = "Hello",
+            From = "sender@example.com",
+            To = new object[] { "recipient@example.com" }
+        };
+    }
+
+    private static List<InlineAttachmentInfo> GetInlineAttachments(MimeMessage message)
+    {
+        var attachments = new List<InlineAttachmentInfo>();
+        foreach (var part in message.BodyParts.OfType<MimePart>())
+        {
+            if (!string.Equals(part.ContentDisposition?.Disposition, ContentDisposition.Inline, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            attachments.Add(new InlineAttachmentInfo(part.ContentId ?? string.Empty, part.ContentType.MimeType));
+        }
+
+        return attachments;
+    }
+
+    private sealed class InlineAttachmentInfo
+    {
+        public InlineAttachmentInfo(string contentId, string mediaType)
+        {
+            ContentId = contentId;
+            MediaType = mediaType;
+        }
+
+        public string ContentId { get; }
+
+        public string MediaType { get; }
+    }
+
+    private sealed class DelayedHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 1, 2, 3 })
+                {
+                    Headers = { ContentType = new MediaTypeHeaderValue("image/png") }
+                }
+            };
+        }
     }
 }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using MimeKit.Utils;
@@ -113,11 +114,27 @@ public partial class ClientSmtp : SmtpClient {
     /// </summary>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public void CreateMessage(CancellationToken cancellationToken = default) {
+        var task = Task.Run(
+            async () => await CreateMessageAsync(cancellationToken).ConfigureAwait(false),
+            cancellationToken);
+        try {
+            task.Wait(cancellationToken);
+        } catch (AggregateException ex) when (ex.InnerExceptions.Count == 1) {
+            ExceptionDispatchInfo.Capture(ex.InnerExceptions[0]).Throw();
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously builds the <see cref="MimeMessage"/> based on the configured properties.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task CreateMessageAsync(CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         InlineAttachments ??= new List<object>();
         var message = new MimeMessage();
         AddAddressesToMessage(message);
         SetMessagePriority(message);
-        BuildMessageBody(message, cancellationToken);
+        await BuildMessageBodyAsync(message, cancellationToken).ConfigureAwait(false);
         message.Subject = Subject;
         AddHeaders(message);
         Message = message;
@@ -167,7 +184,8 @@ public partial class ClientSmtp : SmtpClient {
         }
     }
 
-    private void BuildMessageBody(MimeMessage message, CancellationToken cancellationToken) {
+    private async Task BuildMessageBodyAsync(MimeMessage message, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
         var bodyBuilder = new BodyBuilder();
         if (!string.IsNullOrWhiteSpace(HtmlBody)) {
             bodyBuilder.HtmlBody = HtmlBody;
@@ -234,7 +252,8 @@ public partial class ClientSmtp : SmtpClient {
             }
         }
         if (AutoEmbedRemoteImages && !string.IsNullOrWhiteSpace(bodyBuilder.HtmlBody)) {
-            var (html, images) = HtmlUtils.DownloadRemoteImagesAsync(bodyBuilder.HtmlBody, cancellationToken).GetAwaiter().GetResult();
+            var (html, images) = await HtmlUtils.DownloadRemoteImagesAsync(bodyBuilder.HtmlBody, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
             bodyBuilder.HtmlBody = html;
             HtmlBody = html;
             foreach (var img in images) {
@@ -248,6 +267,7 @@ public partial class ClientSmtp : SmtpClient {
                 bodyBuilder.LinkedResources.Add(part);
             }
         }
+        cancellationToken.ThrowIfCancellationRequested();
         message.Body = bodyBuilder.ToMessageBody();
     }
 

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -353,19 +353,17 @@ public class Smtp {
     /// Creates the MIME message using the current property values.
     /// </summary>
     public void CreateMessage(CancellationToken cancellationToken = default) {
-        if (AutoEmbedImages) {
-            var (html, paths) = HtmlUtils.ExtractLocalImagePaths(HtmlBody);
-            HtmlBody = html;
-            if (paths.Count > 0) {
-                InlineAttachments ??= new List<object>();
-                foreach (var p in paths) {
-                    if (!InlineAttachments.Contains(p)) {
-                        InlineAttachments.Add(p);
-                    }
-                }
-            }
-        }
+        PrepareInlineAttachments();
         Client.CreateMessage(cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously creates the MIME message using the current property values.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task CreateMessageAsync(CancellationToken cancellationToken = default) {
+        PrepareInlineAttachments();
+        await Client.CreateMessageAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -389,6 +387,25 @@ public class Smtp {
         }
 
         return Client.SaveMessageAsync(path, cancellationToken);
+    }
+
+    private void PrepareInlineAttachments() {
+        if (!AutoEmbedImages) {
+            return;
+        }
+
+        var (html, paths) = HtmlUtils.ExtractLocalImagePaths(HtmlBody);
+        HtmlBody = html;
+        if (paths.Count <= 0) {
+            return;
+        }
+
+        InlineAttachments ??= new List<object>();
+        foreach (var path in paths) {
+            if (!InlineAttachments.Contains(path)) {
+                InlineAttachments.Add(path);
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add an asynchronous ClientSmtp.CreateMessageAsync overload and wire the synchronous method through it while honoring cancellation tokens
- expose a matching Smtp.CreateMessageAsync helper that shares inline image preparation logic
- extend ClientSmtp unit tests to validate async/sync parity and cancellation behavior

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68ce92476724832e8ca1a1e64590cef5