### PR TITLE
Add cancellation support to MicrosoftGraphUtils paging APIs

### DIFF
--- a/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsPagingTests.cs
+++ b/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsPagingTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Mailozaurr;
 using Xunit;
@@ -46,6 +47,73 @@ public class MicrosoftGraphUtilsPagingTests {
         } finally {
             handlerField.SetValue(client, original);
             tokenCache.TryRemove(key, out _);
+        }
+    }
+
+    [Fact]
+    public async Task GetMailMessagesAsync_CanBeCancelledDuringPaging() {
+        const string firstPage = "{\"value\":[{\"id\":\"1\"}],\"@odata.nextLink\":\"https://graph.microsoft.com/v1.0/users/u/messages?$skip=1\"}";
+        var handler = new BlockingHandler(firstPage);
+        var httpClientField = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)httpClientField.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        var tokenCacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var tokenCache = (ConcurrentDictionary<string, GraphAuthorization>)tokenCacheField.GetValue(null)!;
+        var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
+        var key = "id|tenant||secret|https://graph.microsoft.com";
+        tokenCache[key] = new GraphAuthorization { AccessToken = "token", TokenType = "Bearer", ExpiresOn = DateTimeOffset.UtcNow.AddHours(1) };
+        using var cts = new CancellationTokenSource();
+        try {
+            var task = MicrosoftGraphUtils.GetMailMessagesAsync(cred, "u", cancellationToken: cts.Token);
+            await handler.FirstRequestProcessed.Task;
+            var secondRequestObserved = await Task.WhenAny(handler.SecondRequestStarted.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(handler.SecondRequestStarted.Task, secondRequestObserved);
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
+            Assert.Equal(2, handler.Requests.Count);
+        } finally {
+            handlerField.SetValue(client, original);
+            tokenCache.TryRemove(key, out _);
+        }
+    }
+
+    private sealed class BlockingHandler : HttpMessageHandler {
+        private readonly string _firstPageJson;
+        public List<HttpRequestMessage> Requests { get; } = new();
+        public TaskCompletionSource<bool> FirstRequestProcessed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<bool> SecondRequestStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public BlockingHandler(string firstPageJson) {
+            _firstPageJson = firstPageJson;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            var copy = new HttpRequestMessage(request.Method, request.RequestUri);
+            foreach (var header in request.Headers) {
+                copy.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+            if (request.Content != null) {
+                var bytes = await request.Content.ReadAsByteArrayAsync();
+                copy.Content = new ByteArrayContent(bytes);
+                foreach (var header in request.Content.Headers) {
+                    copy.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+            Requests.Add(copy);
+            if (Requests.Count == 1) {
+                FirstRequestProcessed.TrySetResult(true);
+                return new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent(_firstPageJson)
+                };
+            }
+
+            SecondRequestStarted.TrySetResult(true);
+            await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("{\"value\":[]}")
+            };
         }
     }
 }

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -466,9 +466,10 @@ namespace Mailozaurr {
         /// <summary>
         /// Retrieves mail messages for the specified user.
         /// </summary>
-        public static async Task<List<Dictionary<string, object>>> GetMailMessagesAsync(GraphCredential credential, string userPrincipalName, IEnumerable<string>? properties = null, string? filter = null, int? limit = null) {
+        public static async Task<List<Dictionary<string, object>>> GetMailMessagesAsync(GraphCredential credential, string userPrincipalName, IEnumerable<string>? properties = null, string? filter = null, int? limit = null, CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com", cancellationToken).ConfigureAwait(false);
             headers["Authorization"] = token ?? string.Empty;
             var queryParams = new Dictionary<string, object>();
             if (!string.IsNullOrWhiteSpace(filter)) queryParams["$filter"] = filter!;
@@ -476,9 +477,11 @@ namespace Mailozaurr {
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/messages", queryParams);
             var messages = new List<Dictionary<string, object>>();
             while (!string.IsNullOrEmpty(uri)) {
-                var doc = await InvokeGraphApiAsync("GET", uri, headers).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                var doc = await InvokeGraphApiAsync("GET", uri, headers, cancellationToken: cancellationToken).ConfigureAwait(false);
                 if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                     foreach (var item in valueElement.EnumerateArray()) {
+                        cancellationToken.ThrowIfCancellationRequested();
                         var native = ConvertJsonElementToNativeObject(item) as Dictionary<string, object>;
                         if (native != null) {
                             messages.Add(native);
@@ -503,17 +506,19 @@ namespace Mailozaurr {
         /// <summary>
         /// Retrieves attachments for a specific message.
         /// </summary>
-        public static async Task<List<Attachment>> GetMailMessageAttachmentsAsync(GraphCredential credential, string userPrincipalName, string messageId, IEnumerable<string>? properties = null) {
+        public static async Task<List<Attachment>> GetMailMessageAttachmentsAsync(GraphCredential credential, string userPrincipalName, string messageId, IEnumerable<string>? properties = null, CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com", cancellationToken).ConfigureAwait(false);
             headers["Authorization"] = token;
             var queryParams = new Dictionary<string, object>();
             if (properties != null && properties.Any()) queryParams["$select"] = string.Join(",", properties);
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/messages/{messageId}/attachments", queryParams);
-            var doc = await InvokeGraphApiAsync("GET", uri, headers).ConfigureAwait(false);
+            var doc = await InvokeGraphApiAsync("GET", uri, headers, cancellationToken: cancellationToken).ConfigureAwait(false);
             var attachments = new List<Attachment>();
             if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                 foreach (var item in valueElement.EnumerateArray()) {
+                    cancellationToken.ThrowIfCancellationRequested();
                     var att = JsonSerializer.Deserialize<Attachment>(item.GetRawText());
                     if (att != null) {
                         attachments.Add(att);
@@ -526,15 +531,17 @@ namespace Mailozaurr {
         /// <summary>
         /// Lists mail folders for the specified user.
         /// </summary>
-        public static async Task<List<JsonElement>> GetMailFoldersAsync(GraphCredential credential, string userPrincipalName) {
+        public static async Task<List<JsonElement>> GetMailFoldersAsync(GraphCredential credential, string userPrincipalName, CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
             var headers = new Dictionary<string, string>();
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com", cancellationToken).ConfigureAwait(false);
             headers["Authorization"] = token;
             var uri = JoinUriQuery(GraphEndpoint.V1, $"/users/{userPrincipalName}/mailFolders");
-            var doc = await InvokeGraphApiAsync("GET", uri, headers).ConfigureAwait(false);
+            var doc = await InvokeGraphApiAsync("GET", uri, headers, cancellationToken: cancellationToken).ConfigureAwait(false);
             var folders = new List<JsonElement>();
             if (doc.RootElement.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array) {
                 foreach (var item in valueElement.EnumerateArray()) {
+                    cancellationToken.ThrowIfCancellationRequested();
                     folders.Add(item);
                 }
             }


### PR DESCRIPTION
## Summary
- add optional `CancellationToken` parameters to the Microsoft Graph paging helpers and propagate the token to HTTP calls and loops
- extend the paging unit tests with a cancellation-focused scenario using a blocking handler

## Testing
- dotnet build Sources/Mailozaurr.sln
- dotnet test Sources/Mailozaurr.sln --no-build

------
https://chatgpt.com/codex/tasks/task_e_68ce92519700832eaaf3c17ade48b120