### PR TITLE
Ensure POP3 poll listener stops asynchronously

### DIFF
--- a/Sources/Mailozaurr.Tests/Pop3PollListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/Pop3PollListenerTests.cs
@@ -14,12 +14,31 @@ public class Pop3PollListenerTests {
     public void Dispose_DisposesCancellationTokenSourceAndNullsField() {
         var listener = new Pop3PollListener(new Pop3Client());
         var field = typeof(Pop3PollListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var pollingTaskField = typeof(Pop3PollListener).GetField("_pollingTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var cts = new CancellationTokenSource();
         field.SetValue(listener, cts);
+        pollingTaskField.SetValue(listener, Task.CompletedTask);
 
         listener.Dispose();
 
         Assert.Null(field.GetValue(listener));
+        Assert.Null(pollingTaskField.GetValue(listener));
+        Assert.Throws<ObjectDisposedException>(() => _ = cts.Token.WaitHandle);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesCancellationTokenSourceAndNullsField() {
+        var listener = new Pop3PollListener(new Pop3Client());
+        var field = typeof(Pop3PollListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var pollingTaskField = typeof(Pop3PollListener).GetField("_pollingTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var cts = new CancellationTokenSource();
+        field.SetValue(listener, cts);
+        pollingTaskField.SetValue(listener, Task.CompletedTask);
+
+        await listener.DisposeAsync();
+
+        Assert.Null(field.GetValue(listener));
+        Assert.Null(pollingTaskField.GetValue(listener));
         Assert.Throws<ObjectDisposedException>(() => _ = cts.Token.WaitHandle);
     }
 
@@ -41,7 +60,7 @@ public class Pop3PollListenerTests {
 
         await listener.WaitForDelayAsync();
 
-        listener.Stop();
+        await listener.StopAsync();
 
         Assert.Single(receivedSubjects);
         Assert.Equal("New", receivedSubjects[0]);
@@ -70,10 +89,70 @@ public class Pop3PollListenerTests {
 
         await listener.WaitForDelayAsync();
 
-        listener.Stop();
+        await listener.StopAsync();
 
         Assert.Single(receivedSubjects);
         Assert.Equal("Third", receivedSubjects[0]);
+    }
+
+    [Fact]
+    public async Task StopAsync_WaitsForPollingLoopToComplete() {
+        var listener = new TestPop3PollListener { DelayIgnoresCancellation = true };
+
+        await listener.StartAsync();
+        await listener.WaitForDelayAsync();
+
+        var stopTask = listener.StopAsync();
+
+        var completed = await Task.WhenAny(stopTask, Task.Delay(100));
+        Assert.NotSame(stopTask, completed);
+
+        listener.ReleaseNextDelay();
+
+        await stopTask;
+
+        var cancelField = typeof(Pop3PollListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var pollingTaskField = typeof(Pop3PollListener).GetField("_pollingTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.Null(cancelField.GetValue(listener));
+        Assert.Null(pollingTaskField.GetValue(listener));
+    }
+
+    [Fact]
+    public async Task PollLoop_RaisesPollErrorAndRecoversAfterException() {
+        var listener = new TestPop3PollListener();
+        listener.SetMessages(new TestPop3PollListener.TestMessage("uid1", CreateMessage("Initial")));
+        var receivedSubjects = new List<string>();
+        var errors = new List<Exception>();
+        listener.MessageArrived += (_, message) => receivedSubjects.Add(message.Message.Subject ?? string.Empty);
+        listener.PollError += (_, exception) => errors.Add(exception);
+
+        await listener.StartAsync();
+        await listener.WaitForDelayAsync();
+
+        listener.SetMessages(
+            new TestPop3PollListener.TestMessage("uid1", CreateMessage("Initial")),
+            new TestPop3PollListener.TestMessage("uid2", CreateMessage("New")));
+        listener.ThrowOnNextFetch(new InvalidOperationException("Boom"));
+        listener.ReleaseNextDelay();
+
+        await listener.WaitForDelayAsync();
+        listener.ReleaseNextDelay();
+
+        await listener.WaitForDelayAsync();
+        listener.SetMessages(
+            new TestPop3PollListener.TestMessage("uid1", CreateMessage("Initial")),
+            new TestPop3PollListener.TestMessage("uid2", CreateMessage("New")));
+        listener.ReleaseNextDelay();
+
+        await listener.WaitForDelayAsync();
+
+        await listener.StopAsync();
+
+        Assert.Single(errors);
+        Assert.IsType<InvalidOperationException>(errors[0]);
+        Assert.Single(receivedSubjects);
+        Assert.Equal("New", receivedSubjects[0]);
     }
 
     private static MimeMessage CreateMessage(string subject) {
@@ -87,10 +166,13 @@ public class Pop3PollListenerTests {
         private readonly List<TestMessage> _messages = new List<TestMessage>();
         private readonly Queue<TaskCompletionSource<bool>> _pendingDelays = new Queue<TaskCompletionSource<bool>>();
         private readonly SemaphoreSlim _delayScheduled = new SemaphoreSlim(0);
+        private Exception? _nextFetchException;
 
         public TestPop3PollListener()
             : base(new Pop3Client(), TimeSpan.Zero) {
         }
+
+        public bool DelayIgnoresCancellation { get; set; }
 
         public void SetMessages(params TestMessage[] messages) {
             lock (_syncRoot) {
@@ -114,6 +196,16 @@ public class Pop3PollListenerTests {
             pending?.TrySetResult(true);
         }
 
+        public void ThrowOnNextFetch(Exception exception) {
+            if (exception == null) {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            lock (_syncRoot) {
+                _nextFetchException = exception;
+            }
+        }
+
         protected override int GetMessageCount() {
             lock (_syncRoot) {
                 return _messages.Count;
@@ -128,6 +220,12 @@ public class Pop3PollListenerTests {
 
         protected override Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken) {
             lock (_syncRoot) {
+                if (_nextFetchException != null) {
+                    var exception = _nextFetchException;
+                    _nextFetchException = null;
+                    throw exception;
+                }
+
                 return Task.FromResult(_messages[index].Message);
             }
         }
@@ -136,7 +234,7 @@ public class Pop3PollListenerTests {
 
         protected override Task DelayAsync(TimeSpan interval, CancellationToken cancellationToken) {
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            if (cancellationToken.CanBeCanceled) {
+            if (!DelayIgnoresCancellation && cancellationToken.CanBeCanceled) {
                 cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
             }
 

--- a/Sources/Mailozaurr/Receive/Pop3PollListener.cs
+++ b/Sources/Mailozaurr/Receive/Pop3PollListener.cs
@@ -14,10 +14,11 @@ namespace Mailozaurr;
 /// Uses basic polling rather than the IMAP IDLE approach and is
 /// therefore best suited for servers without IDLE support.
 /// </remarks>
-public class Pop3PollListener : IDisposable {
+public class Pop3PollListener : IDisposable, IAsyncDisposable {
     private readonly Pop3Client _client;
     private readonly HashSet<string> _knownUids = new HashSet<string>(StringComparer.Ordinal);
     private CancellationTokenSource? _cancel;
+    private Task? _pollingTask;
     private readonly TimeSpan _interval;
 
     /// <summary>
@@ -57,13 +58,47 @@ public class Pop3PollListener : IDisposable {
                 _knownUids.Add(uid);
             }
         }
-        _ = PollLoopAsync();
+        _pollingTask = PollLoopAsync();
     }
 
     /// <summary>
     /// Stops listening for new messages.
     /// </summary>
-    public void Stop() => _cancel?.Cancel();
+    public void Stop() => StopAsync().GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Stops listening for new messages and waits for the polling loop to finish.
+    /// </summary>
+    public async Task StopAsync() {
+        var cancel = _cancel;
+        var pollingTask = _pollingTask;
+
+        if (cancel == null) {
+            if (pollingTask != null) {
+                try {
+                    await pollingTask.ConfigureAwait(false);
+                } finally {
+                    _pollingTask = null;
+                }
+            }
+
+            return;
+        }
+
+        try {
+            cancel.Cancel();
+            if (pollingTask != null) {
+                try {
+                    await pollingTask.ConfigureAwait(false);
+                } catch (OperationCanceledException) when (cancel.IsCancellationRequested) {
+                }
+            }
+        } finally {
+            cancel.Dispose();
+            _cancel = null;
+            _pollingTask = null;
+        }
+    }
 
     private async Task PollLoopAsync() {
         while (!_cancel!.IsCancellationRequested) {
@@ -143,7 +178,12 @@ public class Pop3PollListener : IDisposable {
     /// <inheritdoc />
     public void Dispose() {
         Stop();
-        _cancel?.Dispose();
-        _cancel = null;
+        GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync() {
+        await StopAsync().ConfigureAwait(false);
+        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
## Summary
- capture and await the POP3 polling loop task via a new StopAsync implementation
- implement IAsyncDisposable so asynchronous disposal waits for the polling loop to finish
- extend Pop3PollListener unit tests to cover StopAsync, DisposeAsync, and exception handling scenarios

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68ce924bdacc832e9ec58d3412288c52