### PR TITLE
Handle missing Graph attachments safely

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
@@ -42,13 +42,15 @@ public class GraphCreateMessageTests
     }
 
     [Fact]
-    public void CreateAttachments_WithMissingFile_ThrowsFileNotFoundException()
+    public void CreateAttachments_WithMissingFile_SkipsAttachment()
     {
         using var graph = new Graph
         {
             Attachments = new object[] { "missing.file" }
         };
-        Assert.Throws<FileNotFoundException>(() => graph.CreateAttachments());
+        graph.CreateAttachments();
+
+        Assert.Empty(graph.ConvertedAttachments);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using MailKit.Security;
+using Mailozaurr.Definitions;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -59,7 +62,8 @@ public class SmtpAsyncWrappersTests
 
             await smtp.CreateMessageAsync();
 
-            Assert.Contains(tempFile, smtp.InlineAttachments ?? new List<object>());
+            var inlineAttachments = smtp.InlineAttachments ?? new List<AttachmentDescriptor>();
+            Assert.Contains(inlineAttachments.OfType<FileAttachmentDescriptor>(), a => string.Equals(a.FilePath, tempFile, StringComparison.OrdinalIgnoreCase));
             Assert.Contains($"cid:{Path.GetFileName(tempFile)}", smtp.HtmlBody);
             Assert.Contains($"cid:{Path.GetFileName(tempFile)}", smtp.Message.HtmlBody);
         }
@@ -94,7 +98,8 @@ public class SmtpAsyncWrappersTests
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await smtp.CreateMessageAsync(cts.Token));
 
             Assert.Equal(originalHtml, smtp.HtmlBody);
-            Assert.DoesNotContain(tempFile, smtp.InlineAttachments ?? new List<object>());
+            var inlineAttachments = smtp.InlineAttachments ?? new List<AttachmentDescriptor>();
+            Assert.DoesNotContain(inlineAttachments.OfType<FileAttachmentDescriptor>(), a => string.Equals(a.FilePath, tempFile, StringComparison.OrdinalIgnoreCase));
         }
         finally
         {

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -241,6 +241,7 @@ namespace Mailozaurr;
                     if (!File.Exists(path)) {
                         LogCollector.LogWarning($"Send-EmailMessage - Attachment file not found: {path}");
                         LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{path}' is invalid. Verify the file exists and the path is correct.");
+                        continue;
                     }
                     ConvertedAttachments.Add(GraphAttachment.FromFile(path));
                 } else if (item is GraphAttachment ga) {


### PR DESCRIPTION
## Summary
- skip creating Graph attachments when the source file is missing while preserving existing logging
- update Graph attachment tests to ensure missing files are ignored instead of throwing
- adjust SMTP async wrapper tests to reflect inline attachment descriptor types

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d6331b43c8832e9b7e8d73772c076e