### PR TITLE
GraphApiClient: mailbox primitives (folders/messages/delta/mime/batch)

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphApiClientMailboxTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphApiClientMailboxTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class GraphApiClientMailboxTests {
+    [Fact]
+    public async System.Threading.Tasks.Task ListMessagesAsync_AddsConsistencyHeaders_WhenSearchIsUsed() {
+        var json = "{\"value\":[{\"id\":\"m1\",\"subject\":\"s\",\"receivedDateTime\":\"2026-02-15T00:00:00Z\",\"internetMessageId\":\"<x>\",\"hasAttachments\":false,\"isRead\":true,\"conversationId\":\"c1\",\"from\":{\"emailAddress\":{\"address\":\"a@b.com\"}},\"toRecipients\":[{\"emailAddress\":{\"address\":\"c@d.com\"}}],\"flag\":{\"flagStatus\":\"flagged\"}}]}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(json) });
+        var api = new GraphApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GraphApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(api, new HttpClient(handler) { BaseAddress = new System.Uri("https://graph.microsoft.com/v1.0/") });
+
+        var page = await api.ListMessagesAsync("inbox", search: "hello");
+        Assert.Single(page.Items);
+        Assert.Equal("m1", page.Items[0].Id);
+        Assert.Equal("a@b.com", page.Items[0].From!.Email.Address);
+
+        Assert.Single(handler.Requests);
+        Assert.True(handler.Requests[0].Headers.Contains("ConsistencyLevel"));
+        Assert.True(handler.Requests[0].Headers.Contains("Prefer"));
+        Assert.Contains("/me/mailFolders/inbox/messages?", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task DeltaMessagesAsync_ParsesDeletes_AndCursor() {
+        var json = "{\"@odata.deltaLink\":\"https://graph.microsoft.com/v1.0/delta\",\"value\":[{\"id\":\"d1\",\"@removed\":{}},{\"id\":\"u1\",\"subject\":\"x\"}]}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(json) });
+        var api = new GraphApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GraphApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(api, new HttpClient(handler) { BaseAddress = new System.Uri("https://graph.microsoft.com/v1.0/") });
+
+        var delta = await api.DeltaMessagesAsync("inbox", cursor: null, top: 5);
+        Assert.Equal("https://graph.microsoft.com/v1.0/delta", delta.Cursor);
+        Assert.Single(delta.DeletedIds);
+        Assert.Equal("d1", delta.DeletedIds[0]);
+        Assert.Single(delta.Items);
+        Assert.Equal("u1", delta.Items[0].Id);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SendBatchAsync_UsesBatchEndpoint_AndSerializesRelativeUrls() {
+        var json = "{\"responses\":[{\"id\":\"1\",\"status\":204,\"headers\":{},\"body\":{}}]}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(json) });
+        var api = new GraphApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GraphApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(api, new HttpClient(handler) { BaseAddress = new System.Uri("https://graph.microsoft.com/v1.0/") });
+
+        var r = new GraphBatchRequest { Id = "", Method = GraphHttpMethod.DELETE, Url = "/me/messages/123" };
+        var results = await api.SendBatchAsync(new[] { r });
+        Assert.Single(results);
+        Assert.Equal(204, results[0].Status);
+
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Equal("https://graph.microsoft.com/v1.0/$batch", handler.Requests[0].RequestUri!.ToString());
+        var body = await handler.Requests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"url\":\"me/messages/123\"", body);
+        Assert.Contains("\"method\":\"DELETE\"", body);
+    }
+}
+

--- a/Sources/Mailozaurr.Tests/GraphApiClientMailboxTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphApiClientMailboxTests.cs
@@ -42,6 +42,24 @@ public class GraphApiClientMailboxTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task ListConversationMessagesAsync_BuildsFilterQuery() {
+        var json = "{\"value\":[{\"id\":\"m1\",\"subject\":\"s\"}]}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(json) });
+        var api = new GraphApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue });
+        var field = typeof(GraphApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(api, new HttpClient(handler) { BaseAddress = new System.Uri("https://graph.microsoft.com/v1.0/") });
+
+        var msgs = await api.ListConversationMessagesAsync("conv-1");
+        Assert.Single(msgs);
+        Assert.Single(handler.Requests);
+        var uri = handler.Requests[0].RequestUri!.ToString();
+        Assert.Contains("/me/messages?", uri);
+        Assert.Contains("$filter=", uri);
+        Assert.Contains("conversationId", uri);
+        Assert.Contains("conv-1", uri);
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task SendBatchAsync_UsesBatchEndpoint_AndSerializesRelativeUrls() {
         var json = "{\"responses\":[{\"id\":\"1\",\"status\":204,\"headers\":{},\"body\":{}}]}";
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new System.Net.Http.StringContent(json) });
@@ -62,4 +80,3 @@ public class GraphApiClientMailboxTests {
         Assert.Contains("\"method\":\"DELETE\"", body);
     }
 }
-

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
@@ -31,6 +31,14 @@ public sealed class GraphApiClient : IDisposable {
         }
     }
 
+    private void ApplyAuthHeader(HttpRequestMessage request) {
+        // Avoid mutating HttpClient.DefaultRequestHeaders.Authorization (thread-safety + token refresh semantics).
+        // If no credential was provided, we assume the caller configured auth on the HttpClient itself.
+        if (_credential != null && !string.IsNullOrWhiteSpace(_credential.AccessToken) && request.Headers.Authorization == null) {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _credential.AccessToken);
+        }
+    }
+
     /// <summary>
     /// Initializes the client using the provided OAuth credential.
     /// </summary>
@@ -49,7 +57,6 @@ public sealed class GraphApiClient : IDisposable {
         _client = new HttpClient {
             BaseAddress = baseAddress ?? new Uri("https://graph.microsoft.com/v1.0/")
         };
-        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential.AccessToken);
     }
 
     /// <summary>
@@ -74,9 +81,6 @@ public sealed class GraphApiClient : IDisposable {
         if (_client.BaseAddress == null) {
             _client.BaseAddress = baseAddress ?? new Uri("https://graph.microsoft.com/v1.0/");
         }
-        if (credential != null && !string.IsNullOrEmpty(credential.AccessToken) && _client.DefaultRequestHeaders.Authorization == null) {
-            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential.AccessToken);
-        }
     }
 
     /// <inheritdoc />
@@ -94,7 +98,6 @@ public sealed class GraphApiClient : IDisposable {
             response.StatusCode == HttpStatusCode.Forbidden) {
             if (_refreshToken != null) {
                 string token = await _refreshToken(cancellationToken).ConfigureAwait(false);
-                _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 if (_credential != null) {
                     _credential.AccessToken = token;
                 }
@@ -148,7 +151,9 @@ public sealed class GraphApiClient : IDisposable {
 
         var json = JsonSerializer.Serialize(request, MailozaurrJsonContext.Default.GraphCreateSubscriptionRequest);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var response = await _client.PostAsync("subscriptions", content, cancellationToken).ConfigureAwait(false);
+        using var req = new HttpRequestMessage(HttpMethod.Post, "subscriptions") { Content = content };
+        ApplyAuthHeader(req);
+        using var response = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -186,10 +191,11 @@ public sealed class GraphApiClient : IDisposable {
         var requestUri = _client.BaseAddress != null
             ? new Uri(_client.BaseAddress, $"subscriptions/{encodedId}")
             : new Uri($"subscriptions/{encodedId}", UriKind.Relative);
-        using var msg = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri) {
+        using var req = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri) {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
         };
-        using var response = await _client.SendAsync(msg, cancellationToken).ConfigureAwait(false);
+        ApplyAuthHeader(req);
+        using var response = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -221,7 +227,9 @@ public sealed class GraphApiClient : IDisposable {
             throw new ArgumentException("subscriptionId is required.", nameof(subscriptionId));
         }
         var encodedId = Uri.EscapeDataString(subscriptionId.Trim());
-        using var response = await _client.DeleteAsync($"subscriptions/{encodedId}", cancellationToken).ConfigureAwait(false);
+        using var req = new HttpRequestMessage(HttpMethod.Delete, $"subscriptions/{encodedId}");
+        ApplyAuthHeader(req);
+        using var response = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -238,7 +246,9 @@ public sealed class GraphApiClient : IDisposable {
     /// </summary>
     public async Task<IReadOnlyList<GraphSubscription>> ListSubscriptionsAsync(CancellationToken cancellationToken = default) {
         ThrowIfDisposed();
-        using var response = await _client.GetAsync("subscriptions", cancellationToken).ConfigureAwait(false);
+        using var req = new HttpRequestMessage(HttpMethod.Get, "subscriptions");
+        ApplyAuthHeader(req);
+        using var response = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -457,6 +467,7 @@ public sealed class GraphApiClient : IDisposable {
 
             var url = pending.Dequeue();
             using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            ApplyAuthHeader(req);
             using var resp = await _client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
@@ -532,7 +543,9 @@ public sealed class GraphApiClient : IDisposable {
             url.Append("?$select=").Append(Uri.EscapeDataString(selectValue));
         }
 
-        using var resp = await _client.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
+        using var req = new HttpRequestMessage(HttpMethod.Get, url.ToString());
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -600,6 +613,7 @@ public sealed class GraphApiClient : IDisposable {
         }
 
         using var req = new HttpRequestMessage(HttpMethod.Get, url.ToString());
+        ApplyAuthHeader(req);
         if (searchValue != null && searchValue.Length > 0) {
             req.Headers.TryAddWithoutValidation("ConsistencyLevel", "eventual");
             req.Headers.TryAddWithoutValidation("Prefer", "HonorNonIndexedQueriesWarning=true");
@@ -662,7 +676,9 @@ public sealed class GraphApiClient : IDisposable {
         string nextUrl = url.ToString();
         while (pages++ < safeMaxPages) {
             cancellationToken.ThrowIfCancellationRequested();
-            using var resp = await _client.GetAsync(nextUrl, cancellationToken).ConfigureAwait(false);
+            using var req = new HttpRequestMessage(HttpMethod.Get, nextUrl);
+            ApplyAuthHeader(req);
+            using var resp = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
             await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
             var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -741,7 +757,9 @@ public sealed class GraphApiClient : IDisposable {
         string nextUrl = url.ToString();
         while (pages++ < safeMaxPages) {
             cancellationToken.ThrowIfCancellationRequested();
-            using var resp = await _client.GetAsync(nextUrl, cancellationToken).ConfigureAwait(false);
+            using var req = new HttpRequestMessage(HttpMethod.Get, nextUrl);
+            ApplyAuthHeader(req);
+            using var resp = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
             await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
             var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -800,7 +818,9 @@ public sealed class GraphApiClient : IDisposable {
             url.Append("?$select=").Append(Uri.EscapeDataString(selectValue));
         }
 
-        using var resp = await _client.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
+        using var req = new HttpRequestMessage(HttpMethod.Get, url.ToString());
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -808,7 +828,7 @@ public sealed class GraphApiClient : IDisposable {
         var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
         if (!resp.IsSuccessStatusCode) {
-            throw new GraphApiException(resp.StatusCode, $"Graph message get failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+            throw new GraphApiException(resp.StatusCode, $"Graph message get failed for messageId '{messageId.Trim()}' ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
         }
 
         using var doc = JsonDocument.Parse(body);
@@ -834,12 +854,18 @@ public sealed class GraphApiClient : IDisposable {
         if (maxBytes <= 0) {
             throw new ArgumentOutOfRangeException(nameof(maxBytes), "maxBytes must be > 0.");
         }
+        const int hardLimitBytes = 256 * 1024 * 1024;
+        if (maxBytes > hardLimitBytes) {
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), $"maxBytes must be <= {hardLimitBytes}.");
+        }
 
         var userSegment = BuildUserSegment(userId);
         var selector = Uri.EscapeDataString(messageId.Trim());
         var url = userSegment + "/messages/" + selector + "/$value";
 
-        using var resp = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        using var req = new HttpRequestMessage(HttpMethod.Get, url);
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
         if (!resp.IsSuccessStatusCode) {
 #if NET5_0_OR_GREATER
@@ -914,7 +940,9 @@ public sealed class GraphApiClient : IDisposable {
             url = sb.ToString();
         }
 
-        using var resp = await _client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        using var req = new HttpRequestMessage(HttpMethod.Get, url);
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -982,7 +1010,9 @@ public sealed class GraphApiClient : IDisposable {
         var selector = Uri.EscapeDataString(messageId.Trim());
         var json = JsonSerializer.Serialize(new GraphDestinationRequest { DestinationId = destinationId.Trim() }, MailozaurrJsonContext.Default.GraphDestinationRequest);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var resp = await _client.PostAsync(userSegment + "/messages/" + selector + "/move", content, cancellationToken).ConfigureAwait(false);
+        using var req = new HttpRequestMessage(HttpMethod.Post, userSegment + "/messages/" + selector + "/move") { Content = content };
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -990,7 +1020,7 @@ public sealed class GraphApiClient : IDisposable {
         var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
         if (!resp.IsSuccessStatusCode) {
-            throw new GraphApiException(resp.StatusCode, $"Graph move failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+            throw new GraphApiException(resp.StatusCode, $"Graph move failed for messageId '{messageId.Trim()}' ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
         }
     }
 
@@ -1004,7 +1034,9 @@ public sealed class GraphApiClient : IDisposable {
         }
         var userSegment = BuildUserSegment(userId);
         var selector = Uri.EscapeDataString(messageId.Trim());
-        using var resp = await _client.DeleteAsync(userSegment + "/messages/" + selector, cancellationToken).ConfigureAwait(false);
+        using var req = new HttpRequestMessage(HttpMethod.Delete, userSegment + "/messages/" + selector);
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -1012,7 +1044,7 @@ public sealed class GraphApiClient : IDisposable {
         var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
         if (!resp.IsSuccessStatusCode) {
-            throw new GraphApiException(resp.StatusCode, $"Graph delete failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+            throw new GraphApiException(resp.StatusCode, $"Graph delete failed for messageId '{messageId.Trim()}' ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
         }
     }
 
@@ -1031,10 +1063,11 @@ public sealed class GraphApiClient : IDisposable {
         var userSegment = BuildUserSegment(userId);
         var selector = Uri.EscapeDataString(messageId.Trim());
         var json = JsonSerializer.Serialize(new GraphMarkReadRequest { IsRead = isRead }, MailozaurrJsonContext.Default.GraphMarkReadRequest);
-        using var msg = new HttpRequestMessage(new HttpMethod("PATCH"), userSegment + "/messages/" + selector) {
+        using var req = new HttpRequestMessage(new HttpMethod("PATCH"), userSegment + "/messages/" + selector) {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
         };
-        using var resp = await _client.SendAsync(msg, cancellationToken).ConfigureAwait(false);
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -1061,11 +1094,14 @@ public sealed class GraphApiClient : IDisposable {
         var userSegment = BuildUserSegment(userId);
         var selector = Uri.EscapeDataString(messageId.Trim());
         var status = flagged ? "flagged" : "notFlagged";
-        var json = "{\"flag\":{\"flagStatus\":\"" + status + "\"}}";
-        using var msg = new HttpRequestMessage(new HttpMethod("PATCH"), userSegment + "/messages/" + selector) {
+        var json = JsonSerializer.Serialize(
+            new GraphSetFlagRequest { Flag = new GraphSetFlagRequestFlag { FlagStatus = status } },
+            MailozaurrJsonContext.Default.GraphSetFlagRequest);
+        using var req = new HttpRequestMessage(new HttpMethod("PATCH"), userSegment + "/messages/" + selector) {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
         };
-        using var resp = await _client.SendAsync(msg, cancellationToken).ConfigureAwait(false);
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -1109,7 +1145,9 @@ public sealed class GraphApiClient : IDisposable {
 
         var json = JsonSerializer.Serialize(payload, MailozaurrJsonContext.Default.GraphBatchPayload);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var resp = await _client.PostAsync("$batch", content, cancellationToken).ConfigureAwait(false);
+        using var req = new HttpRequestMessage(HttpMethod.Post, "$batch") { Content = content };
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
 #if NET5_0_OR_GREATER
         var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
@@ -702,6 +702,83 @@ public sealed class GraphApiClient : IDisposable {
     }
 
     /// <summary>
+    /// Lists message metadata for a Graph conversation.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphMailMessage>> ListConversationMessagesAsync(
+        string conversationId,
+        string userId = "me",
+        int top = 100,
+        int maxPages = 25,
+        string? select = "id,subject,receivedDateTime,from,toRecipients,internetMessageId,hasAttachments,isRead,flag,conversationId",
+        string? orderBy = "receivedDateTime desc",
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(conversationId)) {
+            throw new ArgumentException("conversationId is required.", nameof(conversationId));
+        }
+
+        var safeTop = ClampInt(top, 1, 999);
+        var safeMaxPages = ClampInt(maxPages, 1, 500);
+        var userSegment = BuildUserSegment(userId);
+
+        var messages = new List<GraphMailMessage>();
+        var pages = 0;
+        var filter = "conversationId eq '" + EscapeODataStringLiteral(conversationId.Trim()) + "'";
+        var url = new StringBuilder();
+        url.Append(userSegment).Append("/messages?$top=").Append(safeTop.ToString(CultureInfo.InvariantCulture));
+        url.Append("&$filter=").Append(Uri.EscapeDataString(filter));
+
+        var selectValue = select == null ? null : select.Trim();
+        if (selectValue != null && selectValue.Length > 0) {
+            url.Append("&$select=").Append(Uri.EscapeDataString(selectValue));
+        }
+
+        var orderByValue = orderBy == null ? null : orderBy.Trim();
+        if (orderByValue != null && orderByValue.Length > 0) {
+            url.Append("&$orderby=").Append(Uri.EscapeDataString(orderByValue));
+        }
+
+        string nextUrl = url.ToString();
+        while (pages++ < safeMaxPages) {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var resp = await _client.GetAsync(nextUrl, cancellationToken).ConfigureAwait(false);
+            await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+            var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+            var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+            if (!resp.IsSuccessStatusCode) {
+                throw new GraphApiException(resp.StatusCode, $"Graph conversation list failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+            }
+
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("value", out var value) && value.ValueKind == JsonValueKind.Array) {
+                foreach (var it in value.EnumerateArray()) {
+                    var msg = TryParseMailMessage(it);
+                    if (msg != null) {
+                        messages.Add(msg);
+                    }
+                }
+            }
+
+            if (doc.RootElement.TryGetProperty("@odata.nextLink", out var next) && next.ValueKind == JsonValueKind.String) {
+                var link = next.GetString();
+                if (link != null) {
+                    var trimmed = link.Trim();
+                    if (trimmed.Length > 0) {
+                        nextUrl = trimmed;
+                        continue;
+                    }
+                }
+            }
+            break;
+        }
+
+        return messages;
+    }
+
+    /// <summary>
     /// Gets message metadata.
     /// </summary>
     public async Task<GraphMailMessage> GetMessageAsync(

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -256,11 +257,828 @@ public sealed class GraphApiClient : IDisposable {
         return (IReadOnlyList<GraphSubscription>?)result?.Value ?? Array.Empty<GraphSubscription>();
     }
 
+    private static string BuildUserSegment(string userId) {
+        var u = (userId ?? string.Empty).Trim();
+        if (u.Length == 0 || u.Equals("me", StringComparison.OrdinalIgnoreCase)) {
+            return "me";
+        }
+        return "users/" + Uri.EscapeDataString(u);
+    }
+
+    private static int ClampInt(int value, int min, int max) {
+        if (value < min) return min;
+        if (value > max) return max;
+        return value;
+    }
+
+    private static string EscapeODataStringLiteral(string value) => value.Replace("'", "''");
+
+    private static string? TryGetString(JsonElement obj, string propertyName) {
+        if (obj.ValueKind != JsonValueKind.Object) {
+            return null;
+        }
+        if (!obj.TryGetProperty(propertyName, out var el) || el.ValueKind != JsonValueKind.String) {
+            return null;
+        }
+        var s = el.GetString();
+        return string.IsNullOrWhiteSpace(s) ? null : s;
+    }
+
+    private static int? TryGetInt(JsonElement obj, string propertyName) {
+        if (obj.ValueKind != JsonValueKind.Object) {
+            return null;
+        }
+        if (!obj.TryGetProperty(propertyName, out var el) || el.ValueKind != JsonValueKind.Number) {
+            return null;
+        }
+        return el.TryGetInt32(out var v) ? v : null;
+    }
+
+    private static bool? TryGetBool(JsonElement obj, string propertyName) {
+        if (obj.ValueKind != JsonValueKind.Object) {
+            return null;
+        }
+        if (!obj.TryGetProperty(propertyName, out var el)) {
+            return null;
+        }
+        if (el.ValueKind == JsonValueKind.True) {
+            return true;
+        }
+        if (el.ValueKind == JsonValueKind.False) {
+            return false;
+        }
+        return null;
+    }
+
+    private static DateTimeOffset? TryGetDateTimeOffset(JsonElement obj, string propertyName) {
+        var s = TryGetString(obj, propertyName);
+        if (string.IsNullOrWhiteSpace(s)) {
+            return null;
+        }
+        return DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var dt)
+            ? dt
+            : null;
+    }
+
+    private static GraphEmailAddress? TryParseEmailAddress(JsonElement recipient) {
+        if (recipient.ValueKind != JsonValueKind.Object) {
+            return null;
+        }
+        if (!recipient.TryGetProperty("emailAddress", out var emailAddress) || emailAddress.ValueKind != JsonValueKind.Object) {
+            return null;
+        }
+        if (!emailAddress.TryGetProperty("address", out var addressEl) || addressEl.ValueKind != JsonValueKind.String) {
+            return null;
+        }
+        var address = addressEl.GetString();
+        if (address == null) {
+            return null;
+        }
+        address = address.Trim();
+        if (address.Length == 0) {
+            return null;
+        }
+        return new GraphEmailAddress { Email = new GraphEmail { Address = address } };
+    }
+
+    private static List<GraphEmailAddress>? TryParseEmailAddressList(JsonElement obj, string propertyName) {
+        if (obj.ValueKind != JsonValueKind.Object) {
+            return null;
+        }
+        if (!obj.TryGetProperty(propertyName, out var el) || el.ValueKind != JsonValueKind.Array) {
+            return null;
+        }
+        var list = new List<GraphEmailAddress>();
+        foreach (var item in el.EnumerateArray()) {
+            var addr = TryParseEmailAddress(item);
+            if (addr != null) {
+                list.Add(addr);
+            }
+        }
+        return list.Count == 0 ? null : list;
+    }
+
+    private static GraphMailMessage? TryParseMailMessage(JsonElement obj) {
+        if (obj.ValueKind != JsonValueKind.Object) {
+            return null;
+        }
+        var idRaw = TryGetString(obj, "id");
+        if (idRaw == null) {
+            return null;
+        }
+        var id = idRaw.Trim();
+        if (id.Length == 0) {
+            return null;
+        }
+        var msg = new GraphMailMessage {
+            Id = id,
+            Subject = TryGetString(obj, "subject"),
+            ReceivedDateTime = TryGetDateTimeOffset(obj, "receivedDateTime"),
+            InternetMessageId = TryGetString(obj, "internetMessageId"),
+            HasAttachments = TryGetBool(obj, "hasAttachments"),
+            IsRead = TryGetBool(obj, "isRead"),
+            ConversationId = TryGetString(obj, "conversationId")
+        };
+
+        if (obj.TryGetProperty("from", out var fromEl)) {
+            msg.From = TryParseEmailAddress(fromEl);
+        }
+        msg.ToRecipients = TryParseEmailAddressList(obj, "toRecipients");
+
+        if (obj.TryGetProperty("flag", out var flagEl) && flagEl.ValueKind == JsonValueKind.Object) {
+            var status = TryGetString(flagEl, "flagStatus");
+            if (status != null) {
+                var trimmed = status.Trim();
+                if (trimmed.Length > 0) {
+                    msg.Flag = new GraphMailMessageFlag { FlagStatus = trimmed };
+                }
+            }
+        }
+        return msg;
+    }
+
+    private static GraphMailFolder? TryParseMailFolder(JsonElement obj) {
+        if (obj.ValueKind != JsonValueKind.Object) {
+            return null;
+        }
+        var idRaw = TryGetString(obj, "id");
+        if (idRaw == null) {
+            return null;
+        }
+        var id = idRaw.Trim();
+        if (id.Length == 0) {
+            return null;
+        }
+        return new GraphMailFolder {
+            Id = id,
+            DisplayName = (TryGetString(obj, "displayName") ?? string.Empty).Trim(),
+            ParentFolderId = TryGetString(obj, "parentFolderId")?.Trim(),
+            ChildFolderCount = TryGetInt(obj, "childFolderCount"),
+            WellKnownName = TryGetString(obj, "wellKnownName")?.Trim(),
+            TotalItemCount = TryGetInt(obj, "totalItemCount"),
+            UnreadItemCount = TryGetInt(obj, "unreadItemCount")
+        };
+    }
+
+    /// <summary>
+    /// Lists mail folders for the given user, recursively expanding child folders.
+    /// </summary>
+    /// <remarks>
+    /// This performs best-effort traversal with safeguards to prevent infinite loops in pathological cases.
+    /// </remarks>
+    public async Task<IReadOnlyList<GraphMailFolder>> ListMailFoldersRecursiveAsync(
+        string userId = "me",
+        int top = 200,
+        string? select = "id,displayName,parentFolderId,childFolderCount,wellKnownName,totalItemCount,unreadItemCount",
+        int maxRequests = 250,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+
+        var safeTop = ClampInt(top, 1, 999);
+        var safeMax = ClampInt(maxRequests, 1, 5000);
+        var userSegment = BuildUserSegment(userId);
+
+        var foldersById = new Dictionary<string, GraphMailFolder>(StringComparer.Ordinal);
+        var pending = new Queue<string>();
+        var initial = new StringBuilder();
+        initial.Append(userSegment).Append("/mailFolders?$top=").Append(safeTop.ToString(CultureInfo.InvariantCulture));
+        var selectValue = select == null ? null : select.Trim();
+        if (selectValue != null && selectValue.Length > 0) {
+            initial.Append("&$select=").Append(Uri.EscapeDataString(selectValue));
+        }
+        pending.Enqueue(initial.ToString());
+
+        var processed = 0;
+        while (pending.Count > 0) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (processed++ >= safeMax) {
+                break;
+            }
+
+            var url = pending.Dequeue();
+            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            using var resp = await _client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+            var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+            var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+            if (!resp.IsSuccessStatusCode) {
+                throw new GraphApiException(resp.StatusCode, $"Graph mailFolders list failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+            }
+
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("value", out var value) && value.ValueKind == JsonValueKind.Array) {
+                foreach (var item in value.EnumerateArray()) {
+                    var folder = TryParseMailFolder(item);
+                    if (folder == null || string.IsNullOrWhiteSpace(folder.Id)) {
+                        continue;
+                    }
+                    foldersById[folder.Id] = folder;
+
+                    if (folder.ChildFolderCount.HasValue && folder.ChildFolderCount.Value > 0) {
+                        var childUrl = new StringBuilder();
+                        childUrl.Append(userSegment)
+                            .Append("/mailFolders/")
+                            .Append(Uri.EscapeDataString(folder.Id))
+                            .Append("/childFolders?$top=")
+                            .Append(safeTop.ToString(CultureInfo.InvariantCulture));
+                        if (selectValue != null && selectValue.Length > 0) {
+                            childUrl.Append("&$select=").Append(Uri.EscapeDataString(selectValue));
+                        }
+                        pending.Enqueue(childUrl.ToString());
+                    }
+                }
+            }
+
+            if (doc.RootElement.TryGetProperty("@odata.nextLink", out var next) && next.ValueKind == JsonValueKind.String) {
+                var nextLink = next.GetString();
+                if (nextLink != null && nextLink.Trim().Length > 0) {
+                    pending.Enqueue(nextLink);
+                }
+            }
+        }
+
+        var output = new List<GraphMailFolder>(foldersById.Count);
+        output.AddRange(foldersById.Values);
+        output.Sort(static (a, b) => {
+            var r = string.Compare(a.DisplayName, b.DisplayName, StringComparison.OrdinalIgnoreCase);
+            if (r != 0) return r;
+            return string.Compare(a.Id, b.Id, StringComparison.Ordinal);
+        });
+        return output;
+    }
+
+    /// <summary>
+    /// Gets a single mail folder record.
+    /// </summary>
+    public async Task<GraphMailFolder> GetMailFolderAsync(
+        string folderIdOrWellKnownName,
+        string userId = "me",
+        string? select = "id,displayName,parentFolderId,childFolderCount,wellKnownName,totalItemCount,unreadItemCount",
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(folderIdOrWellKnownName)) {
+            throw new ArgumentException("folderIdOrWellKnownName is required.", nameof(folderIdOrWellKnownName));
+        }
+
+        var userSegment = BuildUserSegment(userId);
+        var selector = Uri.EscapeDataString(folderIdOrWellKnownName.Trim());
+        var url = new StringBuilder();
+        url.Append(userSegment).Append("/mailFolders/").Append(selector);
+        var selectValue = select == null ? null : select.Trim();
+        if (selectValue != null && selectValue.Length > 0) {
+            url.Append("?$select=").Append(Uri.EscapeDataString(selectValue));
+        }
+
+        using var resp = await _client.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph mailFolder get failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        var folder = TryParseMailFolder(doc.RootElement);
+        if (folder is null) {
+            throw new InvalidDataException("Graph returned an invalid mail folder response.");
+        }
+        return folder;
+    }
+
+    /// <summary>
+    /// Lists messages within a mail folder.
+    /// </summary>
+    public async Task<GraphPage<GraphMailMessage>> ListMessagesAsync(
+        string folderIdOrWellKnownName,
+        string userId = "me",
+        int top = 100,
+        int? skip = null,
+        string? select = "id,subject,receivedDateTime,from,toRecipients,internetMessageId,hasAttachments,isRead,flag,conversationId",
+        string? orderBy = "receivedDateTime desc",
+        string? filter = null,
+        string? search = null,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(folderIdOrWellKnownName)) {
+            throw new ArgumentException("folderIdOrWellKnownName is required.", nameof(folderIdOrWellKnownName));
+        }
+
+        var safeTop = ClampInt(top, 1, 999);
+        var userSegment = BuildUserSegment(userId);
+        var folderSelector = Uri.EscapeDataString(folderIdOrWellKnownName.Trim());
+
+        var url = new StringBuilder();
+        url.Append(userSegment).Append("/mailFolders/").Append(folderSelector).Append("/messages");
+        url.Append("?$top=").Append(safeTop.ToString(CultureInfo.InvariantCulture));
+        if (skip.HasValue && skip.Value > 0) {
+            url.Append("&$skip=").Append(skip.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        var orderByValue = orderBy == null ? null : orderBy.Trim();
+        if (orderByValue != null && orderByValue.Length > 0) {
+            url.Append("&$orderby=").Append(Uri.EscapeDataString(orderByValue));
+        }
+        var selectValue = select == null ? null : select.Trim();
+        if (selectValue != null && selectValue.Length > 0) {
+            url.Append("&$select=").Append(Uri.EscapeDataString(selectValue));
+        }
+        var filterValue = filter == null ? null : filter.Trim();
+        if (filterValue != null && filterValue.Length > 0) {
+            url.Append("&$filter=").Append(Uri.EscapeDataString(filterValue));
+        }
+        var searchValue = search == null ? null : search.Trim();
+        if (searchValue != null && searchValue.Length > 0) {
+            var sanitized = searchValue.Replace("\"", string.Empty).Trim();
+            if (sanitized.Length > 0) {
+                url.Append("&$search=").Append(Uri.EscapeDataString("\"" + sanitized + "\""));
+            }
+        }
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, url.ToString());
+        if (searchValue != null && searchValue.Length > 0) {
+            req.Headers.TryAddWithoutValidation("ConsistencyLevel", "eventual");
+            req.Headers.TryAddWithoutValidation("Prefer", "HonorNonIndexedQueriesWarning=true");
+        }
+        using var resp = await _client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph messages list failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+
+        var items = new List<GraphMailMessage>();
+        string? nextLink = null;
+        using (var doc = JsonDocument.Parse(body)) {
+            if (doc.RootElement.TryGetProperty("@odata.nextLink", out var next) && next.ValueKind == JsonValueKind.String) {
+                nextLink = next.GetString();
+            }
+            if (doc.RootElement.TryGetProperty("value", out var value) && value.ValueKind == JsonValueKind.Array) {
+                foreach (var it in value.EnumerateArray()) {
+                    var msg = TryParseMailMessage(it);
+                    if (msg != null) {
+                        items.Add(msg);
+                    }
+                }
+            }
+        }
+
+        return new GraphPage<GraphMailMessage>(items, nextLink);
+    }
+
+    /// <summary>
+    /// Lists message ids for a Graph conversation.
+    /// </summary>
+    public async Task<IReadOnlyList<string>> ListConversationMessageIdsAsync(
+        string conversationId,
+        string userId = "me",
+        int top = 100,
+        int maxPages = 25,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(conversationId)) {
+            throw new ArgumentException("conversationId is required.", nameof(conversationId));
+        }
+
+        var safeTop = ClampInt(top, 1, 999);
+        var safeMaxPages = ClampInt(maxPages, 1, 500);
+        var userSegment = BuildUserSegment(userId);
+
+        var ids = new List<string>();
+        var pages = 0;
+        var filter = "conversationId eq '" + EscapeODataStringLiteral(conversationId.Trim()) + "'";
+        var url = new StringBuilder();
+        url.Append(userSegment).Append("/messages?$select=id&$top=").Append(safeTop.ToString(CultureInfo.InvariantCulture));
+        url.Append("&$filter=").Append(Uri.EscapeDataString(filter));
+
+        string nextUrl = url.ToString();
+        while (pages++ < safeMaxPages) {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var resp = await _client.GetAsync(nextUrl, cancellationToken).ConfigureAwait(false);
+            await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+            var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+            var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+            if (!resp.IsSuccessStatusCode) {
+                throw new GraphApiException(resp.StatusCode, $"Graph conversation list failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+            }
+
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("value", out var value) && value.ValueKind == JsonValueKind.Array) {
+                foreach (var it in value.EnumerateArray()) {
+                    var id = TryGetString(it, "id");
+                    if (id != null) {
+                        var trimmed = id.Trim();
+                        if (trimmed.Length > 0) {
+                            ids.Add(trimmed);
+                        }
+                    }
+                }
+            }
+            if (doc.RootElement.TryGetProperty("@odata.nextLink", out var next) && next.ValueKind == JsonValueKind.String) {
+                var link = next.GetString();
+                if (link != null) {
+                    var trimmed = link.Trim();
+                    if (trimmed.Length > 0) {
+                        nextUrl = trimmed;
+                        continue;
+                    }
+                }
+            }
+            break;
+        }
+
+        return ids;
+    }
+
+    /// <summary>
+    /// Gets message metadata.
+    /// </summary>
+    public async Task<GraphMailMessage> GetMessageAsync(
+        string messageId,
+        string userId = "me",
+        string? select = "id,subject,receivedDateTime,from,toRecipients,internetMessageId,hasAttachments,isRead,flag,conversationId",
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        var userSegment = BuildUserSegment(userId);
+        var selector = Uri.EscapeDataString(messageId.Trim());
+        var url = new StringBuilder();
+        url.Append(userSegment).Append("/messages/").Append(selector);
+        var selectValue = select == null ? null : select.Trim();
+        if (selectValue != null && selectValue.Length > 0) {
+            url.Append("?$select=").Append(Uri.EscapeDataString(selectValue));
+        }
+
+        using var resp = await _client.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph message get failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        var msg = TryParseMailMessage(doc.RootElement);
+        if (msg is null) {
+            throw new InvalidDataException("Graph returned an invalid message response.");
+        }
+        return msg;
+    }
+
+    /// <summary>
+    /// Downloads the message MIME content via the <c>/$value</c> endpoint.
+    /// </summary>
+    public async Task<byte[]> GetMessageMimeAsync(
+        string messageId,
+        string userId = "me",
+        int maxBytes = 25 * 1024 * 1024,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+        if (maxBytes <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), "maxBytes must be > 0.");
+        }
+
+        var userSegment = BuildUserSegment(userId);
+        var selector = Uri.EscapeDataString(messageId.Trim());
+        var url = userSegment + "/messages/" + selector + "/$value";
+
+        using var resp = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode) {
+#if NET5_0_OR_GREATER
+            var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+            var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+            throw new GraphApiException(resp.StatusCode, $"Graph MIME fetch failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+
+#if NET5_0_OR_GREATER
+        await using var stream = await resp.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#else
+        using var stream = await resp.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#endif
+        using var ms = new MemoryStream();
+        var buffer = new byte[81920];
+        while (true) {
+            cancellationToken.ThrowIfCancellationRequested();
+#if NET5_0_OR_GREATER
+            var read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+#else
+            var read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+#endif
+            if (read <= 0) {
+                break;
+            }
+            if (ms.Length + read > maxBytes) {
+                throw new InvalidDataException($"Graph MIME content exceeds {maxBytes} bytes.");
+            }
+#if NET5_0_OR_GREATER
+            await ms.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+#else
+            ms.Write(buffer, 0, read);
+#endif
+        }
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Retrieves a delta page for messages in a folder.
+    /// </summary>
+    /// <remarks>
+    /// When <paramref name="cursor"/> is empty, starts a new delta query for the folder.
+    /// Otherwise, continues from a previously returned nextLink/deltaLink.
+    /// </remarks>
+    public async Task<GraphDeltaPage<GraphMailMessage>> DeltaMessagesAsync(
+        string folderIdOrWellKnownName,
+        string? cursor = null,
+        string userId = "me",
+        int top = 100,
+        string? select = "id,subject,receivedDateTime,from,toRecipients,internetMessageId,hasAttachments,isRead,flag,conversationId",
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(folderIdOrWellKnownName)) {
+            throw new ArgumentException("folderIdOrWellKnownName is required.", nameof(folderIdOrWellKnownName));
+        }
+
+        var safeTop = ClampInt(top, 1, 999);
+        var userSegment = BuildUserSegment(userId);
+
+        var url = (cursor ?? string.Empty).Trim();
+        if (url.Length == 0) {
+            var folderSelector = Uri.EscapeDataString(folderIdOrWellKnownName.Trim());
+            var sb = new StringBuilder();
+            sb.Append(userSegment).Append("/mailFolders/").Append(folderSelector).Append("/messages/delta");
+            sb.Append("?$top=").Append(safeTop.ToString(CultureInfo.InvariantCulture));
+            var selectValue = select == null ? null : select.Trim();
+            if (selectValue != null && selectValue.Length > 0) {
+                sb.Append("&$select=").Append(Uri.EscapeDataString(selectValue));
+            }
+            url = sb.ToString();
+        }
+
+        using var resp = await _client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph delta failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+
+        var upserts = new List<GraphMailMessage>();
+        var deletedIds = new List<string>();
+        string? nextLink = null;
+        string? deltaLink = null;
+
+        using (var doc = JsonDocument.Parse(body)) {
+            if (doc.RootElement.TryGetProperty("@odata.nextLink", out var next) && next.ValueKind == JsonValueKind.String) {
+                nextLink = next.GetString();
+            }
+            if (doc.RootElement.TryGetProperty("@odata.deltaLink", out var delta) && delta.ValueKind == JsonValueKind.String) {
+                deltaLink = delta.GetString();
+            }
+            if (doc.RootElement.TryGetProperty("value", out var value) && value.ValueKind == JsonValueKind.Array) {
+                foreach (var item in value.EnumerateArray()) {
+                    var id = TryGetString(item, "id");
+                    if (id == null) {
+                        continue;
+                    }
+                    var trimmedId = id.Trim();
+                    if (trimmedId.Length == 0) {
+                        continue;
+                    }
+                    if (item.TryGetProperty("@removed", out _)) {
+                        deletedIds.Add(trimmedId);
+                        continue;
+                    }
+                    var msg = TryParseMailMessage(item);
+                    if (msg != null) {
+                        upserts.Add(msg);
+                    }
+                }
+            }
+        }
+
+        return new GraphDeltaPage<GraphMailMessage>(upserts, nextLink, deltaLink, deletedIds);
+    }
+
+    /// <summary>
+    /// Moves a message to the specified destination folder id.
+    /// </summary>
+    public async Task MoveMessageAsync(
+        string messageId,
+        string destinationId,
+        string userId = "me",
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+        if (string.IsNullOrWhiteSpace(destinationId)) {
+            throw new ArgumentException("destinationId is required.", nameof(destinationId));
+        }
+
+        var userSegment = BuildUserSegment(userId);
+        var selector = Uri.EscapeDataString(messageId.Trim());
+        var json = JsonSerializer.Serialize(new GraphDestinationRequest { DestinationId = destinationId.Trim() }, MailozaurrJsonContext.Default.GraphDestinationRequest);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var resp = await _client.PostAsync(userSegment + "/messages/" + selector + "/move", content, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph move failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+    }
+
+    /// <summary>
+    /// Deletes a message.
+    /// </summary>
+    public async Task DeleteMessageAsync(string messageId, string userId = "me", CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+        var userSegment = BuildUserSegment(userId);
+        var selector = Uri.EscapeDataString(messageId.Trim());
+        using var resp = await _client.DeleteAsync(userSegment + "/messages/" + selector, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph delete failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+    }
+
+    /// <summary>
+    /// Sets the read state of a message.
+    /// </summary>
+    public async Task SetMessageIsReadAsync(
+        string messageId,
+        bool isRead,
+        string userId = "me",
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+        var userSegment = BuildUserSegment(userId);
+        var selector = Uri.EscapeDataString(messageId.Trim());
+        var json = JsonSerializer.Serialize(new GraphMarkReadRequest { IsRead = isRead }, MailozaurrJsonContext.Default.GraphMarkReadRequest);
+        using var msg = new HttpRequestMessage(new HttpMethod("PATCH"), userSegment + "/messages/" + selector) {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        using var resp = await _client.SendAsync(msg, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph set-isRead failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+    }
+
+    /// <summary>
+    /// Sets the flagged state of a message.
+    /// </summary>
+    public async Task SetMessageFlaggedAsync(
+        string messageId,
+        bool flagged,
+        string userId = "me",
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+        var userSegment = BuildUserSegment(userId);
+        var selector = Uri.EscapeDataString(messageId.Trim());
+        var status = flagged ? "flagged" : "notFlagged";
+        var json = "{\"flag\":{\"flagStatus\":\"" + status + "\"}}";
+        using var msg = new HttpRequestMessage(new HttpMethod("PATCH"), userSegment + "/messages/" + selector) {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        using var resp = await _client.SendAsync(msg, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph set-flag failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+    }
+
+    /// <summary>
+    /// Sends a Graph batch request using the current bearer token.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBatchResult>> SendBatchAsync(IEnumerable<GraphBatchRequest> requests, CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (requests == null) {
+            throw new ArgumentNullException(nameof(requests));
+        }
+
+        var payload = new GraphBatchPayload();
+        var i = 0;
+        foreach (var r in requests) {
+            if (r == null) {
+                continue;
+            }
+            var id = string.IsNullOrWhiteSpace(r.Id) ? (++i).ToString(CultureInfo.InvariantCulture) : r.Id.Trim();
+            var url = (r.Url ?? string.Empty).Trim();
+            if (url.Length == 0) {
+                throw new ArgumentException("GraphBatchRequest.Url is required.", nameof(requests));
+            }
+
+            payload.Requests.Add(new GraphBatchRequestPayload {
+                Id = id,
+                Method = r.Method.ToString(),
+                Url = url.TrimStart('/'),
+                Headers = r.Headers,
+                Body = r.Body
+            });
+        }
+
+        var json = JsonSerializer.Serialize(payload, MailozaurrJsonContext.Default.GraphBatchPayload);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var resp = await _client.PostAsync("$batch", content, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph batch failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+
+        var results = new List<GraphBatchResult>();
+        using (var doc = JsonDocument.Parse(body)) {
+            if (doc.RootElement.TryGetProperty("responses", out var responses) && responses.ValueKind == JsonValueKind.Array) {
+                foreach (var item in responses.EnumerateArray()) {
+                    var result = new GraphBatchResult();
+                    if (item.TryGetProperty("id", out var idEl) && idEl.ValueKind == JsonValueKind.String) {
+                        result.Id = idEl.GetString() ?? string.Empty;
+                    }
+                    if (item.TryGetProperty("status", out var statusEl) && statusEl.TryGetInt32(out var status)) {
+                        result.Status = status;
+                    }
+                    if (item.TryGetProperty("headers", out var headersEl) && headersEl.ValueKind == JsonValueKind.Object) {
+                        var h = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var prop in headersEl.EnumerateObject()) {
+                            if (prop.Value.ValueKind == JsonValueKind.String) {
+                                h[prop.Name] = prop.Value.GetString() ?? string.Empty;
+                            }
+                        }
+                        result.Headers = h;
+                    }
+                    if (item.TryGetProperty("body", out var bodyEl)) {
+                        result.Body = bodyEl;
+                    }
+                    results.Add(result);
+                }
+            }
+        }
+
+        return results;
+    }
+
     /// <summary>Create subscription request payload.</summary>
     public sealed class GraphCreateSubscriptionRequest {
         /// <summary>
-        /// Resource to subscribe to (for example, <c>me/mailFolders('inbox')/messages</c>).
-        /// </summary>
+         /// Resource to subscribe to (for example, <c>me/mailFolders('inbox')/messages</c>).
+         /// </summary>
         [JsonPropertyName("resource")]
         public string Resource { get; set; } = string.Empty;
 

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailFolder.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailFolder.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents a Microsoft Graph mail folder as returned by the <c>/mailFolders</c> endpoints.
+/// </summary>
+public sealed class GraphMailFolder {
+    /// <summary>Folder identifier.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Folder display name.</summary>
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Parent folder identifier (may be null for top-level folders).</summary>
+    [JsonPropertyName("parentFolderId")]
+    public string? ParentFolderId { get; set; }
+
+    /// <summary>Number of child folders.</summary>
+    [JsonPropertyName("childFolderCount")]
+    public int? ChildFolderCount { get; set; }
+
+    /// <summary>Well-known folder name (for example, <c>inbox</c> or <c>sentitems</c>).</summary>
+    [JsonPropertyName("wellKnownName")]
+    public string? WellKnownName { get; set; }
+
+    /// <summary>Total number of items in the folder.</summary>
+    [JsonPropertyName("totalItemCount")]
+    public int? TotalItemCount { get; set; }
+
+    /// <summary>Number of unread items in the folder.</summary>
+    [JsonPropertyName("unreadItemCount")]
+    public int? UnreadItemCount { get; set; }
+}
+

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailMessage.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailMessage.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents a mail message metadata record returned by Graph mailbox endpoints.
+/// </summary>
+public sealed class GraphMailMessage {
+    /// <summary>Message identifier.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Subject line.</summary>
+    [JsonPropertyName("subject")]
+    public string? Subject { get; set; }
+
+    /// <summary>Received date/time in UTC.</summary>
+    [JsonPropertyName("receivedDateTime")]
+    public DateTimeOffset? ReceivedDateTime { get; set; }
+
+    /// <summary>Sender.</summary>
+    [JsonPropertyName("from")]
+    public GraphEmailAddress? From { get; set; }
+
+    /// <summary>Primary recipients.</summary>
+    [JsonPropertyName("toRecipients")]
+    public List<GraphEmailAddress>? ToRecipients { get; set; }
+
+    /// <summary>Internet message id (RFC822 Message-Id).</summary>
+    [JsonPropertyName("internetMessageId")]
+    public string? InternetMessageId { get; set; }
+
+    /// <summary>True when the message has attachments.</summary>
+    [JsonPropertyName("hasAttachments")]
+    public bool? HasAttachments { get; set; }
+
+    /// <summary>True when the message is marked as read.</summary>
+    [JsonPropertyName("isRead")]
+    public bool? IsRead { get; set; }
+
+    /// <summary>Message flag state.</summary>
+    [JsonPropertyName("flag")]
+    public GraphMailMessageFlag? Flag { get; set; }
+
+    /// <summary>Conversation identifier.</summary>
+    [JsonPropertyName("conversationId")]
+    public string? ConversationId { get; set; }
+}
+

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailMessageFlag.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailMessageFlag.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents the flag status of a Graph message.
+/// </summary>
+public sealed class GraphMailMessageFlag {
+    /// <summary>
+    /// Flag status value (for example, <c>flagged</c> or <c>notFlagged</c>).
+    /// </summary>
+    [JsonPropertyName("flagStatus")]
+    public string? FlagStatus { get; set; }
+}
+

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphPages.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphPages.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents a single page of results returned by Microsoft Graph.
+/// </summary>
+public class GraphPage<T> {
+    /// <summary>Items returned in the current page.</summary>
+    public IReadOnlyList<T> Items { get; }
+
+    /// <summary>Link to the next page (when present).</summary>
+    public string? NextLink { get; }
+
+    /// <summary>Creates a page instance.</summary>
+    public GraphPage(IReadOnlyList<T> items, string? nextLink) {
+        Items = items ?? new List<T>();
+        if (nextLink == null) {
+            NextLink = null;
+        } else {
+            var trimmed = nextLink.Trim();
+            NextLink = trimmed.Length == 0 ? null : trimmed;
+        }
+    }
+}
+
+/// <summary>
+/// Represents a delta page returned by Graph delta endpoints.
+/// </summary>
+public sealed class GraphDeltaPage<T> : GraphPage<T> {
+    /// <summary>Link to the delta cursor (when returned by Graph).</summary>
+    public string? DeltaLink { get; }
+
+    /// <summary>Identifiers of deleted items (tombstones) returned in the current page.</summary>
+    public IReadOnlyList<string> DeletedIds { get; }
+
+    /// <summary>The recommended cursor to persist (nextLink when present, otherwise deltaLink).</summary>
+    public string? Cursor => NextLink ?? DeltaLink;
+
+    /// <summary>Creates a delta page instance.</summary>
+    public GraphDeltaPage(IReadOnlyList<T> items, string? nextLink, string? deltaLink, IReadOnlyList<string> deletedIds)
+        : base(items, nextLink) {
+        if (deltaLink == null) {
+            DeltaLink = null;
+        } else {
+            var trimmed = deltaLink.Trim();
+            DeltaLink = trimmed.Length == 0 ? null : trimmed;
+        }
+        DeletedIds = deletedIds ?? new List<string>();
+    }
+}

--- a/Sources/Mailozaurr/Serialization/JsonDtos.cs
+++ b/Sources/Mailozaurr/Serialization/JsonDtos.cs
@@ -95,6 +95,20 @@ public sealed class GraphMarkReadRequest {
     public bool IsRead { get; set; }
 }
 
+/// <summary>Payload to flag/unflag messages.</summary>
+public sealed class GraphSetFlagRequest {
+    /// <summary>Flag object.</summary>
+    [JsonPropertyName("flag")]
+    public GraphSetFlagRequestFlag Flag { get; set; } = new();
+}
+
+/// <summary>Flag object for <see cref="GraphSetFlagRequest"/>.</summary>
+public sealed class GraphSetFlagRequestFlag {
+    /// <summary>Flag status (for example: flagged, notFlagged).</summary>
+    [JsonPropertyName("flagStatus")]
+    public string? FlagStatus { get; set; }
+}
+
 /// <summary>Payload to rename a Graph mail folder.</summary>
 public sealed class GraphFolderRenameRequest {
     /// <summary>New display name.</summary>

--- a/Sources/Mailozaurr/Serialization/MailozaurrJsonContext.cs
+++ b/Sources/Mailozaurr/Serialization/MailozaurrJsonContext.cs
@@ -56,6 +56,8 @@ namespace Mailozaurr;
 [JsonSerializable(typeof(GraphSearchQuery))]
 [JsonSerializable(typeof(GraphDestinationRequest))]
 [JsonSerializable(typeof(GraphMarkReadRequest))]
+[JsonSerializable(typeof(GraphSetFlagRequest))]
+[JsonSerializable(typeof(GraphSetFlagRequestFlag))]
 [JsonSerializable(typeof(GraphFolderRenameRequest))]
 [JsonSerializable(typeof(GraphApiClient.GraphCreateSubscriptionRequest))]
 [JsonSerializable(typeof(GraphApiClient.GraphRenewSubscriptionRequest))]


### PR DESCRIPTION
Adds Graph mailbox primitives to GraphApiClient for reuse by downstream apps:
- recursive folder listing
- list messages with filter/search
- delta sync (nextLink/deltaLink + tombstones)
- get message metadata
- download MIME via /
- move/delete/set-isRead/set-flag
- token-based / helper

Includes unit tests for request shaping and basic response parsing.