### PR TITLE
Add validation for Graph content type defaults

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
@@ -42,6 +42,30 @@ public class GraphCreateMessageTests
     }
 
     [Fact]
+    public void CreateMessage_WithoutExplicitContentType_DefaultsToHtml()
+    {
+        using var graph = new Graph
+        {
+            From = "from@example.com",
+            To = new object[] { "to@example.com" },
+            Subject = "subject",
+            HTML = "body"
+        };
+
+        graph.CreateMessage();
+
+        Assert.Equal("HTML", graph.MessageContainer.Message.Body?.Type);
+    }
+
+    [Fact]
+    public void ContentType_SetToInvalidValue_ThrowsArgumentException()
+    {
+        using var graph = new Graph();
+
+        Assert.Throws<ArgumentException>(() => graph.ContentType = "Markdown");
+    }
+
+    [Fact]
     public void CreateAttachments_WithMissingFile_SkipsAttachment()
     {
         using var graph = new Graph

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -90,10 +90,31 @@ namespace Mailozaurr;
     /// </summary>
     public string HTML { get; set; } = string.Empty;
 
+    private string _contentType = "HTML";
+
     /// <summary>
     /// Content type of the email.
     /// </summary>
-    public string ContentType { get; set; } = string.Empty;
+    public string ContentType {
+        get => _contentType;
+        set {
+            if (value is null) {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (string.Equals(value, "HTML", StringComparison.OrdinalIgnoreCase)) {
+                _contentType = "HTML";
+                return;
+            }
+
+            if (string.Equals(value, "Text", StringComparison.OrdinalIgnoreCase)) {
+                _contentType = "Text";
+                return;
+            }
+
+            throw new ArgumentException("ContentType must be either \"Text\" or \"HTML\".", nameof(value));
+        }
+    }
 
     /// <summary>
     /// Value indicating whether the message should not be saved to the Sent Items folder.


### PR DESCRIPTION
## Summary
- default the Microsoft Graph content type to HTML and restrict assignments to HTML or Text
- add regression tests ensuring the message body uses the default content type and invalid values throw

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68d7f06c6c04832ebc3ad1b7afc4b0a8