### PR TITLE
Improve Graph attachment handling and SMTP reliability

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -311,7 +311,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             graph.WithSendPolicy(p);
         }
         graph.CreateAttachments();
-        long graphSize = GetTotalAttachmentSize(graph.ConvertedAttachments);
+        long graphSize = graph.TotalAttachmentSizeBytes;
         if (graphSize > GraphAttachmentLimitBytes) {
             WriteError(new ErrorRecord(
                 new ArgumentException("Attachments exceed Graph limit of 150MB."),
@@ -371,6 +371,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         graph.Bcc = Bcc;
         graph.ReplyTo = ReplyTo;
         graph.Subject = Subject ?? string.Empty;
+        graph.Priority = Priority;
         graph.DoNotSaveToSentItems = DoNotSaveToSentItems;
         graph.ErrorAction = errorAction;
         graph.RetryCount = RetryCount;
@@ -383,7 +384,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         graph.Attachments = Attachment;
         if (Headers != null) graph.Headers = Headers.Cast<DictionaryEntry>().ToDictionary(d => d.Key?.ToString() ?? string.Empty, d => d.Value?.ToString() ?? string.Empty);
         graph.CreateAttachments();
-        long size = GetTotalAttachmentSize(graph.ConvertedAttachments);
+        long size = graph.TotalAttachmentSizeBytes;
         if (size > GraphAttachmentLimitBytes) {
             WriteError(new ErrorRecord(
                 new ArgumentException("Attachments exceed Graph limit of 150MB."),

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -435,11 +435,10 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         // Attach the LogCollector to the SMTP client's logger
         smtpClient.LogCollector = logCollector;
         
-        string sentLogPath;
         var providedSentLogPath = SentLogPath;
-        sentLogPath = string.IsNullOrWhiteSpace(providedSentLogPath)
+        var sentLogPath = string.IsNullOrWhiteSpace(providedSentLogPath)
             ? Path.Combine(Path.GetTempPath(), "Mailozaurr", "sentlog.json")
-            : providedSentLogPath;
+            : providedSentLogPath!;
         smtpClient.SentMessageRepository = new FileSentMessageRepository(sentLogPath);
         smtpClient.From = Helpers.GetFromObject(fromEmail, fromName);
         smtpClient.ReplyTo = ReplyTo;
@@ -672,7 +671,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
                     if (result.BaseObject is IDictionary dictionary) {
                         var uploadUrl = dictionary["uploadUrl"]?.ToString();
                         if (!string.IsNullOrEmpty(uploadUrl)) {
-                            return uploadUrl;
+                            return uploadUrl!;
                         }
                         // Handle the case where the property is not present
                         throw new InvalidOperationException("The result does not contain an 'uploadUrl' property.");
@@ -717,7 +716,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
                     if (result.BaseObject is IDictionary dictionary) {
                         var id = dictionary["id"]?.ToString();
                         if (!string.IsNullOrEmpty(id)) {
-                            return id;
+                            return id!;
                         }
                         // Handle the case where the property is not present
                         throw new InvalidOperationException("The result does not contain an 'id' property.");

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -748,28 +748,16 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             return null;
         }
 
-        var result = new List<AttachmentDescriptor>();
-        foreach (var entry in attachments) {
-            if (entry == null) {
-                continue;
-            }
-
-            switch (entry) {
-                case AttachmentDescriptor descriptor:
-                    result.Add(descriptor);
-                    break;
-                case string path:
-                    result.Add(new FileAttachmentDescriptor(path));
-                    break;
-                case FileInfo fileInfo:
-                    result.Add(new FileAttachmentDescriptor(fileInfo.FullName));
-                    break;
-                default:
-                    throw new ArgumentException($"Unsupported attachment type: {entry.GetType().Name}");
-            }
-        }
-
-        return result;
+        return attachments
+            .Where(entry => entry != null)
+            .Select(entry => entry!)
+            .Select(entry => entry switch {
+                AttachmentDescriptor descriptor => descriptor,
+                string path => new FileAttachmentDescriptor(path),
+                FileInfo fileInfo => new FileAttachmentDescriptor(fileInfo.FullName),
+                _ => throw new ArgumentException($"Unsupported attachment type: {entry.GetType().Name}")
+            })
+            .ToList();
     }
 
     private object[]? FilterExistingPaths(object[]? paths, string parameterName) {

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -437,11 +437,9 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         
         string sentLogPath;
         var providedSentLogPath = SentLogPath;
-        if (providedSentLogPath == null || providedSentLogPath.Trim().Length == 0) {
-            sentLogPath = Path.Combine(Path.GetTempPath(), "Mailozaurr", "sentlog.json");
-        } else {
-            sentLogPath = providedSentLogPath;
-        }
+        sentLogPath = string.IsNullOrWhiteSpace(providedSentLogPath)
+            ? Path.Combine(Path.GetTempPath(), "Mailozaurr", "sentlog.json")
+            : providedSentLogPath;
         smtpClient.SentMessageRepository = new FileSentMessageRepository(sentLogPath);
         smtpClient.From = Helpers.GetFromObject(fromEmail, fromName);
         smtpClient.ReplyTo = ReplyTo;
@@ -471,6 +469,13 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         smtpClient.RetryAlways = RetryAlways.IsPresent;
         smtpClient.MaxDelayMilliseconds = MaxDelayMilliseconds;
         smtpClient.JitterMilliseconds = JitterMilliseconds;
+        if (UseDefaultCredentials) {
+            smtpClient.ConnectionPoolIdentity = "default";
+        } else if (Credential != null) {
+            smtpClient.ConnectionPoolIdentity = Credential.UserName;
+        } else if (!string.IsNullOrWhiteSpace(Username)) {
+            smtpClient.ConnectionPoolIdentity = Username;
+        }
         smtpClient.DryRun = !ShouldProcess(smtpClient.SentTo, "Sending email message");
         if (smtpClient.DryRun) {
             logCollector.LogVerbose("Send-EmailMessage - Skipping authentication");
@@ -588,24 +593,25 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             { "Body", jsonBody }
         };
 
-        var powerShell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
-        powerShell.AddCommand("Invoke-MgGraphRequest");
-        powerShell.AddParameters(parameters);
-        try {
-            var result = powerShell.Invoke();
-            if (!Suppress) {
-                WriteObject(new SmtpResult(true, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ""));
-            }
-        } catch (RuntimeException ex) {
-            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
-            if (errorAction == ActionPreference.Stop) {
-                throw;
-            }
-            if (!Suppress) {
-                var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
-                    GraphError = GraphApiErrorParser.Parse(ex.Message)
-                };
-                WriteObject(result);
+        using (var powerShell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace)) {
+            powerShell.AddCommand("Invoke-MgGraphRequest");
+            powerShell.AddParameters(parameters);
+            try {
+                powerShell.Invoke();
+                if (!Suppress) {
+                    WriteObject(new SmtpResult(true, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ""));
+                }
+            } catch (RuntimeException ex) {
+                LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
+                if (errorAction == ActionPreference.Stop) {
+                    throw;
+                }
+                if (!Suppress) {
+                    var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
+                        GraphError = GraphApiErrorParser.Parse(ex.Message)
+                    };
+                    WriteObject(result);
+                }
             }
         }
     }
@@ -624,22 +630,23 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
                 }
             };
 
-            var powerShell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
-            powerShell.AddCommand("Invoke-MgGraphRequest");
-            powerShell.AddParameters(parameters);
-            try {
-                var results = powerShell.Invoke();
-            } catch (RuntimeException ex) {
-                LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
-                if (errorAction == ActionPreference.Stop) {
-                    throw;
-                }
+            using (var powerShell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace)) {
+                powerShell.AddCommand("Invoke-MgGraphRequest");
+                powerShell.AddParameters(parameters);
+                try {
+                    powerShell.Invoke();
+                } catch (RuntimeException ex) {
+                    LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
+                    if (errorAction == ActionPreference.Stop) {
+                        throw;
+                    }
 
-                if (!Suppress) {
-                    var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
-                        GraphError = GraphApiErrorParser.Parse(ex.Message)
-                    };
-                    WriteObject(result);
+                    if (!Suppress) {
+                        var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
+                            GraphError = GraphApiErrorParser.Parse(ex.Message)
+                        };
+                        WriteObject(result);
+                    }
                 }
             }
         }
@@ -654,35 +661,35 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             { "Body", jsonBody }
         };
 
-        var powerShell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
-        powerShell.AddCommand("Invoke-MgGraphRequest");
-        powerShell.AddParameters(parameters);
-        try {
-            var results = powerShell.Invoke();
-            if (results.Count > 0) {
-                // Assuming the first result contains the property you're interested in
-                var result = results[0];
-                //var result = results[0];
-                if (result.BaseObject is IDictionary dictionary && dictionary.Contains("uploadUrl")) {
-                    return dictionary["uploadUrl"]?.ToString() ?? string.Empty;
+        using (var powerShell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace)) {
+            powerShell.AddCommand("Invoke-MgGraphRequest");
+            powerShell.AddParameters(parameters);
+            try {
+                var results = powerShell.Invoke();
+                if (results.Count > 0) {
+                    // Assuming the first result contains the property you're interested in
+                    var result = results[0];
+                    if (result.BaseObject is IDictionary dictionary && dictionary.Contains("uploadUrl")) {
+                        return dictionary["uploadUrl"]?.ToString() ?? string.Empty;
+                    } else {
+                        // Handle the case where the property is not present
+                        throw new InvalidOperationException("The result does not contain an 'uploadUrl' property.");
+                    }
                 } else {
-                    // Handle the case where the property is not present
-                    throw new InvalidOperationException("The result does not contain an 'uploadUrl' property.");
+                    // Handle the case where no results were returned
+                    throw new InvalidOperationException("No results were returned from the Invoke-MgGraphRequest command.");
                 }
-            } else {
-                // Handle the case where no results were returned
-                throw new InvalidOperationException("No results were returned from the Invoke-MgGraphRequest command.");
-            }
-        } catch (RuntimeException ex) {
-            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
-            if (errorAction == ActionPreference.Stop) {
-                throw;
-            }
-            if (!Suppress) {
-                var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
-                    GraphError = GraphApiErrorParser.Parse(ex.Message)
-                };
-                WriteObject(result);
+            } catch (RuntimeException ex) {
+                LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
+                if (errorAction == ActionPreference.Stop) {
+                    throw;
+                }
+                if (!Suppress) {
+                    var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
+                        GraphError = GraphApiErrorParser.Parse(ex.Message)
+                    };
+                    WriteObject(result);
+                }
             }
         }
 
@@ -696,52 +703,39 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             { "ContentType", "application/json; charset=UTF-8"},
             { "Body", jsonBody }
         };
-        var powerShell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
-        powerShell.AddCommand("Invoke-MgGraphRequest");
-        powerShell.AddParameters(parameters);
-        try {
-            var results = powerShell.Invoke();
-            if (results.Count > 0) {
-                // Assuming the first result contains the property you're interested in
-                var result = results[0];
-                if (result.BaseObject is IDictionary dictionary && dictionary.Contains("id")) {
-                    return dictionary["id"]?.ToString() ?? string.Empty;
+        using (var powerShell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace)) {
+            powerShell.AddCommand("Invoke-MgGraphRequest");
+            powerShell.AddParameters(parameters);
+            try {
+                var results = powerShell.Invoke();
+                if (results.Count > 0) {
+                    // Assuming the first result contains the property you're interested in
+                    var result = results[0];
+                    if (result.BaseObject is IDictionary dictionary && dictionary.Contains("id")) {
+                        return dictionary["id"]?.ToString() ?? string.Empty;
+                    } else {
+                        // Handle the case where the property is not present
+                        throw new InvalidOperationException("The result does not contain an 'id' property.");
+                    }
                 } else {
-                    // Handle the case where the property is not present
-                    throw new InvalidOperationException("The result does not contain an 'id' property.");
+                    // Handle the case where no results were returned
+                    throw new InvalidOperationException("No results were returned from the Invoke-MgGraphRequest command.");
                 }
-            } else {
-                // Handle the case where no results were returned
-                throw new InvalidOperationException("No results were returned from the Invoke-MgGraphRequest command.");
-            }
-        } catch (RuntimeException ex) {
-            LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
-            if (errorAction == ActionPreference.Stop) {
-                throw;
-            }
-            if (!Suppress) {
-                var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
-                    GraphError = GraphApiErrorParser.Parse(ex.Message)
-                };
-                WriteObject(result);
+            } catch (RuntimeException ex) {
+                LoggingMessages.Logger.WriteWarning($"Send-EmailMessage - Error during sending using Graph Api (MgGraphRequest): {ex.Message}");
+                if (errorAction == ActionPreference.Stop) {
+                    throw;
+                }
+                if (!Suppress) {
+                    var result = new SmtpResult(false, action, sentTo, sentFrom, "GraphAPI", 0, elapsed, "", ex.Message) {
+                        GraphError = GraphApiErrorParser.Parse(ex.Message)
+                    };
+                    WriteObject(result);
+                }
             }
         }
 
         return "";
-    }
-
-    private static long GetTotalAttachmentSize(IEnumerable<GraphAttachment> attachments) {
-        long size = 0;
-        foreach (var a in attachments) {
-            if (string.IsNullOrWhiteSpace(a.ContentBytes)) {
-                continue;
-            }
-            try {
-                size += Convert.FromBase64String(a.ContentBytes).LongLength;
-            } catch (FormatException) {
-            }
-        }
-        return size;
     }
 
     private static List<AttachmentDescriptor>? ConvertToAttachmentDescriptors(object[]? attachments) {

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -669,12 +669,15 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
                 if (results.Count > 0) {
                     // Assuming the first result contains the property you're interested in
                     var result = results[0];
-                    if (result.BaseObject is IDictionary dictionary && dictionary.Contains("uploadUrl")) {
-                        return dictionary["uploadUrl"]?.ToString() ?? string.Empty;
-                    } else {
+                    if (result.BaseObject is IDictionary dictionary) {
+                        var uploadUrl = dictionary["uploadUrl"]?.ToString();
+                        if (!string.IsNullOrEmpty(uploadUrl)) {
+                            return uploadUrl;
+                        }
                         // Handle the case where the property is not present
                         throw new InvalidOperationException("The result does not contain an 'uploadUrl' property.");
                     }
+                    throw new InvalidOperationException("The result does not contain an 'uploadUrl' property.");
                 } else {
                     // Handle the case where no results were returned
                     throw new InvalidOperationException("No results were returned from the Invoke-MgGraphRequest command.");
@@ -711,12 +714,15 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
                 if (results.Count > 0) {
                     // Assuming the first result contains the property you're interested in
                     var result = results[0];
-                    if (result.BaseObject is IDictionary dictionary && dictionary.Contains("id")) {
-                        return dictionary["id"]?.ToString() ?? string.Empty;
-                    } else {
+                    if (result.BaseObject is IDictionary dictionary) {
+                        var id = dictionary["id"]?.ToString();
+                        if (!string.IsNullOrEmpty(id)) {
+                            return id;
+                        }
                         // Handle the case where the property is not present
                         throw new InvalidOperationException("The result does not contain an 'id' property.");
                     }
+                    throw new InvalidOperationException("The result does not contain an 'id' property.");
                 } else {
                     // Handle the case where no results were returned
                     throw new InvalidOperationException("No results were returned from the Invoke-MgGraphRequest command.");

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -37,6 +37,6 @@ namespace Mailozaurr.PowerShell;
 [Cmdlet(VerbsCommunications.Send, "EmailMessage", DefaultParameterSetName = "Compatibility", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Medium)]
 [CmdletBinding()]
 public sealed partial class CmdletSendEmailMessage : PSCmdlet {
-    private const long GraphAttachmentLimitBytes = 150000000;
+    private const long GraphAttachmentLimitBytes = 150_000_000;
 
 }

--- a/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphUploadRangeTests.cs
@@ -54,4 +54,27 @@ public class GraphUploadRangeTests
         Assert.Equal(allBytes.Skip(10).Take(10), chunk1);
         Assert.Equal(allBytes.Skip(20).Take(5), chunk2);
     }
+
+    [Fact]
+    public void PrepareByteArrayContentForUpload_ClampsChunkSizeToMax()
+    {
+        string tmp = Path.GetTempFileName();
+        var fileSize = Graph.MaxChunkSize + 10;
+        var bytes = new byte[fileSize];
+        for (var i = 0; i < bytes.Length; i++) {
+            bytes[i] = (byte)(i % 256);
+        }
+        File.WriteAllBytes(tmp, bytes);
+        using Graph graph = new Graph();
+        MethodInfo? method = typeof(Graph).GetMethod(
+            "PrepareByteArrayContentForUpload",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        var nonNullMethod = method!;
+        List<StreamContent> chunks = (List<StreamContent>)nonNullMethod.Invoke(graph, new object[] { tmp, Graph.MaxChunkSize * 2, CancellationToken.None })!;
+        File.Delete(tmp);
+        Assert.Equal(2, chunks.Count);
+        Assert.Equal($"bytes 0-{Graph.MaxChunkSize - 1}/{fileSize}", chunks[0].Headers.GetValues("Content-Range").First());
+        Assert.Equal($"bytes {Graph.MaxChunkSize}-{fileSize - 1}/{fileSize}", chunks[1].Headers.GetValues("Content-Range").First());
+    }
 }

--- a/Sources/Mailozaurr.Tests/SmtpConnectionPoolMetricsTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConnectionPoolMetricsTests.cs
@@ -71,5 +71,27 @@ public class SmtpConnectionPoolMetricsTests {
         SmtpConnectionPool.ClearConnectionPool();
         SmtpConnectionPool.SetPoolingEnabled(false);
     }
+
+    [Fact]
+    public void GetSnapshot_DecodesServerWithDelimiters() {
+        SmtpConnectionPool.SetPoolingEnabled(true);
+        SmtpConnectionPool.ClearConnectionPool();
+
+        var client = new FakeClient();
+        var server = "smtp:host|name";
+        var identity = "user|domain:ssl";
+        SmtpConnectionPool.ReturnClient(server, 25, client, identity);
+
+        var snapshot = SmtpConnectionPool.GetSnapshot();
+        Assert.Equal(1, snapshot.CurrentPoolSize);
+        Assert.Single(snapshot.Entries);
+        var entry = snapshot.Entries[0];
+        Assert.Equal(server, entry.Server);
+        Assert.Equal(25, entry.Port);
+        Assert.Equal(1, entry.Count);
+
+        SmtpConnectionPool.ClearConnectionPool();
+        SmtpConnectionPool.SetPoolingEnabled(false);
+    }
 }
 

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -32,10 +32,15 @@ namespace Mailozaurr;
     /// <summary>Measures elapsed time spent during send operations.</summary>
     public readonly Stopwatch Stopwatch;
 
-    /// <summary>
-    /// Value indicating whether the total size of the attachments is larger than 4MB.
-    /// </summary>
-    public bool IsLargerAttachment { get; set; }
+        /// <summary>
+        /// Value indicating whether the total size of the attachments is larger than 4MB.
+        /// </summary>
+        public bool IsLargerAttachment { get; set; }
+
+        /// <summary>
+        /// Total size of all attachments in bytes (including file paths and in-memory attachments).
+        /// </summary>
+        public long TotalAttachmentSizeBytes { get; private set; }
 
     /// <summary>
     /// List of GraphAttachment objects created from the file paths in the Attachments property.
@@ -322,40 +327,73 @@ namespace Mailozaurr;
     /// </summary>
     public void CreateAttachments() {
         ConvertedAttachments.Clear();
+        TotalAttachmentSizeBytes = 0;
+        IsLargerAttachment = false;
         if (Attachments != null && Attachments.Any()) {
-            // Convert provided attachments into GraphAttachment objects
+            var fileAttachments = new List<string>();
+            long fileTotalBytes = 0;
+            long inMemoryTotalBytes = 0;
+
+            // First pass: compute total size without loading file contents.
             foreach (var item in Attachments) {
                 if (item is string path) {
                     if (!File.Exists(path)) {
                         LogMissingAttachmentWarning(path);
                         continue;
                     }
-                    ConvertedAttachments.Add(GraphAttachment.FromFile(path));
+                    fileAttachments.Add(path);
+                    try {
+                        var length = new FileInfo(path).Length;
+                        fileTotalBytes += length;
+                    } catch (Exception ex) {
+                        LogCollector.LogError($"Send-EmailMessage - Failed to read attachment '{path}': {ex.Message}");
+                    }
                 } else if (item is GraphAttachment ga) {
                     ConvertedAttachments.Add(ga);
+                    inMemoryTotalBytes += EstimateAttachmentSize(ga);
                 }
             }
 
-            var totalSize = 0;
-            foreach (var a in ConvertedAttachments) {
-                if (string.IsNullOrWhiteSpace(a.ContentBytes)) {
-                    continue;
-                }
-                try {
-                    totalSize += Convert.FromBase64String(a.ContentBytes).Length;
-                } catch (FormatException ex) {
-                    LogCollector.LogError($"Send-EmailMessage - Invalid base64 for attachment '{a.Name}': {ex.Message}");
+            TotalAttachmentSizeBytes = fileTotalBytes + inMemoryTotalBytes;
+            IsLargerAttachment = fileAttachments.Count > 0 && TotalAttachmentSizeBytes > 4_000_000;
+
+            // Only load file attachments into memory when they fit in a simple send payload.
+            if (!IsLargerAttachment && fileAttachments.Count > 0) {
+                foreach (var path in fileAttachments) {
+                    ConvertedAttachments.Add(GraphAttachment.FromFile(path));
                 }
             }
 
-            if (totalSize > 4_000_000) {
-                // Create a draft message if the total size of the attachments is larger than 4MB
-                IsLargerAttachment = true;
-            } else {
-                // Otherwise, include the attachments in the message
-                IsLargerAttachment = false;
+            if (inMemoryTotalBytes > 4_000_000) {
+                LogCollector.LogWarning("Send-EmailMessage - Large in-memory attachments detected. Consider using file paths for large attachments to enable upload sessions.");
             }
         }
+    }
+
+    private static long EstimateTotalSize(IEnumerable<GraphAttachment> attachments) {
+        long total = 0;
+        foreach (var attachment in attachments) {
+            total += EstimateAttachmentSize(attachment);
+        }
+        return total;
+    }
+
+    private static long EstimateAttachmentSize(GraphAttachment attachment) {
+        if (string.IsNullOrWhiteSpace(attachment.ContentBytes)) {
+            return 0;
+        }
+        var value = attachment.ContentBytes.Trim();
+        if (value.Length == 0) {
+            return 0;
+        }
+        var padding = 0;
+        if (value.EndsWith("==", StringComparison.Ordinal)) {
+            padding = 2;
+        } else if (value.EndsWith("=", StringComparison.Ordinal)) {
+            padding = 1;
+        }
+        var bytes = (long)value.Length * 3 / 4 - padding;
+        return bytes < 0 ? 0 : bytes;
     }
 
     /// <summary>
@@ -398,7 +436,7 @@ namespace Mailozaurr;
             },
             SaveToSentItems = !DoNotSaveToSentItems
         };
-        if (ConvertedAttachments.Count > 0 && IsLargerAttachment == false) {
+        if (ConvertedAttachments.Count > 0) {
             MessageContainer.Message.Attachments = ConvertedAttachments;
         }
         if (Headers != null && Headers.Count > 0) {
@@ -850,8 +888,12 @@ namespace Mailozaurr;
         /// </summary>
         /// <param name="attachmentPath">Path to the attachment file.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <param name="preloadContent">
+        /// When true, loads file chunks into memory and populates <see cref="GraphAttachmentPlaceHolder.Content"/>.
+        /// When false, only metadata is prepared and chunk content is generated on demand.
+        /// </param>
         /// <returns>The placeholder representing the attachment.</returns>
-        public Task<GraphAttachmentPlaceHolder> CreateGraphAttachment(string attachmentPath, CancellationToken cancellationToken = default) {
+        public Task<GraphAttachmentPlaceHolder> CreateGraphAttachment(string attachmentPath, CancellationToken cancellationToken = default, bool preloadContent = true) {
         if (!File.Exists(attachmentPath)) {
             LogMissingAttachmentWarning(attachmentPath);
             throw new FileNotFoundException($"Send-EmailMessage - Attachment file not found: {attachmentPath}", attachmentPath);
@@ -864,7 +906,9 @@ namespace Mailozaurr;
         var attachmentItemWrapper = new GraphAttachmentItemWrapper(attachmentItem);
         var attachmentItemJson = JsonSerializer.Serialize(attachmentItemWrapper, MailozaurrJsonContext.Default.GraphAttachmentItemWrapper);
 
-        List<StreamContent> content = PrepareByteArrayContentForUpload(attachmentPath, ChunkSize, cancellationToken);
+        List<StreamContent> content = preloadContent
+            ? PrepareByteArrayContentForUpload(attachmentPath, ChunkSize, cancellationToken)
+            : new List<StreamContent>();
 
         var placeholder = new GraphAttachmentPlaceHolder {
             Json = attachmentItemJson,
@@ -888,25 +932,29 @@ namespace Mailozaurr;
         var uploadSessionUrl = MicrosoftGraphUtils.BuildGraphUri(
             GraphEndpoint.V1,
             $"/users('{SentFrom}')/messages/{draftMessage.Id}/attachments/createUploadSession");
-        using var client = new HttpClient();
-        client.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+        using var request = new HttpRequestMessage(HttpMethod.Post, uploadSessionUrl) {
+            Content = new StringContent(attachmentItemJson, Encoding.UTF8, "application/json")
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue(TokenType, AccessToken);
         await MicrosoftGraphUtils.ConcurrencySemaphore.WaitAsync(cancellationToken);
         HttpResponseMessage uploadSessionResponse;
         try {
-            uploadSessionResponse = await client.PostAsync(
-                uploadSessionUrl,
-                new StringContent(attachmentItemJson, Encoding.UTF8, "application/json"),
-                cancellationToken);
+            uploadSessionResponse = await _client.SendAsync(request, cancellationToken);
         } finally {
             MicrosoftGraphUtils.ConcurrencySemaphore.Release();
         }
 
         using (uploadSessionResponse) {
             var uploadSessionContent = await uploadSessionResponse.Content.ReadAsStringAsync();
+            if (!uploadSessionResponse.IsSuccessStatusCode) {
+                var error = JsonSerializer.Deserialize(uploadSessionContent, MailozaurrJsonContext.Default.GraphApiError);
+                var errorMessage = (error == null || error.Error == null)
+                    ? $"Unknown error: {uploadSessionContent}"
+                    : $"Error code: {error.Error.Code}, message: {error.Error.Message}";
+                var retryAfter = ParseRetryAfter(uploadSessionResponse);
+                throw new GraphApiException(uploadSessionResponse.StatusCode, errorMessage, uploadSessionContent, retryAfter);
+            }
 
-            // {"error":{"code":"InvalidAuthenticationToken","message":"Access token is empty.","innerError":{"date":"2024-06-15T09:51:54","request-id":"4a43e743-e897-4758-8d7d-21858c198e1d","client-request-id":"4a43e743-e897-4758-8d7d-21858c198e1d"}}}
-            //Console.WriteLine(uploadSessionContent);
             return ParseUploadSessionResult(uploadSessionContent);
         }
     }
@@ -966,9 +1014,7 @@ namespace Mailozaurr;
             foreach (var attachmentPath in Attachments) {
                 if (attachmentPath is string path) {
                     try {
-                        var attachmentItemJson = await CreateGraphAttachment(path, cancellationToken);
-                        var uploadUrl = await CreateUploadSession(draftMessage, attachmentItemJson.Json, cancellationToken);
-                        await SendFileChunks(uploadUrl, attachmentItemJson.Content, cancellationToken);
+                        await UploadAttachmentWithRetryAsync(draftMessage, path, cancellationToken);
                     } catch (FileNotFoundException) {
                         // Already logged by CreateGraphAttachment.
                     }
@@ -1009,6 +1055,23 @@ namespace Mailozaurr;
     }
 
         /// <summary>
+        /// Uploads all chunks of a file to the provided upload session URL without buffering the entire file.
+        /// </summary>
+        public async Task SendFileChunks(string uploadUrl, string filePath, long fileSize, CancellationToken cancellationToken = default) {
+        var chunkSize = Math.Min(ChunkSize, MaxChunkSize);
+        var buffer = new byte[chunkSize];
+        long offset = 0;
+        using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        int bytesRead;
+        while ((bytesRead = await fileStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0) {
+            var chunk = new byte[bytesRead];
+            Buffer.BlockCopy(buffer, 0, chunk, 0, bytesRead);
+            await SendAttachmentChunkWithRetryAsync(uploadUrl, chunk, offset, fileSize, cancellationToken);
+            offset += bytesRead;
+        }
+    }
+
+        /// <summary>
         /// Uploads a single attachment chunk to the Graph API.
         /// </summary>
         /// <param name="uploadUrl">The upload session URL.</param>
@@ -1018,16 +1081,93 @@ namespace Mailozaurr;
         using var requestMessage = new HttpRequestMessage(HttpMethod.Put, uploadUrl) {
             Content = byteArrayContent
         };
-        requestMessage.Headers.Add("AnchorMailbox", SentFrom); // This is correctly added to HttpRequestMessage
-        using var client = new HttpClient();
-        client.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
+        requestMessage.Headers.Add("AnchorMailbox", SentFrom);
         await MicrosoftGraphUtils.ConcurrencySemaphore.WaitAsync(cancellationToken);
         try {
-            var uploadChunkResponse = await client.SendAsync(requestMessage, cancellationToken);
+            using var uploadChunkResponse = await _client.SendAsync(requestMessage, cancellationToken);
             if (!uploadChunkResponse.IsSuccessStatusCode) {
-                // Handle upload error
                 LogCollector.LogWarning(uploadChunkResponse.ToString());
+            }
+        } finally {
+            MicrosoftGraphUtils.ConcurrencySemaphore.Release();
+        }
+    }
+
+    private async Task SendAttachmentChunkWithRetryAsync(string uploadUrl, byte[] chunk, long offset, long fileSize, CancellationToken cancellationToken) {
+        var policy = SendPolicy ?? MailozaurrOptions.DefaultGraphPolicy;
+        int attempts = 0;
+        Exception? lastException = null;
+        var maxRetries = policy?.MaxRetries ?? RetryCount;
+        do {
+            try {
+                await SendAttachmentChunkOnceAsync(uploadUrl, chunk, offset, fileSize, cancellationToken);
                 return;
+            } catch (Exception ex) {
+                lastException = ex;
+                var shouldRetry = (policy?.RetryOnTransient ?? true) ? GraphRetryHelper.IsTransient(ex) : RetryAlways;
+                if ((!shouldRetry && !RetryAlways) || attempts >= maxRetries) {
+                    throw;
+                }
+                var retryAfter = (ex as GraphApiException)?.RetryAfter;
+                await DelayWithBackoffAsync(policy, attempts, retryAfter, ex, cancellationToken);
+            }
+            attempts++;
+        } while (attempts <= maxRetries);
+
+        if (lastException != null) {
+            throw lastException;
+        }
+    }
+
+    private async Task UploadAttachmentWithRetryAsync(GraphMessage draftMessage, string path, CancellationToken cancellationToken) {
+        var policy = SendPolicy ?? MailozaurrOptions.DefaultGraphPolicy;
+        int attempts = 0;
+        Exception? lastException = null;
+        var maxRetries = policy?.MaxRetries ?? RetryCount;
+        do {
+            try {
+                var attachmentItemJson = await CreateGraphAttachment(path, cancellationToken, preloadContent: false);
+                var uploadUrl = await CreateUploadSession(draftMessage, attachmentItemJson.Json, cancellationToken);
+                await SendFileChunks(uploadUrl, attachmentItemJson.FilePath, attachmentItemJson.FileSize, cancellationToken);
+                return;
+            } catch (FileNotFoundException) {
+                throw;
+            } catch (Exception ex) {
+                lastException = ex;
+                var shouldRetry = (policy?.RetryOnTransient ?? true) ? GraphRetryHelper.IsTransient(ex) : RetryAlways;
+                if ((!shouldRetry && !RetryAlways) || attempts >= maxRetries) {
+                    throw;
+                }
+                var retryAfter = (ex as GraphApiException)?.RetryAfter;
+                await DelayWithBackoffAsync(policy, attempts, retryAfter, ex, cancellationToken);
+            }
+            attempts++;
+        } while (attempts <= maxRetries);
+
+        if (lastException != null) {
+            throw lastException;
+        }
+    }
+
+    private async Task SendAttachmentChunkOnceAsync(string uploadUrl, byte[] chunk, long offset, long fileSize, CancellationToken cancellationToken) {
+        using var content = new StreamContent(new MemoryStream(chunk, writable: false));
+        var contentRange = $"bytes {offset}-{offset + chunk.Length - 1}/{fileSize}";
+        content.Headers.Add("Content-Range", contentRange);
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Put, uploadUrl) {
+            Content = content
+        };
+        requestMessage.Headers.Add("AnchorMailbox", SentFrom);
+        await MicrosoftGraphUtils.ConcurrencySemaphore.WaitAsync(cancellationToken);
+        try {
+            using var uploadChunkResponse = await _client.SendAsync(requestMessage, cancellationToken);
+            if (!uploadChunkResponse.IsSuccessStatusCode) {
+                var responseContent = await uploadChunkResponse.Content.ReadAsStringAsync();
+                var error = JsonSerializer.Deserialize(responseContent, MailozaurrJsonContext.Default.GraphApiError);
+                var errorMessage = (error == null || error.Error == null)
+                    ? $"Unknown error: {responseContent}"
+                    : $"Error code: {error.Error.Code}, message: {error.Error.Message}";
+                var retryAfter = ParseRetryAfter(uploadChunkResponse);
+                throw new GraphApiException(uploadChunkResponse.StatusCode, errorMessage, responseContent, retryAfter);
             }
         } finally {
             MicrosoftGraphUtils.ConcurrencySemaphore.Release();

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -518,11 +518,9 @@ namespace Mailozaurr;
             return null;
         }
 
-        var list = new List<GraphEmailAddress>();
-        foreach (var email in Helpers.UniqueAddresses(emails, seen)) {
-            var address = Helpers.GetEmailAddress(email);
-            list.Add(new GraphEmailAddress { Email = new GraphEmail { Address = address } });
-        }
+        var list = Helpers.UniqueAddresses(emails, seen)
+            .Select(email => new GraphEmailAddress { Email = new GraphEmail { Address = Helpers.GetEmailAddress(email) } })
+            .ToList();
         return list.Count == 0 ? null : list;
     }
 
@@ -1039,13 +1037,11 @@ namespace Mailozaurr;
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         public async Task UploadAttachmentsAsync(GraphMessage draftMessage, CancellationToken cancellationToken = default) {
         if (Attachments != null && Attachments.Length > 0) {
-            foreach (var attachmentPath in Attachments) {
-                if (attachmentPath is string path) {
-                    try {
-                        await UploadAttachmentWithRetryAsync(draftMessage, path, cancellationToken);
-                    } catch (FileNotFoundException) {
-                        // Already logged by CreateGraphAttachment.
-                    }
+            foreach (var path in Attachments.OfType<string>()) {
+                try {
+                    await UploadAttachmentWithRetryAsync(draftMessage, path, cancellationToken);
+                } catch (FileNotFoundException) {
+                    // Already logged by CreateGraphAttachment.
                 }
             }
         }
@@ -1057,14 +1053,12 @@ namespace Mailozaurr;
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         public async Task PrepareAttachments(CancellationToken cancellationToken = default) {
         if (Attachments != null && Attachments.Length > 0) {
-            foreach (var attachmentPath in Attachments) {
-                if (attachmentPath is string path) {
-                    try {
-                        var attachmentItemJson = await CreateGraphAttachment(path, cancellationToken);
-                        AttachmentsPlaceHolders.Add(attachmentItemJson);
-                    } catch (FileNotFoundException) {
-                        // Already logged by CreateGraphAttachment.
-                    }
+            foreach (var path in Attachments.OfType<string>()) {
+                try {
+                    var attachmentItemJson = await CreateGraphAttachment(path, cancellationToken);
+                    AttachmentsPlaceHolders.Add(attachmentItemJson);
+                } catch (FileNotFoundException) {
+                    // Already logged by CreateGraphAttachment.
                 }
             }
         }

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -947,7 +948,12 @@ namespace Mailozaurr;
         using (uploadSessionResponse) {
             var uploadSessionContent = await uploadSessionResponse.Content.ReadAsStringAsync();
             if (!uploadSessionResponse.IsSuccessStatusCode) {
-                var error = JsonSerializer.Deserialize(uploadSessionContent, MailozaurrJsonContext.Default.GraphApiError);
+                GraphApiError? error = null;
+                try {
+                    error = JsonSerializer.Deserialize(uploadSessionContent, MailozaurrJsonContext.Default.GraphApiError);
+                } catch (JsonException) {
+                    // Non-JSON error response; fall back to raw content.
+                }
                 var errorMessage = (error == null || error.Error == null)
                     ? $"Unknown error: {uploadSessionContent}"
                     : $"Error code: {error.Error.Code}, message: {error.Error.Message}";
@@ -983,22 +989,26 @@ namespace Mailozaurr;
         var fileSize = new FileInfo(filePath).Length;
 
         using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        var buffer = new byte[chunkSize];
+        var buffer = ArrayPool<byte>.Shared.Rent(chunkSize);
         int bytesRead;
         long offset = 0;
-        while ((bytesRead = fileStream.Read(buffer, 0, buffer.Length)) > 0) {
-            if (cancellationToken.IsCancellationRequested) {
-                return fileContents;
-            }
+        try {
+            while ((bytesRead = fileStream.Read(buffer, 0, buffer.Length)) > 0) {
+                if (cancellationToken.IsCancellationRequested) {
+                    return fileContents;
+                }
 
-            var chunk = new byte[bytesRead];
-            Array.Copy(buffer, chunk, bytesRead);
-            var memoryStream = new MemoryStream(chunk, writable: false);
-            var contentRange = $"bytes {offset}-{offset + bytesRead - 1}/{fileSize}";
-            var streamContent = new StreamContent(memoryStream);
-            streamContent.Headers.Add("Content-Range", contentRange);
-            fileContents.Add(streamContent);
-            offset += bytesRead;
+                var chunk = new byte[bytesRead];
+                Array.Copy(buffer, chunk, bytesRead);
+                var memoryStream = new MemoryStream(chunk, writable: false);
+                var contentRange = $"bytes {offset}-{offset + bytesRead - 1}/{fileSize}";
+                var streamContent = new StreamContent(memoryStream);
+                streamContent.Headers.Add("Content-Range", contentRange);
+                fileContents.Add(streamContent);
+                offset += bytesRead;
+            }
+        } finally {
+            ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
         }
 
         return fileContents;
@@ -1162,7 +1172,12 @@ namespace Mailozaurr;
             using var uploadChunkResponse = await _client.SendAsync(requestMessage, cancellationToken);
             if (!uploadChunkResponse.IsSuccessStatusCode) {
                 var responseContent = await uploadChunkResponse.Content.ReadAsStringAsync();
-                var error = JsonSerializer.Deserialize(responseContent, MailozaurrJsonContext.Default.GraphApiError);
+                GraphApiError? error = null;
+                try {
+                    error = JsonSerializer.Deserialize(responseContent, MailozaurrJsonContext.Default.GraphApiError);
+                } catch (JsonException) {
+                    // Non-JSON error response; fall back to raw content.
+                }
                 var errorMessage = (error == null || error.Error == null)
                     ? $"Unknown error: {responseContent}"
                     : $"Error code: {error.Error.Code}, message: {error.Error.Message}";
@@ -1259,9 +1274,10 @@ namespace Mailozaurr;
         } catch (Exception ex) {
             LogCollector.LogWarning($"Send-EmailMessage - SMTP fallback failed: {ex.Message}");
             // Preserve original Graph failure, but add fallback context to Error for diagnostics
+            var fallbackError = ex.ToString();
             var mergedError = string.IsNullOrWhiteSpace(current.Error)
-                ? $"Graph failed; SMTP fallback error: {ex.Message}"
-                : $"{current.Error} | SMTP fallback error: {ex.Message}";
+                ? $"Graph failed; SMTP fallback error: {fallbackError}"
+                : $"{current.Error} | SMTP fallback error: {fallbackError}";
             return new SmtpResult(current.Status, current.EmailAction, current.SentTo, current.SentFrom, current.Server, current.Port, current.TimeToExecute, current.Message, mergedError)
             {
                 GraphError = current.GraphError,

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -38,10 +38,13 @@ namespace Mailozaurr;
         /// </summary>
         public bool IsLargerAttachment { get; set; }
 
-        /// <summary>
-        /// Total size of all attachments in bytes (including file paths and in-memory attachments).
-        /// </summary>
-        public long TotalAttachmentSizeBytes { get; private set; }
+    /// <summary>
+    /// Total size of all attachments in bytes (including file paths and in-memory attachments).
+    /// </summary>
+    public long TotalAttachmentSizeBytes { get; private set; }
+
+    private long _inlineAttachmentSizeBytes;
+    private int _fileAttachmentCount;
 
     /// <summary>
     /// List of GraphAttachment objects created from the file paths in the Attachments property.
@@ -330,6 +333,8 @@ namespace Mailozaurr;
         ConvertedAttachments.Clear();
         TotalAttachmentSizeBytes = 0;
         IsLargerAttachment = false;
+        _inlineAttachmentSizeBytes = 0;
+        _fileAttachmentCount = 0;
         if (Attachments != null && Attachments.Any()) {
             var fileAttachments = new List<string>();
             long fileTotalBytes = 0;
@@ -346,17 +351,20 @@ namespace Mailozaurr;
                     try {
                         var length = new FileInfo(path).Length;
                         fileTotalBytes += length;
+                        _fileAttachmentCount++;
                     } catch (Exception ex) {
                         LogCollector.LogError($"Send-EmailMessage - Failed to read attachment '{path}': {ex.Message}");
                     }
                 } else if (item is GraphAttachment ga) {
                     ConvertedAttachments.Add(ga);
-                    inMemoryTotalBytes += EstimateAttachmentSize(ga);
+                    var size = EstimateAttachmentSize(ga);
+                    inMemoryTotalBytes += size;
                 }
             }
 
+            _inlineAttachmentSizeBytes = inMemoryTotalBytes;
             TotalAttachmentSizeBytes = fileTotalBytes + inMemoryTotalBytes;
-            IsLargerAttachment = fileAttachments.Count > 0 && TotalAttachmentSizeBytes > 4_000_000;
+            IsLargerAttachment = TotalAttachmentSizeBytes > 4_000_000;
 
             // Only load file attachments into memory when they fit in a simple send payload.
             if (!IsLargerAttachment && fileAttachments.Count > 0) {
@@ -365,7 +373,7 @@ namespace Mailozaurr;
                 }
             }
 
-            if (inMemoryTotalBytes > 4_000_000) {
+            if (_inlineAttachmentSizeBytes > 4_000_000) {
                 LogCollector.LogWarning("Send-EmailMessage - Large in-memory attachments detected. Consider using file paths for large attachments to enable upload sessions.");
             }
         }
@@ -410,6 +418,9 @@ namespace Mailozaurr;
                 att.IsInline = true;
                 att.ContentId = Path.GetFileName(p);
                 ConvertedAttachments.Add(att);
+                var size = EstimateAttachmentSize(att);
+                _inlineAttachmentSizeBytes += size;
+                TotalAttachmentSizeBytes += size;
             }
         }
         if (From is null) {
@@ -437,6 +448,12 @@ namespace Mailozaurr;
             },
             SaveToSentItems = !DoNotSaveToSentItems
         };
+        if (_inlineAttachmentSizeBytes > 4_000_000) {
+            throw new InvalidOperationException("In-memory attachments exceed the 4MB Graph payload limit. Use file path attachments or reduce attachment size.");
+        }
+        if (!IsLargerAttachment && TotalAttachmentSizeBytes > 4_000_000 && _fileAttachmentCount > 0) {
+            throw new InvalidOperationException("Total attachment payload exceeds the 4MB Graph limit after embedding images. Use file attachments or reduce attachment size.");
+        }
         if (ConvertedAttachments.Count > 0) {
             MessageContainer.Message.Attachments = ConvertedAttachments;
         }
@@ -530,7 +547,8 @@ namespace Mailozaurr;
         try {
             await WaitForConcurrencyAsync(operationStopwatch, cancellationToken);
             try {
-                using var response = await _client.PostAsync($"https://login.microsoftonline.com/{TenantDomain}/oauth2/token", new FormUrlEncodedContent(body), cancellationToken);
+                using var requestContent = new FormUrlEncodedContent(body);
+                using var response = await _client.PostAsync($"https://login.microsoftonline.com/{TenantDomain}/oauth2/token", requestContent, cancellationToken);
                 var content = await response.Content.ReadAsStringAsync();
                 if (!response.IsSuccessStatusCode) {
                     LogCollector.LogWarning($"Send-EmailMessage - Error during connection using Graph API: {content}");
@@ -820,7 +838,7 @@ namespace Mailozaurr;
         var draftRequestUri = MicrosoftGraphUtils.BuildGraphUri(
             GraphEndpoint.V1,
             $"/users/{MessageContainer.Message.From!.Email.Address}/mailfolders/drafts/messages");
-        var draftRequest = new HttpRequestMessage(HttpMethod.Post, draftRequestUri) {
+        using var draftRequest = new HttpRequestMessage(HttpMethod.Post, draftRequestUri) {
             Content = new StringContent(messageJson, Encoding.UTF8, "application/json")
         };
 

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -1009,7 +1009,7 @@ namespace Mailozaurr;
         int bytesRead;
         long offset = 0;
         try {
-            while ((bytesRead = fileStream.Read(buffer, 0, buffer.Length)) > 0) {
+            while ((bytesRead = fileStream.Read(buffer, 0, chunkSize)) > 0) {
                 if (cancellationToken.IsCancellationRequested) {
                     return fileContents;
                 }

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -16,9 +16,10 @@ namespace Mailozaurr;
     public class Graph : IDisposable {
         private readonly HttpClient _client;
         /// <summary>
-        /// Maximum size of an attachment chunk when uploading large files (4 MB).
+        /// Maximum size of an attachment chunk when uploading large files (4 MiB).
         /// </summary>
         public const int MaxChunkSize = 4 * 1024 * 1024;
+        private const long GraphPayloadLimitBytes = 4_000_000;
     private int _chunkSize = MaxChunkSize;
     /// <summary>
     /// Serialized JSON representation of the current Graph message.
@@ -34,7 +35,7 @@ namespace Mailozaurr;
     public readonly Stopwatch Stopwatch;
 
         /// <summary>
-        /// Value indicating whether the total size of the attachments is larger than 4MB.
+        /// Value indicating whether the total size of the attachments is larger than the Graph payload limit.
         /// </summary>
         public bool IsLargerAttachment { get; set; }
 
@@ -364,7 +365,7 @@ namespace Mailozaurr;
 
             _inlineAttachmentSizeBytes = inMemoryTotalBytes;
             TotalAttachmentSizeBytes = fileTotalBytes + inMemoryTotalBytes;
-            IsLargerAttachment = TotalAttachmentSizeBytes > 4_000_000;
+            IsLargerAttachment = TotalAttachmentSizeBytes > GraphPayloadLimitBytes;
 
             // Only load file attachments into memory when they fit in a simple send payload.
             if (!IsLargerAttachment && fileAttachments.Count > 0) {
@@ -373,7 +374,7 @@ namespace Mailozaurr;
                 }
             }
 
-            if (_inlineAttachmentSizeBytes > 4_000_000) {
+            if (_inlineAttachmentSizeBytes > GraphPayloadLimitBytes) {
                 LogCollector.LogWarning("Send-EmailMessage - Large in-memory attachments detected. Consider using file paths for large attachments to enable upload sessions.");
             }
         }
@@ -448,10 +449,10 @@ namespace Mailozaurr;
             },
             SaveToSentItems = !DoNotSaveToSentItems
         };
-        if (_inlineAttachmentSizeBytes > 4_000_000) {
+        if (_inlineAttachmentSizeBytes > GraphPayloadLimitBytes) {
             throw new InvalidOperationException("In-memory attachments exceed the 4MB Graph payload limit. Use file path attachments or reduce attachment size.");
         }
-        if (!IsLargerAttachment && TotalAttachmentSizeBytes > 4_000_000 && _fileAttachmentCount > 0) {
+        if (!IsLargerAttachment && TotalAttachmentSizeBytes > GraphPayloadLimitBytes && _fileAttachmentCount > 0) {
             throw new InvalidOperationException("Total attachment payload exceeds the 4MB Graph limit after embedding images. Use file attachments or reduce attachment size.");
         }
         if (ConvertedAttachments.Count > 0) {

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -983,7 +983,7 @@ public class Smtp {
         await PendingMessageRepository.RemoveAsync(messageId, cancellationToken);
     }
 
-    private async Task EnqueuePendingMessageAsync(string messageId, CredentialProtection credentialProtector, CancellationToken cancellationToken) {
+    private async Task EnqueuePendingMessageAsync(string messageId, ICredentialProtector credentialProtector, CancellationToken cancellationToken) {
         if (PendingMessageRepository == null) {
             return;
         }

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -76,6 +76,11 @@ public class Smtp {
     /// <summary>Credentials used during authentication.</summary>
     public NetworkCredential? Credential { get; private set; }
 
+    /// <summary>
+    /// Optional identity hint used to isolate SMTP connection pooling by credentials.
+    /// </summary>
+    public string? ConnectionPoolIdentity { get; set; }
+
     /// <summary>Subject of the message.</summary>
     public string Subject {
         get => Client.Subject;
@@ -217,6 +222,7 @@ public class Smtp {
 
     private bool _skipCertificateValidation;
     private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private string? _poolIdentity;
     /// <summary>Skip server certificate validation.</summary>
     public bool SkipCertificateValidation {
         get => _skipCertificateValidation;
@@ -439,7 +445,7 @@ public class Smtp {
     public SmtpResult Connect(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false) {
         var oldServer = Server;
         var oldPort = Port;
-        var oldPoolIdentity = GetConnectionPoolIdentity();
+        var oldPoolIdentity = _poolIdentity ?? GetConnectionPoolIdentity();
         Server = server;
         Port = port;
         var effectiveOptions = secureSocketOptions;
@@ -468,7 +474,8 @@ public class Smtp {
             Client = ClientFactory(Logging?.ProtocolLogger);
         }
 
-        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port, GetConnectionPoolIdentity()) : null;
+        var poolIdentity = GetConnectionPoolIdentity();
+        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port, poolIdentity) : null;
         if (pooled != null)
         {
             Client = pooled;
@@ -478,6 +485,7 @@ public class Smtp {
             {
                 Client.Connect(server, port, effectiveOptions);
             }
+            _poolIdentity = poolIdentity;
             LogVerbose($"Connected to {server} on {port} port using SSL: {effectiveOptions}");
             return new SmtpResult(true, EmailAction.Connect, SentTo, SentFrom, server, port, Stopwatch.Elapsed, "");
         } catch (Exception ex) {
@@ -505,7 +513,7 @@ public class Smtp {
     public async Task<SmtpResult> ConnectAsync(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false) {
         var oldServer = Server;
         var oldPort = Port;
-        var oldPoolIdentity = GetConnectionPoolIdentity();
+        var oldPoolIdentity = _poolIdentity ?? GetConnectionPoolIdentity();
         Server = server;
         Port = port;
         var effectiveOptions = secureSocketOptions;
@@ -534,7 +542,8 @@ public class Smtp {
             Client = ClientFactory(Logging?.ProtocolLogger);
         }
 
-        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port, GetConnectionPoolIdentity()) : null;
+        var poolIdentity = GetConnectionPoolIdentity();
+        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port, poolIdentity) : null;
         if (pooled != null)
         {
             Client = pooled;
@@ -544,6 +553,7 @@ public class Smtp {
             {
                 await Client.ConnectAsync(server, port, effectiveOptions);
             }
+            _poolIdentity = poolIdentity;
             LogVerbose($"Connected to {server} on {port} port using SSL: {effectiveOptions}");
             return new SmtpResult(true, EmailAction.Connect, SentTo, SentFrom, server, port, Stopwatch.Elapsed, "");
         } catch (Exception ex) {
@@ -806,6 +816,7 @@ public class Smtp {
             var originalTimeout = Timeout;
             var originalSecureOptions = _activeSecureSocketOptions;
             var originalUseSsl = _activeUseSsl;
+            var originalPoolIdentity = ConnectionPoolIdentity;
             var secureSocketOptions = _activeSecureSocketOptions;
             var useSsl = _activeUseSsl;
             if (record.ProviderData != null && record.ProviderData.Count > 0) {
@@ -829,6 +840,9 @@ public class Smtp {
                     && int.TryParse(timeoutValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var timeout)) {
                     Timeout = timeout;
                 }
+            }
+            if (!string.IsNullOrWhiteSpace(record.UserName)) {
+                ConnectionPoolIdentity = record.UserName;
             }
 
             try {
@@ -870,6 +884,7 @@ public class Smtp {
                 Timeout = originalTimeout;
                 _activeSecureSocketOptions = originalSecureOptions;
                 _activeUseSsl = originalUseSsl;
+                ConnectionPoolIdentity = originalPoolIdentity;
             }
         }
     }
@@ -909,8 +924,12 @@ public class Smtp {
     }
 
     private string GetConnectionPoolIdentity() {
-        var userName = Credential?.UserName;
-        var domain = Credential?.Domain;
+        var userName = ConnectionPoolIdentity;
+        var domain = string.Empty;
+        if (string.IsNullOrWhiteSpace(userName)) {
+            userName = Credential?.UserName;
+            domain = Credential?.Domain ?? string.Empty;
+        }
         if (!string.IsNullOrWhiteSpace(domain)) {
             userName = string.IsNullOrWhiteSpace(userName) ? domain : $"{domain}\\{userName}";
         }
@@ -1054,7 +1073,8 @@ public class Smtp {
     public void Disconnect() {
         if (Client.IsConnected) {
             if (SmtpConnectionPool.PoolingEnabled) {
-                SmtpConnectionPool.ReturnClient(Server, Port, Client, GetConnectionPoolIdentity());
+                var identity = _poolIdentity ?? GetConnectionPoolIdentity();
+                SmtpConnectionPool.ReturnClient(Server, Port, Client, identity);
                 Client = ClientFactory(Logging?.ProtocolLogger);
             } else {
                 Client.Disconnect(true);
@@ -1069,7 +1089,8 @@ public class Smtp {
     public void Dispose() {
         if (Client.IsConnected) {
             if (SmtpConnectionPool.PoolingEnabled) {
-                SmtpConnectionPool.ReturnClient(Server, Port, Client, GetConnectionPoolIdentity());
+                var identity = _poolIdentity ?? GetConnectionPoolIdentity();
+                SmtpConnectionPool.ReturnClient(Server, Port, Client, identity);
             } else {
                 Client.Disconnect(true);
             }

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -980,7 +980,8 @@ public class Smtp {
             return;
         }
 
-        await PendingMessageRepository.RemoveAsync(messageId, cancellationToken);
+        var safeMessageId = messageId!;
+        await PendingMessageRepository.RemoveAsync(safeMessageId, cancellationToken);
     }
 
     private async Task EnqueuePendingMessageAsync(string messageId, ICredentialProtector credentialProtector, CancellationToken cancellationToken) {

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -953,6 +953,60 @@ public class Smtp {
             : TimeSpan.Zero;
     }
 
+    private string EnsureMessageId() {
+        var id = Message.MessageId;
+        if (string.IsNullOrEmpty(id)) {
+            Message.MessageId = id = MimeKit.Utils.MimeUtils.GenerateMessageId();
+        }
+        return id;
+    }
+
+    private async Task SaveSentMessageAsync(string messageId, CancellationToken cancellationToken) {
+        if (SentMessageRepository == null) {
+            return;
+        }
+
+        var record = new SentMessageRecord {
+            MessageId = messageId,
+            Recipients = SentTo,
+            Subject = Subject,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+        await SentMessageRepository.SaveAsync(record, cancellationToken);
+    }
+
+    private async Task RemovePendingMessageAsync(string? messageId, CancellationToken cancellationToken) {
+        if (PendingMessageRepository == null || string.IsNullOrEmpty(messageId)) {
+            return;
+        }
+
+        await PendingMessageRepository.RemoveAsync(messageId, cancellationToken);
+    }
+
+    private async Task EnqueuePendingMessageAsync(string messageId, CredentialProtection credentialProtector, CancellationToken cancellationToken) {
+        if (PendingMessageRepository == null) {
+            return;
+        }
+
+        using var ms = new MemoryStream();
+        await Message.WriteToAsync(ms, cancellationToken);
+        var record = new PendingMessageRecord {
+            MessageId = messageId,
+            MimeMessage = Convert.ToBase64String(ms.ToArray()),
+            Timestamp = DateTimeOffset.UtcNow,
+            NextAttemptAt = DateTimeOffset.UtcNow,
+            Provider = EmailProvider.None,
+            Server = Server,
+            Port = Port,
+            UserName = Credential?.UserName,
+            Password = string.IsNullOrEmpty(Credential?.Password)
+                ? null
+                : credentialProtector.Protect(Credential!.Password),
+            ProviderData = CreateProviderDataSnapshot()
+        };
+        await PendingMessageRepository.SaveAsync(record, cancellationToken);
+    }
+
     private async Task<SmtpResult> SendCoreAsync(CancellationToken cancellationToken = default) {
         if (DryRun) {
             LogVerbose("Send-EmailMessage - DryRun enabled, skipping send.");
@@ -968,18 +1022,8 @@ public class Smtp {
             try {
                 await Client.SendAsync(Message, cancellationToken);
                 LogVerbose($"Send-EmailMessage - Sent email to {SentTo}");
-                if (SentMessageRepository != null) {
-                    var record = new SentMessageRecord {
-                        MessageId = Message.MessageId ?? string.Empty,
-                        Recipients = SentTo,
-                        Subject = Subject,
-                        Timestamp = DateTimeOffset.UtcNow
-                    };
-                    await SentMessageRepository.SaveAsync(record, cancellationToken);
-                }
-                if (PendingMessageRepository != null && !string.IsNullOrEmpty(Message.MessageId)) {
-                    await PendingMessageRepository.RemoveAsync(Message.MessageId!, cancellationToken);
-                }
+                await SaveSentMessageAsync(Message.MessageId ?? string.Empty, cancellationToken);
+                await RemovePendingMessageAsync(Message.MessageId, cancellationToken);
                 var result = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging) {
                     MessageId = Message.MessageId
                 };
@@ -992,29 +1036,8 @@ public class Smtp {
                     if (ErrorAction == ActionPreference.Stop) {
                         throw;
                     }
-                    var id = Message.MessageId;
-                    if (string.IsNullOrEmpty(id)) {
-                        Message.MessageId = id = MimeKit.Utils.MimeUtils.GenerateMessageId();
-                    }
-                    if (PendingMessageRepository != null) {
-                        using var ms = new MemoryStream();
-                        await Message.WriteToAsync(ms, cancellationToken);
-                        var record = new PendingMessageRecord {
-                            MessageId = id,
-                            MimeMessage = Convert.ToBase64String(ms.ToArray()),
-                            Timestamp = DateTimeOffset.UtcNow,
-                            NextAttemptAt = DateTimeOffset.UtcNow,
-                            Provider = EmailProvider.None,
-                            Server = Server,
-                            Port = Port,
-                            UserName = Credential?.UserName,
-                            Password = string.IsNullOrEmpty(Credential?.Password)
-                                ? null
-                                : credentialProtector.Protect(Credential!.Password),
-                            ProviderData = CreateProviderDataSnapshot()
-                        };
-                        await PendingMessageRepository.SaveAsync(record, cancellationToken);
-                    }
+                    var id = EnsureMessageId();
+                    await EnqueuePendingMessageAsync(id, credentialProtector, cancellationToken);
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message) {
                         MessageId = id
                     };
@@ -1022,43 +1045,16 @@ public class Smtp {
                     return failResult;
                 }
 
-                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-                if (MaxDelayMilliseconds > 0 && delayMilliseconds > MaxDelayMilliseconds) {
-                    delayMilliseconds = MaxDelayMilliseconds;
-                }
-                if (JitterMilliseconds > 0 && delayMilliseconds > 0) {
-                    delayMilliseconds += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
-                }
-                if (delayMilliseconds > 0) {
-                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken);
+                var delay = CalculateRetryDelay(attempts);
+                if (delay > TimeSpan.Zero) {
+                    await Task.Delay(delay, cancellationToken);
                 }
             }
             attempts++;
         } while (attempts <= RetryCount);
 
-        var finalId = Message.MessageId;
-        if (string.IsNullOrEmpty(finalId)) {
-            Message.MessageId = finalId = MimeKit.Utils.MimeUtils.GenerateMessageId();
-        }
-        if (PendingMessageRepository != null) {
-            using var ms = new MemoryStream();
-            await Message.WriteToAsync(ms, cancellationToken);
-            var record = new PendingMessageRecord {
-                MessageId = finalId,
-                MimeMessage = Convert.ToBase64String(ms.ToArray()),
-                Timestamp = DateTimeOffset.UtcNow,
-                NextAttemptAt = DateTimeOffset.UtcNow,
-                Provider = EmailProvider.None,
-                Server = Server,
-                Port = Port,
-                UserName = Credential?.UserName,
-                Password = string.IsNullOrEmpty(Credential?.Password)
-                    ? null
-                    : credentialProtector.Protect(Credential!.Password),
-                ProviderData = CreateProviderDataSnapshot()
-            };
-            await PendingMessageRepository.SaveAsync(record, cancellationToken);
-        }
+        var finalId = EnsureMessageId();
+        await EnqueuePendingMessageAsync(finalId, credentialProtector, cancellationToken);
         var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", lastException?.Message) {
             MessageId = finalId
         };

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -439,6 +439,7 @@ public class Smtp {
     public SmtpResult Connect(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false) {
         var oldServer = Server;
         var oldPort = Port;
+        var oldPoolIdentity = GetConnectionPoolIdentity();
         Server = server;
         Port = port;
         var effectiveOptions = secureSocketOptions;
@@ -458,7 +459,7 @@ public class Smtp {
         {
             if (SmtpConnectionPool.PoolingEnabled)
             {
-                SmtpConnectionPool.ReturnClient(oldServer, oldPort, Client);
+                SmtpConnectionPool.ReturnClient(oldServer, oldPort, Client, oldPoolIdentity);
             }
             else
             {
@@ -467,7 +468,7 @@ public class Smtp {
             Client = ClientFactory(Logging?.ProtocolLogger);
         }
 
-        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port) : null;
+        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port, GetConnectionPoolIdentity()) : null;
         if (pooled != null)
         {
             Client = pooled;
@@ -504,6 +505,7 @@ public class Smtp {
     public async Task<SmtpResult> ConnectAsync(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false) {
         var oldServer = Server;
         var oldPort = Port;
+        var oldPoolIdentity = GetConnectionPoolIdentity();
         Server = server;
         Port = port;
         var effectiveOptions = secureSocketOptions;
@@ -523,7 +525,7 @@ public class Smtp {
         {
             if (SmtpConnectionPool.PoolingEnabled)
             {
-                SmtpConnectionPool.ReturnClient(oldServer, oldPort, Client);
+                SmtpConnectionPool.ReturnClient(oldServer, oldPort, Client, oldPoolIdentity);
             }
             else
             {
@@ -532,7 +534,7 @@ public class Smtp {
             Client = ClientFactory(Logging?.ProtocolLogger);
         }
 
-        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port) : null;
+        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port, GetConnectionPoolIdentity()) : null;
         if (pooled != null)
         {
             Client = pooled;
@@ -799,11 +801,41 @@ public class Smtp {
                 continue;
             }
 
+            var originalSkipValidation = SkipCertificateValidation;
+            var originalCheckRevocation = CheckCertificateRevocation;
+            var originalTimeout = Timeout;
+            var originalSecureOptions = _activeSecureSocketOptions;
+            var originalUseSsl = _activeUseSsl;
+            var secureSocketOptions = _activeSecureSocketOptions;
+            var useSsl = _activeUseSsl;
+            if (record.ProviderData != null && record.ProviderData.Count > 0) {
+                if (record.ProviderData.TryGetValue(ProviderDataSecureSocketOptionsKey, out var secureValue)
+                    && Enum.TryParse(secureValue, out SecureSocketOptions parsedSecure)) {
+                    secureSocketOptions = parsedSecure;
+                }
+                if (record.ProviderData.TryGetValue(ProviderDataUseSslKey, out var useSslValue)
+                    && bool.TryParse(useSslValue, out var parsedUseSsl)) {
+                    useSsl = parsedUseSsl;
+                }
+                if (record.ProviderData.TryGetValue(ProviderDataSkipCertificateValidationKey, out var skipValue)
+                    && bool.TryParse(skipValue, out var parsedSkip)) {
+                    SkipCertificateValidation = parsedSkip;
+                }
+                if (record.ProviderData.TryGetValue(ProviderDataCheckCertificateRevocationKey, out var revocationValue)
+                    && bool.TryParse(revocationValue, out var parsedRevocation)) {
+                    CheckCertificateRevocation = parsedRevocation;
+                }
+                if (record.ProviderData.TryGetValue(ProviderDataTimeoutKey, out var timeoutValue)
+                    && int.TryParse(timeoutValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var timeout)) {
+                    Timeout = timeout;
+                }
+            }
+
             try {
                 var server = record.Server ?? Server;
                 var port = record.Port ?? Port;
                 if (!string.IsNullOrWhiteSpace(server)) {
-                    Connect(server, port);
+                    Connect(server, port, secureSocketOptions, useSsl);
                     if (!string.IsNullOrEmpty(record.UserName)) {
                         var pwd = CredentialProtection.UnprotectWithFallback(record.Password);
                         var cred = Helpers.ConvertFromPlainText(record.UserName!, pwd);
@@ -825,10 +857,19 @@ public class Smtp {
                 await PendingMessageRepository.RemoveAsync(record.MessageId!, cancellationToken);
             } catch (Exception ex) {
                 LogWarning($"ProcessPendingMessages - Error sending {record.MessageId}: {ex.Message}");
-                record.NextAttemptAt = DateTimeOffset.UtcNow;
+                var attempt = record.IncrementAttemptCount();
+                var delay = CalculateRetryDelay(attempt - 1);
+                record.NextAttemptAt = delay > TimeSpan.Zero
+                    ? DateTimeOffset.UtcNow.Add(delay)
+                    : DateTimeOffset.UtcNow;
                 await PendingMessageRepository.SaveAsync(record, cancellationToken);
             } finally {
                 Disconnect();
+                SkipCertificateValidation = originalSkipValidation;
+                CheckCertificateRevocation = originalCheckRevocation;
+                Timeout = originalTimeout;
+                _activeSecureSocketOptions = originalSecureOptions;
+                _activeUseSsl = originalUseSsl;
             }
         }
     }
@@ -865,6 +906,32 @@ public class Smtp {
         };
 
         return data;
+    }
+
+    private string GetConnectionPoolIdentity() {
+        var userName = Credential?.UserName;
+        var domain = Credential?.Domain;
+        if (!string.IsNullOrWhiteSpace(domain)) {
+            userName = string.IsNullOrWhiteSpace(userName) ? domain : $"{domain}\\{userName}";
+        }
+        if (string.IsNullOrWhiteSpace(userName)) {
+            userName = "anonymous";
+        }
+        return $"{userName}|{_activeSecureSocketOptions}|{_activeUseSsl}";
+    }
+
+    private TimeSpan CalculateRetryDelay(int attempt) {
+        if (attempt < 0) attempt = 0;
+        var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempt));
+        if (MaxDelayMilliseconds > 0 && delayMilliseconds > MaxDelayMilliseconds) {
+            delayMilliseconds = MaxDelayMilliseconds;
+        }
+        if (JitterMilliseconds > 0 && delayMilliseconds > 0) {
+            delayMilliseconds += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
+        }
+        return delayMilliseconds > 0
+            ? TimeSpan.FromMilliseconds(delayMilliseconds)
+            : TimeSpan.Zero;
     }
 
     private async Task<SmtpResult> SendCoreAsync(CancellationToken cancellationToken = default) {
@@ -987,7 +1054,7 @@ public class Smtp {
     public void Disconnect() {
         if (Client.IsConnected) {
             if (SmtpConnectionPool.PoolingEnabled) {
-                SmtpConnectionPool.ReturnClient(Server, Port, Client);
+                SmtpConnectionPool.ReturnClient(Server, Port, Client, GetConnectionPoolIdentity());
                 Client = ClientFactory(Logging?.ProtocolLogger);
             } else {
                 Client.Disconnect(true);
@@ -1002,7 +1069,7 @@ public class Smtp {
     public void Dispose() {
         if (Client.IsConnected) {
             if (SmtpConnectionPool.PoolingEnabled) {
-                SmtpConnectionPool.ReturnClient(Server, Port, Client);
+                SmtpConnectionPool.ReturnClient(Server, Port, Client, GetConnectionPoolIdentity());
             } else {
                 Client.Disconnect(true);
             }

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
@@ -78,7 +78,7 @@ public static class SmtpConnectionPool {
         PoolSizeChanged?.Invoke(size);
     }
 
-    private static string EncodeKeyPart(string value) {
+    private static string EncodeKeyPart(string? value) {
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(value ?? string.Empty));
     }
 

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
@@ -3,6 +3,7 @@ namespace Mailozaurr;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 
 /// <summary>
@@ -77,9 +78,17 @@ public static class SmtpConnectionPool {
         PoolSizeChanged?.Invoke(size);
     }
 
+    private static string EncodeKeyPart(string value) {
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(value ?? string.Empty));
+    }
+
     private static string BuildKey(string server, int port, string? identity) {
-        var baseKey = $"{server}:{port}";
-        return string.IsNullOrWhiteSpace(identity) ? baseKey : $"{baseKey}|{identity}";
+        var serverKey = EncodeKeyPart(server);
+        if (string.IsNullOrWhiteSpace(identity)) {
+            return $"{serverKey}:{port}";
+        }
+        var identityKey = EncodeKeyPart(identity);
+        return $"{serverKey}:{port}:{identityKey}";
     }
 
     internal static ClientSmtp? TryRentClient(string server, int port, string? identity = null) {
@@ -151,15 +160,16 @@ public static class SmtpConnectionPool {
         var entries = new List<SmtpConnectionPoolEntry>();
         foreach (var kv in _connectionPool) {
             var key = kv.Key;
-            var identitySeparator = key.IndexOf('|');
-            if (identitySeparator >= 0) {
-                key = key.Substring(0, identitySeparator);
-            }
-            var index = key.LastIndexOf(':');
-            var server = index >= 0 ? key.Substring(0, index) : key;
+            var parts = key.Split(':');
+            var server = parts.Length > 0 ? parts[0] : key;
             var port = 0;
-            if (index >= 0) {
-                int.TryParse(key.Substring(index + 1), out port);
+            if (parts.Length > 1) {
+                int.TryParse(parts[1], out port);
+            }
+            try {
+                server = Encoding.UTF8.GetString(Convert.FromBase64String(server));
+            } catch (FormatException) {
+                // Keep raw server key if decoding fails.
             }
             entries.Add(new SmtpConnectionPoolEntry(server, port, kv.Value.Count));
         }

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
@@ -77,12 +77,17 @@ public static class SmtpConnectionPool {
         PoolSizeChanged?.Invoke(size);
     }
 
-    internal static ClientSmtp? TryRentClient(string server, int port) {
+    private static string BuildKey(string server, int port, string? identity) {
+        var baseKey = $"{server}:{port}";
+        return string.IsNullOrWhiteSpace(identity) ? baseKey : $"{baseKey}|{identity}";
+    }
+
+    internal static ClientSmtp? TryRentClient(string server, int port, string? identity = null) {
         if (!PoolingEnabled) {
             return null;
         }
 
-        var key = $"{server}:{port}";
+        var key = BuildKey(server, port, identity);
         if (_connectionPool.TryGetValue(key, out var entry)) {
             while (entry.Bag.TryTake(out var pooled)) {
                 Interlocked.Decrement(ref entry.Count);
@@ -98,7 +103,7 @@ public static class SmtpConnectionPool {
         return null;
     }
 
-    internal static void ReturnClient(string server, int port, ClientSmtp client) {
+    internal static void ReturnClient(string server, int port, ClientSmtp client, string? identity = null) {
         if (!PoolingEnabled) {
             client.Dispose();
             return;
@@ -109,7 +114,7 @@ public static class SmtpConnectionPool {
             return;
         }
 
-        var key = $"{server}:{port}";
+        var key = BuildKey(server, port, identity);
         var entry = _connectionPool.GetOrAdd(key, _ => new PoolEntry());
         var current = Interlocked.Increment(ref entry.Count);
         if (current > MaxPoolSize) {
@@ -146,6 +151,10 @@ public static class SmtpConnectionPool {
         var entries = new List<SmtpConnectionPoolEntry>();
         foreach (var kv in _connectionPool) {
             var key = kv.Key;
+            var identitySeparator = key.IndexOf('|');
+            if (identitySeparator >= 0) {
+                key = key.Substring(0, identitySeparator);
+            }
             var index = key.LastIndexOf(':');
             var server = index >= 0 ? key.Substring(0, index) : key;
             var port = 0;


### PR DESCRIPTION
## Summary
- avoid loading large Graph attachments into memory; stream upload chunks with retries and proper error propagation
- reuse Graph client for upload session/chunks and surface non-success upload session errors
- add SMTP pending-message backoff and restore saved connection settings
- pool SMTP connections by identity + TLS options to prevent cross-credential reuse
- use total attachment size for Graph 150MB guard in cmdlet

## Testing
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --filter FullyQualifiedName~SmtpPendingMessageTests
