### PR TITLE
Validate SMTP connection pool configuration inputs

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
@@ -1,3 +1,4 @@
+using System;
 using MailKit.Security;
 using System.Threading;
 using Xunit;
@@ -53,5 +54,57 @@ public class SmtpConnectionPoolTests {
 
         SmtpConnectionPool.ClearConnectionPool();
         SmtpConnectionPool.SetPoolingEnabled(false);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void SetMaxPoolSize_InvalidValue_Throws(int value) {
+        var original = SmtpConnectionPool.MaxPoolSize;
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => SmtpConnectionPool.SetMaxPoolSize(value));
+        Assert.Equal("value", ex.ParamName);
+        Assert.Equal(original, SmtpConnectionPool.MaxPoolSize);
+    }
+
+    [Fact]
+    public void SetMaxPoolSize_ValidValue_UpdatesProperty() {
+        var original = SmtpConnectionPool.MaxPoolSize;
+        var expected = original + 1;
+
+        try {
+            SmtpConnectionPool.SetMaxPoolSize(expected);
+            Assert.Equal(expected, SmtpConnectionPool.MaxPoolSize);
+        } finally {
+            SmtpConnectionPool.SetMaxPoolSize(original);
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void Configure_InvalidMaxPoolSize_Throws(int value) {
+        var originalEnabled = SmtpConnectionPool.PoolingEnabled;
+        var originalMax = SmtpConnectionPool.MaxPoolSize;
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => SmtpConnectionPool.Configure(true, value));
+        Assert.Equal("maxPoolSize", ex.ParamName);
+        Assert.Equal(originalEnabled, SmtpConnectionPool.PoolingEnabled);
+        Assert.Equal(originalMax, SmtpConnectionPool.MaxPoolSize);
+    }
+
+    [Fact]
+    public void Configure_ValidMaxPoolSize_UpdatesProperty() {
+        var originalEnabled = SmtpConnectionPool.PoolingEnabled;
+        var originalMax = SmtpConnectionPool.MaxPoolSize;
+        var expected = originalMax + 1;
+
+        try {
+            SmtpConnectionPool.Configure(true, expected);
+            Assert.True(SmtpConnectionPool.PoolingEnabled);
+            Assert.Equal(expected, SmtpConnectionPool.MaxPoolSize);
+        } finally {
+            SmtpConnectionPool.Configure(originalEnabled, originalMax);
+        }
     }
 }

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
@@ -25,11 +25,21 @@ public static class SmtpConnectionPool {
     /// <summary>Enables or disables connection pooling.</summary>
     public static bool PoolingEnabled => Volatile.Read(ref _poolingEnabled) == 1;
 
-    public static void SetMaxPoolSize(int value) => Interlocked.Exchange(ref _maxPoolSize, value);
+    public static void SetMaxPoolSize(int value) {
+        if (value < 1) {
+            throw new ArgumentOutOfRangeException(nameof(value), value, "Max pool size must be at least 1.");
+        }
+
+        Interlocked.Exchange(ref _maxPoolSize, value);
+    }
 
     public static void SetPoolingEnabled(bool enabled) => Interlocked.Exchange(ref _poolingEnabled, enabled ? 1 : 0);
 
     public static void Configure(bool poolingEnabled, int maxPoolSize) {
+        if (maxPoolSize < 1) {
+            throw new ArgumentOutOfRangeException(nameof(maxPoolSize), maxPoolSize, "Max pool size must be at least 1.");
+        }
+
         SetPoolingEnabled(poolingEnabled);
         SetMaxPoolSize(maxPoolSize);
     }


### PR DESCRIPTION
## Summary
- enforce a minimum connection pool size when setting or configuring the SMTP pool
- add unit tests covering invalid inputs and successful pool size updates

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68d7f08f1020832e9e89d7ace3d1fa84