### PR TITLE
smtp: add sent-folder session execution primitive

### DIFF
--- a/Sources/Mailozaurr.Tests/SmtpSentFolderSessionPipelineTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSentFolderSessionPipelineTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Search;
+using MimeKit;
+using Moq;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpSentFolderSessionPipelineTests {
+    [Fact]
+    public async Task TryFindExistingSentCopyAsync_UsesConnectedSession_AndDisconnects() {
+        var connectCalls = 0;
+        var resolveCalls = 0;
+        var disconnectCalls = 0;
+
+        var folder = new Mock<IMailFolder>();
+        var matched = new MimeMessage { MessageId = "matched@example.test" };
+        folder.SetupGet(f => f.FullName).Returns("Sent");
+        folder.Setup(f => f.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UniqueId> { new(42) });
+        folder.Setup(f => f.GetMessageAsync(It.IsAny<UniqueId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(matched);
+
+        var result = await SmtpSentFolderSessionPipeline.TryFindExistingSentCopyAsync(
+            connectAsync: _ => {
+                connectCalls++;
+                return Task.FromResult(new ImapClient());
+            },
+            resolveSentFolderAsync: (_, _) => {
+                resolveCalls++;
+                return Task.FromResult(folder.Object);
+            },
+            idempotencyHeaderName: "X-Test-Idempotency",
+            idempotencyKey: "idem-42",
+            idempotentMessageId: "fallback@example.test",
+            disconnectAsync: (_, _) => {
+                disconnectCalls++;
+                return Task.CompletedTask;
+            });
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("Sent", result.Folder);
+        Assert.Equal("matched@example.test", result.MessageId);
+        Assert.Equal(1, connectCalls);
+        Assert.Equal(1, resolveCalls);
+        Assert.Equal(1, disconnectCalls);
+    }
+
+    [Fact]
+    public async Task TryAppendToSentAsync_UsesConnectedSession_AndDisconnects() {
+        var connectCalls = 0;
+        var resolveCalls = 0;
+        var appendCalls = 0;
+        var disconnectCalls = 0;
+
+        var folder = new Mock<IMailFolder>();
+        folder.SetupGet(f => f.FullName).Returns("Sent Items");
+        folder.SetupGet(f => f.IsOpen).Returns(true);
+        folder.SetupGet(f => f.Access).Returns(FolderAccess.ReadWrite);
+
+        var result = await SmtpSentFolderSessionPipeline.TryAppendToSentAsync(
+            connectAsync: _ => {
+                connectCalls++;
+                return Task.FromResult(new ImapClient());
+            },
+            resolveSentFolderAsync: (_, _) => {
+                resolveCalls++;
+                return Task.FromResult(folder.Object);
+            },
+            message: new MimeMessage(),
+            flags: MessageFlags.Seen,
+            appendAsync: (_, _, _, _) => {
+                appendCalls++;
+                return Task.CompletedTask;
+            },
+            disconnectAsync: (_, _) => {
+                disconnectCalls++;
+                return Task.CompletedTask;
+            });
+
+        Assert.True(result.Appended);
+        Assert.Equal("Sent Items", result.Folder);
+        Assert.Null(result.Error);
+        Assert.Equal(1, connectCalls);
+        Assert.Equal(1, resolveCalls);
+        Assert.Equal(1, appendCalls);
+        Assert.Equal(1, disconnectCalls);
+    }
+
+    [Fact]
+    public async Task TryAppendToSentAsync_Throws_ForInvalidArguments() {
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            SmtpSentFolderSessionPipeline.TryAppendToSentAsync(
+                connectAsync: null!,
+                resolveSentFolderAsync: (_, _) => Task.FromResult(Mock.Of<IMailFolder>()),
+                message: new MimeMessage()));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            SmtpSentFolderSessionPipeline.TryAppendToSentAsync(
+                connectAsync: _ => Task.FromResult(new ImapClient()),
+                resolveSentFolderAsync: null!,
+                message: new MimeMessage()));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            SmtpSentFolderSessionPipeline.TryAppendToSentAsync(
+                connectAsync: _ => Task.FromResult(new ImapClient()),
+                resolveSentFolderAsync: (_, _) => Task.FromResult(Mock.Of<IMailFolder>()),
+                message: null!));
+    }
+}

--- a/Sources/Mailozaurr/Smtp/SmtpSentFolderSessionPipeline.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpSentFolderSessionPipeline.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Net.Imap;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Provides IMAP sent-folder session execution primitives for SMTP pipeline consumers.
+/// </summary>
+public static class SmtpSentFolderSessionPipeline {
+    /// <summary>
+    /// Connects IMAP session, resolves sent folder, probes for duplicate sent copy, and disconnects.
+    /// </summary>
+    /// <param name="connectAsync">Callback used to create and connect IMAP client.</param>
+    /// <param name="resolveSentFolderAsync">Callback used to resolve sent folder from connected client.</param>
+    /// <param name="idempotencyHeaderName">Header name used for idempotency lookup.</param>
+    /// <param name="idempotencyKey">Idempotency key value.</param>
+    /// <param name="idempotentMessageId">Optional deterministic message-id fallback.</param>
+    /// <param name="disconnectAsync">Optional disconnect callback override.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Duplicate-probe execution result.</returns>
+    public static async Task<SmtpDuplicateProbeResult> TryFindExistingSentCopyAsync(
+        Func<CancellationToken, Task<ImapClient>> connectAsync,
+        Func<ImapClient, CancellationToken, Task<IMailFolder>> resolveSentFolderAsync,
+        string idempotencyHeaderName,
+        string idempotencyKey,
+        string? idempotentMessageId,
+        Func<ImapClient, CancellationToken, Task>? disconnectAsync = null,
+        CancellationToken cancellationToken = default) {
+        if (connectAsync is null) {
+            throw new ArgumentNullException(nameof(connectAsync));
+        }
+        if (resolveSentFolderAsync is null) {
+            throw new ArgumentNullException(nameof(resolveSentFolderAsync));
+        }
+        if (string.IsNullOrWhiteSpace(idempotencyHeaderName)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(idempotencyHeaderName));
+        }
+        if (string.IsNullOrWhiteSpace(idempotencyKey)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(idempotencyKey));
+        }
+
+        var client = await connectAsync(cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Connected IMAP client is required.");
+
+        try {
+            var sentFolder = await resolveSentFolderAsync(client, cancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException("Resolved sent folder is required.");
+
+            return await SmtpSendPipeline.TryFindExistingSentCopyAsync(
+                sentFolder,
+                idempotencyHeaderName,
+                idempotencyKey,
+                idempotentMessageId,
+                cancellationToken).ConfigureAwait(false);
+        } finally {
+            await DisconnectAndDisposeAsync(client, disconnectAsync, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Connects IMAP session, resolves sent folder, appends message, and disconnects.
+    /// </summary>
+    /// <param name="connectAsync">Callback used to create and connect IMAP client.</param>
+    /// <param name="resolveSentFolderAsync">Callback used to resolve sent folder from connected client.</param>
+    /// <param name="message">Message to append.</param>
+    /// <param name="flags">Message flags used for append operation.</param>
+    /// <param name="appendAsync">Optional append callback override for folder append operation.</param>
+    /// <param name="disconnectAsync">Optional disconnect callback override.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Append execution result.</returns>
+    public static async Task<SmtpAppendExecutionResult> TryAppendToSentAsync(
+        Func<CancellationToken, Task<ImapClient>> connectAsync,
+        Func<ImapClient, CancellationToken, Task<IMailFolder>> resolveSentFolderAsync,
+        MimeMessage message,
+        MessageFlags flags = MessageFlags.Seen,
+        Func<IMailFolder, MimeMessage, MessageFlags, CancellationToken, Task>? appendAsync = null,
+        Func<ImapClient, CancellationToken, Task>? disconnectAsync = null,
+        CancellationToken cancellationToken = default) {
+        if (connectAsync is null) {
+            throw new ArgumentNullException(nameof(connectAsync));
+        }
+        if (resolveSentFolderAsync is null) {
+            throw new ArgumentNullException(nameof(resolveSentFolderAsync));
+        }
+        if (message is null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var client = await connectAsync(cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Connected IMAP client is required.");
+
+        try {
+            var sentFolder = await resolveSentFolderAsync(client, cancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException("Resolved sent folder is required.");
+
+            return await SmtpAppendPipeline.TryAppendToSentAsync(
+                sentFolder,
+                message,
+                flags,
+                appendAsync,
+                cancellationToken).ConfigureAwait(false);
+        } finally {
+            await DisconnectAndDisposeAsync(client, disconnectAsync, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task DisconnectAndDisposeAsync(
+        ImapClient client,
+        Func<ImapClient, CancellationToken, Task>? disconnectAsync,
+        CancellationToken cancellationToken) {
+        try {
+            if (disconnectAsync is not null) {
+                await disconnectAsync(client, cancellationToken).ConfigureAwait(false);
+            } else if (client.IsConnected) {
+                client.Disconnect(true);
+            }
+        } catch {
+            // best-effort cleanup
+        } finally {
+            client.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SmtpSentFolderSessionPipeline` to centralize IMAP sent-folder session lifecycle (connect/use/disconnect) for SMTP duplicate-probe and append flows
- keep folder-level `SmtpSendPipeline` / `SmtpAppendPipeline` primitives unchanged and reuse them internally
- add focused tests for session execution behavior and argument validation

## Validation
- `dotnet build Sources/Mailozaurr.sln -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release -f net8.0 --no-build --filter "FullyQualifiedName~SmtpSendPipelineTests|FullyQualifiedName~SmtpSentFolderSessionPipelineTests"`
