### PR TITLE
smtp: add send pipeline threading and duplicate-probe primitives

### DIFF
--- a/Sources/Mailozaurr.Tests/ConnectorTests.cs
+++ b/Sources/Mailozaurr.Tests/ConnectorTests.cs
@@ -16,6 +16,9 @@ public class ConnectorTests
     {
         public int FailuresBeforeSuccess { get; set; }
         public int ConnectCalls { get; private set; }
+        public string? LastHost { get; private set; }
+        public int LastPort { get; private set; }
+        public SecureSocketOptions LastSecureSocketOptions { get; private set; }
         public new bool Authenticated { get; set; }
         public override bool IsAuthenticated => Authenticated;
         private bool _connected;
@@ -26,6 +29,9 @@ public class ConnectorTests
         public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
         {
             ConnectCalls++;
+            LastHost = host;
+            LastPort = port;
+            LastSecureSocketOptions = options;
             if (ConnectCalls <= FailuresBeforeSuccess)
             {
                 throw new HttpRequestException("fail");
@@ -123,6 +129,49 @@ public class ConnectorTests
         ImapConnector.DelayAsync = null;
         Assert.Equal(3, fake.ConnectCalls);
         Assert.Equal(new[] { 10, 20 }, delays);
+    }
+
+    [Fact]
+    public async Task ImapConnector_RequestOverload_UsesRequestSettings()
+    {
+        var fake = new FakeImapClient();
+        ImapConnector.ClientFactory = () => fake;
+        var request = new ImapConnectionRequest(
+            "imap.example.test",
+            1993,
+            SecureSocketOptions.SslOnConnect,
+            timeout: 4321,
+            skipCertificateRevocation: true,
+            skipCertificateValidation: true,
+            retryCount: 0,
+            retryDelayMilliseconds: 10,
+            retryDelayBackoff: 2.0);
+
+        var client = await ImapConnector.ConnectAsync(
+            request,
+            (c, ct) => { ((FakeImapClient)c).Authenticated = true; return Task.CompletedTask; });
+
+        ImapConnector.ClientFactory = () => new ImapClient();
+
+        Assert.Same(fake, client);
+        Assert.Equal("imap.example.test", fake.LastHost);
+        Assert.Equal(1993, fake.LastPort);
+        Assert.Equal(SecureSocketOptions.SslOnConnect, fake.LastSecureSocketOptions);
+        Assert.Equal(4321, fake.Timeout);
+    }
+
+    [Fact]
+    public async Task ImapConnector_RequestOverload_ValidatesArguments()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            ImapConnector.ConnectAsync(
+                null!,
+                (_, _) => Task.CompletedTask));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            ImapConnector.ConnectAsync(
+                new ImapConnectionRequest("imap.example.test", 993),
+                null!));
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/ImapConnectionRequestTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapConnectionRequestTests.cs
@@ -1,0 +1,41 @@
+using MailKit.Security;
+using System;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ImapConnectionRequestTests {
+    [Fact]
+    public void Constructor_SetsValues() {
+        var request = new ImapConnectionRequest(
+            "imap.example.test",
+            993,
+            SecureSocketOptions.StartTls,
+            timeout: 1234,
+            skipCertificateRevocation: true,
+            skipCertificateValidation: true,
+            retryCount: 7,
+            retryDelayMilliseconds: 150,
+            retryDelayBackoff: 1.5);
+
+        Assert.Equal("imap.example.test", request.Server);
+        Assert.Equal(993, request.Port);
+        Assert.Equal(SecureSocketOptions.StartTls, request.Options);
+        Assert.Equal(1234, request.Timeout);
+        Assert.True(request.SkipCertificateRevocation);
+        Assert.True(request.SkipCertificateValidation);
+        Assert.Equal(7, request.RetryCount);
+        Assert.Equal(150, request.RetryDelayMilliseconds);
+        Assert.Equal(1.5, request.RetryDelayBackoff);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsForInvalidInput() {
+        Assert.Throws<ArgumentException>(() => new ImapConnectionRequest("", 993));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, timeout: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, retryCount: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, retryDelayMilliseconds: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, retryDelayBackoff: 0));
+    }
+}

--- a/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
@@ -116,6 +116,61 @@ public class SmtpSendPipelineTests {
     }
 
     [Fact]
+    public async Task TryAppendToSentAsync_AppendsMessage_WhenFolderIsWritable() {
+        var folder = new Mock<IMailFolder>();
+        var appendCalls = 0;
+        folder.SetupGet(f => f.FullName).Returns("Sent");
+        folder.SetupGet(f => f.IsOpen).Returns(true);
+        folder.SetupGet(f => f.Access).Returns(FolderAccess.ReadWrite);
+
+        var result = await SmtpAppendPipeline.TryAppendToSentAsync(
+            folder.Object,
+            new MimeMessage(),
+            MessageFlags.Seen,
+            appendAsync: (_, _, _, _) => {
+                appendCalls++;
+                return Task.CompletedTask;
+            });
+
+        Assert.Equal(1, appendCalls);
+        Assert.True(result.Appended);
+        Assert.Equal("Sent", result.Folder);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task TryAppendToSentAsync_ReturnsFailure_WhenAppendThrows() {
+        var folder = new Mock<IMailFolder>();
+        folder.SetupGet(f => f.FullName).Returns("Sent");
+        folder.SetupGet(f => f.IsOpen).Returns(true);
+        folder.SetupGet(f => f.Access).Returns(FolderAccess.ReadWrite);
+
+        var result = await SmtpAppendPipeline.TryAppendToSentAsync(
+            folder.Object,
+            new MimeMessage(),
+            MessageFlags.Seen,
+            appendAsync: (_, _, _, _) => throw new InvalidOperationException("append failed"));
+
+        Assert.False(result.Appended);
+        Assert.Equal("Sent", result.Folder);
+        Assert.Equal("append failed", result.Error);
+    }
+
+    [Fact]
+    public async Task TryAppendToSentAsync_Throws_ForInvalidArguments() {
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            SmtpAppendPipeline.TryAppendToSentAsync(
+                sentFolder: null!,
+                message: new MimeMessage()));
+
+        var folder = new Mock<IMailFolder>();
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            SmtpAppendPipeline.TryAppendToSentAsync(
+                folder.Object,
+                message: null!));
+    }
+
+    [Fact]
     public void ApplyThreadingHeaders_SetsNormalizedMessageThreadAndIdempotencyHeaders() {
         var message = new MimeMessage();
         var references = new List<string?> { "ref-1@example.test", " <ref-1@example.test> ", "ref-2@example.test" };

--- a/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
@@ -1,5 +1,10 @@
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Search;
 using MimeKit;
+using Moq;
 
 namespace Mailozaurr.Tests;
 
@@ -35,6 +40,94 @@ public class SmtpSendPipelineTests {
                 message: null!,
                 inReplyToCandidate: null,
                 referenceCandidates: null));
+    }
+
+    [Fact]
+    public async Task TryFindExistingSentCopyAsync_ReturnsMatch_FromIdempotencyHeaderProbe() {
+        var folder = new Mock<IMailFolder>();
+        var matched = new MimeMessage { MessageId = "matched-101@example.test" };
+        folder.SetupGet(f => f.FullName).Returns("Sent");
+        folder.Setup(f => f.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UniqueId> { new(101) });
+        folder.Setup(f => f.GetMessageAsync(It.IsAny<UniqueId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(matched);
+
+        var result = await SmtpSendPipeline.TryFindExistingSentCopyAsync(
+            folder.Object,
+            idempotencyHeaderName: "X-Test-Idempotency",
+            idempotencyKey: "idem-101",
+            idempotentMessageId: "fallback@example.test");
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("Sent", result.Folder);
+        Assert.Equal("matched-101@example.test", result.MessageId);
+        folder.Verify(f => f.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TryFindExistingSentCopyAsync_FallsBackToMessageIdProbe_WhenHeaderProbeMisses() {
+        var folder = new Mock<IMailFolder>();
+        var matched = new MimeMessage { MessageId = "matched-202@example.test" };
+        folder.SetupGet(f => f.FullName).Returns("Sent Items");
+        folder.SetupSequence(f => f.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UniqueId>())
+            .ReturnsAsync(new List<UniqueId> { new(202) });
+        folder.Setup(f => f.GetMessageAsync(It.IsAny<UniqueId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(matched);
+
+        var result = await SmtpSendPipeline.TryFindExistingSentCopyAsync(
+            folder.Object,
+            idempotencyHeaderName: "X-Test-Idempotency",
+            idempotencyKey: "idem-202",
+            idempotentMessageId: "<message-202@example.test>");
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("Sent Items", result.Folder);
+        Assert.Equal("matched-202@example.test", result.MessageId);
+        folder.Verify(f => f.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task TryFindExistingSentCopyAsync_ReturnsNone_WhenProbeThrows() {
+        var folder = new Mock<IMailFolder>();
+        folder.Setup(f => f.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("search failed"));
+
+        var result = await SmtpSendPipeline.TryFindExistingSentCopyAsync(
+            folder.Object,
+            idempotencyHeaderName: "X-Test-Idempotency",
+            idempotencyKey: "idem-500",
+            idempotentMessageId: "fallback@example.test");
+
+        Assert.False(result.IsMatch);
+        Assert.Null(result.Folder);
+        Assert.Null(result.MessageId);
+    }
+
+    [Fact]
+    public async Task TryFindExistingSentCopyAsync_Throws_ForInvalidArguments() {
+        var folder = new Mock<IMailFolder>();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            SmtpSendPipeline.TryFindExistingSentCopyAsync(
+                sentFolder: null!,
+                idempotencyHeaderName: "X-Test-Idempotency",
+                idempotencyKey: "idem",
+                idempotentMessageId: null));
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            SmtpSendPipeline.TryFindExistingSentCopyAsync(
+                folder.Object,
+                idempotencyHeaderName: "",
+                idempotencyKey: "idem",
+                idempotentMessageId: null));
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            SmtpSendPipeline.TryFindExistingSentCopyAsync(
+                folder.Object,
+                idempotencyHeaderName: "X-Test-Idempotency",
+                idempotencyKey: "",
+                idempotentMessageId: null));
     }
 
     private static List<string> Canonicalize(IEnumerable<string> values) {

--- a/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using MimeKit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpSendPipelineTests {
+    [Fact]
+    public void ApplyThreadingHeaders_SetsNormalizedMessageThreadAndIdempotencyHeaders() {
+        var message = new MimeMessage();
+        var references = new List<string?> { "ref-1@example.test", " <ref-1@example.test> ", "ref-2@example.test" };
+
+        SmtpSendPipeline.ApplyThreadingHeaders(
+            message,
+            inReplyToCandidate: "in-reply@example.test",
+            referenceCandidates: references,
+            messageId: "message-id@example.test",
+            idempotencyHeaderName: "X-Test-Idempotency",
+            idempotencyKey: "idem-1");
+
+        Assert.Equal("idem-1", message.Headers["X-Test-Idempotency"]);
+        Assert.Equal("message-id@example.test", TrimBrackets(message.MessageId));
+        Assert.Equal("in-reply@example.test", TrimBrackets(message.InReplyTo));
+
+        var refs = Canonicalize(message.References);
+        Assert.Contains("ref-1@example.test", refs);
+        Assert.Contains("ref-2@example.test", refs);
+        Assert.Contains("in-reply@example.test", refs);
+        Assert.Equal(3, refs.Count);
+    }
+
+    [Fact]
+    public void ApplyThreadingHeaders_Throws_WhenMessageIsNull() {
+        Assert.Throws<ArgumentNullException>(() =>
+            SmtpSendPipeline.ApplyThreadingHeaders(
+                message: null!,
+                inReplyToCandidate: null,
+                referenceCandidates: null));
+    }
+
+    private static List<string> Canonicalize(IEnumerable<string> values) {
+        var output = new List<string>();
+        foreach (var value in values) {
+            output.Add(TrimBrackets(value));
+        }
+        return output;
+    }
+
+    private static string TrimBrackets(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return string.Empty;
+        }
+        return value.Trim().Trim('<', '>');
+    }
+}

--- a/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
@@ -303,6 +303,6 @@ public class SmtpSendPipelineTests {
         if (string.IsNullOrWhiteSpace(value)) {
             return string.Empty;
         }
-        return value.Trim().Trim('<', '>');
+        return (value ?? string.Empty).Trim().Trim('<', '>');
     }
 }

--- a/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
@@ -50,6 +50,72 @@ public class SmtpSendPipelineTests {
     }
 
     [Fact]
+    public async Task BuildExecutionResultWithOptionalSentAppendAsync_InvokesAppend_WhenRealSendSucceeded() {
+        var appendCalled = 0;
+
+        var result = await SmtpSendPipeline.BuildExecutionResultWithOptionalSentAppendAsync(
+            sendRequested: true,
+            sendSucceeded: true,
+            messageId: "msg-3@example.test",
+            sendError: null,
+            appendToSentRequested: true,
+            appendAsync: _ => {
+                appendCalled++;
+                return Task.FromResult(new SmtpAppendExecutionResult {
+                    Appended = true,
+                    Folder = "Sent Items",
+                    Error = null
+                });
+            });
+
+        Assert.Equal(1, appendCalled);
+        Assert.True(result.Ok);
+        Assert.True(result.Sent);
+        Assert.True(result.AppendedToSent);
+        Assert.Equal("Sent Items", result.AppendedSentFolder);
+        Assert.Null(result.AppendError);
+    }
+
+    [Fact]
+    public async Task BuildExecutionResultWithOptionalSentAppendAsync_DoesNotInvokeAppend_WhenDryRun() {
+        var appendCalled = 0;
+
+        var result = await SmtpSendPipeline.BuildExecutionResultWithOptionalSentAppendAsync(
+            sendRequested: false,
+            sendSucceeded: true,
+            messageId: "msg-4@example.test",
+            sendError: null,
+            appendToSentRequested: true,
+            appendAsync: _ => {
+                appendCalled++;
+                return Task.FromResult(SmtpAppendExecutionResult.None);
+            });
+
+        Assert.Equal(0, appendCalled);
+        Assert.True(result.Ok);
+        Assert.False(result.Sent);
+        Assert.False(result.AppendedToSent);
+        Assert.Null(result.AppendedSentFolder);
+        Assert.Null(result.AppendError);
+    }
+
+    [Fact]
+    public async Task BuildExecutionResultWithOptionalSentAppendAsync_CapturesAppendException() {
+        var result = await SmtpSendPipeline.BuildExecutionResultWithOptionalSentAppendAsync(
+            sendRequested: true,
+            sendSucceeded: true,
+            messageId: "msg-5@example.test",
+            sendError: null,
+            appendToSentRequested: true,
+            appendAsync: _ => throw new InvalidOperationException("append crashed"));
+
+        Assert.True(result.Ok);
+        Assert.True(result.Sent);
+        Assert.False(result.AppendedToSent);
+        Assert.Equal("append crashed", result.AppendError);
+    }
+
+    [Fact]
     public void ApplyThreadingHeaders_SetsNormalizedMessageThreadAndIdempotencyHeaders() {
         var message = new MimeMessage();
         var references = new List<string?> { "ref-1@example.test", " <ref-1@example.test> ", "ref-2@example.test" };

--- a/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSendPipelineTests.cs
@@ -10,6 +10,46 @@ namespace Mailozaurr.Tests;
 
 public class SmtpSendPipelineTests {
     [Fact]
+    public void BuildExecutionResult_MapsSuccessOutcome() {
+        var result = SmtpSendPipeline.BuildExecutionResult(
+            sendRequested: true,
+            sendSucceeded: true,
+            messageId: "msg-1@example.test",
+            sendError: null,
+            appendedToSent: true,
+            appendedSentFolder: "Sent",
+            appendError: null);
+
+        Assert.True(result.Ok);
+        Assert.True(result.Sent);
+        Assert.Equal("msg-1@example.test", result.MessageId);
+        Assert.Null(result.Error);
+        Assert.True(result.AppendedToSent);
+        Assert.Equal("Sent", result.AppendedSentFolder);
+        Assert.Null(result.AppendError);
+    }
+
+    [Fact]
+    public void BuildExecutionResult_MapsDryRunAndAppendFailureOutcome() {
+        var result = SmtpSendPipeline.BuildExecutionResult(
+            sendRequested: false,
+            sendSucceeded: true,
+            messageId: "msg-2@example.test",
+            sendError: null,
+            appendedToSent: false,
+            appendedSentFolder: null,
+            appendError: "append failed");
+
+        Assert.True(result.Ok);
+        Assert.False(result.Sent);
+        Assert.Equal("msg-2@example.test", result.MessageId);
+        Assert.Null(result.Error);
+        Assert.False(result.AppendedToSent);
+        Assert.Null(result.AppendedSentFolder);
+        Assert.Equal("append failed", result.AppendError);
+    }
+
+    [Fact]
     public void ApplyThreadingHeaders_SetsNormalizedMessageThreadAndIdempotencyHeaders() {
         var message = new MimeMessage();
         var references = new List<string?> { "ref-1@example.test", " <ref-1@example.test> ", "ref-2@example.test" };

--- a/Sources/Mailozaurr/Connections/ImapConnectionRequest.cs
+++ b/Sources/Mailozaurr/Connections/ImapConnectionRequest.cs
@@ -1,0 +1,108 @@
+using MailKit.Security;
+using System;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents connection settings used by <see cref="ImapConnector"/>.
+/// </summary>
+public sealed class ImapConnectionRequest {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImapConnectionRequest"/> class.
+    /// </summary>
+    /// <param name="server">IMAP server hostname.</param>
+    /// <param name="port">IMAP server port.</param>
+    /// <param name="options">Secure socket options.</param>
+    /// <param name="timeout">Connection timeout in milliseconds.</param>
+    /// <param name="skipCertificateRevocation">Whether to skip certificate revocation checks.</param>
+    /// <param name="skipCertificateValidation">Whether to skip certificate validation checks.</param>
+    /// <param name="retryCount">Retry count for transient failures.</param>
+    /// <param name="retryDelayMilliseconds">Initial retry delay in milliseconds.</param>
+    /// <param name="retryDelayBackoff">Retry delay backoff multiplier.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="server"/> is empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a numeric argument is outside supported range.</exception>
+    public ImapConnectionRequest(
+        string server,
+        int port,
+        SecureSocketOptions options = SecureSocketOptions.Auto,
+        int timeout = 30000,
+        bool skipCertificateRevocation = false,
+        bool skipCertificateValidation = false,
+        int retryCount = 3,
+        int retryDelayMilliseconds = 500,
+        double retryDelayBackoff = 2.0) {
+        if (string.IsNullOrWhiteSpace(server)) {
+            throw new ArgumentException("Server cannot be null or whitespace.", nameof(server));
+        }
+        if (port <= 0 || port > 65535) {
+            throw new ArgumentOutOfRangeException(nameof(port), "Port must be between 1 and 65535.");
+        }
+        if (timeout < 0) {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be >= 0.");
+        }
+        if (retryCount < 0) {
+            throw new ArgumentOutOfRangeException(nameof(retryCount), "Retry count must be >= 0.");
+        }
+        if (retryDelayMilliseconds < 0) {
+            throw new ArgumentOutOfRangeException(nameof(retryDelayMilliseconds), "Retry delay must be >= 0.");
+        }
+        if (retryDelayBackoff <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(retryDelayBackoff), "Retry backoff must be > 0.");
+        }
+
+        Server = server;
+        Port = port;
+        Options = options;
+        Timeout = timeout;
+        SkipCertificateRevocation = skipCertificateRevocation;
+        SkipCertificateValidation = skipCertificateValidation;
+        RetryCount = retryCount;
+        RetryDelayMilliseconds = retryDelayMilliseconds;
+        RetryDelayBackoff = retryDelayBackoff;
+    }
+
+    /// <summary>
+    /// Gets the IMAP server hostname.
+    /// </summary>
+    public string Server { get; }
+
+    /// <summary>
+    /// Gets the IMAP server port.
+    /// </summary>
+    public int Port { get; }
+
+    /// <summary>
+    /// Gets secure socket options.
+    /// </summary>
+    public SecureSocketOptions Options { get; }
+
+    /// <summary>
+    /// Gets connection timeout in milliseconds.
+    /// </summary>
+    public int Timeout { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether certificate revocation checks are skipped.
+    /// </summary>
+    public bool SkipCertificateRevocation { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether certificate validation checks are skipped.
+    /// </summary>
+    public bool SkipCertificateValidation { get; }
+
+    /// <summary>
+    /// Gets retry count for transient failures.
+    /// </summary>
+    public int RetryCount { get; }
+
+    /// <summary>
+    /// Gets initial retry delay in milliseconds.
+    /// </summary>
+    public int RetryDelayMilliseconds { get; }
+
+    /// <summary>
+    /// Gets retry delay backoff multiplier.
+    /// </summary>
+    public double RetryDelayBackoff { get; }
+}

--- a/Sources/Mailozaurr/Connections/ImapConnector.cs
+++ b/Sources/Mailozaurr/Connections/ImapConnector.cs
@@ -23,6 +23,38 @@ public static class ImapConnector {
     /// <summary>
     /// Connects and authenticates to an IMAP server with retry support.
     /// </summary>
+    /// <param name="request">Connection request settings.</param>
+    /// <param name="authenticateAsync">Delegate performing authentication.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>Authenticated <see cref="ImapClient"/> instance.</returns>
+    public static Task<ImapClient> ConnectAsync(
+        ImapConnectionRequest request,
+        Func<ImapClient, CancellationToken, Task> authenticateAsync,
+        CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+        if (authenticateAsync is null) {
+            throw new ArgumentNullException(nameof(authenticateAsync));
+        }
+
+        return ConnectAsync(
+            request.Server,
+            request.Port,
+            request.Options,
+            request.Timeout,
+            request.SkipCertificateRevocation,
+            request.SkipCertificateValidation,
+            authenticateAsync,
+            request.RetryCount,
+            request.RetryDelayMilliseconds,
+            request.RetryDelayBackoff,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Connects and authenticates to an IMAP server with retry support.
+    /// </summary>
     /// <param name="server">Server hostname.</param>
     /// <param name="port">Server port.</param>
     /// <param name="options">Secure socket options.</param>

--- a/Sources/Mailozaurr/Smtp/SmtpAppendExecutionResult.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpAppendExecutionResult.cs
@@ -7,17 +7,17 @@ public sealed class SmtpAppendExecutionResult {
     /// <summary>
     /// Gets a value indicating whether append operation succeeded.
     /// </summary>
-    public bool Appended { get; init; }
+    public bool Appended { get; set; }
 
     /// <summary>
     /// Gets appended folder name when append succeeded.
     /// </summary>
-    public string? Folder { get; init; }
+    public string? Folder { get; set; }
 
     /// <summary>
     /// Gets append error when append failed.
     /// </summary>
-    public string? Error { get; init; }
+    public string? Error { get; set; }
 
     /// <summary>
     /// Gets empty append outcome.

--- a/Sources/Mailozaurr/Smtp/SmtpAppendExecutionResult.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpAppendExecutionResult.cs
@@ -1,0 +1,26 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Describes optional append-to-sent outcome for SMTP pipeline orchestration.
+/// </summary>
+public sealed class SmtpAppendExecutionResult {
+    /// <summary>
+    /// Gets a value indicating whether append operation succeeded.
+    /// </summary>
+    public bool Appended { get; init; }
+
+    /// <summary>
+    /// Gets appended folder name when append succeeded.
+    /// </summary>
+    public string? Folder { get; init; }
+
+    /// <summary>
+    /// Gets append error when append failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// Gets empty append outcome.
+    /// </summary>
+    public static SmtpAppendExecutionResult None { get; } = new();
+}

--- a/Sources/Mailozaurr/Smtp/SmtpAppendPipeline.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpAppendPipeline.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Provides append-to-sent execution primitives for SMTP send pipelines.
+/// </summary>
+public static class SmtpAppendPipeline {
+    /// <summary>
+    /// Appends a message to a sent folder and returns normalized append outcome.
+    /// </summary>
+    /// <param name="sentFolder">Target sent folder.</param>
+    /// <param name="message">Message to append.</param>
+    /// <param name="flags">Message flags used for appended copy.</param>
+    /// <param name="appendAsync">Optional append callback override (for testing/customization).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Append execution result.</returns>
+    public static async Task<SmtpAppendExecutionResult> TryAppendToSentAsync(
+        IMailFolder sentFolder,
+        MimeMessage message,
+        MessageFlags flags = MessageFlags.Seen,
+        Func<IMailFolder, MimeMessage, MessageFlags, CancellationToken, Task>? appendAsync = null,
+        CancellationToken cancellationToken = default) {
+        if (sentFolder is null) {
+            throw new ArgumentNullException(nameof(sentFolder));
+        }
+        if (message is null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        try {
+            if (sentFolder.IsOpen && sentFolder.Access != FolderAccess.ReadWrite) {
+                await sentFolder.CloseAsync(false, cancellationToken).ConfigureAwait(false);
+            }
+            if (!sentFolder.IsOpen || sentFolder.Access != FolderAccess.ReadWrite) {
+                await sentFolder.OpenAsync(FolderAccess.ReadWrite, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (appendAsync is null) {
+                await sentFolder.AppendAsync(message, flags, cancellationToken).ConfigureAwait(false);
+            } else {
+                await appendAsync(sentFolder, message, flags, cancellationToken).ConfigureAwait(false);
+            }
+            return new SmtpAppendExecutionResult {
+                Appended = true,
+                Folder = sentFolder.FullName
+            };
+        } catch (Exception ex) {
+            return new SmtpAppendExecutionResult {
+                Appended = false,
+                Folder = sentFolder.FullName,
+                Error = ex.Message
+            };
+        }
+    }
+}

--- a/Sources/Mailozaurr/Smtp/SmtpDuplicateProbeResult.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpDuplicateProbeResult.cs
@@ -7,17 +7,17 @@ public sealed class SmtpDuplicateProbeResult {
     /// <summary>
     /// Gets a value indicating whether a matching sent copy was found.
     /// </summary>
-    public bool IsMatch { get; init; }
+    public bool IsMatch { get; set; }
 
     /// <summary>
     /// Gets a folder full name where the match was detected.
     /// </summary>
-    public string? Folder { get; init; }
+    public string? Folder { get; set; }
 
     /// <summary>
     /// Gets a detected or fallback message-id associated with the match.
     /// </summary>
-    public string? MessageId { get; init; }
+    public string? MessageId { get; set; }
 
     /// <summary>
     /// Gets empty match result.

--- a/Sources/Mailozaurr/Smtp/SmtpDuplicateProbeResult.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpDuplicateProbeResult.cs
@@ -1,0 +1,26 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Describes duplicate sent-copy probe result for idempotent SMTP send flows.
+/// </summary>
+public sealed class SmtpDuplicateProbeResult {
+    /// <summary>
+    /// Gets a value indicating whether a matching sent copy was found.
+    /// </summary>
+    public bool IsMatch { get; init; }
+
+    /// <summary>
+    /// Gets a folder full name where the match was detected.
+    /// </summary>
+    public string? Folder { get; init; }
+
+    /// <summary>
+    /// Gets a detected or fallback message-id associated with the match.
+    /// </summary>
+    public string? MessageId { get; init; }
+
+    /// <summary>
+    /// Gets empty match result.
+    /// </summary>
+    public static SmtpDuplicateProbeResult None { get; } = new();
+}

--- a/Sources/Mailozaurr/Smtp/SmtpSendExecutionResult.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpSendExecutionResult.cs
@@ -1,0 +1,41 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Describes normalized SMTP send execution outcome for pipeline consumers.
+/// </summary>
+public sealed class SmtpSendExecutionResult {
+    /// <summary>
+    /// Gets a value indicating whether send execution completed successfully.
+    /// </summary>
+    public bool Ok { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the message was actually sent.
+    /// </summary>
+    public bool Sent { get; init; }
+
+    /// <summary>
+    /// Gets emitted message-id when available.
+    /// </summary>
+    public string? MessageId { get; init; }
+
+    /// <summary>
+    /// Gets send error when send execution failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether append-to-sent completed.
+    /// </summary>
+    public bool AppendedToSent { get; init; }
+
+    /// <summary>
+    /// Gets appended sent folder name when append completed.
+    /// </summary>
+    public string? AppendedSentFolder { get; init; }
+
+    /// <summary>
+    /// Gets append-to-sent error when append failed.
+    /// </summary>
+    public string? AppendError { get; init; }
+}

--- a/Sources/Mailozaurr/Smtp/SmtpSendExecutionResult.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpSendExecutionResult.cs
@@ -7,35 +7,35 @@ public sealed class SmtpSendExecutionResult {
     /// <summary>
     /// Gets a value indicating whether send execution completed successfully.
     /// </summary>
-    public bool Ok { get; init; }
+    public bool Ok { get; set; }
 
     /// <summary>
     /// Gets a value indicating whether the message was actually sent.
     /// </summary>
-    public bool Sent { get; init; }
+    public bool Sent { get; set; }
 
     /// <summary>
     /// Gets emitted message-id when available.
     /// </summary>
-    public string? MessageId { get; init; }
+    public string? MessageId { get; set; }
 
     /// <summary>
     /// Gets send error when send execution failed.
     /// </summary>
-    public string? Error { get; init; }
+    public string? Error { get; set; }
 
     /// <summary>
     /// Gets a value indicating whether append-to-sent completed.
     /// </summary>
-    public bool AppendedToSent { get; init; }
+    public bool AppendedToSent { get; set; }
 
     /// <summary>
     /// Gets appended sent folder name when append completed.
     /// </summary>
-    public string? AppendedSentFolder { get; init; }
+    public string? AppendedSentFolder { get; set; }
 
     /// <summary>
     /// Gets append-to-sent error when append failed.
     /// </summary>
-    public string? AppendError { get; init; }
+    public string? AppendError { get; set; }
 }

--- a/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Provides reusable SMTP send-pipeline primitives for threading/idempotency header shaping.
+/// </summary>
+public static class SmtpSendPipeline {
+    /// <summary>
+    /// Applies normalized threading/idempotency headers to a MIME message.
+    /// </summary>
+    /// <param name="message">Message instance to update.</param>
+    /// <param name="inReplyToCandidate">Optional In-Reply-To message-id token.</param>
+    /// <param name="referenceCandidates">Optional References message-id tokens.</param>
+    /// <param name="messageId">Optional deterministic Message-Id token.</param>
+    /// <param name="idempotencyHeaderName">Optional custom idempotency header name.</param>
+    /// <param name="idempotencyKey">Optional idempotency header value.</param>
+    public static void ApplyThreadingHeaders(
+        MimeMessage message,
+        string? inReplyToCandidate,
+        IEnumerable<string?>? referenceCandidates,
+        string? messageId = null,
+        string? idempotencyHeaderName = null,
+        string? idempotencyKey = null) {
+        if (message is null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        if (!string.IsNullOrWhiteSpace(idempotencyHeaderName) && !string.IsNullOrWhiteSpace(idempotencyKey)) {
+            message.Headers.Replace(idempotencyHeaderName, idempotencyKey);
+        }
+
+        var normalizedMessageId = NormalizeMessageIdToken(messageId);
+        if (!string.IsNullOrWhiteSpace(normalizedMessageId)) {
+            message.MessageId = normalizedMessageId;
+        }
+
+        var inReplyTo = NormalizeMessageIdToken(inReplyToCandidate);
+        if (!string.IsNullOrWhiteSpace(inReplyTo)) {
+            message.InReplyTo = inReplyTo;
+        }
+
+        var refs = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (referenceCandidates is not null) {
+            foreach (var candidate in referenceCandidates) {
+                AddReference(candidate);
+            }
+        }
+        AddReference(inReplyTo);
+
+        if (refs.Count == 0) {
+            return;
+        }
+
+        message.References.Clear();
+        foreach (var reference in refs) {
+            message.References.Add(reference);
+        }
+
+        void AddReference(string? candidate) {
+            var token = NormalizeMessageIdToken(candidate);
+            if (string.IsNullOrWhiteSpace(token)) {
+                return;
+            }
+            if (seen.Add(token)) {
+                refs.Add(token);
+            }
+        }
+    }
+
+    private static string? NormalizeMessageIdToken(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        var normalized = value.Trim();
+        if (normalized.StartsWith("<", StringComparison.Ordinal)) {
+            normalized = normalized.Substring(1);
+        }
+        if (normalized.EndsWith(">", StringComparison.Ordinal)) {
+            normalized = normalized.Substring(0, normalized.Length - 1);
+        }
+        normalized = normalized.Trim();
+
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+}

--- a/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
@@ -145,7 +145,7 @@ public static class SmtpSendPipeline {
 
         void AddReference(string? candidate) {
             var token = NormalizeMessageIdToken(candidate);
-            if (string.IsNullOrWhiteSpace(token)) {
+            if (token is null || token.Length == 0) {
                 return;
             }
             if (seen.Add(token)) {
@@ -211,11 +211,14 @@ public static class SmtpSendPipeline {
     }
 
     private static string? NormalizeMessageIdToken(string? value) {
-        if (string.IsNullOrWhiteSpace(value)) {
+        if (value is null) {
             return null;
         }
 
         var normalized = value.Trim();
+        if (normalized.Length == 0) {
+            return null;
+        }
         if (normalized.StartsWith("<", StringComparison.Ordinal)) {
             normalized = normalized.Substring(1);
         }

--- a/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
@@ -43,6 +43,54 @@ public static class SmtpSendPipeline {
     }
 
     /// <summary>
+    /// Builds send execution result and optionally performs append-to-sent orchestration.
+    /// </summary>
+    /// <param name="sendRequested">Whether send was requested by caller.</param>
+    /// <param name="sendSucceeded">Whether send execution succeeded.</param>
+    /// <param name="messageId">Optional emitted message-id.</param>
+    /// <param name="sendError">Optional send error.</param>
+    /// <param name="appendToSentRequested">Whether append-to-sent was requested.</param>
+    /// <param name="appendAsync">Optional append callback executed only on successful real send + append request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Normalized execution result with append metadata.</returns>
+    public static async Task<SmtpSendExecutionResult> BuildExecutionResultWithOptionalSentAppendAsync(
+        bool sendRequested,
+        bool sendSucceeded,
+        string? messageId,
+        string? sendError,
+        bool appendToSentRequested,
+        Func<CancellationToken, Task<SmtpAppendExecutionResult>>? appendAsync = null,
+        CancellationToken cancellationToken = default) {
+        var appendedToSent = false;
+        string? appendedSentFolder = null;
+        string? appendError = null;
+
+        if (sendRequested && sendSucceeded && appendToSentRequested) {
+            if (appendAsync is null) {
+                appendError = "append callback is not configured";
+            } else {
+                try {
+                    var appendResult = await appendAsync(cancellationToken).ConfigureAwait(false) ?? SmtpAppendExecutionResult.None;
+                    appendedToSent = appendResult.Appended;
+                    appendedSentFolder = appendResult.Folder;
+                    appendError = appendResult.Error;
+                } catch (Exception ex) {
+                    appendError = ex.Message;
+                }
+            }
+        }
+
+        return BuildExecutionResult(
+            sendRequested,
+            sendSucceeded,
+            messageId,
+            sendError,
+            appendedToSent,
+            appendedSentFolder,
+            appendError);
+    }
+
+    /// <summary>
     /// Applies normalized threading/idempotency headers to a MIME message.
     /// </summary>
     /// <param name="message">Message instance to update.</param>

--- a/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
@@ -13,6 +13,36 @@ namespace Mailozaurr;
 /// </summary>
 public static class SmtpSendPipeline {
     /// <summary>
+    /// Creates a normalized send execution result contract for pipeline consumers.
+    /// </summary>
+    /// <param name="sendRequested">Whether send was requested by caller.</param>
+    /// <param name="sendSucceeded">Whether send execution succeeded.</param>
+    /// <param name="messageId">Optional emitted message-id.</param>
+    /// <param name="sendError">Optional send error.</param>
+    /// <param name="appendedToSent">Whether append-to-sent succeeded.</param>
+    /// <param name="appendedSentFolder">Optional appended sent folder name.</param>
+    /// <param name="appendError">Optional append error.</param>
+    /// <returns>Normalized execution result.</returns>
+    public static SmtpSendExecutionResult BuildExecutionResult(
+        bool sendRequested,
+        bool sendSucceeded,
+        string? messageId,
+        string? sendError,
+        bool appendedToSent,
+        string? appendedSentFolder,
+        string? appendError) {
+        return new SmtpSendExecutionResult {
+            Ok = sendSucceeded,
+            Sent = sendRequested && sendSucceeded,
+            MessageId = messageId,
+            Error = sendError,
+            AppendedToSent = appendedToSent,
+            AppendedSentFolder = appendedSentFolder,
+            AppendError = appendError
+        };
+    }
+
+    /// <summary>
     /// Applies normalized threading/idempotency headers to a MIME message.
     /// </summary>
     /// <param name="message">Message instance to update.</param>

--- a/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Search;
 using MimeKit;
 
 namespace Mailozaurr;
@@ -69,6 +73,62 @@ public static class SmtpSendPipeline {
             if (seen.Add(token)) {
                 refs.Add(token);
             }
+        }
+    }
+
+    /// <summary>
+    /// Probes a sent folder for an existing copy using idempotency header, then Message-Id fallback.
+    /// </summary>
+    /// <param name="sentFolder">Opened sent folder to probe.</param>
+    /// <param name="idempotencyHeaderName">Header name used for idempotency tagging.</param>
+    /// <param name="idempotencyKey">Idempotency value to search by.</param>
+    /// <param name="idempotentMessageId">Optional deterministic Message-Id fallback.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Duplicate probe result.</returns>
+    public static async Task<SmtpDuplicateProbeResult> TryFindExistingSentCopyAsync(
+        IMailFolder sentFolder,
+        string idempotencyHeaderName,
+        string idempotencyKey,
+        string? idempotentMessageId,
+        CancellationToken cancellationToken = default) {
+        if (sentFolder is null) {
+            throw new ArgumentNullException(nameof(sentFolder));
+        }
+        if (string.IsNullOrWhiteSpace(idempotencyHeaderName)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(idempotencyHeaderName));
+        }
+        if (string.IsNullOrWhiteSpace(idempotencyKey)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(idempotencyKey));
+        }
+
+        try {
+            var uids = await sentFolder.SearchAsync(SearchQuery.HeaderContains(idempotencyHeaderName, idempotencyKey), cancellationToken).ConfigureAwait(false);
+            if (uids.Count == 0) {
+                var token = NormalizeMessageIdToken(idempotentMessageId);
+                if (!string.IsNullOrWhiteSpace(token)) {
+                    uids = await sentFolder.SearchAsync(SearchQuery.HeaderContains("Message-Id", token), cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            if (uids.Count == 0) {
+                return SmtpDuplicateProbeResult.None;
+            }
+
+            string? matchedMessageId = null;
+            try {
+                var message = await sentFolder.GetMessageAsync(uids[0], cancellationToken).ConfigureAwait(false);
+                matchedMessageId = message?.MessageId;
+            } catch {
+                // best-effort
+            }
+
+            return new SmtpDuplicateProbeResult {
+                IsMatch = true,
+                Folder = sentFolder.FullName,
+                MessageId = string.IsNullOrWhiteSpace(matchedMessageId) ? idempotentMessageId : matchedMessageId
+            };
+        } catch {
+            return SmtpDuplicateProbeResult.None;
         }
     }
 


### PR DESCRIPTION
## Summary
- add `SmtpSendPipeline.ApplyThreadingHeaders(...)` utility for normalized Message-Id/In-Reply-To/References shaping
- support optional idempotency header name/value wiring
- add focused unit tests in `SmtpSendPipelineTests`

## Validation
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --filter "FullyQualifiedName~SmtpSendPipelineTests"
