### PR TITLE
fix(smtp): auto-create message guard

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphStopwatchTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphStopwatchTests.cs
@@ -26,6 +26,8 @@ public class GraphStopwatchTests
     [Fact]
     public async Task ConnectO365GraphAsync_SuccessiveCallsHaveIndependentDurations()
     {
+        var interCallDelay = TimeSpan.FromSeconds(1);
+        var maxExpectedDuration = TimeSpan.FromMilliseconds(800);
         var responsePayload = "{\"access_token\":\"token\",\"token_type\":\"Bearer\"}";
         var handler = new RecordingHandler(
             CreateJsonResponse(responsePayload),
@@ -35,24 +37,26 @@ public class GraphStopwatchTests
         SetHttpClient(graph, handler);
         graph.Authenticate(new NetworkCredential("client@tenant", "secret"));
 
-        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        await Task.Delay(interCallDelay);
         var first = await graph.ConnectO365GraphAsync();
         Assert.True(first.Status);
         Assert.True(
-            first.TimeToExecute < TimeSpan.FromMilliseconds(250),
-            $"Expected first elapsed time to be reset but was {first.TimeToExecute.TotalMilliseconds}ms");
+            first.TimeToExecute < maxExpectedDuration,
+            $"Expected first elapsed time to be well below the idle delay of {interCallDelay.TotalMilliseconds}ms but was {first.TimeToExecute.TotalMilliseconds}ms");
 
-        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        await Task.Delay(interCallDelay);
         var second = await graph.ConnectO365GraphAsync();
         Assert.True(second.Status);
         Assert.True(
-            second.TimeToExecute < TimeSpan.FromMilliseconds(250),
-            $"Expected second elapsed time to be reset but was {second.TimeToExecute.TotalMilliseconds}ms");
+            second.TimeToExecute < maxExpectedDuration,
+            $"Expected second elapsed time to be well below the idle delay of {interCallDelay.TotalMilliseconds}ms but was {second.TimeToExecute.TotalMilliseconds}ms");
     }
 
     [Fact]
     public async Task SendMessageAsync_SuccessiveCallsHaveIndependentDurations()
     {
+        var interCallDelay = TimeSpan.FromSeconds(1);
+        var maxExpectedDuration = TimeSpan.FromMilliseconds(800);
         var handler = new RecordingHandler(
             CreateJsonResponse("{}"),
             CreateJsonResponse("{}"));
@@ -67,18 +71,18 @@ public class GraphStopwatchTests
         graph.AccessToken = "token";
         graph.TokenType = "Bearer";
 
-        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        await Task.Delay(interCallDelay);
         var first = await graph.SendMessageAsync();
         Assert.True(first.Status);
         Assert.True(
-            first.TimeToExecute < TimeSpan.FromMilliseconds(250),
-            $"Expected first elapsed time to be reset but was {first.TimeToExecute.TotalMilliseconds}ms");
+            first.TimeToExecute < maxExpectedDuration,
+            $"Expected first elapsed time to be well below the idle delay of {interCallDelay.TotalMilliseconds}ms but was {first.TimeToExecute.TotalMilliseconds}ms");
 
-        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        await Task.Delay(interCallDelay);
         var second = await graph.SendMessageAsync();
         Assert.True(second.Status);
         Assert.True(
-            second.TimeToExecute < TimeSpan.FromMilliseconds(250),
-            $"Expected second elapsed time to be reset but was {second.TimeToExecute.TotalMilliseconds}ms");
+            second.TimeToExecute < maxExpectedDuration,
+            $"Expected second elapsed time to be well below the idle delay of {interCallDelay.TotalMilliseconds}ms but was {second.TimeToExecute.TotalMilliseconds}ms");
     }
 }

--- a/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
+++ b/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.IO;
+using System.Management.Automation;
 using MimeKit;
 
 namespace Mailozaurr.Tests {
@@ -98,6 +99,25 @@ namespace Mailozaurr.Tests {
 
             Assert.False(result.Status);
             Assert.Contains("CreateMessage", result.Error);
+            Assert.False(fake.SendCalled);
+        }
+
+        [Fact]
+        public void SendEmail_Smtp_WithErrorActionStopAndMissingSender_Throws() {
+            var smtp = new Smtp {
+                AutoCreateMessage = true,
+                ErrorAction = ActionPreference.Stop
+            };
+            var fake = new FakeSmtpClient();
+            var field = typeof(Smtp).GetField("<Client>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            field.SetValue(smtp, fake);
+
+            smtp.To = new[] { "recipient@example.com" };
+            smtp.Subject = "Missing sender";
+            smtp.HtmlBody = "<b>Hello</b>";
+
+            var ex = Assert.Throws<InvalidOperationException>(() => smtp.Send());
+            Assert.Contains("no sender", ex.Message, System.StringComparison.OrdinalIgnoreCase);
             Assert.False(fake.SendCalled);
         }
 

--- a/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
+++ b/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
@@ -63,6 +63,26 @@ namespace Mailozaurr.Tests {
         }
 
         [Fact]
+        public void SendEmail_Smtp_WithAutoCreateMessage_PreservesCustomHeaders() {
+            var smtp = new Smtp { AutoCreateMessage = true };
+            var fake = new FakeSmtpClient();
+            var field = typeof(Smtp).GetField("<Client>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            field.SetValue(smtp, fake);
+
+            smtp.Message.Headers.Add("X-Test", "1");
+            smtp.From = "sender@example.com";
+            smtp.To = new[] { "recipient@example.com" };
+            smtp.Subject = "Test Email (SMTP)";
+            smtp.HtmlBody = "<b>Hello from Mailozaurr SMTP!</b>";
+
+            var result = smtp.Send();
+
+            Assert.True(result.Status, $"SMTP send failed: {result.Error}");
+            Assert.NotNull(fake.LastMessage);
+            Assert.Equal("1", fake.LastMessage!.Headers["X-Test"]);
+        }
+
+        [Fact]
         public void SendEmail_Smtp_WithoutCreateMessage_ReturnsHelpfulError() {
             var smtp = new Smtp();
             var fake = new FakeSmtpClient();

--- a/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
+++ b/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
@@ -13,10 +13,12 @@ namespace Mailozaurr.Tests {
         private class FakeSmtpClient : ClientSmtp
         {
             public bool SendCalled;
+            public MimeMessage? LastMessage;
 
             public override Task<string> SendAsync(MimeMessage message, System.Threading.CancellationToken cancellationToken = default, MailKit.ITransferProgress? progress = null)
             {
                 SendCalled = true;
+                LastMessage = message;
                 return Task.FromResult(string.Empty);
             }
         }
@@ -38,6 +40,45 @@ namespace Mailozaurr.Tests {
 
             Assert.True(result.Status, $"SMTP send failed: {result.Error}");
             Assert.True(fake.SendCalled);
+        }
+
+        [Fact]
+        public void SendEmail_Smtp_WithAutoCreateMessage_BuildsMessage() {
+            var smtp = new Smtp { AutoCreateMessage = true };
+            var fake = new FakeSmtpClient();
+            var field = typeof(Smtp).GetField("<Client>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            field.SetValue(smtp, fake);
+
+            smtp.From = "sender@example.com";
+            smtp.To = new[] { "recipient@example.com" };
+            smtp.Subject = "Test Email (SMTP)";
+            smtp.HtmlBody = "<b>Hello from Mailozaurr SMTP!</b>";
+
+            var result = smtp.Send();
+
+            Assert.True(result.Status, $"SMTP send failed: {result.Error}");
+            Assert.True(fake.SendCalled);
+            Assert.NotNull(fake.LastMessage);
+            Assert.NotEmpty(fake.LastMessage!.From);
+        }
+
+        [Fact]
+        public void SendEmail_Smtp_WithoutCreateMessage_ReturnsHelpfulError() {
+            var smtp = new Smtp();
+            var fake = new FakeSmtpClient();
+            var field = typeof(Smtp).GetField("<Client>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            field.SetValue(smtp, fake);
+
+            smtp.From = "sender@example.com";
+            smtp.To = new[] { "recipient@example.com" };
+            smtp.Subject = "Test Email (SMTP)";
+            smtp.HtmlBody = "<b>Hello from Mailozaurr SMTP!</b>";
+
+            var result = smtp.Send();
+
+            Assert.False(result.Status);
+            Assert.Contains("CreateMessage", result.Error);
+            Assert.False(fake.SendCalled);
         }
 
         [Fact]

--- a/Sources/Mailozaurr.Tests/SmtpValidationTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpValidationTests.cs
@@ -1,0 +1,48 @@
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpValidationTests {
+    [Fact]
+    public void TryValidateServer_WithMissingServer_Fails() {
+        var ok = SmtpValidation.TryValidateServer(null, 25, out var error);
+        Assert.False(ok);
+        Assert.Contains("server", error);
+    }
+
+    [Fact]
+    public void TryValidateServer_WithInvalidPort_Fails() {
+        var ok = SmtpValidation.TryValidateServer("smtp.example.com", 0, out var error);
+        Assert.False(ok);
+        Assert.Contains("port", error);
+    }
+
+    [Fact]
+    public void TryValidateServer_WithValidInputs_Succeeds() {
+        var ok = SmtpValidation.TryValidateServer("smtp.example.com", 25, out var error);
+        Assert.True(ok);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryValidateCredentials_WithMissingUsername_Fails() {
+        var ok = SmtpValidation.TryValidateCredentials(null, "secret", out var error);
+        Assert.False(ok);
+        Assert.Contains("username", error);
+    }
+
+    [Fact]
+    public void TryValidateCredentials_WithMissingPassword_Fails() {
+        var ok = SmtpValidation.TryValidateCredentials("user", null, out var error);
+        Assert.False(ok);
+        Assert.Contains("password", error);
+    }
+
+    [Fact]
+    public void TryValidateCredentials_WithValidInputs_Succeeds() {
+        var ok = SmtpValidation.TryValidateCredentials("user", "secret", out var error);
+        Assert.True(ok);
+        Assert.Null(error);
+    }
+}
+

--- a/Sources/Mailozaurr/README.md
+++ b/Sources/Mailozaurr/README.md
@@ -47,6 +47,9 @@ smtp.SecureSocketOptions = SecureSocketOptions.StartTls;
 // Optional: authentication
 smtp.Authenticate("username", "password");
 
+// Build the MIME message
+smtp.CreateMessage();
+
 // Send the email
 var result = smtp.Send();
 if (result.Status)
@@ -58,6 +61,10 @@ else
 Console.WriteLine($"Failed: {result.ErrorMessage}");
 }
 ```
+
+> **Tip**
+> You can set `smtp.AutoCreateMessage = true` to build the MIME message
+> automatically before sending if you forget to call `CreateMessage()`.
 
 > **Note**
 > When `Connect` is called with the `useSsl` flag and

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -197,6 +197,12 @@ public class Smtp {
     public bool AutoEmbedImages { get; set; } = false;
 
     /// <summary>
+    /// When set to <see langword="true"/>, automatically builds the MIME message
+    /// from the configured properties before sending when the message is empty.
+    /// </summary>
+    public bool AutoCreateMessage { get; set; } = false;
+
+    /// <summary>
     /// When set to <see langword="true"/>, downloads remote images referenced in
     /// <see cref="HtmlBody"/> and embeds them as inline attachments.
     /// </summary>
@@ -1008,6 +1014,158 @@ public class Smtp {
         await PendingMessageRepository.SaveAsync(record, cancellationToken);
     }
 
+    private async Task<SmtpResult?> EnsureMessageReadyAsync(CancellationToken cancellationToken)
+    {
+        var message = Message;
+        bool messageHasContent = message != null && MessageHasContent(message);
+        bool hasPayload = HasPropertyPayload();
+
+        if (AutoCreateMessage && !messageHasContent && hasPayload)
+        {
+            await CreateMessageAsync(cancellationToken).ConfigureAwait(false);
+            message = Message;
+            messageHasContent = message != null && MessageHasContent(message);
+        }
+
+        bool hasSender = message != null && MessageHasSender(message);
+        if (!hasSender && (hasPayload || messageHasContent))
+        {
+            string messageText = "SMTP message has no sender. Call CreateMessage/CreateMessageAsync after setting From/To/Subject, or enable AutoCreateMessage.";
+            LogWarning($"Send-EmailMessage - {messageText}");
+            if (ErrorAction == ActionPreference.Stop)
+            {
+                throw new InvalidOperationException(messageText);
+            }
+
+            var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText)
+            {
+                MessageId = Message?.MessageId
+            };
+            await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
+            return failResult;
+        }
+
+        return null;
+    }
+
+    private bool HasPropertyPayload()
+    {
+        if (HasAddressValue(From) || HasAddressValue(ReplyTo))
+        {
+            return true;
+        }
+
+        if (HasRecipientValues(To) || HasRecipientValues(Cc) || HasRecipientValues(Bcc))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(Subject) ||
+            !string.IsNullOrWhiteSpace(HtmlBody) ||
+            !string.IsNullOrWhiteSpace(TextBody))
+        {
+            return true;
+        }
+
+        if (Attachments != null && Attachments.Count > 0)
+        {
+            return true;
+        }
+
+        if (InlineAttachments != null && InlineAttachments.Count > 0)
+        {
+            return true;
+        }
+
+        if (Headers != null && Headers.Count > 0)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool MessageHasSender(MimeMessage message)
+    {
+        if (message == null)
+        {
+            return false;
+        }
+
+        if (message.From.Count > 0)
+        {
+            return true;
+        }
+
+        return message.Sender != null;
+    }
+
+    private static bool MessageHasContent(MimeMessage message)
+    {
+        if (message == null)
+        {
+            return false;
+        }
+
+        if (message.From.Count > 0 || message.To.Count > 0 || message.Cc.Count > 0 || message.Bcc.Count > 0 ||
+            message.ReplyTo.Count > 0 || message.Sender != null)
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(message.Subject))
+        {
+            return true;
+        }
+
+        return message.Body != null;
+    }
+
+    private static bool HasAddressValue(object? value)
+    {
+        if (value == null)
+        {
+            return false;
+        }
+
+        if (value is string text)
+        {
+            return !string.IsNullOrWhiteSpace(text);
+        }
+
+        return true;
+    }
+
+    private static bool HasRecipientValues(IEnumerable<object>? recipients)
+    {
+        if (recipients == null)
+        {
+            return false;
+        }
+
+        foreach (var recipient in recipients)
+        {
+            if (recipient == null)
+            {
+                continue;
+            }
+
+            if (recipient is string text)
+            {
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
     private async Task<SmtpResult> SendCoreAsync(CancellationToken cancellationToken = default) {
         if (DryRun) {
             LogVerbose("Send-EmailMessage - DryRun enabled, skipping send.");
@@ -1018,6 +1176,11 @@ public class Smtp {
         int attempts = 0;
         Exception? lastException = null;
         var credentialProtector = CredentialProtection.Default;
+        var readinessResult = await EnsureMessageReadyAsync(cancellationToken).ConfigureAwait(false);
+        if (readinessResult != null)
+        {
+            return readinessResult;
+        }
 
         do {
             try {

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -1019,16 +1019,18 @@ public class Smtp {
         var message = Message;
         bool messageHasContent = message != null && MessageHasContent(message);
         bool hasPayload = HasPropertyPayload();
+        bool hasHeaderPayload = message != null && message.Headers != null && message.Headers.Count > 0;
 
         if (AutoCreateMessage && !messageHasContent && hasPayload)
         {
+            PreserveCustomHeaders(message);
             await CreateMessageAsync(cancellationToken).ConfigureAwait(false);
             message = Message;
             messageHasContent = message != null && MessageHasContent(message);
         }
 
         bool hasSender = message != null && MessageHasSender(message);
-        if (!hasSender && (hasPayload || messageHasContent))
+        if (!hasSender && (hasPayload || messageHasContent || hasHeaderPayload))
         {
             string messageText = "SMTP message has no sender. Call CreateMessage/CreateMessageAsync after setting From/To/Subject, or enable AutoCreateMessage.";
             LogWarning($"Send-EmailMessage - {messageText}");
@@ -1119,6 +1121,39 @@ public class Smtp {
         }
 
         return message.Body != null;
+    }
+
+    private void PreserveCustomHeaders(MimeMessage? message)
+    {
+        if (message == null || message.Headers == null || message.Headers.Count == 0)
+        {
+            return;
+        }
+
+        Dictionary<string, string>? merged = null;
+        foreach (var header in message.Headers)
+        {
+            if (header.Id != MimeKit.HeaderId.Unknown)
+            {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(header.Field))
+            {
+                continue;
+            }
+
+            merged ??= Headers as Dictionary<string, string> ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (!merged.ContainsKey(header.Field))
+            {
+                merged[header.Field] = header.Value ?? string.Empty;
+            }
+        }
+
+        if (merged != null && !ReferenceEquals(merged, Headers))
+        {
+            Headers = merged;
+        }
     }
 
     private static bool HasAddressValue(object? value)

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -454,6 +454,15 @@ public class Smtp {
         var oldPoolIdentity = _poolIdentity ?? GetConnectionPoolIdentity();
         Server = server;
         Port = port;
+        if (!SmtpValidation.TryValidateServer(server, port, out var validationError))
+        {
+            string message = validationError ?? "Invalid SMTP server settings.";
+            LogWarning($"Send-EmailMessage - {message}");
+            if (ErrorAction == ActionPreference.Stop) {
+                throw new InvalidOperationException(message);
+            }
+            return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, server ?? string.Empty, port, Stopwatch.Elapsed, "", message);
+        }
         var effectiveOptions = secureSocketOptions;
         if (useSsl && effectiveOptions == SecureSocketOptions.Auto) {
             // Maintain backwards compatibility with Send-MailMessage by
@@ -522,6 +531,15 @@ public class Smtp {
         var oldPoolIdentity = _poolIdentity ?? GetConnectionPoolIdentity();
         Server = server;
         Port = port;
+        if (!SmtpValidation.TryValidateServer(server, port, out var validationError))
+        {
+            string message = validationError ?? "Invalid SMTP server settings.";
+            LogWarning($"Send-EmailMessage - {message}");
+            if (ErrorAction == ActionPreference.Stop) {
+                throw new InvalidOperationException(message);
+            }
+            return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, server ?? string.Empty, port, Stopwatch.Elapsed, "", message);
+        }
         var effectiveOptions = secureSocketOptions;
         if (useSsl && effectiveOptions == SecureSocketOptions.Auto) {
             // Maintain backwards compatibility with Send-MailMessage by
@@ -583,12 +601,24 @@ public class Smtp {
             LogVerbose("Send-EmailMessage - DryRun enabled, skipping authentication.");
             return new SmtpResult(true, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "Authentication skipped (WhatIf)");
         }
+        if (Credentials is NetworkCredential networkCredential)
+        {
+            if (!SmtpValidation.TryValidateCredentials(networkCredential.UserName, networkCredential.Password, out var validationError))
+            {
+                string message = validationError ?? "Invalid SMTP credentials.";
+                LogWarning($"Send-EmailMessage - {message}");
+                if (ErrorAction == ActionPreference.Stop) {
+                    throw new InvalidOperationException(message);
+                }
+                return new SmtpResult(false, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", message);
+            }
+        }
         try {
             if (isOAuth) {
-                var networkCredential = Credentials as NetworkCredential;
-                if (networkCredential != null) {
-                    Credential = networkCredential;
-                    var (userName, token) = Helpers.ConvertFromOAuth2Credential(networkCredential);
+                var oauthCredential = Credentials as NetworkCredential;
+                if (oauthCredential != null) {
+                    Credential = oauthCredential;
+                    var (userName, token) = Helpers.ConvertFromOAuth2Credential(oauthCredential);
                     var oauth2 = new SaslMechanismOAuth2(userName, token);
                     Client.Authenticate(oauth2);
                 }
@@ -713,6 +743,15 @@ public class Smtp {
         password = ConvertSecureStringToPlainString(password, isSecureString);
         Credential = new NetworkCredential(username, password);
         try {
+            if (!SmtpValidation.TryValidateCredentials(username, password, out var validationError))
+            {
+                string message = validationError ?? "Invalid SMTP credentials.";
+                LogWarning($"Send-EmailMessage - {message}");
+                if (ErrorAction == ActionPreference.Stop) {
+                    throw new InvalidOperationException(message);
+                }
+                return new SmtpResult(false, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", message);
+            }
             switch (mechanism) {
                 case AuthenticationMechanism.CramMd5:
                     Client.Authenticate(new SaslMechanismCramMd5(username, password));

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -1019,9 +1019,11 @@ public class Smtp {
         var message = Message;
         bool messageHasContent = message != null && MessageHasContent(message);
         bool hasPayload = HasPropertyPayload();
-        bool hasHeaderPayload = message != null && message.Headers != null && message.Headers.Count > 0;
+        bool hasHeaderPayload = (message != null && message.Headers != null && message.Headers.Count > 0) ||
+                                (Headers != null && Headers.Count > 0);
 
-        if (AutoCreateMessage && !messageHasContent && hasPayload)
+        bool shouldAutoCreate = AutoCreateMessage && !messageHasContent && hasPayload;
+        if (shouldAutoCreate)
         {
             PreserveCustomHeaders(message);
             await CreateMessageAsync(cancellationToken).ConfigureAwait(false);
@@ -1030,7 +1032,8 @@ public class Smtp {
         }
 
         bool hasSender = message != null && MessageHasSender(message);
-        if (!hasSender && (hasPayload || messageHasContent || hasHeaderPayload))
+        bool hasMaterial = hasPayload || messageHasContent || hasHeaderPayload;
+        if (!hasSender && hasMaterial)
         {
             string messageText = "SMTP message has no sender. Call CreateMessage/CreateMessageAsync after setting From/To/Subject, or enable AutoCreateMessage.";
             LogWarning($"Send-EmailMessage - {messageText}");
@@ -1131,6 +1134,15 @@ public class Smtp {
         }
 
         Dictionary<string, string>? merged = null;
+        if (Headers is Dictionary<string, string> headerDict)
+        {
+            merged = headerDict;
+        }
+        else if (Headers != null && Headers.Count > 0)
+        {
+            merged = new Dictionary<string, string>(Headers, StringComparer.OrdinalIgnoreCase);
+        }
+
         foreach (var header in message.Headers)
         {
             if (header.Id != MimeKit.HeaderId.Unknown)
@@ -1143,7 +1155,7 @@ public class Smtp {
                 continue;
             }
 
-            merged ??= Headers as Dictionary<string, string> ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            merged ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             if (!merged.ContainsKey(header.Field))
             {
                 merged[header.Field] = header.Value ?? string.Empty;

--- a/Sources/Mailozaurr/Smtp/SmtpValidation.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpValidation.cs
@@ -1,0 +1,49 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Helper methods for validating SMTP connection and authentication settings.
+/// </summary>
+public static class SmtpValidation
+{
+    /// <summary>
+    /// Validates the SMTP server and port values.
+    /// </summary>
+    public static bool TryValidateServer(string? server, int port, out string? error)
+    {
+        if (string.IsNullOrWhiteSpace(server))
+        {
+            error = "SMTP server is required.";
+            return false;
+        }
+
+        if (port <= 0)
+        {
+            error = "SMTP port must be greater than 0.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Validates credentials intended for SMTP authentication.
+    /// </summary>
+    public static bool TryValidateCredentials(string? username, string? password, out string? error)
+    {
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            error = "SMTP username is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            error = "SMTP password is required.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add AutoCreateMessage option to build MIME message before send when message is empty
- guard Send/SendAsync with a clear error when sender is missing
- preserve custom Message headers during auto-create
- update guard readability and ensure header payload is respected
- add SMTP tests and update README example

## Testing
- dotnet.exe test C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.sln -c Debug
