### PR TITLE
Add cancellation support for OAuth token cache

### DIFF
--- a/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
@@ -1,10 +1,18 @@
 using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Mailozaurr.Tests;
 
 public class OAuthHelpersCachedTokenTests {
+    public OAuthHelpersCachedTokenTests() {
+        ResetCache();
+        DeleteCacheFile();
+    }
+
     [Fact]
     public async Task AcquireO365TokenCachedAsync_ReturnsCachedToken() {
         var cacheKey = "o365:test@example.com";
@@ -24,6 +32,50 @@ public class OAuthHelpersCachedTokenTests {
 
         Assert.Equal(credential.AccessToken, result.AccessToken);
         Assert.Equal(credential.UserName, result.UserName);
+    }
+
+    [Fact]
+    public async Task GetAsync_ThrowsWhenCancellationRequested() {
+        var cacheKey = "o365:cancel@example.com";
+        var credential = new OAuthCredential {
+            UserName = "cancel@example.com",
+            AccessToken = "token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        await OAuthTokenCache.SetAsync(cacheKey, credential);
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => OAuthTokenCache.GetAsync(cacheKey, cts.Token));
+    }
+
+    [Fact]
+    public async Task SetAsync_ThrowsWhenCancellationRequested() {
+        var cacheKey = "o365:cancel-set@example.com";
+        var credential = new OAuthCredential {
+            UserName = "cancel-set@example.com",
+            AccessToken = "token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => OAuthTokenCache.SetAsync(cacheKey, credential, cts.Token));
+    }
+
+    private static void ResetCache() {
+        var field = typeof(OAuthTokenCache).GetField("_cache", BindingFlags.Static | BindingFlags.NonPublic);
+        field?.SetValue(null, null);
+    }
+
+    private static void DeleteCacheFile() {
+        var pathField = typeof(OAuthTokenCache).GetField("CacheFilePath", BindingFlags.Static | BindingFlags.NonPublic);
+        var path = pathField?.GetValue(null) as string;
+        if (!string.IsNullOrEmpty(path) && File.Exists(path)) {
+            File.Delete(path);
+        }
     }
 }
 

--- a/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Mailozaurr;
@@ -18,25 +19,25 @@ internal static class OAuthTokenCache {
 
     private static Dictionary<string, OAuthCredential>? _cache;
 
-    private static async Task<Dictionary<string, OAuthCredential>> LoadCacheAsync() {
+    private static async Task<Dictionary<string, OAuthCredential>> LoadCacheAsync(CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         if (_cache != null) {
+            cancellationToken.ThrowIfCancellationRequested();
             return _cache;
         }
+
         Dictionary<string, OAuthCredential> cache;
         if (File.Exists(CacheFilePath)) {
 #if NETFRAMEWORK || NETSTANDARD2_0
-            string json;
-            using (var stream = new FileStream(CacheFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true))
-            using (var reader = new StreamReader(stream)) {
-                json = await reader.ReadToEndAsync().ConfigureAwait(false);
-            }
+            var json = await ReadCacheFileAsync(cancellationToken).ConfigureAwait(false);
 #else
-            var json = await File.ReadAllTextAsync(CacheFilePath).ConfigureAwait(false);
+            var json = await File.ReadAllTextAsync(CacheFilePath, cancellationToken).ConfigureAwait(false);
 #endif
             cache = JsonSerializer.Deserialize<Dictionary<string, OAuthCredential>>(json) ?? new();
         } else {
             cache = new Dictionary<string, OAuthCredential>();
         }
+
         lock (LockObj) {
             _cache ??= cache;
             return _cache;
@@ -48,8 +49,9 @@ internal static class OAuthTokenCache {
     /// </summary>
     /// <param name="key">Unique cache key.</param>
     /// <returns>The cached credential or <c>null</c> if not found.</returns>
-    public static async Task<OAuthCredential?> GetAsync(string key) {
-        var cache = await LoadCacheAsync().ConfigureAwait(false);
+    public static async Task<OAuthCredential?> GetAsync(string key, CancellationToken cancellationToken = default) {
+        var cache = await LoadCacheAsync(cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
         lock (LockObj) {
             cache.TryGetValue(key, out var cred);
             return cred;
@@ -61,11 +63,12 @@ internal static class OAuthTokenCache {
     /// </summary>
     /// <param name="key">Unique cache key.</param>
     /// <param name="credential">Credential to cache.</param>
-    public static async Task SetAsync(string key, OAuthCredential credential) {
-        var cache = await LoadCacheAsync().ConfigureAwait(false);
+    public static async Task SetAsync(string key, OAuthCredential credential, CancellationToken cancellationToken = default) {
+        var cache = await LoadCacheAsync(cancellationToken).ConfigureAwait(false);
         string? dir;
         string json;
         lock (LockObj) {
+            cancellationToken.ThrowIfCancellationRequested();
             cache[key] = credential;
             dir = Path.GetDirectoryName(CacheFilePath);
             if (!Directory.Exists(dir)) {
@@ -73,13 +76,46 @@ internal static class OAuthTokenCache {
             }
             json = JsonSerializer.Serialize(cache);
         }
+        cancellationToken.ThrowIfCancellationRequested();
 #if NETFRAMEWORK || NETSTANDARD2_0
-        using (var stream = new FileStream(CacheFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true))
-        using (var writer = new StreamWriter(stream)) {
-            await writer.WriteAsync(json).ConfigureAwait(false);
-        }
+        await WriteCacheFileAsync(json, cancellationToken).ConfigureAwait(false);
 #else
-        await File.WriteAllTextAsync(CacheFilePath, json).ConfigureAwait(false);
+        await File.WriteAllTextAsync(CacheFilePath, json, cancellationToken).ConfigureAwait(false);
 #endif
     }
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+    private static async Task<string> ReadCacheFileAsync(CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        using (var stream = new FileStream(CacheFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true))
+        using (cancellationToken.Register(() => stream.Dispose()))
+        using (var reader = new StreamReader(stream))
+        using (cancellationToken.Register(() => reader.Dispose())) {
+            try {
+                var json = await reader.ReadToEndAsync().ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                return json;
+            } catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested) {
+                throw new OperationCanceledException(cancellationToken);
+            }
+        }
+    }
+
+    private static async Task WriteCacheFileAsync(string json, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        using (var stream = new FileStream(CacheFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true))
+        using (cancellationToken.Register(() => stream.Dispose()))
+        using (var writer = new StreamWriter(stream))
+        using (cancellationToken.Register(() => writer.Dispose())) {
+            try {
+                await writer.WriteAsync(json).ConfigureAwait(false);
+                await writer.FlushAsync().ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+            } catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested) {
+                throw new OperationCanceledException(cancellationToken);
+            }
+        }
+    }
+#endif
 }


### PR DESCRIPTION
## Summary
- add optional cancellation tokens to the OAuth token cache load, get, and set operations
- ensure legacy file IO uses cancellation-aware helpers and pass tokens to async file APIs
- expand OAuth token cache tests with cancellation coverage and cache cleanup helpers

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d067e0bdfc832e80d06eb204abcd6c