### PR TITLE
Ensure SMTP pool clears when pooling is disabled

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
@@ -17,6 +17,23 @@ public class SmtpConnectionPoolTests {
         }
     }
 
+    private sealed class TrackingClient : ClientSmtp {
+        private bool _connected = true;
+        private bool _disposed;
+
+        public bool Disposed => _disposed;
+
+        public override bool IsConnected => _connected;
+
+        public void SetConnected(bool value) => _connected = value;
+
+        protected override void Dispose(bool disposing) {
+            _disposed = true;
+            _connected = false;
+            base.Dispose(disposing);
+        }
+    }
+
     [Fact]
     public void Disconnect_ReturnsClientToPool() {
         SmtpConnectionPool.SetPoolingEnabled(true);
@@ -104,6 +121,32 @@ public class SmtpConnectionPoolTests {
             Assert.True(SmtpConnectionPool.PoolingEnabled);
             Assert.Equal(expected, SmtpConnectionPool.MaxPoolSize);
         } finally {
+            SmtpConnectionPool.Configure(originalEnabled, originalMax);
+        }
+    }
+
+    [Fact]
+    public void Configure_DisablingPooling_ClearsCachedClients() {
+        var originalEnabled = SmtpConnectionPool.PoolingEnabled;
+        var originalMax = SmtpConnectionPool.MaxPoolSize;
+
+        var client = new TrackingClient();
+        client.SetConnected(true);
+
+        try {
+            SmtpConnectionPool.Configure(true, Math.Max(2, originalMax));
+            SmtpConnectionPool.ClearConnectionPool();
+
+            SmtpConnectionPool.ReturnClient("h", 25, client);
+            Assert.Equal(1, SmtpConnectionPool.CurrentPoolSize);
+
+            SmtpConnectionPool.Configure(false, originalMax);
+
+            Assert.True(client.Disposed);
+            Assert.Equal(0, SmtpConnectionPool.CurrentPoolSize);
+            Assert.False(SmtpConnectionPool.PoolingEnabled);
+        } finally {
+            SmtpConnectionPool.ClearConnectionPool();
             SmtpConnectionPool.Configure(originalEnabled, originalMax);
         }
     }

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
@@ -33,7 +33,13 @@ public static class SmtpConnectionPool {
         Interlocked.Exchange(ref _maxPoolSize, value);
     }
 
-    public static void SetPoolingEnabled(bool enabled) => Interlocked.Exchange(ref _poolingEnabled, enabled ? 1 : 0);
+    public static void SetPoolingEnabled(bool enabled) {
+        var newValue = enabled ? 1 : 0;
+        var previous = Interlocked.Exchange(ref _poolingEnabled, newValue);
+        if (previous == 1 && newValue == 0) {
+            ClearConnectionPool();
+        }
+    }
 
     public static void Configure(bool poolingEnabled, int maxPoolSize) {
         if (maxPoolSize < 1) {


### PR DESCRIPTION
## Summary
- clear cached SMTP clients when connection pooling is turned off
- add a regression test ensuring Configure(false, ...) disposes pooled clients and resets the pool size

## Testing
- dotnet test Sources/Mailozaurr.sln

------
https://chatgpt.com/codex/tasks/task_e_68e2c1085508832e95b28acf680ce606