### PR TITLE
Add typed IMAP connection request API

### DIFF
--- a/Sources/Mailozaurr.Tests/ConnectorTests.cs
+++ b/Sources/Mailozaurr.Tests/ConnectorTests.cs
@@ -16,6 +16,9 @@ public class ConnectorTests
     {
         public int FailuresBeforeSuccess { get; set; }
         public int ConnectCalls { get; private set; }
+        public string? LastHost { get; private set; }
+        public int LastPort { get; private set; }
+        public SecureSocketOptions LastSecureSocketOptions { get; private set; }
         public new bool Authenticated { get; set; }
         public override bool IsAuthenticated => Authenticated;
         private bool _connected;
@@ -26,6 +29,9 @@ public class ConnectorTests
         public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
         {
             ConnectCalls++;
+            LastHost = host;
+            LastPort = port;
+            LastSecureSocketOptions = options;
             if (ConnectCalls <= FailuresBeforeSuccess)
             {
                 throw new HttpRequestException("fail");
@@ -123,6 +129,49 @@ public class ConnectorTests
         ImapConnector.DelayAsync = null;
         Assert.Equal(3, fake.ConnectCalls);
         Assert.Equal(new[] { 10, 20 }, delays);
+    }
+
+    [Fact]
+    public async Task ImapConnector_RequestOverload_UsesRequestSettings()
+    {
+        var fake = new FakeImapClient();
+        ImapConnector.ClientFactory = () => fake;
+        var request = new ImapConnectionRequest(
+            "imap.example.test",
+            1993,
+            SecureSocketOptions.SslOnConnect,
+            timeout: 4321,
+            skipCertificateRevocation: true,
+            skipCertificateValidation: true,
+            retryCount: 0,
+            retryDelayMilliseconds: 10,
+            retryDelayBackoff: 2.0);
+
+        var client = await ImapConnector.ConnectAsync(
+            request,
+            (c, ct) => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; });
+
+        ImapConnector.ClientFactory = () => new ImapClient();
+
+        Assert.Same(fake, client);
+        Assert.Equal("imap.example.test", fake.LastHost);
+        Assert.Equal(1993, fake.LastPort);
+        Assert.Equal(SecureSocketOptions.SslOnConnect, fake.LastSecureSocketOptions);
+        Assert.Equal(4321, fake.Timeout);
+    }
+
+    [Fact]
+    public async Task ImapConnector_RequestOverload_ValidatesArguments()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            ImapConnector.ConnectAsync(
+                null!,
+                (_, _) => Task.CompletedTask));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            ImapConnector.ConnectAsync(
+                new ImapConnectionRequest("imap.example.test", 993),
+                null!));
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/ImapConnectionRequestTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapConnectionRequestTests.cs
@@ -1,0 +1,41 @@
+using MailKit.Security;
+using System;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ImapConnectionRequestTests {
+    [Fact]
+    public void Constructor_SetsValues() {
+        var request = new ImapConnectionRequest(
+            "imap.example.test",
+            993,
+            SecureSocketOptions.StartTls,
+            timeout: 1234,
+            skipCertificateRevocation: true,
+            skipCertificateValidation: true,
+            retryCount: 7,
+            retryDelayMilliseconds: 150,
+            retryDelayBackoff: 1.5);
+
+        Assert.Equal("imap.example.test", request.Server);
+        Assert.Equal(993, request.Port);
+        Assert.Equal(SecureSocketOptions.StartTls, request.Options);
+        Assert.Equal(1234, request.Timeout);
+        Assert.True(request.SkipCertificateRevocation);
+        Assert.True(request.SkipCertificateValidation);
+        Assert.Equal(7, request.RetryCount);
+        Assert.Equal(150, request.RetryDelayMilliseconds);
+        Assert.Equal(1.5, request.RetryDelayBackoff);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsForInvalidInput() {
+        Assert.Throws<ArgumentException>(() => new ImapConnectionRequest("", 993));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, timeout: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, retryCount: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, retryDelayMilliseconds: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, retryDelayBackoff: 0));
+    }
+}

--- a/Sources/Mailozaurr/Connections/ImapConnectionRequest.cs
+++ b/Sources/Mailozaurr/Connections/ImapConnectionRequest.cs
@@ -1,0 +1,108 @@
+using MailKit.Security;
+using System;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents connection settings used by <see cref="ImapConnector"/>.
+/// </summary>
+public sealed class ImapConnectionRequest {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImapConnectionRequest"/> class.
+    /// </summary>
+    /// <param name="server">IMAP server hostname.</param>
+    /// <param name="port">IMAP server port.</param>
+    /// <param name="options">Secure socket options.</param>
+    /// <param name="timeout">Connection timeout in milliseconds.</param>
+    /// <param name="skipCertificateRevocation">Whether to skip certificate revocation checks.</param>
+    /// <param name="skipCertificateValidation">Whether to skip certificate validation checks.</param>
+    /// <param name="retryCount">Retry count for transient failures.</param>
+    /// <param name="retryDelayMilliseconds">Initial retry delay in milliseconds.</param>
+    /// <param name="retryDelayBackoff">Retry delay backoff multiplier.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="server"/> is empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a numeric argument is outside supported range.</exception>
+    public ImapConnectionRequest(
+        string server,
+        int port,
+        SecureSocketOptions options = SecureSocketOptions.Auto,
+        int timeout = 30000,
+        bool skipCertificateRevocation = false,
+        bool skipCertificateValidation = false,
+        int retryCount = 3,
+        int retryDelayMilliseconds = 500,
+        double retryDelayBackoff = 2.0) {
+        if (string.IsNullOrWhiteSpace(server)) {
+            throw new ArgumentException("Server cannot be null or whitespace.", nameof(server));
+        }
+        if (port <= 0 || port > 65535) {
+            throw new ArgumentOutOfRangeException(nameof(port), "Port must be between 1 and 65535.");
+        }
+        if (timeout < 0) {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be >= 0.");
+        }
+        if (retryCount < 0) {
+            throw new ArgumentOutOfRangeException(nameof(retryCount), "Retry count must be >= 0.");
+        }
+        if (retryDelayMilliseconds < 0) {
+            throw new ArgumentOutOfRangeException(nameof(retryDelayMilliseconds), "Retry delay must be >= 0.");
+        }
+        if (retryDelayBackoff <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(retryDelayBackoff), "Retry backoff must be > 0.");
+        }
+
+        Server = server;
+        Port = port;
+        Options = options;
+        Timeout = timeout;
+        SkipCertificateRevocation = skipCertificateRevocation;
+        SkipCertificateValidation = skipCertificateValidation;
+        RetryCount = retryCount;
+        RetryDelayMilliseconds = retryDelayMilliseconds;
+        RetryDelayBackoff = retryDelayBackoff;
+    }
+
+    /// <summary>
+    /// Gets the IMAP server hostname.
+    /// </summary>
+    public string Server { get; }
+
+    /// <summary>
+    /// Gets the IMAP server port.
+    /// </summary>
+    public int Port { get; }
+
+    /// <summary>
+    /// Gets secure socket options.
+    /// </summary>
+    public SecureSocketOptions Options { get; }
+
+    /// <summary>
+    /// Gets connection timeout in milliseconds.
+    /// </summary>
+    public int Timeout { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether certificate revocation checks are skipped.
+    /// </summary>
+    public bool SkipCertificateRevocation { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether certificate validation checks are skipped.
+    /// </summary>
+    public bool SkipCertificateValidation { get; }
+
+    /// <summary>
+    /// Gets retry count for transient failures.
+    /// </summary>
+    public int RetryCount { get; }
+
+    /// <summary>
+    /// Gets initial retry delay in milliseconds.
+    /// </summary>
+    public int RetryDelayMilliseconds { get; }
+
+    /// <summary>
+    /// Gets retry delay backoff multiplier.
+    /// </summary>
+    public double RetryDelayBackoff { get; }
+}

--- a/Sources/Mailozaurr/Connections/ImapConnector.cs
+++ b/Sources/Mailozaurr/Connections/ImapConnector.cs
@@ -23,6 +23,38 @@ public static class ImapConnector {
     /// <summary>
     /// Connects and authenticates to an IMAP server with retry support.
     /// </summary>
+    /// <param name="request">Connection request settings.</param>
+    /// <param name="authenticateAsync">Delegate performing authentication.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>Authenticated <see cref="ImapClient"/> instance.</returns>
+    public static Task<ImapClient> ConnectAsync(
+        ImapConnectionRequest request,
+        Func<ImapClient, CancellationToken, Task> authenticateAsync,
+        CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+        if (authenticateAsync is null) {
+            throw new ArgumentNullException(nameof(authenticateAsync));
+        }
+
+        return ConnectAsync(
+            request.Server,
+            request.Port,
+            request.Options,
+            request.Timeout,
+            request.SkipCertificateRevocation,
+            request.SkipCertificateValidation,
+            authenticateAsync,
+            request.RetryCount,
+            request.RetryDelayMilliseconds,
+            request.RetryDelayBackoff,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Connects and authenticates to an IMAP server with retry support.
+    /// </summary>
     /// <param name="server">Server hostname.</param>
     /// <param name="port">Server port.</param>
     /// <param name="options">Secure socket options.</param>


### PR DESCRIPTION
## Summary
- add new `ImapConnectionRequest` model for reusable IMAP connect settings
- add `ImapConnector.ConnectAsync(ImapConnectionRequest, ...)` overload
- extend connector tests for request overload and argument validation
- add request model validation tests

## Validation
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --filter "FullyQualifiedName~ConnectorTests|FullyQualifiedName~ImapConnectionRequestTests"`

## Notes
- this is PR-A foundation for BayManager M6.1 upstreamization (connection abstraction)
