### PR TITLE
Add async create message preprocessing and tests

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
-using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using MailKit.Security;
 using Xunit;
@@ -8,28 +10,99 @@ namespace Mailozaurr.Tests;
 
 public class SmtpAsyncWrappersTests
 {
-    private class FakeClient : ClientSmtp
+    private class FakeConnectClient : ClientSmtp
     {
         public bool ConnectCalled;
-        public override Task ConnectAsync(string host, int port, SecureSocketOptions options, System.Threading.CancellationToken cancellationToken = default)
+        public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
         {
             ConnectCalled = true;
             return Task.CompletedTask;
         }
     }
 
+    private static void SetClient(Smtp smtp, ClientSmtp client)
+    {
+        var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(smtp, client);
+    }
+
     [Fact]
     public async Task ConnectAsync_InvokesClientConnectAsync()
     {
         var smtp = new Smtp();
-        var fake = new FakeClient();
-        var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        field.SetValue(smtp, fake);
+        var fake = new FakeConnectClient();
+        SetClient(smtp, fake);
 
         var result = await smtp.ConnectAsync("host", 25);
 
         Assert.True(fake.ConnectCalled);
         Assert.True(result.Status);
+    }
+
+    [Fact]
+    public async Task CreateMessageAsync_AutoEmbedImagesAddsInlineAttachment()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "data");
+
+            var smtp = new Smtp
+            {
+                AutoEmbedImages = true,
+                HtmlBody = $"<img src=\"{tempFile}\">",
+                From = "sender@example.com",
+                To = new object[] { "recipient@example.com" },
+                Subject = "test",
+                TextBody = "body"
+            };
+
+            await smtp.CreateMessageAsync();
+
+            Assert.Contains(tempFile, smtp.InlineAttachments ?? new List<object>());
+            Assert.Contains($"cid:{Path.GetFileName(tempFile)}", smtp.HtmlBody);
+            Assert.Contains($"cid:{Path.GetFileName(tempFile)}", smtp.Message.HtmlBody);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CreateMessageAsync_CancellationTokenPreventsClientInvocation()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "data");
+
+            var smtp = new Smtp
+            {
+                AutoEmbedImages = true,
+                HtmlBody = $"<img src=\"{tempFile}\">"
+            };
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var originalHtml = smtp.HtmlBody;
+
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await smtp.CreateMessageAsync(cts.Token));
+
+            Assert.Equal(originalHtml, smtp.HtmlBody);
+            Assert.DoesNotContain(tempFile, smtp.InlineAttachments ?? new List<object>());
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
     }
 
 }

--- a/Sources/Mailozaurr.Tests/SmtpSendAsyncTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSendAsyncTests.cs
@@ -31,7 +31,7 @@ public class SmtpSendAsyncTests
         smtp.Subject = "test";
         smtp.TextBody = "body";
         smtp.WebhookUrl = null;
-        smtp.CreateMessage();
+        await smtp.CreateMessageAsync();
 
         var result = await smtp.SendAsync();
 

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -353,6 +353,7 @@ public class Smtp {
     /// Creates the MIME message using the current property values.
     /// </summary>
     public void CreateMessage(CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         PrepareInlineAttachments();
         Client.CreateMessage(cancellationToken);
     }
@@ -362,6 +363,7 @@ public class Smtp {
     /// </summary>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task CreateMessageAsync(CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         PrepareInlineAttachments();
         await Client.CreateMessageAsync(cancellationToken).ConfigureAwait(false);
     }


### PR DESCRIPTION
## Summary
- ensure the SMTP wrapper checks cancellation before preparing inline attachments in both sync and async builders
- switch the async send test to build messages via the new asynchronous helper
- add wrapper tests proving that CreateMessageAsync embeds local images and stops when cancellation is requested

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d067ec7c58832eb8952f71fd9de928