### PR TITLE
Validate Microsoft Graph credential format

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphAuthenticateTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphAuthenticateTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Net;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class GraphAuthenticateTests
+{
+    [Fact]
+    public void Authenticate_WithNonNetworkCredential_Throws()
+    {
+        using var graph = new Graph();
+        ICredentials credentials = new DummyCredentials();
+
+        var exception = Assert.Throws<ArgumentException>(() => graph.Authenticate(credentials));
+        Assert.Contains("NetworkCredential", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("client")]
+    [InlineData("client@")]
+    [InlineData("@tenant")]
+    public void Authenticate_WithMalformedUserName_Throws(string username)
+    {
+        using var graph = new Graph();
+        var credential = new NetworkCredential(username, "secret");
+
+        var exception = Assert.Throws<ArgumentException>(() => graph.Authenticate(credential));
+        Assert.Contains("clientid@directoryid", exception.Message);
+    }
+
+    private sealed class DummyCredentials : ICredentials
+    {
+        public NetworkCredential? GetCredential(Uri uri, string authType) => null;
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -359,19 +359,32 @@ namespace Mailozaurr;
     /// </summary>
     /// <param name="Credentials">The credentials to parse.</param>
     public void Authenticate(ICredentials Credentials) {
-        var networkCredential = Credentials as NetworkCredential;
-        if (networkCredential != null) {
-            var userSplit = networkCredential.UserName.Split('@');
-            if (userSplit.Length != 2) {
-                throw new ArgumentException(
-                    "Credential.UserName must be in the format 'clientid@directoryid'",
-                    nameof(Credentials));
-            }
-
-            ApplicationID = userSplit[0];
-            ApplicationKey = networkCredential.Password;
-            TenantDomain = userSplit[1];
+        if (Credentials is null) {
+            throw new ArgumentNullException(nameof(Credentials));
         }
+
+        if (Credentials is not NetworkCredential networkCredential) {
+            throw new ArgumentException(
+                "Credentials must be of type NetworkCredential.",
+                nameof(Credentials));
+        }
+
+        if (string.IsNullOrWhiteSpace(networkCredential.UserName)) {
+            throw new ArgumentException(
+                "Credential.UserName must be in the format 'clientid@directoryid'",
+                nameof(Credentials));
+        }
+
+        var userSplit = networkCredential.UserName.Split('@');
+        if (userSplit.Length != 2 || string.IsNullOrWhiteSpace(userSplit[0]) || string.IsNullOrWhiteSpace(userSplit[1])) {
+            throw new ArgumentException(
+                "Credential.UserName must be in the format 'clientid@directoryid'",
+                nameof(Credentials));
+        }
+
+        ApplicationID = userSplit[0];
+        ApplicationKey = networkCredential.Password;
+        TenantDomain = userSplit[1];
     }
 
     private GraphEmailAddress? ConvertToGraphEmailAddress(object? email) {


### PR DESCRIPTION
## Summary
- validate `Graph.Authenticate` requires a `NetworkCredential` with the expected client@tenant format and surface clear exceptions when inputs are invalid
- add unit tests that cover unsupported credential types and malformed usernames

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68de19461420832ebbdd9976ca7db693