### PR TITLE
Handle missing Microsoft Graph attachment file paths gracefully

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphDraftTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphDraftTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -44,5 +45,32 @@ public class GraphDraftTests
         Assert.True(graph.IsLargerAttachment);
         Assert.Equal(2, graph.AttachmentsPlaceHolders.Count);
         Assert.All(graph.AttachmentsPlaceHolders, p => Assert.False(string.IsNullOrWhiteSpace(p.FileName)));
+    }
+
+    [Fact]
+    public async Task CreateGraphAttachment_MissingFile_ThrowsAndLogsWarning()
+    {
+        string missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        using var graph = new Graph();
+
+        var exception = await Assert.ThrowsAsync<FileNotFoundException>(() => graph.CreateGraphAttachment(missing));
+        Assert.Contains("Attachment file not found", exception.Message);
+        Assert.Equal(missing, exception.FileName);
+
+        var warnings = graph.LogCollector.Logs.ToArray();
+        Assert.Contains(warnings, entry => entry.Type == LogType.Warning && entry.Message.IndexOf(missing, StringComparison.OrdinalIgnoreCase) >= 0);
+    }
+
+    [Fact]
+    public async Task PrepareAttachments_MissingFile_SkipsPlaceholderAndLogs()
+    {
+        string missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        using var graph = new Graph { Attachments = new object[] { missing } };
+
+        await graph.PrepareAttachments();
+
+        Assert.Empty(graph.AttachmentsPlaceHolders);
+        var warnings = graph.LogCollector.Logs.ToArray();
+        Assert.True(warnings.Count(entry => entry.Type == LogType.Warning && entry.Message.IndexOf(missing, StringComparison.OrdinalIgnoreCase) >= 0) >= 1);
     }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -229,6 +229,14 @@ namespace Mailozaurr;
         if (LogCollector == null) LogCollector = new();
     }
 
+    private void LogMissingAttachmentWarning(string attachmentPath) {
+        var pathForMessage = string.IsNullOrWhiteSpace(attachmentPath)
+            ? "(empty path)"
+            : attachmentPath;
+        LogCollector.LogWarning($"Send-EmailMessage - Attachment file not found: {pathForMessage}");
+        LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{pathForMessage}' is invalid. Verify the file exists and the path is correct.");
+    }
+
     /// <summary>
     /// Converts the <see cref="Attachments"/> collection into <see cref="GraphAttachment"/> instances.
     /// </summary>
@@ -239,8 +247,7 @@ namespace Mailozaurr;
             foreach (var item in Attachments) {
                 if (item is string path) {
                     if (!File.Exists(path)) {
-                        LogCollector.LogWarning($"Send-EmailMessage - Attachment file not found: {path}");
-                        LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{path}' is invalid. Verify the file exists and the path is correct.");
+                        LogMissingAttachmentWarning(path);
                         continue;
                     }
                     ConvertedAttachments.Add(GraphAttachment.FromFile(path));
@@ -720,6 +727,10 @@ namespace Mailozaurr;
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The placeholder representing the attachment.</returns>
         public Task<GraphAttachmentPlaceHolder> CreateGraphAttachment(string attachmentPath, CancellationToken cancellationToken = default) {
+        if (!File.Exists(attachmentPath)) {
+            LogMissingAttachmentWarning(attachmentPath);
+            throw new FileNotFoundException($"Send-EmailMessage - Attachment file not found: {attachmentPath}", attachmentPath);
+        }
         var fileName = Path.GetFileName(attachmentPath);
         var fileSize = new FileInfo(attachmentPath).Length;
 
@@ -829,9 +840,13 @@ namespace Mailozaurr;
         if (Attachments != null && Attachments.Length > 0) {
             foreach (var attachmentPath in Attachments) {
                 if (attachmentPath is string path) {
-                    var attachmentItemJson = await CreateGraphAttachment(path, cancellationToken);
-                    var uploadUrl = await CreateUploadSession(draftMessage, attachmentItemJson.Json, cancellationToken);
-                    await SendFileChunks(uploadUrl, attachmentItemJson.Content, cancellationToken);
+                    try {
+                        var attachmentItemJson = await CreateGraphAttachment(path, cancellationToken);
+                        var uploadUrl = await CreateUploadSession(draftMessage, attachmentItemJson.Json, cancellationToken);
+                        await SendFileChunks(uploadUrl, attachmentItemJson.Content, cancellationToken);
+                    } catch (FileNotFoundException) {
+                        // Already logged by CreateGraphAttachment.
+                    }
                 }
             }
         }
@@ -845,8 +860,12 @@ namespace Mailozaurr;
         if (Attachments != null && Attachments.Length > 0) {
             foreach (var attachmentPath in Attachments) {
                 if (attachmentPath is string path) {
-                    var attachmentItemJson = await CreateGraphAttachment(path, cancellationToken);
-                    AttachmentsPlaceHolders.Add(attachmentItemJson);
+                    try {
+                        var attachmentItemJson = await CreateGraphAttachment(path, cancellationToken);
+                        AttachmentsPlaceHolders.Add(attachmentItemJson);
+                    } catch (FileNotFoundException) {
+                        // Already logged by CreateGraphAttachment.
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- centralize logging for missing attachment paths and guard large-attachment preparation against nonexistent files
- skip nonexistent attachment paths when creating upload placeholders and sessions
- extend Graph draft tests to cover missing attachment paths and verify warnings

## Testing
- dotnet build Sources/Mailozaurr/Mailozaurr.csproj
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d7f07b1e50832e8be61ff872d524af