### PR TITLE
Stream Mailgun attachments and test streaming

### DIFF
--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -190,6 +190,54 @@ public class MailgunClientTests
     }
 
     [Fact]
+    public async Task CreateContentAsync_UsesStreamContentForFiles()
+    {
+        var attachment = Path.GetTempFileName();
+        var inline = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(attachment, new byte[1024]);
+            File.WriteAllBytes(inline, new byte[1024]);
+
+            using var client = new MailgunClient
+            {
+                From = "sender@example.com",
+                To = new List<object> { "to@example.com" },
+                Attachment = new[] { attachment },
+                InlineAttachment = new[] { inline }
+            };
+
+            MethodInfo? method = typeof(MailgunClient).GetMethod("CreateContentAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            var task = (Task<MultipartFormDataContent>)method!.Invoke(client, new object[] { default(CancellationToken) })!;
+            using var content = await task;
+
+            var attachmentContent = content.Single(c => c.Headers.ContentDisposition?.Name?.Trim('"') == "attachment");
+            var inlineContent = content.Single(c => c.Headers.ContentDisposition?.Name?.Trim('"') == "inline");
+
+            Assert.IsType<StreamContent>(attachmentContent);
+            Assert.IsType<StreamContent>(inlineContent);
+
+            var streamField = typeof(StreamContent)
+                .GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
+                .FirstOrDefault(f => typeof(Stream).IsAssignableFrom(f.FieldType));
+            Assert.NotNull(streamField);
+
+            var attachmentStream = (Stream)streamField!.GetValue(attachmentContent)!;
+            var inlineStream = (Stream)streamField.GetValue(inlineContent)!;
+
+            Assert.IsType<FileStream>(attachmentStream);
+            Assert.IsType<FileStream>(inlineStream);
+            Assert.Equal(new FileInfo(attachment).Length, attachmentContent.Headers.ContentLength);
+            Assert.Equal(new FileInfo(inline).Length, inlineContent.Headers.ContentLength);
+        }
+        finally
+        {
+            File.Delete(attachment);
+            File.Delete(inline);
+        }
+    }
+
+    [Fact]
     public async Task SendEmailAsync_InvalidCredentials_ThrowsInvalidOperationException()
     {
         using var client = new MailgunClient

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -119,16 +119,18 @@ public class MailgunClient : IDisposable {
         return string.IsNullOrWhiteSpace(name) ? email : $"{name} <{email}>";
     }
 
-    private static async Task<byte[]> ReadFileBytesAsync(string path, CancellationToken cancellationToken) {
-        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
-        var bytes = new byte[fs.Length];
-        var read = 0;
-        while (read < bytes.Length) {
-            var r = await fs.ReadAsync(bytes, read, bytes.Length - read, cancellationToken).ConfigureAwait(false);
-            if (r == 0) break;
-            read += r;
-        }
-        return bytes;
+    private static StreamContent CreateStreamContent(string path) {
+        var stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 8192,
+            options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        var streamContent = new StreamContent(stream);
+        streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        return streamContent;
     }
 
     /// <summary>
@@ -157,9 +159,7 @@ public class MailgunClient : IDisposable {
                     continue;
                 }
 
-                var bytes = await ReadFileBytesAsync(path, cancellationToken).ConfigureAwait(false);
-                var fileContent = new ByteArrayContent(bytes);
-                fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                var fileContent = CreateStreamContent(path);
                 content.Add(fileContent, "attachment", Path.GetFileName(path));
             }
         }
@@ -172,9 +172,7 @@ public class MailgunClient : IDisposable {
                     continue;
                 }
 
-                var bytes = await ReadFileBytesAsync(path, cancellationToken).ConfigureAwait(false);
-                var fileContent = new ByteArrayContent(bytes);
-                fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                var fileContent = CreateStreamContent(path);
                 content.Add(fileContent, "inline", Path.GetFileName(path));
             }
         }


### PR DESCRIPTION
## Summary
- replace Mailgun attachment buffering with StreamContent so files are streamed from disk
- add a unit test confirming Mailgun multipart parts use file streams for attachments and inline content

## Testing
- dotnet build Sources/Mailozaurr/Mailozaurr.csproj
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d7f09a593c832ebba22a00830a112d