### PR TITLE
Graph/Gmail: allow providing HttpClient

### DIFF
--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -45,10 +45,28 @@ public sealed class GmailApiClient : IDisposable {
         _refreshToken = refreshToken;
     }
 
-    internal GmailApiClient(HttpClient client, Func<CancellationToken, Task<string>>? refreshToken = null, OAuthCredential? credential = null) {
+    /// <summary>
+    /// Initializes the client using an externally managed <see cref="HttpClient"/>.
+    /// </summary>
+    /// <remarks>
+    /// If <paramref name="client"/> does not specify <see cref="HttpClient.BaseAddress"/>, it will be set to the Gmail v1 endpoint
+    /// (or <paramref name="baseAddress"/> if provided).
+    /// </remarks>
+    /// <param name="client">HTTP client to use for requests.</param>
+    /// <param name="refreshToken">Optional delegate used to refresh an access token when a request returns 401/403.</param>
+    /// <param name="credential">Optional OAuth credential holding an access token.</param>
+    /// <param name="baseAddress">Optional Gmail base address used when <paramref name="client"/> has no base address configured.</param>
+    public GmailApiClient(
+        HttpClient client,
+        Func<CancellationToken, Task<string>>? refreshToken = null,
+        OAuthCredential? credential = null,
+        Uri? baseAddress = null) {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _refreshToken = refreshToken;
         _credential = credential;
+        if (_client.BaseAddress == null) {
+            _client.BaseAddress = baseAddress ?? new Uri("https://gmail.googleapis.com/gmail/v1/");
+        }
         if (credential != null && !string.IsNullOrEmpty(credential.AccessToken) && _client.DefaultRequestHeaders.Authorization == null) {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential.AccessToken);
         }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
@@ -51,10 +51,28 @@ public sealed class GraphApiClient : IDisposable {
         _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential.AccessToken);
     }
 
-    internal GraphApiClient(HttpClient client, Func<CancellationToken, Task<string>>? refreshToken = null, OAuthCredential? credential = null) {
+    /// <summary>
+    /// Initializes the client using an externally managed <see cref="HttpClient"/>.
+    /// </summary>
+    /// <remarks>
+    /// If <paramref name="client"/> does not specify <see cref="HttpClient.BaseAddress"/>, it will be set to the Graph v1.0 endpoint
+    /// (or <paramref name="baseAddress"/> if provided).
+    /// </remarks>
+    /// <param name="client">HTTP client to use for requests.</param>
+    /// <param name="refreshToken">Optional delegate used to refresh an access token when a request returns 401/403.</param>
+    /// <param name="credential">Optional OAuth credential holding an access token.</param>
+    /// <param name="baseAddress">Optional Graph base address used when <paramref name="client"/> has no base address configured.</param>
+    public GraphApiClient(
+        HttpClient client,
+        Func<CancellationToken, Task<string>>? refreshToken = null,
+        OAuthCredential? credential = null,
+        Uri? baseAddress = null) {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _refreshToken = refreshToken;
         _credential = credential;
+        if (_client.BaseAddress == null) {
+            _client.BaseAddress = baseAddress ?? new Uri("https://graph.microsoft.com/v1.0/");
+        }
         if (credential != null && !string.IsNullOrEmpty(credential.AccessToken) && _client.DefaultRequestHeaders.Authorization == null) {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential.AccessToken);
         }


### PR DESCRIPTION
Expose public constructors for GraphApiClient and GmailApiClient that accept HttpClient so callers (and tests) can inject handlers/base addresses without duplicating provider logic.\n\n- Sets BaseAddress to the default Graph/Gmail endpoint when not provided.\n- Preserves existing credential-based constructors.\n