### PR TITLE
Add configurable retention for GraphMessageListener

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -218,6 +218,57 @@ public class GraphMessageListenerTests {
     }
 
     [Fact]
+    public async Task Listener_RaisesExpiredId_WhenItReturnsWithoutOtherTraffic() {
+        var baseTime = DateTimeOffset.UtcNow;
+        var currentTime = baseTime;
+        var responses = new[] {
+            (CreateTokenResponse(), (Action<HttpRequestMessage>?)null),
+            (CreateMessagesResponse("old1"), (Action<HttpRequestMessage>?)(_ => currentTime = baseTime)),
+            (CreateTokenResponse(), (Action<HttpRequestMessage>?)(_ => currentTime = baseTime.AddMilliseconds(10))),
+            (CreateMessagesResponse(), (Action<HttpRequestMessage>?)(_ => currentTime = baseTime.AddMilliseconds(10))),
+            (CreateTokenResponse(), (Action<HttpRequestMessage>?)(_ => currentTime = baseTime.AddMilliseconds(75))),
+            (CreateMessagesResponse("old1"), (Action<HttpRequestMessage>?)(_ => currentTime = baseTime.AddMilliseconds(75)))
+        };
+
+        var handler = new QueueHandler(responses);
+        var overrideInfo = OverrideHttpClient(handler);
+        ResetGraphCaches();
+
+        GraphMessageListener? listener = null;
+        try {
+            var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            var options = new GraphMessageListenerRetentionOptions {
+                MaxSeenIds = null,
+                SlidingExpiration = TimeSpan.FromMilliseconds(50)
+            };
+            options.Clock = () => currentTime;
+            listener = new GraphMessageListener(cred, "user", TimeSpan.FromMilliseconds(20), options);
+            var ids = new List<string>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            listener.MessageArrived += (_, msg) => {
+                if (msg.TryGetValue("id", out var idObj) && idObj is string id) {
+                    lock (ids) {
+                        ids.Add(id);
+                        if (ids.Count >= 1) {
+                            tcs.TrySetResult(true);
+                        }
+                    }
+                }
+            };
+
+            await listener.StartAsync();
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            listener.Dispose();
+
+            Assert.Same(tcs.Task, completed);
+            Assert.Equal(new[] { "old1" }, ids);
+        } finally {
+            listener?.Dispose();
+            overrideInfo.HandlerField.SetValue(overrideInfo.Client, overrideInfo.OriginalHandler);
+        }
+    }
+
+    [Fact]
     public void Listener_Throws_WhenRetentionHasNoLimits() {
         var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
         var options = new GraphMessageListenerRetentionOptions {

--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -216,5 +216,17 @@ public class GraphMessageListenerTests {
             overrideInfo.HandlerField.SetValue(overrideInfo.Client, overrideInfo.OriginalHandler);
         }
     }
+
+    [Fact]
+    public void Listener_Throws_WhenRetentionHasNoLimits() {
+        var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+        var options = new GraphMessageListenerRetentionOptions {
+            MaxSeenIds = null,
+            SlidingExpiration = null
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() => new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1), options));
+        Assert.Equal("retentionOptions", ex.ParamName);
+    }
 }
 }

--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -13,16 +15,23 @@ namespace Mailozaurr.Tests;
 [Collection("GraphCollection")]
 public class GraphMessageListenerTests {
     private class QueueHandler : HttpMessageHandler {
-        private readonly Queue<HttpResponseMessage> _responses;
+        private readonly Queue<(HttpResponseMessage Response, Action<HttpRequestMessage>? Callback)> _responses;
 
-        public QueueHandler(IEnumerable<HttpResponseMessage> responses) {
-            _responses = new Queue<HttpResponseMessage>(responses);
+        public QueueHandler(IEnumerable<HttpResponseMessage> responses)
+            : this(responses.Select(response => (response, (Action<HttpRequestMessage>?)null))) {
+        }
+
+        public QueueHandler(IEnumerable<(HttpResponseMessage Response, Action<HttpRequestMessage>? Callback)> responses) {
+            _responses = new Queue<(HttpResponseMessage, Action<HttpRequestMessage>?)>(responses);
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
             if (_responses.Count > 0) {
-                return Task.FromResult(_responses.Dequeue());
+                var (response, callback) = _responses.Dequeue();
+                callback?.Invoke(request);
+                return Task.FromResult(response);
             }
+
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
                 Content = new StringContent("{\"value\":[]}")
             });
@@ -34,28 +43,52 @@ public class GraphMessageListenerTests {
         typeof(HttpMessageInvoker).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance) ??
         throw new InvalidOperationException("HttpClient handler field not found");
 
-    [Fact]
-    public async Task Listener_StartStopMultipleTimes_DoesNotLeakResources() {
-        var responses = new[] {
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"access_token\":\"token\",\"token_type\":\"Bearer\"}") },
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") },
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"access_token\":\"token\",\"token_type\":\"Bearer\"}") },
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") }
+    private static HttpResponseMessage CreateTokenResponse() =>
+        new(HttpStatusCode.OK) {
+            Content = new StringContent("{\"access_token\":\"token\",\"token_type\":\"Bearer\",\"expires_in\":3600}")
         };
-        var handler = new QueueHandler(responses);
+
+    private static HttpResponseMessage CreateMessagesResponse(params string[] ids) {
+        var payload = string.Join(",", ids.Select(id => $"{{\"id\":\"{id}\"}}"));
+        var json = $"{{\"value\":[{payload}]}}";
+        return new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StringContent(json)
+        };
+    }
+
+    private static (HttpClient Client, FieldInfo HandlerField, HttpMessageHandler OriginalHandler) OverrideHttpClient(HttpMessageHandler handler) {
         var clientField = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
         var client = (HttpClient)clientField.GetValue(null)!;
         var handlerField = GetHandlerField();
         var original = (HttpMessageHandler)handlerField.GetValue(client)!;
         handlerField.SetValue(client, handler);
+        return (client, handlerField, original);
+    }
+
+    private static void ResetGraphCaches() {
         var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var cache = (ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
         cache.Clear();
         var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
         var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
         oauthField?.SetValue(null, null);
-        string cachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
-        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        string cachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
+        if (File.Exists(cachePath)) {
+            File.Delete(cachePath);
+        }
+    }
+
+    [Fact]
+    public async Task Listener_StartStopMultipleTimes_DoesNotLeakResources() {
+        var responses = new[] {
+            CreateTokenResponse(),
+            CreateMessagesResponse(),
+            CreateTokenResponse(),
+            CreateMessagesResponse()
+        };
+        var handler = new QueueHandler(responses);
+        var overrideInfo = OverrideHttpClient(handler);
+        ResetGraphCaches();
         try {
             var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
             var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
@@ -85,6 +118,103 @@ public class GraphMessageListenerTests {
             Assert.NotNull(secondPoll);
             Assert.NotSame(firstPoll, secondPoll);
         } finally {
-            handlerField.SetValue(client, original);
+            overrideInfo.HandlerField.SetValue(overrideInfo.Client, overrideInfo.OriginalHandler);
         }
-    }}
+    }
+
+    [Fact]
+    public async Task Listener_EvictsOldSeenIds_WhenCapacityExceeded() {
+        var responses = new[] {
+            CreateTokenResponse(),
+            CreateMessagesResponse("old1", "old2"),
+            CreateTokenResponse(),
+            CreateMessagesResponse("new1"),
+            CreateTokenResponse(),
+            CreateMessagesResponse("new2"),
+            CreateTokenResponse(),
+            CreateMessagesResponse("old1")
+        };
+
+        var handler = new QueueHandler(responses);
+        var overrideInfo = OverrideHttpClient(handler);
+        ResetGraphCaches();
+
+        GraphMessageListener? listener = null;
+        try {
+            var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            var options = new GraphMessageListenerRetentionOptions { MaxSeenIds = 2 };
+            listener = new GraphMessageListener(cred, "user", TimeSpan.FromMilliseconds(10), options);
+            var ids = new List<string>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            listener.MessageArrived += (_, msg) => {
+                if (msg.TryGetValue("id", out var idObj) && idObj is string id) {
+                    lock (ids) {
+                        ids.Add(id);
+                        if (ids.Count >= 3) {
+                            tcs.TrySetResult(true);
+                        }
+                    }
+                }
+            };
+
+            await listener.StartAsync();
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            listener.Dispose();
+
+            Assert.Same(tcs.Task, completed);
+            Assert.Equal(new[] { "new1", "new2", "old1" }, ids);
+        } finally {
+            listener?.Dispose();
+            overrideInfo.HandlerField.SetValue(overrideInfo.Client, overrideInfo.OriginalHandler);
+        }
+    }
+
+    [Fact]
+    public async Task Listener_EvictsExpiredIds_WhenSlidingWindowElapsed() {
+        var responses = new[] {
+            CreateTokenResponse(),
+            CreateMessagesResponse("old1"),
+            CreateTokenResponse(),
+            CreateMessagesResponse("new1"),
+            CreateTokenResponse(),
+            CreateMessagesResponse("old1")
+        };
+
+        var handler = new QueueHandler(responses);
+        var overrideInfo = OverrideHttpClient(handler);
+        ResetGraphCaches();
+
+        GraphMessageListener? listener = null;
+        try {
+            var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            var options = new GraphMessageListenerRetentionOptions {
+                MaxSeenIds = null,
+                SlidingExpiration = TimeSpan.FromMilliseconds(50)
+            };
+            listener = new GraphMessageListener(cred, "user", TimeSpan.FromMilliseconds(100), options);
+            var ids = new List<string>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            listener.MessageArrived += (_, msg) => {
+                if (msg.TryGetValue("id", out var idObj) && idObj is string id) {
+                    lock (ids) {
+                        ids.Add(id);
+                        if (ids.Count >= 2) {
+                            tcs.TrySetResult(true);
+                        }
+                    }
+                }
+            };
+
+            await listener.StartAsync();
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            listener.Dispose();
+
+            Assert.Same(tcs.Task, completed);
+            Assert.Equal(new[] { "new1", "old1" }, ids);
+        } finally {
+            listener?.Dispose();
+            overrideInfo.HandlerField.SetValue(overrideInfo.Client, overrideInfo.OriginalHandler);
+        }
+    }
+}
+}

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -38,6 +38,11 @@ public class GraphMessageListener : IDisposable {
         _userPrincipalName = userPrincipalName ?? throw new ArgumentNullException(nameof(userPrincipalName));
         _interval = interval ?? TimeSpan.FromMinutes(1);
         _retentionOptions = (retentionOptions ?? new GraphMessageListenerRetentionOptions()).Clone();
+        if (!_retentionOptions.MaxSeenIds.HasValue && !_retentionOptions.SlidingExpiration.HasValue) {
+            throw new ArgumentException(
+                "Retention options must configure either MaxSeenIds or SlidingExpiration.",
+                nameof(retentionOptions));
+        }
     }
 
     /// <summary>
@@ -112,31 +117,21 @@ public class GraphMessageListener : IDisposable {
     private bool TryRegisterMessage(string id) {
         var now = _retentionOptions.Clock();
         lock (_seenLock) {
+            var alreadySeen = _seenIds.ContainsKey(id);
+            _seenIds[id] = now;
+            _seenQueue.Enqueue((id, now));
             PruneSeenIds(now);
-            if (_seenIds.ContainsKey(id)) {
-                _seenIds[id] = now;
-                _seenQueue.Enqueue((id, now));
-                PruneSeenIds(now);
-                return false;
-            }
-
-            AddSeenIdInternal(id, now);
-            return true;
+            return !alreadySeen;
         }
     }
 
     private void TrackSeenMessage(string id) {
         var now = _retentionOptions.Clock();
         lock (_seenLock) {
+            _seenIds[id] = now;
+            _seenQueue.Enqueue((id, now));
             PruneSeenIds(now);
-            AddSeenIdInternal(id, now);
         }
-    }
-
-    private void AddSeenIdInternal(string id, DateTimeOffset timestamp) {
-        _seenIds[id] = timestamp;
-        _seenQueue.Enqueue((id, timestamp));
-        PruneSeenIds(timestamp);
     }
 
     private void PruneSeenIds(DateTimeOffset now) {
@@ -144,14 +139,14 @@ public class GraphMessageListener : IDisposable {
             var expirationThreshold = now - _retentionOptions.SlidingExpiration.Value;
             while (_seenQueue.Count > 0) {
                 var (seenId, timestamp) = _seenQueue.Peek();
-                if (_seenIds.TryGetValue(seenId, out var recordedTimestamp) && recordedTimestamp > timestamp) {
+                if (!_seenIds.TryGetValue(seenId, out var recordedTimestamp) || recordedTimestamp > timestamp) {
                     _seenQueue.Dequeue();
                     continue;
                 }
 
                 if (timestamp < expirationThreshold) {
                     _seenQueue.Dequeue();
-                    if (_seenIds.TryGetValue(seenId, out recordedTimestamp) && recordedTimestamp <= timestamp) {
+                    if (recordedTimestamp <= timestamp) {
                         _seenIds.Remove(seenId);
                     }
                 } else {

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -29,6 +29,7 @@ public class GraphMessageListener : IDisposable {
     /// <param name="credential">Graph credential to use.</param>
     /// <param name="userPrincipalName">User principal name to monitor.</param>
     /// <param name="interval">Polling interval.</param>
+    /// <param name="retentionOptions">Policy controlling how seen message identifiers are retained.</param>
     public GraphMessageListener(
         GraphCredential credential,
         string userPrincipalName,
@@ -118,9 +119,7 @@ public class GraphMessageListener : IDisposable {
         var now = _retentionOptions.Clock();
         lock (_seenLock) {
             PruneExpiredEntries(now);
-            var alreadySeen = _seenIds.ContainsKey(id);
-            _seenIds[id] = now;
-            _seenQueue.Enqueue((id, now));
+            var alreadySeen = RecordSeenMessage(id, now);
             TrimCapacity();
             return !alreadySeen;
         }
@@ -130,10 +129,16 @@ public class GraphMessageListener : IDisposable {
         var now = _retentionOptions.Clock();
         lock (_seenLock) {
             PruneExpiredEntries(now);
-            _seenIds[id] = now;
-            _seenQueue.Enqueue((id, now));
+            RecordSeenMessage(id, now);
             TrimCapacity();
         }
+    }
+
+    private bool RecordSeenMessage(string id, DateTimeOffset timestamp) {
+        var alreadySeen = _seenIds.TryGetValue(id, out _);
+        _seenIds[id] = timestamp;
+        _seenQueue.Enqueue((id, timestamp));
+        return alreadySeen;
     }
 
     private void PruneExpiredEntries(DateTimeOffset now) {

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -117,10 +117,11 @@ public class GraphMessageListener : IDisposable {
     private bool TryRegisterMessage(string id) {
         var now = _retentionOptions.Clock();
         lock (_seenLock) {
+            PruneExpiredEntries(now);
             var alreadySeen = _seenIds.ContainsKey(id);
             _seenIds[id] = now;
             _seenQueue.Enqueue((id, now));
-            PruneSeenIds(now);
+            TrimCapacity();
             return !alreadySeen;
         }
     }
@@ -128,39 +129,46 @@ public class GraphMessageListener : IDisposable {
     private void TrackSeenMessage(string id) {
         var now = _retentionOptions.Clock();
         lock (_seenLock) {
+            PruneExpiredEntries(now);
             _seenIds[id] = now;
             _seenQueue.Enqueue((id, now));
-            PruneSeenIds(now);
+            TrimCapacity();
         }
     }
 
-    private void PruneSeenIds(DateTimeOffset now) {
-        if (_retentionOptions.SlidingExpiration.HasValue) {
-            var expirationThreshold = now - _retentionOptions.SlidingExpiration.Value;
-            while (_seenQueue.Count > 0) {
-                var (seenId, timestamp) = _seenQueue.Peek();
-                if (!_seenIds.TryGetValue(seenId, out var recordedTimestamp) || recordedTimestamp > timestamp) {
-                    _seenQueue.Dequeue();
-                    continue;
-                }
-
-                if (timestamp < expirationThreshold) {
-                    _seenQueue.Dequeue();
-                    if (recordedTimestamp <= timestamp) {
-                        _seenIds.Remove(seenId);
-                    }
-                } else {
-                    break;
-                }
-            }
+    private void PruneExpiredEntries(DateTimeOffset now) {
+        if (!_retentionOptions.SlidingExpiration.HasValue) {
+            return;
         }
 
-        if (_retentionOptions.MaxSeenIds.HasValue) {
-            while (_seenIds.Count > _retentionOptions.MaxSeenIds.Value && _seenQueue.Count > 0) {
-                var (seenId, timestamp) = _seenQueue.Dequeue();
-                if (_seenIds.TryGetValue(seenId, out var recordedTimestamp) && recordedTimestamp <= timestamp) {
+        var expirationThreshold = now - _retentionOptions.SlidingExpiration.Value;
+        while (_seenQueue.Count > 0) {
+            var (seenId, timestamp) = _seenQueue.Peek();
+            if (!_seenIds.TryGetValue(seenId, out var recordedTimestamp) || recordedTimestamp > timestamp) {
+                _seenQueue.Dequeue();
+                continue;
+            }
+
+            if (timestamp < expirationThreshold) {
+                _seenQueue.Dequeue();
+                if (recordedTimestamp <= timestamp) {
                     _seenIds.Remove(seenId);
                 }
+            } else {
+                break;
+            }
+        }
+    }
+
+    private void TrimCapacity() {
+        if (!_retentionOptions.MaxSeenIds.HasValue) {
+            return;
+        }
+
+        while (_seenIds.Count > _retentionOptions.MaxSeenIds.Value && _seenQueue.Count > 0) {
+            var (seenId, timestamp) = _seenQueue.Dequeue();
+            if (_seenIds.TryGetValue(seenId, out var recordedTimestamp) && recordedTimestamp <= timestamp) {
+                _seenIds.Remove(seenId);
             }
         }
     }

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -15,10 +15,13 @@ namespace Mailozaurr;
 public class GraphMessageListener : IDisposable {
     private readonly GraphCredential _credential;
     private readonly string _userPrincipalName;
-    private readonly HashSet<string> _seenIds = new();
+    private readonly Dictionary<string, DateTimeOffset> _seenIds = new();
+    private readonly Queue<(string Id, DateTimeOffset Timestamp)> _seenQueue = new();
+    private readonly object _seenLock = new();
     private CancellationTokenSource? _cancel;
     private Task? _pollTask;
     private readonly TimeSpan _interval;
+    private readonly GraphMessageListenerRetentionOptions _retentionOptions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GraphMessageListener"/> class.
@@ -26,10 +29,15 @@ public class GraphMessageListener : IDisposable {
     /// <param name="credential">Graph credential to use.</param>
     /// <param name="userPrincipalName">User principal name to monitor.</param>
     /// <param name="interval">Polling interval.</param>
-    public GraphMessageListener(GraphCredential credential, string userPrincipalName, TimeSpan? interval = null) {
+    public GraphMessageListener(
+        GraphCredential credential,
+        string userPrincipalName,
+        TimeSpan? interval = null,
+        GraphMessageListenerRetentionOptions? retentionOptions = null) {
         _credential = credential ?? throw new ArgumentNullException(nameof(credential));
         _userPrincipalName = userPrincipalName ?? throw new ArgumentNullException(nameof(userPrincipalName));
         _interval = interval ?? TimeSpan.FromMinutes(1);
+        _retentionOptions = (retentionOptions ?? new GraphMessageListenerRetentionOptions()).Clone();
     }
 
     /// <summary>
@@ -55,7 +63,7 @@ public class GraphMessageListener : IDisposable {
         var initial = await MicrosoftGraphUtils.GetMailMessagesAsync(_credential, _userPrincipalName).ConfigureAwait(false);
         foreach (var msg in initial) {
             if (msg.TryGetValue("id", out var idObj) && idObj is string id) {
-                _seenIds.Add(id);
+                TrackSeenMessage(id);
             }
         }
 
@@ -88,8 +96,7 @@ public class GraphMessageListener : IDisposable {
                 await Task.Delay(_interval, _cancel.Token).ConfigureAwait(false);
                 var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(_credential, _userPrincipalName).ConfigureAwait(false);
                 foreach (var msg in messages) {
-                    if (msg.TryGetValue("id", out var idObj) && idObj is string id && !_seenIds.Contains(id)) {
-                        _seenIds.Add(id);
+                    if (msg.TryGetValue("id", out var idObj) && idObj is string id && TryRegisterMessage(id)) {
                         MessageArrived?.Invoke(this, msg);
                     }
                 }
@@ -98,6 +105,67 @@ public class GraphMessageListener : IDisposable {
             } catch (Exception ex) {
                 PollError?.Invoke(this, ex);
                 await Task.Delay(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private bool TryRegisterMessage(string id) {
+        var now = _retentionOptions.Clock();
+        lock (_seenLock) {
+            PruneSeenIds(now);
+            if (_seenIds.ContainsKey(id)) {
+                _seenIds[id] = now;
+                _seenQueue.Enqueue((id, now));
+                PruneSeenIds(now);
+                return false;
+            }
+
+            AddSeenIdInternal(id, now);
+            return true;
+        }
+    }
+
+    private void TrackSeenMessage(string id) {
+        var now = _retentionOptions.Clock();
+        lock (_seenLock) {
+            PruneSeenIds(now);
+            AddSeenIdInternal(id, now);
+        }
+    }
+
+    private void AddSeenIdInternal(string id, DateTimeOffset timestamp) {
+        _seenIds[id] = timestamp;
+        _seenQueue.Enqueue((id, timestamp));
+        PruneSeenIds(timestamp);
+    }
+
+    private void PruneSeenIds(DateTimeOffset now) {
+        if (_retentionOptions.SlidingExpiration.HasValue) {
+            var expirationThreshold = now - _retentionOptions.SlidingExpiration.Value;
+            while (_seenQueue.Count > 0) {
+                var (seenId, timestamp) = _seenQueue.Peek();
+                if (_seenIds.TryGetValue(seenId, out var recordedTimestamp) && recordedTimestamp > timestamp) {
+                    _seenQueue.Dequeue();
+                    continue;
+                }
+
+                if (timestamp < expirationThreshold) {
+                    _seenQueue.Dequeue();
+                    if (_seenIds.TryGetValue(seenId, out recordedTimestamp) && recordedTimestamp <= timestamp) {
+                        _seenIds.Remove(seenId);
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+
+        if (_retentionOptions.MaxSeenIds.HasValue) {
+            while (_seenIds.Count > _retentionOptions.MaxSeenIds.Value && _seenQueue.Count > 0) {
+                var (seenId, timestamp) = _seenQueue.Dequeue();
+                if (_seenIds.TryGetValue(seenId, out var recordedTimestamp) && recordedTimestamp <= timestamp) {
+                    _seenIds.Remove(seenId);
+                }
             }
         }
     }

--- a/Sources/Mailozaurr/Receive/GraphMessageListenerRetentionOptions.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListenerRetentionOptions.cs
@@ -6,8 +6,13 @@ namespace Mailozaurr;
 /// Configures how <see cref="GraphMessageListener"/> retains identifiers of processed messages.
 /// </summary>
 public class GraphMessageListenerRetentionOptions {
+    /// <summary>
+    /// Default capacity used when <see cref="MaxSeenIds"/> is not specified.
+    /// </summary>
+    public const int DefaultMaxSeenIds = 1024;
+
     private static readonly Func<DateTimeOffset> DefaultClock = () => DateTimeOffset.UtcNow;
-    private int? _maxSeenIds = 1024;
+    private int? _maxSeenIds = DefaultMaxSeenIds;
     private TimeSpan? _slidingExpiration;
     private Func<DateTimeOffset>? _clock;
 
@@ -55,7 +60,7 @@ public class GraphMessageListenerRetentionOptions {
     /// </remarks>
     public Func<DateTimeOffset> Clock {
         get => _clock ?? DefaultClock;
-        set => _clock = value ?? throw new ArgumentNullException(nameof(value));
+        internal set => _clock = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     internal GraphMessageListenerRetentionOptions Clone() => new() {

--- a/Sources/Mailozaurr/Receive/GraphMessageListenerRetentionOptions.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListenerRetentionOptions.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Configures how <see cref="GraphMessageListener"/> retains identifiers of processed messages.
+/// </summary>
+public class GraphMessageListenerRetentionOptions {
+    private static readonly Func<DateTimeOffset> DefaultClock = () => DateTimeOffset.UtcNow;
+    private int? _maxSeenIds = 1024;
+    private TimeSpan? _slidingExpiration;
+    private Func<DateTimeOffset>? _clock;
+
+    /// <summary>
+    /// Gets or sets the maximum number of message identifiers that should be retained.
+    /// </summary>
+    /// <remarks>
+    /// When the limit is exceeded, the oldest identifiers are evicted first.
+    /// Specify <c>null</c> to disable the limit.
+    /// </remarks>
+    public int? MaxSeenIds {
+        get => _maxSeenIds;
+        set {
+            if (value.HasValue && value.Value <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(value), "MaxSeenIds must be greater than zero.");
+            }
+
+            _maxSeenIds = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the sliding expiration applied to message identifiers.
+    /// </summary>
+    /// <remarks>
+    /// Identifiers older than the configured window are removed.
+    /// Specify <c>null</c> to disable the expiration.
+    /// </remarks>
+    public TimeSpan? SlidingExpiration {
+        get => _slidingExpiration;
+        set {
+            if (value.HasValue && value.Value <= TimeSpan.Zero) {
+                throw new ArgumentOutOfRangeException(nameof(value), "SlidingExpiration must be greater than zero.");
+            }
+
+            _slidingExpiration = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the clock used for retention checks.
+    /// </summary>
+    /// <remarks>
+    /// Primarily intended for testing.
+    /// </remarks>
+    public Func<DateTimeOffset> Clock {
+        get => _clock ?? DefaultClock;
+        set => _clock = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    internal GraphMessageListenerRetentionOptions Clone() => new() {
+        MaxSeenIds = MaxSeenIds,
+        SlidingExpiration = SlidingExpiration,
+        Clock = Clock,
+    };
+}


### PR DESCRIPTION
## Summary
- add configurable retention options for GraphMessageListener and wire them into the constructor
- create GraphMessageListenerRetentionOptions to control capacity and sliding expiration
- extend GraphMessageListenerTests to cover cache eviction scenarios and helper setup

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --filter GraphMessageListener`


------
https://chatgpt.com/codex/tasks/task_e_68d067e5f890832e99f96c71f0fda683