### PR TITLE
feat(microsoftgraph): ✨ Add Graph send policy, retry/backoff and SMTP…

### DIFF
--- a/Examples/Example-SendEmail-Graph-Policy.ps1
+++ b/Examples/Example-SendEmail-Graph-Policy.ps1
@@ -1,5 +1,8 @@
 <#
 Demonstrates throttling-safe Graph sending with retry/backoff knobs from PowerShell.
+
+Security note: Do not hardcode client secrets in scripts. Use secure storage
+such as SecretManagement or environment variables and retrieve them at runtime.
 #>
 
 $ClientId = 'your-app-id'
@@ -12,4 +15,3 @@ Send-EmailMessage -Graph -From 'sender@example.com' -To 'recipient@example.com' 
   -Credential $cred -HTML '<b>Hello</b>' -Subject 'Graph policy demo' `
   -RetryCount 4 -RetryDelayMilliseconds 1000 -JitterMilliseconds 500 -MaxDelayMilliseconds 30000 `
   -GraphMaxConcurrency 2 -Verbose
-

--- a/Examples/Example-SendEmail-Graph-Policy.ps1
+++ b/Examples/Example-SendEmail-Graph-Policy.ps1
@@ -1,0 +1,15 @@
+<#
+Demonstrates throttling-safe Graph sending with retry/backoff knobs from PowerShell.
+#>
+
+$ClientId = 'your-app-id'
+$ClientSecret = 'your-secret'
+$TenantId = 'your-tenant-id'
+
+$cred = ConvertTo-GraphCredential -ClientId $ClientId -ClientSecret $ClientSecret -DirectoryId $TenantId
+
+Send-EmailMessage -Graph -From 'sender@example.com' -To 'recipient@example.com' `
+  -Credential $cred -HTML '<b>Hello</b>' -Subject 'Graph policy demo' `
+  -RetryCount 4 -RetryDelayMilliseconds 1000 -JitterMilliseconds 500 -MaxDelayMilliseconds 30000 `
+  -GraphMaxConcurrency 2 -Verbose
+

--- a/Examples/Example-SendEmail-Graph-SmtpFallback.ps1
+++ b/Examples/Example-SendEmail-Graph-SmtpFallback.ps1
@@ -1,0 +1,22 @@
+<#
+Configures a global SMTP fallback factory and sends via Graph with fallback enabled.
+#>
+
+# Configure once per session
+[Mailozaurr.MailozaurrOptions]::SmtpFallbackFactory = {
+  param($graph)
+  $s = [Mailozaurr.Smtp]::new()
+  $s.Connect('smtp.office365.com', 587)
+  $s.Authenticate([System.Net.NetworkCredential]::new('user@example.com','password'))
+  $s
+}
+
+$ClientId = 'your-app-id'
+$ClientSecret = 'your-secret'
+$TenantId = 'your-tenant-id'
+$cred = ConvertTo-GraphCredential -ClientId $ClientId -ClientSecret $ClientSecret -DirectoryId $TenantId
+
+Send-EmailMessage -Graph -EnableSmtpFallback -From 'sender@example.com' -To 'recipient@example.com' `
+  -Credential $cred -HTML '<b>Hello via fallback</b>' -Subject 'Graph+SMTP fallback' `
+  -RetryCount 4 -RetryDelayMilliseconds 1000 -JitterMilliseconds 500 -MaxDelayMilliseconds 30000
+

--- a/Examples/Example-SendEmail-Graph-SmtpFallback.ps1
+++ b/Examples/Example-SendEmail-Graph-SmtpFallback.ps1
@@ -2,11 +2,14 @@
 Configures a global SMTP fallback factory and sends via Graph with fallback enabled.
 #>
 
+# WARNING: Do not hardcode credentials in scripts. Use Get-Credential, environment variables
+# or a secure secret store (e.g., SecretManagement) for production scenarios.
 # Configure once per session
 [Mailozaurr.MailozaurrOptions]::SmtpFallbackFactory = {
   param($graph)
   $s = [Mailozaurr.Smtp]::new()
   $s.Connect('smtp.office365.com', 587)
+  # Example only — replace with secure credential retrieval
   $s.Authenticate([System.Net.NetworkCredential]::new('user@example.com','password'))
   $s
 }
@@ -19,4 +22,3 @@ $cred = ConvertTo-GraphCredential -ClientId $ClientId -ClientSecret $ClientSecre
 Send-EmailMessage -Graph -EnableSmtpFallback -From 'sender@example.com' -To 'recipient@example.com' `
   -Credential $cred -HTML '<b>Hello via fallback</b>' -Subject 'Graph+SMTP fallback' `
   -RetryCount 4 -RetryDelayMilliseconds 1000 -JitterMilliseconds 500 -MaxDelayMilliseconds 30000
-

--- a/README.MD
+++ b/README.MD
@@ -236,6 +236,81 @@ Wait-GraphMessage -Connection $graph -UserPrincipalName 'user@example.com' -Unti
 }
 ```
 
+### Throttling‑safe sending (Graph) and retry/backoff knobs
+
+Mailozaurr v2 includes a built‑in policy for Microsoft Graph sends that handles throttling and transient errors:
+
+- Concurrency limiting to avoid request bursts
+- Exponential backoff with jitter and a max cap
+- Honors Retry-After header on 429
+- Optional SMTP fallback when Graph ultimately fails
+
+PowerShell
+
+```powershell
+# Graph send with conservative retry/backoff and concurrency
+$cred = ConvertTo-GraphCredential -ClientId $ClientId -ClientSecret $ClientSecret -DirectoryId $TenantId
+
+Send-EmailMessage -Graph -From 'sender@example.com' -To 'user@example.com' `
+  -Credential $cred -HTML '<b>Hello</b>' -Subject 'Graph policy demo' `
+  -RetryCount 4 -RetryDelayMilliseconds 1000 `
+  -JitterMilliseconds 500 -MaxDelayMilliseconds 30000 `
+  -GraphMaxConcurrency 2 -Verbose
+
+# Optional: SMTP fallback when Graph keeps failing (configure once)
+[Mailozaurr.MailozaurrOptions]::SmtpFallbackFactory = {
+  param($graph)
+  $s = [Mailozaurr.Smtp]::new()
+  $s.Connect('smtp.office365.com', 587)
+  $s.Authenticate([System.Net.NetworkCredential]::new('user','pass'))
+  $s
+}
+Send-EmailMessage -Graph -EnableSmtpFallback -From 'sender@example.com' -To 'user@example.com' `
+  -Credential $cred -HTML '<b>Hello via fallback</b>' -Subject 'Graph+SMTP fallback'
+
+# Same jitter/max-delay knobs also apply to SMTP/SendGrid/Mailgun/SES
+Send-EmailMessage -Server 'smtp.office365.com' -Port 587 -UseSsl `
+  -From 'sender@example.com' -To 'user@example.com' -Credential (Get-Credential) `
+  -RetryCount 4 -RetryDelayMilliseconds 2000 -JitterMilliseconds 400 -MaxDelayMilliseconds 30000
+```
+
+C# (Graph)
+
+```csharp
+using Mailozaurr;
+var policy = new GraphSendPolicy {
+    MaxConcurrency = 2,
+    MaxRetries = 4,
+    BaseDelayMs = 1000,
+    MaxDelayMs = 30000,
+    JitterMs = 500,
+    RetryOnTransient = true,
+    EnableSmtpFallback = true
+};
+
+var graph = new Graph()
+    .WithSendPolicy(policy)
+    .WithSmtpFallback(() => {
+        var s = new Smtp();
+        s.Connect("smtp.office365.com", 587);
+        s.Authenticate("user@example.com", "password");
+        return s;
+    });
+
+graph.From = "sender@example.com";
+graph.To = new object[] { "user@example.com" };
+graph.Subject = "Graph policy demo";
+graph.HTML = "<b>Hello</b>";
+graph.Authenticate(new System.Net.NetworkCredential("clientid@tenant.onmicrosoft.com", "client-secret"));
+await graph.ConnectO365GraphAsync();
+await graph.SendMessageAsync();
+```
+
+Notes
+
+- Defaults are conservative. Override per‑invocation in PowerShell or set `MailozaurrOptions.DefaultGraphPolicy` in code.
+- For raw `Invoke‑MgGraphRequest` scenarios, use `-GraphMaxConcurrency` to keep batch operations within Graph tenancy limits.
+
 ```powershell
 $cred = Get-Credential
 $client = Connect-POP3 -Server 'pop.example.com' -Credential $cred

--- a/Sources/Mailozaurr.Examples/SendEmailGraphWithPolicy.cs
+++ b/Sources/Mailozaurr.Examples/SendEmailGraphWithPolicy.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.Examples;
+
+public static class SendEmailGraphWithPolicy
+{
+    public static async Task RunAsync()
+    {
+        var policy = new GraphSendPolicy
+        {
+            MaxConcurrency = 2,
+            MaxRetries = 4,
+            BaseDelayMs = 1000,
+            MaxDelayMs = 30000,
+            JitterMs = 500,
+            RetryOnTransient = true,
+            EnableSmtpFallback = true
+        };
+
+        using var graph = new Graph()
+            .WithSendPolicy(policy)
+            .WithSmtpFallback(() =>
+            {
+                var smtp = new Smtp();
+                smtp.Connect("smtp.office365.com", 587);
+                smtp.Authenticate(new NetworkCredential("user@example.com", "password"));
+                return smtp;
+            });
+
+        graph.From = "sender@example.com";
+        graph.To = new object[] { "recipient@example.com" };
+        graph.Subject = "Graph policy demo";
+        graph.HTML = "<b>Hello</b>";
+        graph.Authenticate(new NetworkCredential("clientid@tenant.onmicrosoft.com", "client-secret"));
+
+        var connect = await graph.ConnectO365GraphAsync();
+        if (!connect.Status)
+        {
+            Console.WriteLine($"Connect failed: {connect.Error}");
+            return;
+        }
+        var send = await graph.SendMessageAsync();
+        Console.WriteLine($"Status: {send.Status}, Message: {send.Message ?? send.Error}");
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
@@ -308,6 +308,18 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
     public double RetryDelayBackoff { get; set; } = 1.0;
 
     /// <summary>
+    /// <para>Maximum delay in milliseconds between retries. 0 disables capping. Applies to all providers.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public int MaxDelayMilliseconds { get; set; } = 0;
+
+    /// <summary>
+    /// <para>Jitter window in milliseconds added to each retry delay. 0 disables jitter. Applies to all providers.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public int JitterMilliseconds { get; set; } = 0;
+
+    /// <summary>
     /// <para>When specified, retries are attempted regardless of the error
     /// type. Without this switch, only transient errors are retried.</para>
     /// </summary>
@@ -338,6 +350,19 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
     [Parameter(Mandatory = false)]
     [ValidateRange(1, int.MaxValue)]
     public int ConnectionPoolSize { get; set; } = 2;
+
+    /// <summary>
+    /// <para>Overrides Graph concurrency for this invocation. When set, caps parallel Graph HTTP requests.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Graph")]
+    [Parameter(Mandatory = false, ParameterSetName = "MgGraphRequest")]
+    public int GraphMaxConcurrency { get; set; } = 0;
+
+    /// <summary>
+    /// <para>Enables SMTP fallback when Graph ultimately fails. Requires a configured factory via [Mailozaurr.MailozaurrOptions]::SmtpFallbackFactory.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Graph")]
+    public SwitchParameter EnableSmtpFallback { get; set; }
 
 
     /// <summary>

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -114,6 +114,8 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         sendGrid.RetryDelayMilliseconds = RetryDelayMilliseconds;
         sendGrid.RetryDelayBackoff = RetryDelayBackoff;
         sendGrid.RetryAlways = RetryAlways.IsPresent;
+        sendGrid.MaxDelayMilliseconds = MaxDelayMilliseconds;
+        sendGrid.JitterMilliseconds = JitterMilliseconds;
         NetworkCredential networkCredential = new NetworkCredential(Credential.UserName, Credential.Password);
         sendGrid.Credentials = networkCredential;
         sendGrid.CreateMessage();
@@ -155,6 +157,8 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         mailgun.RetryDelayMilliseconds = RetryDelayMilliseconds;
         mailgun.RetryDelayBackoff = RetryDelayBackoff;
         mailgun.RetryAlways = RetryAlways.IsPresent;
+        mailgun.MaxDelayMilliseconds = MaxDelayMilliseconds;
+        mailgun.JitterMilliseconds = JitterMilliseconds;
         NetworkCredential networkCredential = new NetworkCredential(Credential.UserName, Credential.Password);
         mailgun.Credentials = networkCredential;
         if (ShouldProcess(mailgun.SentTo, "Sending email message via Mailgun")) {
@@ -195,6 +199,8 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         ses.RetryDelayMilliseconds = RetryDelayMilliseconds;
         ses.RetryDelayBackoff = RetryDelayBackoff;
         ses.RetryAlways = RetryAlways.IsPresent;
+        ses.MaxDelayMilliseconds = MaxDelayMilliseconds;
+        ses.JitterMilliseconds = JitterMilliseconds;
         var region = Region;
         if (region != null && region.Length > 0) {
             ses.Region = region;
@@ -282,6 +288,36 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         graph.ContentType = "HTML";
         graph.Attachments = Attachment;
         if (Headers != null) graph.Headers = Headers.Cast<DictionaryEntry>().ToDictionary(d => d.Key?.ToString() ?? string.Empty, d => d.Value?.ToString() ?? string.Empty);
+        // Apply optional Graph policy without introducing new cmdlets
+        var applyPolicy = MailozaurrOptions.DefaultGraphPolicy != null
+            || GraphMaxConcurrency > 0
+            || MaxDelayMilliseconds > 0
+            || JitterMilliseconds > 0
+            || EnableSmtpFallback.IsPresent
+            || (RetryCount > 0 && this.MyInvocation.BoundParameters.ContainsKey(nameof(RetryCount)))
+            || (RetryDelayMilliseconds > 0 && this.MyInvocation.BoundParameters.ContainsKey(nameof(RetryDelayMilliseconds)));
+
+        if (applyPolicy) {
+            var p = MailozaurrOptions.DefaultGraphPolicy != null
+                ? new GraphSendPolicy {
+                    MaxConcurrency = MailozaurrOptions.DefaultGraphPolicy.MaxConcurrency,
+                    MaxRetries = MailozaurrOptions.DefaultGraphPolicy.MaxRetries,
+                    BaseDelayMs = MailozaurrOptions.DefaultGraphPolicy.BaseDelayMs,
+                    MaxDelayMs = MailozaurrOptions.DefaultGraphPolicy.MaxDelayMs,
+                    JitterMs = MailozaurrOptions.DefaultGraphPolicy.JitterMs,
+                    RetryOnTransient = MailozaurrOptions.DefaultGraphPolicy.RetryOnTransient,
+                    EnableSmtpFallback = MailozaurrOptions.DefaultGraphPolicy.EnableSmtpFallback
+                }
+                : new GraphSendPolicy();
+            if (RetryCount > 0 && this.MyInvocation.BoundParameters.ContainsKey(nameof(RetryCount))) p.MaxRetries = RetryCount;
+            if (RetryDelayMilliseconds > 0 && this.MyInvocation.BoundParameters.ContainsKey(nameof(RetryDelayMilliseconds))) p.BaseDelayMs = RetryDelayMilliseconds;
+            if (MaxDelayMilliseconds > 0) p.MaxDelayMs = MaxDelayMilliseconds;
+            if (JitterMilliseconds > 0) p.JitterMs = JitterMilliseconds;
+            if (GraphMaxConcurrency > 0) p.MaxConcurrency = GraphMaxConcurrency;
+            if (EnableSmtpFallback.IsPresent) p.EnableSmtpFallback = true;
+
+            graph.WithSendPolicy(p);
+        }
         graph.CreateAttachments();
         long graphSize = GetTotalAttachmentSize(graph.ConvertedAttachments);
         if (graphSize > GraphAttachmentLimitBytes) {
@@ -328,6 +364,9 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
     }
 
     private async Task ProcessMgGraphRequest(string fromEmail, string fromName) {
+        if (GraphMaxConcurrency > 0) {
+            MicrosoftGraphUtils.MaxConcurrentRequests = GraphMaxConcurrency;
+        }
         using Graph graph = new Graph();
         graph.ChunkSize = ChunkSize;
         graph.From = Helpers.GetFromObject(fromEmail, fromName);
@@ -425,6 +464,8 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         smtpClient.RetryDelayMilliseconds = RetryDelayMilliseconds;
         smtpClient.RetryDelayBackoff = RetryDelayBackoff;
         smtpClient.RetryAlways = RetryAlways.IsPresent;
+        smtpClient.MaxDelayMilliseconds = MaxDelayMilliseconds;
+        smtpClient.JitterMilliseconds = JitterMilliseconds;
 
         if (!ShouldProcess(smtpClient.SentTo, "Sending email message")) {
             logCollector.LogVerbose("Send-EmailMessage - Skipping authentication");

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -61,6 +61,10 @@ public class SesClient : IDisposable {
     public double RetryDelayBackoff { get; set; } = 1.0;
     /// <summary>Retry even on non-transient errors.</summary>
     public bool RetryAlways { get; set; } = false;
+    /// <summary>Maximum delay in milliseconds between retries. 0 disables capping.</summary>
+    public int MaxDelayMilliseconds { get; set; } = 0;
+    /// <summary>Jitter window in milliseconds added to retry delay. 0 disables jitter.</summary>
+    public int JitterMilliseconds { get; set; } = 0;
 
     /// <summary>AWS region to use.</summary>
     public string Region { get; set; } = "us-east-1";
@@ -295,6 +299,12 @@ public class SesClient : IDisposable {
             }
 
             int delay = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+            if (MaxDelayMilliseconds > 0 && delay > MaxDelayMilliseconds) {
+                delay = MaxDelayMilliseconds;
+            }
+            if (JitterMilliseconds > 0 && delay > 0) {
+                delay += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
+            }
             if (delay > 0)
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(delay), cancellationToken);

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -74,6 +74,10 @@ public class MailgunClient : IDisposable {
     public int RetryDelayMilliseconds { get; set; } = 0;
     /// <summary>Exponential backoff multiplier for retries.</summary>
     public double RetryDelayBackoff { get; set; } = 1.0;
+    /// <summary>Maximum delay in milliseconds between retries. 0 disables capping.</summary>
+    public int MaxDelayMilliseconds { get; set; } = 0;
+    /// <summary>Jitter window in milliseconds added to retry delay. 0 disables jitter.</summary>
+    public int JitterMilliseconds { get; set; } = 0;
 
     /// <summary>
     /// When set to <c>true</c> the client retries sending even if the
@@ -313,6 +317,12 @@ public class MailgunClient : IDisposable {
                     return failResult;
                 }
                 var delay = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (MaxDelayMilliseconds > 0 && delay > MaxDelayMilliseconds) {
+                    delay = MaxDelayMilliseconds;
+                }
+                if (JitterMilliseconds > 0 && delay > 0) {
+                    delay += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
+                }
                 if (delay > 0) await Task.Delay(TimeSpan.FromMilliseconds(delay), cancellationToken).ConfigureAwait(false);
             }
             attempts++;

--- a/Sources/Mailozaurr/MailozaurrOptions.cs
+++ b/Sources/Mailozaurr/MailozaurrOptions.cs
@@ -5,6 +5,16 @@ namespace Mailozaurr;
 /// </summary>
 public static class MailozaurrOptions
 {
+    static MailozaurrOptions()
+    {
+        // Internal default for PowerShell and other hosts that rebuild or do not execute psm1 init.
+        // Can be overridden at runtime by assigning DefaultGraphPolicy.
+        DefaultGraphPolicy = GraphSendPolicy.Default;
+        if (DefaultGraphPolicy.MaxConcurrency > 0)
+        {
+            MicrosoftGraphUtils.MaxConcurrentRequests = DefaultGraphPolicy.MaxConcurrency;
+        }
+    }
     /// <summary>
     /// Default policy applied to all Graph send operations when an instance policy is not supplied.
     /// Leave <c>null</c> to preserve legacy behavior (no policy applied by default).
@@ -17,4 +27,3 @@ public static class MailozaurrOptions
     /// </summary>
     public static Func<Graph, Smtp?>? SmtpFallbackFactory { get; set; }
 }
-

--- a/Sources/Mailozaurr/MailozaurrOptions.cs
+++ b/Sources/Mailozaurr/MailozaurrOptions.cs
@@ -1,0 +1,20 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Global options for Mailozaurr behavior.
+/// </summary>
+public static class MailozaurrOptions
+{
+    /// <summary>
+    /// Default policy applied to all Graph send operations when an instance policy is not supplied.
+    /// Leave <c>null</c> to preserve legacy behavior (no policy applied by default).
+    /// </summary>
+    public static GraphSendPolicy? DefaultGraphPolicy { get; set; }
+
+    /// <summary>
+    /// Optional global factory used to construct an SMTP sender for fallback scenarios.
+    /// If set and the active <see cref="GraphSendPolicy"/> enables fallback, the factory will be invoked.
+    /// </summary>
+    public static Func<Graph, Smtp?>? SmtpFallbackFactory { get; set; }
+}
+

--- a/Sources/Mailozaurr/MailozaurrOptions.cs
+++ b/Sources/Mailozaurr/MailozaurrOptions.cs
@@ -10,10 +10,6 @@ public static class MailozaurrOptions
         // Internal default for PowerShell and other hosts that rebuild or do not execute psm1 init.
         // Can be overridden at runtime by assigning DefaultGraphPolicy.
         DefaultGraphPolicy = GraphSendPolicy.Default;
-        if (DefaultGraphPolicy.MaxConcurrency > 0)
-        {
-            MicrosoftGraphUtils.MaxConcurrentRequests = DefaultGraphPolicy.MaxConcurrency;
-        }
     }
     /// <summary>
     /// Default policy applied to all Graph send operations when an instance policy is not supplied.

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -183,6 +183,13 @@ namespace Mailozaurr;
     /// </summary>
     public bool RetryAlways { get; set; } = false;
 
+    /// <summary>
+    /// Optional policy controlling throttling/backoff and fallback behavior for Graph sends.
+    /// </summary>
+    public GraphSendPolicy? SendPolicy { get; private set; }
+
+    private Func<Smtp>? _smtpFallbackFactory;
+
     /// <summary>Webhook invoked after sending.</summary>
     public string? WebhookUrl { get; set; }
 
@@ -249,6 +256,25 @@ namespace Mailozaurr;
         _client = new HttpClient();
         _client.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
         if (LogCollector == null) LogCollector = new();
+    }
+
+    /// <summary>
+    /// Apply a send policy to this instance. Also updates the global Graph concurrency limit.
+    /// </summary>
+    public Graph WithSendPolicy(GraphSendPolicy policy) {
+        SendPolicy = policy ?? throw new ArgumentNullException(nameof(policy));
+        if (policy.MaxConcurrency > 0) {
+            MicrosoftGraphUtils.MaxConcurrentRequests = policy.MaxConcurrency;
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Provide an SMTP factory used for fallback when the active policy enables SMTP fallback.
+    /// </summary>
+    public Graph WithSmtpFallback(Func<Smtp> factory) {
+        _smtpFallbackFactory = factory ?? throw new ArgumentNullException(nameof(factory));
+        return this;
     }
 
     private void LogMissingAttachmentWarning(string attachmentPath) {
@@ -478,6 +504,16 @@ namespace Mailozaurr;
             GraphEndpoint.V1,
             $"/users/{MessageContainer.Message.From!.Email.Address}/sendMail");
 
+        var policy = SendPolicy ?? MailozaurrOptions.DefaultGraphPolicy;
+        if (policy != null && policy.MaxConcurrency > 0) {
+            MicrosoftGraphUtils.MaxConcurrentRequests = policy.MaxConcurrency;
+        }
+
+        var policyDraft = SendPolicy ?? MailozaurrOptions.DefaultGraphPolicy;
+        if (policyDraft != null && policyDraft.MaxConcurrency > 0) {
+            MicrosoftGraphUtils.MaxConcurrentRequests = policyDraft.MaxConcurrency;
+        }
+
         int attempts = 0;
         Exception? lastException = null;
         do {
@@ -500,44 +536,44 @@ namespace Mailozaurr;
                     var errorMessage = (error == null || error.Error == null || error.Error.InnerError == null)
                         ? $"Unknown error: {content}"
                         : $"Error code: {error.Error.Code}, message: {error.Error.Message}, request ID: {error.Error.InnerError.RequestId}, date: {error.Error.InnerError.Date}";
-                    throw new GraphApiException(response.StatusCode, errorMessage, content);
+                    var retryAfter = ParseRetryAfter(response);
+                    throw new GraphApiException(response.StatusCode, errorMessage, content, retryAfter);
                 } finally {
                     MicrosoftGraphUtils.ConcurrencySemaphore.Release();
                 }
             } catch (TaskCanceledException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Sending via Graph API cancelled: {ex.Message}");
-                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
+                var maxRetries = policy?.MaxRetries ?? RetryCount;
+                var shouldRetry = (policy?.RetryOnTransient ?? true) ? GraphRetryHelper.IsTransient(ex) : RetryAlways;
+                if ((!shouldRetry && !RetryAlways) || attempts >= maxRetries) {
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, string.Empty, ex.Message);
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
-                    return failResult;
+                    return await TrySmtpFallbackAsync(policy, failResult, ex, cancellationToken);
                 }
-                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-                if (delayMilliseconds > 0) {
-                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken);
-                }
+                await DelayWithBackoffAsync(policy, attempts, null, ex, cancellationToken);
             } catch (Exception ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Graph API: {ex.Message}");
-                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
+                var maxRetries = policy?.MaxRetries ?? RetryCount;
+                var shouldRetry = (policy?.RetryOnTransient ?? true) ? GraphRetryHelper.IsTransient(ex) : RetryAlways;
+                if ((!shouldRetry && !RetryAlways) || attempts >= maxRetries) {
                     if (ErrorAction == ActionPreference.Stop) {
                         throw;
                     }
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", ex.Message);
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
-                    return failResult;
+                    return await TrySmtpFallbackAsync(policy, failResult, ex, cancellationToken);
                 }
-                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-                if (delayMilliseconds > 0) {
-                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken);
-                }
+                var retryAfter = (ex as GraphApiException)?.RetryAfter;
+                await DelayWithBackoffAsync(policy, attempts, retryAfter, ex, cancellationToken);
             }
             attempts++;
-        } while (attempts <= RetryCount);
+        } while (attempts <= (policy?.MaxRetries ?? RetryCount));
 
         var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", lastException?.Message);
         await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken);
-        return finalResult;
+        return await TrySmtpFallbackAsync(policy, finalResult, lastException, cancellationToken);
     }
 
     /// <summary>
@@ -552,6 +588,11 @@ namespace Mailozaurr;
         // Upload attachments to the draft message
         await UploadAttachmentsAsync(draftMessage, cancellationToken);
 
+        var policyDraft = SendPolicy ?? MailozaurrOptions.DefaultGraphPolicy;
+        if (policyDraft != null && policyDraft.MaxConcurrency > 0) {
+            MicrosoftGraphUtils.MaxConcurrentRequests = policyDraft.MaxConcurrency;
+        }
+
         int attempts = 0;
         Exception? lastException = null;
         do {
@@ -560,37 +601,36 @@ namespace Mailozaurr;
             } catch (TaskCanceledException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Sending draft via Graph API cancelled: {ex.Message}");
-                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
+                var maxRetries = policyDraft?.MaxRetries ?? RetryCount;
+                var shouldRetry = (policyDraft?.RetryOnTransient ?? true) ? GraphRetryHelper.IsTransient(ex) : RetryAlways;
+                if ((!shouldRetry && !RetryAlways) || attempts >= maxRetries) {
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, string.Empty, ex.Message);
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
-                    return failResult;
+                    return await TrySmtpFallbackAsync(policyDraft, failResult, ex, cancellationToken);
                 }
-                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-                if (delayMilliseconds > 0) {
-                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken);
-                }
+                await DelayWithBackoffAsync(policyDraft, attempts, null, ex, cancellationToken);
             } catch (Exception ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Graph API: {ex.Message}");
-                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
+                var maxRetries = policyDraft?.MaxRetries ?? RetryCount;
+                var shouldRetry = (policyDraft?.RetryOnTransient ?? true) ? GraphRetryHelper.IsTransient(ex) : RetryAlways;
+                if ((!shouldRetry && !RetryAlways) || attempts >= maxRetries) {
                     if (ErrorAction == ActionPreference.Stop) {
                         throw;
                     }
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", ex.Message);
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
-                    return failResult;
+                    return await TrySmtpFallbackAsync(policyDraft, failResult, ex, cancellationToken);
                 }
-                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-                if (delayMilliseconds > 0) {
-                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken);
-                }
+                var ra = (ex as GraphApiException)?.RetryAfter;
+                await DelayWithBackoffAsync(policyDraft, attempts, ra, ex, cancellationToken);
             }
             attempts++;
-        } while (attempts <= RetryCount);
+        } while (attempts <= (policyDraft?.MaxRetries ?? RetryCount));
 
         var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, "", lastException?.Message);
         await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken);
-        return finalResult;
+        return await TrySmtpFallbackAsync(policyDraft, finalResult, lastException, cancellationToken);
     }
 
         /// <summary>
@@ -628,7 +668,8 @@ namespace Mailozaurr;
             var sendErrorMessage = (sendError == null || sendError.Error == null || sendError.Error.InnerError == null)
                 ? $"Unknown error: {sendContent}"
                 : $"Error code: {sendError.Error.Code}, message: {sendError.Error.Message}, request ID: {sendError.Error.InnerError.RequestId}, date: {sendError.Error.InnerError.Date}";
-            throw new GraphApiException(sendResponse.StatusCode, sendErrorMessage, sendContent);
+            var retryAfter = ParseRetryAfter(sendResponse);
+            throw new GraphApiException(sendResponse.StatusCode, sendErrorMessage, sendContent, retryAfter);
         } catch (GraphApiException ex) {
             LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Graph API: {ex.Message}");
             var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "GraphAPI", 0, Stopwatch.Elapsed, ex.ResponseContent, ex.Message);
@@ -718,7 +759,8 @@ namespace Mailozaurr;
                 var errorMessage = (error == null || error.Error == null)
                     ? $"Unknown error: {draftContent}"
                     : $"Error code: {error.Error.Code}, message: {error.Error.Message}";
-                throw new GraphApiException(draftResponse.StatusCode, errorMessage, draftContent);
+                var retryAfter = ParseRetryAfter(draftResponse);
+                throw new GraphApiException(draftResponse.StatusCode, errorMessage, draftContent, retryAfter);
             }
 
             // Deserialize the draft message
@@ -946,6 +988,89 @@ namespace Mailozaurr;
             }
         } finally {
             MicrosoftGraphUtils.ConcurrencySemaphore.Release();
+        }
+    }
+
+    private static TimeSpan? ParseRetryAfter(HttpResponseMessage response) {
+        if (response.Headers.TryGetValues("Retry-After", out var values)) {
+            var first = values.FirstOrDefault();
+            if (int.TryParse(first, out var seconds)) {
+                return TimeSpan.FromSeconds(Math.Max(0, seconds));
+            }
+            if (DateTimeOffset.TryParse(first, out var ts)) {
+                var delta = ts - DateTimeOffset.UtcNow;
+                return delta > TimeSpan.Zero ? delta : TimeSpan.Zero;
+            }
+        }
+        return null;
+    }
+
+    private async Task DelayWithBackoffAsync(GraphSendPolicy? policy, int attempts, TimeSpan? retryAfter, Exception ex, CancellationToken cancellationToken) {
+        TimeSpan delay = TimeSpan.Zero;
+        if (policy != null) {
+            delay = GraphRetryHelper.CalculateDelay(policy, attempts);
+            if (GraphRetryHelper.IsThrottled(ex) && retryAfter.HasValue && retryAfter.Value > delay) {
+                delay = retryAfter.Value;
+            }
+            if (policy.MaxDelayMs > 0 && delay > TimeSpan.FromMilliseconds(policy.MaxDelayMs)) {
+                delay = TimeSpan.FromMilliseconds(policy.MaxDelayMs);
+            }
+        } else {
+            var delayMs = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+            if (delayMs > 0) delay = TimeSpan.FromMilliseconds(delayMs);
+        }
+
+        if (delay > TimeSpan.Zero) {
+            var reason = GraphRetryHelper.IsThrottled(ex) ? "throttling" : "transient";
+            LogCollector.LogVerbose($"Send-EmailMessage - Retry attempt {attempts + 1}, delaying {delay.TotalMilliseconds:N0} ms due to {reason}.");
+            await Task.Delay(delay, cancellationToken);
+        }
+    }
+
+    private async Task<SmtpResult> TrySmtpFallbackAsync(GraphSendPolicy? policy, SmtpResult current, Exception? lastException, CancellationToken cancellationToken) {
+        if (policy == null || !policy.EnableSmtpFallback) {
+            return current;
+        }
+
+        var smtp = _smtpFallbackFactory?.Invoke() ?? MailozaurrOptions.SmtpFallbackFactory?.Invoke(this);
+        if (smtp == null) {
+            LogCollector.LogVerbose("Send-EmailMessage - SMTP fallback requested but no SMTP factory configured.");
+            return current;
+        }
+
+        try {
+            smtp.From = this.From;
+            smtp.To = this.To;
+            smtp.Cc = this.Cc;
+            smtp.Bcc = this.Bcc;
+            smtp.ReplyTo = string.IsNullOrWhiteSpace(this.ReplyTo) ? null : this.ReplyTo;
+            smtp.Subject = this.Subject;
+            smtp.HtmlBody = this.HTML;
+            smtp.Headers = this.Headers;
+            smtp.WebhookUrl = this.WebhookUrl;
+
+            if (this.ConvertedAttachments != null && this.ConvertedAttachments.Count > 0) {
+                var attachments = new List<Definitions.AttachmentDescriptor>();
+                var inline = new List<Definitions.AttachmentDescriptor>();
+                foreach (var a in this.ConvertedAttachments) {
+                    if (string.IsNullOrWhiteSpace(a.ContentBytes)) continue;
+                    try {
+                        var bytes = Convert.FromBase64String(a.ContentBytes);
+                        var d = new Definitions.ByteArrayAttachmentDescriptor(bytes, string.IsNullOrWhiteSpace(a.Name) ? "attachment.bin" : a.Name);
+                        if (!string.IsNullOrWhiteSpace(a.ContentId)) d.ContentId = a.ContentId;
+                        if (a.IsInline) inline.Add(d); else attachments.Add(d);
+                    } catch { /* ignore invalid base64 */ }
+                }
+                if (attachments.Count > 0) smtp.Attachments = attachments;
+                if (inline.Count > 0) smtp.InlineAttachments = inline;
+            }
+
+            await smtp.CreateMessageAsync(cancellationToken).ConfigureAwait(false);
+            LogCollector.LogVerbose("Send-EmailMessage - Sending via SMTP fallback after Graph failure.");
+            return await smtp.SendAsync(cancellationToken).ConfigureAwait(false);
+        } catch (Exception ex) {
+            LogCollector.LogWarning($"Send-EmailMessage - SMTP fallback failed: {ex.Message}");
+            return current;
         }
     }
 

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -261,6 +261,11 @@ namespace Mailozaurr;
     /// <summary>
     /// Apply a send policy to this instance. Also updates the global Graph concurrency limit.
     /// </summary>
+    /// <remarks>
+    /// The concurrency limit is process-wide and affects all Graph operations within the AppDomain.
+    /// The update is performed using a thread-safe semaphore swap, but callers should be aware of
+    /// the global nature of this setting when running multiple independent pipelines in parallel.
+    /// </remarks>
     public Graph WithSendPolicy(GraphSendPolicy policy) {
         SendPolicy = policy ?? throw new ArgumentNullException(nameof(policy));
         if (policy.MaxConcurrency > 0) {
@@ -1027,6 +1032,8 @@ namespace Mailozaurr;
         }
     }
 
+    private const string DefaultAttachmentName = "attachment.bin";
+
     private async Task<SmtpResult> TrySmtpFallbackAsync(GraphSendPolicy? policy, SmtpResult current, Exception? lastException, CancellationToken cancellationToken) {
         if (policy == null || !policy.EnableSmtpFallback) {
             return current;
@@ -1056,10 +1063,12 @@ namespace Mailozaurr;
                     if (string.IsNullOrWhiteSpace(a.ContentBytes)) continue;
                     try {
                         var bytes = Convert.FromBase64String(a.ContentBytes);
-                        var d = new Definitions.ByteArrayAttachmentDescriptor(bytes, string.IsNullOrWhiteSpace(a.Name) ? "attachment.bin" : a.Name);
+                        var d = new Definitions.ByteArrayAttachmentDescriptor(bytes, string.IsNullOrWhiteSpace(a.Name) ? DefaultAttachmentName : a.Name);
                         if (!string.IsNullOrWhiteSpace(a.ContentId)) d.ContentId = a.ContentId;
                         if (a.IsInline) inline.Add(d); else attachments.Add(d);
-                    } catch { /* ignore invalid base64 */ }
+                    } catch (FormatException fex) {
+                        LogCollector.LogWarning($"Send-EmailMessage - SMTP fallback skipped invalid base64 attachment '{(a?.Name ?? "(unnamed)")}' : {fex.Message}");
+                    }
                 }
                 if (attachments.Count > 0) smtp.Attachments = attachments;
                 if (inline.Count > 0) smtp.InlineAttachments = inline;
@@ -1070,7 +1079,15 @@ namespace Mailozaurr;
             return await smtp.SendAsync(cancellationToken).ConfigureAwait(false);
         } catch (Exception ex) {
             LogCollector.LogWarning($"Send-EmailMessage - SMTP fallback failed: {ex.Message}");
-            return current;
+            // Preserve original Graph failure, but add fallback context to Error for diagnostics
+            var mergedError = string.IsNullOrWhiteSpace(current.Error)
+                ? $"Graph failed; SMTP fallback error: {ex.Message}"
+                : $"{current.Error} | SMTP fallback error: {ex.Message}";
+            return new SmtpResult(current.Status, current.EmailAction, current.SentTo, current.SentFrom, current.Server, current.Port, current.TimeToExecute, current.Message, mergedError)
+            {
+                GraphError = current.GraphError,
+                MessageId = current.MessageId
+            };
         }
     }
 

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiException.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiException.cs
@@ -22,14 +22,30 @@ public class GraphApiException : Exception {
     public string ResponseContent { get; }
 
     /// <summary>
+    /// Optional server-provided retry-after delay when throttled.
+    /// </summary>
+    public TimeSpan? RetryAfter { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="GraphApiException"/> class.
     /// </summary>
     /// <param name="statusCode">The HTTP status code.</param>
     /// <param name="message">The error message.</param>
     /// <param name="responseContent">Raw response content from the server.</param>
     public GraphApiException(HttpStatusCode statusCode, string message, string responseContent)
+        : this(statusCode, message, responseContent, null) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GraphApiException"/> class.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <param name="message">The error message.</param>
+    /// <param name="responseContent">Raw response content from the server.</param>
+    /// <param name="retryAfter">Optional server-provided retry-after hint.</param>
+    public GraphApiException(HttpStatusCode statusCode, string message, string responseContent, TimeSpan? retryAfter)
         : base(message) {
         StatusCode = statusCode;
         ResponseContent = responseContent;
+        RetryAfter = retryAfter;
     }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphRetryHelper.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphRetryHelper.cs
@@ -1,0 +1,122 @@
+using System.Net;
+using System.Threading;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Classification and backoff helpers for Microsoft Graph send operations.
+/// </summary>
+internal static class GraphRetryHelper
+{
+    private static readonly string[] ThrottleMarkers = new[]
+    {
+        "ApplicationThrottled",
+        "MailboxConcurrency",
+        "TooManyRequests",
+        "Throttled"
+    };
+
+    internal static bool IsThrottled(Exception ex)
+    {
+        if (ex is GraphApiException gex)
+        {
+            if ((int)gex.StatusCode == 429)
+            {
+                return true;
+            }
+            var parsed = GraphApiErrorParser.Parse(gex.ResponseContent);
+            var code = parsed?.Error?.Code ?? string.Empty;
+            foreach (var marker in ThrottleMarkers)
+            {
+                if (code.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return true;
+            }
+            if (!string.IsNullOrWhiteSpace(parsed?.Raw))
+            {
+                foreach (var marker in ThrottleMarkers)
+                {
+                    if (parsed!.Raw.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0)
+                        return true;
+                }
+            }
+        }
+
+        if (ex is HttpRequestException httpEx)
+        {
+#if NET5_0_OR_GREATER
+            if (httpEx.StatusCode.HasValue && (int)httpEx.StatusCode.Value == 429)
+                return true;
+#endif
+        }
+
+        return false;
+    }
+
+    internal static bool IsTransient(Exception ex)
+    {
+        if (IsThrottled(ex))
+        {
+            return true;
+        }
+
+        if (ex is GraphApiException gex)
+        {
+            var code = (int)gex.StatusCode;
+            if (code == 408 || code == 429)
+                return true;
+            if (code >= 500 && code <= 599)
+                return true;
+
+            var parsed = GraphApiErrorParser.Parse(gex.ResponseContent);
+            var message = parsed?.Error?.Message ?? parsed?.Raw ?? string.Empty;
+            if (message.IndexOf("timeout", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            if (message.IndexOf("temporarily", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            if (message.IndexOf("gateway", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            if (message.IndexOf("503", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        }
+
+        // Fall back to generic library-wide transient classification.
+        return Helpers.IsTransient(ex);
+    }
+
+    /// <summary>
+    /// Calculate exponential backoff delay with optional jitter and cap.
+    /// </summary>
+    internal static TimeSpan CalculateDelay(GraphSendPolicy policy, int attempt)
+    {
+        if (attempt < 0) attempt = 0;
+        var baseDelay = (double)Math.Max(0, policy.BaseDelayMs);
+        var delay = baseDelay * Math.Pow(2, attempt);
+        var max = Math.Max(0, policy.MaxDelayMs);
+        if (max > 0)
+        {
+            delay = Math.Min(delay, max);
+        }
+
+        var jitterWindow = Math.Max(0, policy.JitterMs);
+        if (jitterWindow > 0)
+        {
+            var jitter = GraphRetryHelperRandom.NextInt(jitterWindow + 1);
+            delay += jitter;
+        }
+
+        return TimeSpan.FromMilliseconds(Math.Max(0, (int)Math.Round(delay)));
+    }
+}
+
+internal static class GraphRetryHelperRandom
+{
+    [ThreadStatic]
+    private static Random? s_random;
+
+    internal static int NextInt(int maxExclusive)
+    {
+        if (maxExclusive <= 1) return 0;
+#if NET5_0_OR_GREATER
+        return System.Security.Cryptography.RandomNumberGenerator.GetInt32(0, maxExclusive);
+#else
+        var rnd = s_random ??= new Random(unchecked(Environment.TickCount * 31 + Thread.CurrentThread.ManagedThreadId));
+        return rnd.Next(0, maxExclusive);
+#endif
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphRetryHelper.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphRetryHelper.cs
@@ -8,6 +8,10 @@ namespace Mailozaurr;
 /// </summary>
 internal static class GraphRetryHelper
 {
+    private const int StatusRequestTimeout = 408;
+    private const int StatusTooManyRequests = 429;
+    private const int StatusServerErrorMin = 500;
+    private const int StatusServerErrorMax = 599;
     private static readonly string[] ThrottleMarkers = new[]
     {
         "ApplicationThrottled",
@@ -20,7 +24,7 @@ internal static class GraphRetryHelper
     {
         if (ex is GraphApiException gex)
         {
-            if ((int)gex.StatusCode == 429)
+            if ((int)gex.StatusCode == StatusTooManyRequests)
             {
                 return true;
             }
@@ -44,7 +48,7 @@ internal static class GraphRetryHelper
         if (ex is HttpRequestException httpEx)
         {
 #if NET5_0_OR_GREATER
-            if (httpEx.StatusCode.HasValue && (int)httpEx.StatusCode.Value == 429)
+            if (httpEx.StatusCode.HasValue && (int)httpEx.StatusCode.Value == StatusTooManyRequests)
                 return true;
 #endif
         }
@@ -62,9 +66,9 @@ internal static class GraphRetryHelper
         if (ex is GraphApiException gex)
         {
             var code = (int)gex.StatusCode;
-            if (code == 408 || code == 429)
+            if (code == StatusRequestTimeout || code == StatusTooManyRequests)
                 return true;
-            if (code >= 500 && code <= 599)
+            if (code >= StatusServerErrorMin && code <= StatusServerErrorMax)
                 return true;
 
             var parsed = GraphApiErrorParser.Parse(gex.ResponseContent);

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphRetryHelper.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphRetryHelper.cs
@@ -106,8 +106,10 @@ internal static class GraphRetryHelper
 
 internal static class GraphRetryHelperRandom
 {
+#if !NET5_0_OR_GREATER
     [ThreadStatic]
     private static Random? s_random;
+#endif
 
     internal static int NextInt(int maxExclusive)
     {

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphSendPolicy.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphSendPolicy.cs
@@ -1,0 +1,32 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Policy controlling how Graph send operations are throttled and retried.
+/// </summary>
+public sealed class GraphSendPolicy
+{
+    /// <summary>Maximum number of concurrent Graph HTTP requests. Applies globally.</summary>
+    public int MaxConcurrency { get; set; } = 2;
+
+    /// <summary>Maximum number of retries upon transient errors.</summary>
+    public int MaxRetries { get; set; } = 4;
+
+    /// <summary>Base delay in milliseconds for backoff calculation.</summary>
+    public int BaseDelayMs { get; set; } = 1000;
+
+    /// <summary>Maximum delay in milliseconds between retries.</summary>
+    public int MaxDelayMs { get; set; } = 30000;
+
+    /// <summary>Jitter window in milliseconds added to each delay.</summary>
+    public int JitterMs { get; set; } = 500;
+
+    /// <summary>Retry only when the error is classified as transient or throttling related.</summary>
+    public bool RetryOnTransient { get; set; } = true;
+
+    /// <summary>When true and SMTP is configured, fallback to SMTP after Graph retries are exhausted.</summary>
+    public bool EnableSmtpFallback { get; set; } = false;
+
+    /// <summary>Returns a conservative default policy suitable for most workloads.</summary>
+    public static GraphSendPolicy Default => new GraphSendPolicy();
+}
+

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -30,6 +30,11 @@ namespace Mailozaurr {
         /// <summary>
         /// Gets or sets the maximum number of concurrent HTTP requests allowed.
         /// </summary>
+        /// <remarks>
+        /// This is a process-wide limit. Setting this property affects all Graph operations in the
+        /// current AppDomain. The underlying semaphore is swapped using a thread-safe exchange to
+        /// ensure safe updates under concurrency.
+        /// </remarks>
         public static int MaxConcurrentRequests {
             get => _maxConcurrentRequests;
             set {

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -115,6 +115,10 @@ public sealed class SendGridClient : IDisposable {
     /// 1 disables backoff.
     /// </summary>
     public double RetryDelayBackoff { get; set; } = 1.0;
+    /// <summary>Maximum delay in milliseconds between retries. 0 disables capping.</summary>
+    public int MaxDelayMilliseconds { get; set; } = 0;
+    /// <summary>Jitter window in milliseconds added to retry delay. 0 disables jitter.</summary>
+    public int JitterMilliseconds { get; set; } = 0;
 
     /// <summary>
     /// If set to <c>true</c>, retries will occur even on non-transient
@@ -393,6 +397,12 @@ public sealed class SendGridClient : IDisposable {
                 }
 
                 var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (MaxDelayMilliseconds > 0 && delayMilliseconds > MaxDelayMilliseconds) {
+                    delayMilliseconds = MaxDelayMilliseconds;
+                }
+                if (JitterMilliseconds > 0 && delayMilliseconds > 0) {
+                    delayMilliseconds += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
+                }
                 if (delayMilliseconds > 0) {
                     await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken).ConfigureAwait(false);
                 }
@@ -409,6 +419,12 @@ public sealed class SendGridClient : IDisposable {
                     return failResult;
                 }
                 var delayMs = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (MaxDelayMilliseconds > 0 && delayMs > MaxDelayMilliseconds) {
+                    delayMs = MaxDelayMilliseconds;
+                }
+                if (JitterMilliseconds > 0 && delayMs > 0) {
+                    delayMs += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
+                }
                 if (delayMs > 0) {
                     await Task.Delay(TimeSpan.FromMilliseconds(delayMs), cancellationToken).ConfigureAwait(false);
                 }

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -174,6 +174,12 @@ public class Smtp {
     /// <summary>Exponential backoff multiplier for retries.</summary>
     public double RetryDelayBackoff { get; set; } = 1.0;
 
+    /// <summary>Maximum delay in milliseconds between retries. 0 disables capping.</summary>
+    public int MaxDelayMilliseconds { get; set; } = 0;
+
+    /// <summary>Jitter window in milliseconds added to retry delay. 0 disables jitter.</summary>
+    public int JitterMilliseconds { get; set; } = 0;
+
     /// <summary>
     /// When set to <see langword="true"/>, replaces local image references in
     /// <see cref="HtmlBody"/> with inline attachments.
@@ -892,6 +898,12 @@ public class Smtp {
                 }
 
                 var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
+                if (MaxDelayMilliseconds > 0 && delayMilliseconds > MaxDelayMilliseconds) {
+                    delayMilliseconds = MaxDelayMilliseconds;
+                }
+                if (JitterMilliseconds > 0 && delayMilliseconds > 0) {
+                    delayMilliseconds += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
+                }
                 if (delayMilliseconds > 0) {
                     await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken);
                 }

--- a/Tests/GraphSendPolicy.Tests.ps1
+++ b/Tests/GraphSendPolicy.Tests.ps1
@@ -1,0 +1,19 @@
+Describe 'GraphSendPolicy and Options' {
+    It 'Allows setting default policy' {
+        $policy = [Mailozaurr.GraphSendPolicy]::new()
+        $policy.MaxConcurrency = 2
+        $policy.MaxRetries = 4
+        [Mailozaurr.MailozaurrOptions]::DefaultGraphPolicy = $policy
+        [Mailozaurr.MailozaurrOptions]::DefaultGraphPolicy | Should -Not -BeNullOrEmpty
+        [Mailozaurr.MailozaurrOptions]::DefaultGraphPolicy.MaxRetries | Should -Be 4
+    }
+
+    It 'Graph.WithSendPolicy adjusts global concurrency' {
+        $g = [Mailozaurr.Graph]::new()
+        $p = [Mailozaurr.GraphSendPolicy]::new()
+        $p.MaxConcurrency = 3
+        $null = $g.WithSendPolicy($p)
+        [Mailozaurr.MicrosoftGraphUtils]::MaxConcurrentRequests | Should -Be 3
+    }
+}
+


### PR DESCRIPTION
… fallback support

* Introduce `GraphSendPolicy` and `MailozaurrOptions` defaults (`DefaultGraphPolicy`, `SmtpFallbackFactory`) to control global Graph behavior.
* Extend `Graph` with `WithSendPolicy` and `WithSmtpFallback`, apply policy-driven `MaxConcurrency`, and honor policy settings during send/draft flows.
* Add robust retry/backoff handling:
  * Parse server `Retry-After` and surface via `GraphApiException.RetryAfter`.
  * New `GraphRetryHelper` for throttle/transient classification and exponential backoff with jitter.
  * `DelayWithBackoffAsync` centralizes delay calculation and logging.
* Implement SMTP fallback flow (`TrySmtpFallbackAsync`) that converts Graph attachments and delegates to configured SMTP factory when policy enables fallback.
* Update send loops to consult policy for retry counts, transient logic, and max concurrency.
* Add unit tests for `GraphSendPolicy` and `Graph.WithSendPolicy` behavior.