### PR TITLE
Cache certificate tokens for Microsoft Graph

### DIFF
--- a/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsCertificateTokenCachingTests.cs
+++ b/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsCertificateTokenCachingTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+using Mailozaurr;
+
+namespace Mailozaurr.Tests;
+
+[Collection("GraphCollection")]
+public class MicrosoftGraphUtilsCertificateTokenCachingTests : IDisposable {
+    public MicrosoftGraphUtilsCertificateTokenCachingTests() {
+        ClearCaches();
+    }
+
+    [Fact]
+    public async Task ConnectO365GraphAsync_WithCertificateBytes_UsesCachedToken() {
+        ClearCaches();
+        int callCount = 0;
+        var authorization = new GraphAuthorization {
+            AccessToken = "bytes-token",
+            TokenType = "Bearer",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        MicrosoftGraphUtils.AcquireGraphCertificateBytesTokenAsyncFunc = (clientId, tenant, bytes, password, scopes) => {
+            callCount++;
+            return Task.FromResult(authorization);
+        };
+        var credential = new GraphCredential {
+            ClientId = "client-id",
+            DirectoryId = "tenant-id",
+            CertificateBytes = new byte[] { 1, 2, 3 },
+            CertificatePassword = "pwd"
+        };
+
+        try {
+            var token1 = await MicrosoftGraphUtils.ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token2 = await MicrosoftGraphUtils.ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+
+            Assert.Equal("Bearer bytes-token", token1);
+            Assert.Equal(token1, token2);
+            Assert.Equal(1, callCount);
+        } finally {
+            MicrosoftGraphUtils.ResetOAuthHelperOverrides();
+        }
+    }
+
+    [Fact]
+    public async Task ConnectO365GraphAsync_WithCertificatePem_UsesCachedToken() {
+        ClearCaches();
+        int callCount = 0;
+        var authorization = new GraphAuthorization {
+            AccessToken = "pem-token",
+            TokenType = "Bearer",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        MicrosoftGraphUtils.AcquireGraphCertificatePemTokenAsyncFunc = (clientId, tenant, path, scopes) => {
+            callCount++;
+            return Task.FromResult(authorization);
+        };
+        var credential = new GraphCredential {
+            ClientId = "client-id",
+            DirectoryId = "tenant-id",
+            CertificatePemPath = "certificate.pem"
+        };
+
+        try {
+            var token1 = await MicrosoftGraphUtils.ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+            var token2 = await MicrosoftGraphUtils.ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com");
+
+            Assert.Equal("Bearer pem-token", token1);
+            Assert.Equal(token1, token2);
+            Assert.Equal(1, callCount);
+        } finally {
+            MicrosoftGraphUtils.ResetOAuthHelperOverrides();
+        }
+    }
+
+    private static void ClearCaches() {
+        var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static);
+        if (cacheField?.GetValue(null) is ConcurrentDictionary<string, GraphAuthorization> cache) {
+            cache.Clear();
+        }
+
+        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
+        var internalCacheField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+        internalCacheField?.SetValue(null, null);
+        var cachePathField = oauthType?.GetField("CacheFilePath", BindingFlags.NonPublic | BindingFlags.Static);
+        var cachePath = cachePathField?.GetValue(null) as string;
+        if (!string.IsNullOrEmpty(cachePath) && File.Exists(cachePath)) {
+            File.Delete(cachePath);
+        }
+    }
+
+    public void Dispose() {
+        MicrosoftGraphUtils.ResetOAuthHelperOverrides();
+        ClearCaches();
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -21,6 +21,9 @@ namespace Mailozaurr {
     public static class MicrosoftGraphUtils {
         private static readonly HttpClient HttpClient;
         private static readonly ConcurrentDictionary<string, GraphAuthorization> TokenCache = new();
+        internal static Func<string, string, string, string, IEnumerable<string>?, Task<GraphAuthorization>> AcquireGraphCertificateTokenAsyncFunc { get; set; } = AcquireGraphCertificateTokenAsyncDefault;
+        internal static Func<string, string, byte[], string, IEnumerable<string>?, Task<GraphAuthorization>> AcquireGraphCertificateBytesTokenAsyncFunc { get; set; } = AcquireGraphCertificateBytesTokenAsyncDefault;
+        internal static Func<string, string, string, IEnumerable<string>?, Task<GraphAuthorization>> AcquireGraphCertificatePemTokenAsyncFunc { get; set; } = AcquireGraphCertificatePemTokenAsyncDefault;
         private static SemaphoreSlim _concurrencySemaphore = new(5, 5);
         private static int _maxConcurrentRequests = 5;
 
@@ -76,6 +79,30 @@ namespace Mailozaurr {
             HttpClient.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
             AppDomain.CurrentDomain.ProcessExit += (_, _) => HttpClient.Dispose();
         }
+
+        internal static void ResetOAuthHelperOverrides() {
+            AcquireGraphCertificateTokenAsyncFunc = AcquireGraphCertificateTokenAsyncDefault;
+            AcquireGraphCertificateBytesTokenAsyncFunc = AcquireGraphCertificateBytesTokenAsyncDefault;
+            AcquireGraphCertificatePemTokenAsyncFunc = AcquireGraphCertificatePemTokenAsyncDefault;
+        }
+
+        private static Task<GraphAuthorization> AcquireGraphCertificateTokenAsyncDefault(string clientId, string tenantDomain, string certificatePath, string certificatePassword, IEnumerable<string>? scopes) =>
+            OAuthHelpers.AcquireGraphCertificateTokenAsync(clientId, tenantDomain, certificatePath, certificatePassword, scopes);
+
+        private static Task<GraphAuthorization> AcquireGraphCertificateBytesTokenAsyncDefault(string clientId, string tenantDomain, byte[] certificateBytes, string certificatePassword, IEnumerable<string>? scopes) =>
+            OAuthHelpers.AcquireGraphCertificateTokenAsync(clientId, tenantDomain, certificateBytes, certificatePassword, scopes);
+
+        private static Task<GraphAuthorization> AcquireGraphCertificatePemTokenAsyncDefault(string clientId, string tenantDomain, string pemPath, IEnumerable<string>? scopes) =>
+            OAuthHelpers.AcquireGraphCertificatePemTokenAsync(clientId, tenantDomain, pemPath, scopes);
+
+        private static async Task CacheGraphAuthorizationAsync(string key, string clientId, GraphAuthorization authorization) {
+            TokenCache[key] = authorization;
+            await OAuthTokenCache.SetAsync($"graph:{key}", new OAuthCredential {
+                UserName = clientId,
+                AccessToken = authorization.AccessToken,
+                ExpiresOn = authorization.ExpiresOn
+            }).ConfigureAwait(false);
+        }
         /// <summary>
         /// Converts a credential string (username@directory) and secret to a GraphCredential object.
         /// </summary>
@@ -124,32 +151,34 @@ namespace Mailozaurr {
             }
             if (!string.IsNullOrWhiteSpace(credential.CertificatePath)) {
                 var scopes = new[] { $"{resource}/.default" };
-                var auth = await OAuthHelpers.AcquireGraphCertificateTokenAsync(
+                var auth = await AcquireGraphCertificateTokenAsyncFunc(
                     credential.ClientId,
                     tenantDomain,
                     credential.CertificatePath!,
                     credential.CertificatePassword ?? string.Empty,
                     scopes).ConfigureAwait(false);
-                TokenCache[key] = auth;
+                await CacheGraphAuthorizationAsync(key, credential.ClientId, auth).ConfigureAwait(false);
                 return $"{auth.TokenType} {auth.AccessToken}";
             }
             if (credential.CertificateBytes != null) {
                 var scopes = new[] { $"{resource}/.default" };
-                var auth = await OAuthHelpers.AcquireGraphCertificateTokenAsync(
+                var auth = await AcquireGraphCertificateBytesTokenAsyncFunc(
                     credential.ClientId,
                     tenantDomain,
                     credential.CertificateBytes,
                     credential.CertificatePassword ?? string.Empty,
                     scopes).ConfigureAwait(false);
+                await CacheGraphAuthorizationAsync(key, credential.ClientId, auth).ConfigureAwait(false);
                 return $"{auth.TokenType} {auth.AccessToken}";
             }
             if (!string.IsNullOrWhiteSpace(credential.CertificatePemPath)) {
                 var scopes = new[] { $"{resource}/.default" };
-                var auth = await OAuthHelpers.AcquireGraphCertificatePemTokenAsync(
+                var auth = await AcquireGraphCertificatePemTokenAsyncFunc(
                     credential.ClientId,
                     tenantDomain,
                     credential.CertificatePemPath!,
                     scopes).ConfigureAwait(false);
+                await CacheGraphAuthorizationAsync(key, credential.ClientId, auth).ConfigureAwait(false);
                 return $"{auth.TokenType} {auth.AccessToken}";
             }
 


### PR DESCRIPTION
## Summary
- cache Microsoft Graph certificate tokens after acquisition and allow overriding the helper delegates for testing
- persist certificate-based tokens to the OAuth token cache for all credential sources
- add unit tests that verify repeated calls with certificate bytes and PEM paths reuse the cached token

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e2c1009f60832e874933c715e3f1e6