### PR TITLE
Fix PowerShell Gallery preview badge

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -10,7 +10,7 @@ NuGet Package
 PowerShell Module
 
 [![powershell gallery version](https://img.shields.io/powershellgallery/v/Mailozaurr.svg)](https://www.powershellgallery.com/packages/Mailozaurr)
-[![powershell gallery preview](https://img.shields.io/powershellgallery/vpre/Mailozaurr.svg?label=powershell%20gallery%20preview&colorB=yellow)](https://www.powershellgallery.com/packages/Mailozaurr)
+[![powershell gallery preview](https://img.shields.io/powershellgallery/v/Mailozaurr.svg?label=powershell%20gallery%20preview&colorB=yellow&include_prereleases)](https://www.powershellgallery.com/packages/Mailozaurr)
 [![powershell gallery platforms](https://img.shields.io/powershellgallery/p/Mailozaurr.svg)](https://www.powershellgallery.com/packages/Mailozaurr)
 [![powershell gallery downloads](https://img.shields.io/powershellgallery/dt/Mailozaurr.svg)](https://www.powershellgallery.com/packages/Mailozaurr)
 


### PR DESCRIPTION
Shields changed the PowerShell Gallery prerelease badge endpoint and the old vpre badge now renders a placeholder link.

This updates README badge URLs to use the normal PowerShell Gallery version badge with include_prereleases, so it displays the prerelease version again.

Ref: https://github.com/badges/shields/issues/11583