### PR TITLE
Fix Graph expires_on unix timestamp parsing

### DIFF
--- a/Sources/Mailozaurr.Tests/SerializationContextTests.cs
+++ b/Sources/Mailozaurr.Tests/SerializationContextTests.cs
@@ -78,6 +78,24 @@ public class SerializationContextTests {
     }
 
     [Fact]
+    public void ShouldDeserializeGraphAuthorizationExpiresOnFromUnixSecondsDouble() {
+        const long unixSeconds = 1700000000;
+        var json = $"{{\"token_type\":\"Bearer\",\"access_token\":\"abc\",\"expires_on\":{unixSeconds}.5}}";
+        var auth = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.GraphAuthorization);
+        Assert.NotNull(auth);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(unixSeconds), auth!.ExpiresOn);
+    }
+
+    [Fact]
+    public void ShouldDeserializeGraphAuthorizationExpiresOnFromUnixSecondsDoubleString() {
+        const long unixSeconds = 1700000000;
+        var json = $"{{\"token_type\":\"Bearer\",\"access_token\":\"abc\",\"expires_on\":\"{unixSeconds}.5\"}}";
+        var auth = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.GraphAuthorization);
+        Assert.NotNull(auth);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(unixSeconds), auth!.ExpiresOn);
+    }
+
+    [Fact]
     public void ShouldHandleGraphAuthorizationExpiresOnNullOrEmpty() {
         var jsonNull = "{\"token_type\":\"Bearer\",\"access_token\":\"abc\",\"expires_on\":null}";
         var authNull = JsonSerializer.Deserialize(jsonNull, MailozaurrJsonContext.Default.GraphAuthorization);

--- a/Sources/Mailozaurr.Tests/SerializationContextTests.cs
+++ b/Sources/Mailozaurr.Tests/SerializationContextTests.cs
@@ -40,4 +40,13 @@ public class SerializationContextTests {
         Assert.Equal(record.Provider, roundtrip.Provider);
         Assert.Equal(record.ProviderData["k"], roundtrip.ProviderData["k"]);
     }
+
+    [Fact]
+    public void ShouldDeserializeGraphAuthorizationExpiresOnFromUnixSeconds() {
+        const long unixSeconds = 1700000000;
+        var json = $"{{\"token_type\":\"Bearer\",\"access_token\":\"abc\",\"expires_on\":\"{unixSeconds}\"}}";
+        var auth = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.GraphAuthorization);
+        Assert.NotNull(auth);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(unixSeconds), auth!.ExpiresOn);
+    }
 }

--- a/Sources/Mailozaurr.Tests/SerializationContextTests.cs
+++ b/Sources/Mailozaurr.Tests/SerializationContextTests.cs
@@ -49,4 +49,52 @@ public class SerializationContextTests {
         Assert.NotNull(auth);
         Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(unixSeconds), auth!.ExpiresOn);
     }
+
+    [Fact]
+    public void ShouldDeserializeGraphAuthorizationExpiresOnFromUnixSecondsNumber() {
+        const long unixSeconds = 1700000000;
+        var json = $"{{\"token_type\":\"Bearer\",\"access_token\":\"abc\",\"expires_on\":{unixSeconds}}}";
+        var auth = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.GraphAuthorization);
+        Assert.NotNull(auth);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(unixSeconds), auth!.ExpiresOn);
+    }
+
+    [Fact]
+    public void ShouldDeserializeGraphAuthorizationExpiresOnFromUnixMilliseconds() {
+        const long unixMilliseconds = 1700000000000;
+        var json = $"{{\"token_type\":\"Bearer\",\"access_token\":\"abc\",\"expires_on\":{unixMilliseconds}}}";
+        var auth = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.GraphAuthorization);
+        Assert.NotNull(auth);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(unixMilliseconds), auth!.ExpiresOn);
+    }
+
+    [Fact]
+    public void ShouldDeserializeGraphAuthorizationExpiresOnFromIsoString() {
+        const string iso = "2023-11-14T22:13:20.000Z";
+        var json = $"{{\"token_type\":\"Bearer\",\"access_token\":\"abc\",\"expires_on\":\"{iso}\"}}";
+        var auth = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.GraphAuthorization);
+        Assert.NotNull(auth);
+        Assert.Equal(DateTimeOffset.Parse(iso), auth!.ExpiresOn);
+    }
+
+    [Fact]
+    public void ShouldHandleGraphAuthorizationExpiresOnNullOrEmpty() {
+        var jsonNull = "{\"token_type\":\"Bearer\",\"access_token\":\"abc\",\"expires_on\":null}";
+        var authNull = JsonSerializer.Deserialize(jsonNull, MailozaurrJsonContext.Default.GraphAuthorization);
+        Assert.NotNull(authNull);
+        Assert.Equal(DateTimeOffset.MinValue, authNull!.ExpiresOn);
+
+        var jsonEmpty = "{\"token_type\":\"Bearer\",\"access_token\":\"abc\",\"expires_on\":\"\"}";
+        var authEmpty = JsonSerializer.Deserialize(jsonEmpty, MailozaurrJsonContext.Default.GraphAuthorization);
+        Assert.NotNull(authEmpty);
+        Assert.Equal(DateTimeOffset.MinValue, authEmpty!.ExpiresOn);
+    }
+
+    [Fact]
+    public void ShouldHandleGraphAuthorizationExpiresOnInvalid() {
+        var json = "{\"token_type\":\"Bearer\",\"access_token\":\"abc\",\"expires_on\":\"not-a-date\"}";
+        var auth = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.GraphAuthorization);
+        Assert.NotNull(auth);
+        Assert.Equal(DateTimeOffset.MinValue, auth!.ExpiresOn);
+    }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAuthorization.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAuthorization.cs
@@ -20,5 +20,6 @@ public class GraphAuthorization {
 
     /// <summary>Time when the access token expires.</summary>
     [JsonPropertyName("expires_on")]
+    [JsonConverter(typeof(UnixTimeSecondsDateTimeOffsetConverter))]
     public DateTimeOffset ExpiresOn { get; set; }
 }

--- a/Sources/Mailozaurr/Serialization/UnixTimeSecondsDateTimeOffsetConverter.cs
+++ b/Sources/Mailozaurr/Serialization/UnixTimeSecondsDateTimeOffsetConverter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Mailozaurr;
+
+internal sealed class UnixTimeSecondsDateTimeOffsetConverter : JsonConverter<DateTimeOffset> {
+    public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+        if (reader.TokenType == JsonTokenType.Null) {
+            return DateTimeOffset.MinValue;
+        }
+
+        if (reader.TokenType == JsonTokenType.Number) {
+            if (reader.TryGetInt64(out var numeric)) {
+                return FromUnix(numeric);
+            }
+
+            if (reader.TryGetDouble(out var numericDouble)) {
+                return FromUnix((long)numericDouble);
+            }
+        }
+
+        if (reader.TokenType == JsonTokenType.String) {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) {
+                return DateTimeOffset.MinValue;
+            }
+
+            if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var numeric)) {
+                return FromUnix(numeric);
+            }
+
+            if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var numericDouble)) {
+                return FromUnix((long)numericDouble);
+            }
+
+            if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed)) {
+                return parsed;
+            }
+
+            if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out parsed)) {
+                return parsed;
+            }
+        }
+
+        return DateTimeOffset.MinValue;
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options) {
+        writer.WriteStringValue(value.ToString("O", CultureInfo.InvariantCulture));
+    }
+
+    private static DateTimeOffset FromUnix(long value) {
+        return value > 9_999_999_999L
+            ? DateTimeOffset.FromUnixTimeMilliseconds(value)
+            : DateTimeOffset.FromUnixTimeSeconds(value);
+    }
+}

--- a/Sources/Mailozaurr/Serialization/UnixTimeSecondsDateTimeOffsetConverter.cs
+++ b/Sources/Mailozaurr/Serialization/UnixTimeSecondsDateTimeOffsetConverter.cs
@@ -52,6 +52,7 @@ internal sealed class UnixTimeSecondsDateTimeOffsetConverter : JsonConverter<Dat
     }
 
     private static DateTimeOffset FromUnix(long value) {
+        // Threshold: ~316 years from epoch (year 2286); values beyond are assumed to be milliseconds.
         return value > 9_999_999_999L
             ? DateTimeOffset.FromUnixTimeMilliseconds(value)
             : DateTimeOffset.FromUnixTimeSeconds(value);


### PR DESCRIPTION
## Summary
- handle Graph token expires_on values returned as Unix seconds/milliseconds or ISO
- add regression test for Unix-seconds expires_on

## Testing
- not run (not requested)

Fixes #538