### PR TITLE
Restart Graph stopwatch for connect and send operations

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphStopwatchTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphStopwatchTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class GraphStopwatchTests
+{
+    private static void SetHttpClient(Graph graph, HttpMessageHandler handler)
+    {
+        var field = typeof(Graph).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(graph, new HttpClient(handler));
+    }
+
+    private static HttpResponseMessage CreateJsonResponse(string content)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content)
+        };
+    }
+
+    [Fact]
+    public async Task ConnectO365GraphAsync_SuccessiveCallsHaveIndependentDurations()
+    {
+        var responsePayload = "{\"access_token\":\"token\",\"token_type\":\"Bearer\"}";
+        var handler = new RecordingHandler(
+            CreateJsonResponse(responsePayload),
+            CreateJsonResponse(responsePayload));
+
+        using var graph = new Graph();
+        SetHttpClient(graph, handler);
+        graph.Authenticate(new NetworkCredential("client@tenant", "secret"));
+
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        var first = await graph.ConnectO365GraphAsync();
+        Assert.True(first.Status);
+        Assert.True(
+            first.TimeToExecute < TimeSpan.FromMilliseconds(250),
+            $"Expected first elapsed time to be reset but was {first.TimeToExecute.TotalMilliseconds}ms");
+
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        var second = await graph.ConnectO365GraphAsync();
+        Assert.True(second.Status);
+        Assert.True(
+            second.TimeToExecute < TimeSpan.FromMilliseconds(250),
+            $"Expected second elapsed time to be reset but was {second.TimeToExecute.TotalMilliseconds}ms");
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_SuccessiveCallsHaveIndependentDurations()
+    {
+        var handler = new RecordingHandler(
+            CreateJsonResponse("{}"),
+            CreateJsonResponse("{}"));
+
+        using var graph = new Graph();
+        SetHttpClient(graph, handler);
+        graph.From = "sender@example.com";
+        graph.To = new object[] { "recipient@example.com" };
+        graph.Subject = "Test";
+        graph.HTML = "<p>Hello</p>";
+        graph.ContentType = "HTML";
+        graph.AccessToken = "token";
+        graph.TokenType = "Bearer";
+
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        var first = await graph.SendMessageAsync();
+        Assert.True(first.Status);
+        Assert.True(
+            first.TimeToExecute < TimeSpan.FromMilliseconds(250),
+            $"Expected first elapsed time to be reset but was {first.TimeToExecute.TotalMilliseconds}ms");
+
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        var second = await graph.SendMessageAsync();
+        Assert.True(second.Status);
+        Assert.True(
+            second.TimeToExecute < TimeSpan.FromMilliseconds(250),
+            $"Expected second elapsed time to be reset but was {second.TimeToExecute.TotalMilliseconds}ms");
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -1,5 +1,6 @@
 using System;
-﻿using System.Net.Http.Headers;
+using System.Diagnostics;
+using System.Net.Http.Headers;
 using System.Threading;
 
 namespace Mailozaurr;
@@ -378,6 +379,7 @@ namespace Mailozaurr;
     /// </summary>
     /// <returns>The result of the connection attempt.</returns>
     public async Task<SmtpResult> ConnectO365GraphAsync(CancellationToken cancellationToken = default) {
+        Stopwatch.Restart();
         string resource = "https://graph.microsoft.com";
         var body = new Dictionary<string, string> {
             { "grant_type", "client_credentials" },
@@ -426,6 +428,7 @@ namespace Mailozaurr;
     /// </summary>
     /// <returns>The result of the send operation.</returns>
     public async Task<SmtpResult> SendMessageAsync(CancellationToken cancellationToken = default) {
+        Stopwatch.Restart();
         // create message
         CreateMessage();
         LogCollector.LogVerbose("Send-EmailMessage - Sending email via Graph API");
@@ -501,6 +504,7 @@ namespace Mailozaurr;
     /// </summary>
     /// <returns>The result of the send operation.</returns>
     public async Task<SmtpResult> SendMessageDraftAsync(CancellationToken cancellationToken = default) {
+        Stopwatch.Restart();
         // Create the draft message using the new method
         var draftMessage = await CreateDraftMessageAsync(cancellationToken);
 
@@ -555,6 +559,7 @@ namespace Mailozaurr;
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The result of the send operation.</returns>
         public async Task<SmtpResult> SendDraftMessage(GraphMessage draftMessage, CancellationToken cancellationToken = default) {
+        Stopwatch.Restart();
         // Send the draft message
         var sendRequestUri = MicrosoftGraphUtils.BuildGraphUri(
             GraphEndpoint.V1,
@@ -597,6 +602,7 @@ namespace Mailozaurr;
     /// Sends the current message using Microsoft Graph batch requests.
     /// </summary>
     public async Task<SmtpResult> SendMessageBatchAsync(CancellationToken cancellationToken = default) {
+        Stopwatch.Restart();
         CreateMessage();
         var credential = new GraphCredential {
             ClientId = ApplicationID,


### PR DESCRIPTION
## Summary
- restart the Microsoft Graph stopwatch before every connect and send entry point so elapsed times stay scoped to each call
- add regression tests that confirm successive connect and send invocations report independent durations

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68d7f082a618832eba2c07a78c065596