### PR TITLE
Validate Graph credential format during authentication

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphAuthenticateTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphAuthenticateTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Net;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class GraphAuthenticateTests {
+    private sealed class FakeCredentials : ICredentials {
+        public NetworkCredential? GetCredential(Uri? uri, string? authType)
+            => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public void Authenticate_WithNonNetworkCredential_ThrowsArgumentException() {
+        using var graph = new Graph();
+        var credentials = new FakeCredentials();
+
+        var exception = Assert.Throws<ArgumentException>(() => graph.Authenticate(credentials));
+
+        Assert.Contains("NetworkCredential", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("invalid")]
+    [InlineData("user@")]
+    [InlineData("@tenant")]
+    public void Authenticate_WithMalformedUserName_ThrowsArgumentException(string userName) {
+        using var graph = new Graph();
+        var credentials = new NetworkCredential(userName, "secret");
+
+        var exception = Assert.Throws<ArgumentException>(() => graph.Authenticate(credentials));
+
+        Assert.Contains("clientid@directoryid", exception.Message);
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 ﻿using System.Net.Http.Headers;
 using System.Threading;
 
@@ -330,19 +331,32 @@ namespace Mailozaurr;
     /// </summary>
     /// <param name="Credentials">The credentials to parse.</param>
     public void Authenticate(ICredentials Credentials) {
-        var networkCredential = Credentials as NetworkCredential;
-        if (networkCredential != null) {
-            var userSplit = networkCredential.UserName.Split('@');
-            if (userSplit.Length != 2) {
-                throw new ArgumentException(
-                    "Credential.UserName must be in the format 'clientid@directoryid'",
-                    nameof(Credentials));
-            }
-
-            ApplicationID = userSplit[0];
-            ApplicationKey = networkCredential.Password;
-            TenantDomain = userSplit[1];
+        if (Credentials == null) {
+            throw new ArgumentNullException(nameof(Credentials));
         }
+
+        if (Credentials is not NetworkCredential networkCredential) {
+            throw new ArgumentException(
+                "Credentials must be provided as a NetworkCredential with a UserName in the format 'clientid@directoryid'",
+                nameof(Credentials));
+        }
+
+        if (string.IsNullOrWhiteSpace(networkCredential.UserName)) {
+            throw new ArgumentException(
+                "Credential.UserName must be in the format 'clientid@directoryid'",
+                nameof(Credentials));
+        }
+
+        var userSplit = networkCredential.UserName.Split('@');
+        if (userSplit.Length != 2 || string.IsNullOrWhiteSpace(userSplit[0]) || string.IsNullOrWhiteSpace(userSplit[1])) {
+            throw new ArgumentException(
+                "Credential.UserName must be in the format 'clientid@directoryid'",
+                nameof(Credentials));
+        }
+
+        ApplicationID = userSplit[0];
+        ApplicationKey = networkCredential.Password;
+        TenantDomain = userSplit[1];
     }
 
     private GraphEmailAddress? ConvertToGraphEmailAddress(object? email) {


### PR DESCRIPTION
## Summary
- ensure `Graph.Authenticate` requires `NetworkCredential` input and enforces the `user@tenant` pattern
- throw clear exceptions when credentials are missing or malformed
- add xUnit coverage for non-network credentials and malformed usernames

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68d7f072c58c832e83fb8a0ff11f106c