### PR TITLE
POP3: add lightweight mailbox browser helpers

### DIFF
--- a/Sources/Mailozaurr.Tests/Pop3MailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/Pop3MailboxBrowserTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MimeKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class Pop3MailboxBrowserTests {
+    [Fact]
+    public async Task ListMessageHeadersCoreAsync_ListsNewestFirst_WithOffsetAndLimit() {
+        var fake = new FakePop3Client(count: 5);
+        // indices: 0..4, newest is 4
+        fake.SetHeaders(4, BuildHeaders(messageId: "<m4>", from: "f4", to: "t4", subject: "s4", date: "Mon, 01 Jan 2024 10:00:00 +0000"));
+        fake.SetHeaders(3, BuildHeaders(messageId: "<m3>", from: "f3", to: "t3", subject: "s3", date: "Mon, 01 Jan 2024 09:00:00 +0000"));
+        fake.SetHeaders(2, BuildHeaders(messageId: "<m2>", from: "f2", to: "t2", subject: "s2", date: "Mon, 01 Jan 2024 08:00:00 +0000"));
+        fake.SetHeaders(1, BuildHeaders(messageId: "<m1>", from: "f1", to: "t1", subject: "s1", date: "Mon, 01 Jan 2024 07:00:00 +0000"));
+        fake.SetHeaders(0, BuildHeaders(messageId: "<m0>", from: "f0", to: "t0", subject: "s0", date: "Mon, 01 Jan 2024 06:00:00 +0000"));
+
+        fake.SetUid(4, "u4");
+        fake.SetUid(3, "u3");
+        fake.SetUid(2, "u2");
+        fake.SetUid(1, "u1");
+        fake.SetUid(0, "u0");
+
+        fake.SetSize(4, 400);
+        fake.SetSize(3, 300);
+        fake.SetSize(2, 200);
+        fake.SetSize(1, 100);
+        fake.SetSize(0, 0);
+
+        var list = await Pop3MailboxBrowser.ListMessageHeadersCoreAsync(fake, limit: 2, offset: 1, CancellationToken.None);
+        Assert.Equal(5, list.TotalCount);
+        Assert.Equal(2, list.Messages.Count);
+
+        // offset=1 skips newest (4), so first is 3 then 2.
+        Assert.Equal(3, list.Messages[0].Index);
+        Assert.Equal("u3", list.Messages[0].Uid);
+        Assert.Equal(300, list.Messages[0].MessageSize);
+        Assert.Equal("m3", list.Messages[0].MessageId);
+        Assert.Equal("f3", list.Messages[0].From);
+        Assert.Equal("t3", list.Messages[0].To);
+        Assert.Equal("s3", list.Messages[0].Subject);
+
+        Assert.Equal(2, list.Messages[1].Index);
+        Assert.Equal("m2", list.Messages[1].MessageId);
+    }
+
+    [Fact]
+    public async Task ResolveMessageCoreAsync_MissingIdentifier_ReturnsMissingIdentifier() {
+        var fake = new FakePop3Client(count: 1);
+        var result = await Pop3MailboxBrowser.ResolveMessageCoreAsync(fake, requestedIndex: null, requestedUid: null, CancellationToken.None);
+        Assert.Equal(Pop3MailboxBrowser.Pop3MessageResolveStatus.MissingIdentifier, result.Status);
+        Assert.Null(result.Snapshot);
+    }
+
+    [Fact]
+    public async Task ResolveMessageCoreAsync_InvalidIndex_ReturnsInvalidIndex() {
+        var fake = new FakePop3Client(count: 1);
+        var result = await Pop3MailboxBrowser.ResolveMessageCoreAsync(fake, requestedIndex: -1, requestedUid: null, CancellationToken.None);
+        Assert.Equal(Pop3MailboxBrowser.Pop3MessageResolveStatus.InvalidIndex, result.Status);
+    }
+
+    [Fact]
+    public async Task ResolveMessageCoreAsync_UidLookupUnsupported_ReturnsUidLookupUnsupported() {
+        var fake = new FakePop3Client(count: 1) { ThrowUidListNotSupported = true };
+        var result = await Pop3MailboxBrowser.ResolveMessageCoreAsync(fake, requestedIndex: null, requestedUid: "u1", CancellationToken.None);
+        Assert.Equal(Pop3MailboxBrowser.Pop3MessageResolveStatus.UidLookupUnsupported, result.Status);
+    }
+
+    [Fact]
+    public async Task ResolveMessageCoreAsync_ResolvesByUid() {
+        var fake = new FakePop3Client(count: 3);
+        fake.Uids = new List<string> { "u0", "u1", "u2" };
+        fake.SetSize(1, 123);
+        fake.SetMessage(1, new MimeMessage { Subject = "x" });
+
+        var result = await Pop3MailboxBrowser.ResolveMessageCoreAsync(fake, requestedIndex: null, requestedUid: "u1", CancellationToken.None);
+        Assert.Equal(Pop3MailboxBrowser.Pop3MessageResolveStatus.Success, result.Status);
+        Assert.NotNull(result.Snapshot);
+        Assert.Equal(1, result.Snapshot!.Index);
+        Assert.Equal("u1", result.Snapshot.Uid);
+        Assert.Equal(123, result.Snapshot.MessageSize);
+        Assert.Equal("x", result.Snapshot.Message.Subject);
+    }
+
+    [Fact]
+    public void NormalizeMessageIdValue_StripsAngleBrackets() {
+        Assert.Equal("x@y", Pop3MailboxBrowser.NormalizeMessageIdValue("<x@y>"));
+        Assert.Equal("x@y", Pop3MailboxBrowser.NormalizeMessageIdValue("x@y"));
+        Assert.Null(Pop3MailboxBrowser.NormalizeMessageIdValue("   "));
+    }
+
+    private static HeaderList BuildHeaders(string messageId, string from, string to, string subject, string date) {
+        var headers = new HeaderList();
+        headers.Add(HeaderId.MessageId, messageId);
+        headers.Add(HeaderId.From, from);
+        headers.Add(HeaderId.To, to);
+        headers.Add(HeaderId.Subject, subject);
+        headers.Add(HeaderId.Date, date);
+        return headers;
+    }
+
+    private sealed class FakePop3Client : Pop3MailboxBrowser.IPop3MailboxClient {
+        private readonly Dictionary<int, HeaderList> _headers = new();
+        private readonly Dictionary<int, string> _uids = new();
+        private readonly Dictionary<int, long> _sizes = new();
+        private readonly Dictionary<int, MimeMessage> _messages = new();
+
+        internal FakePop3Client(int count) {
+            Count = count;
+        }
+
+        public int Count { get; }
+        public bool ThrowUidListNotSupported { get; set; }
+        public IList<string> Uids { get; set; } = new List<string>();
+
+        internal void SetHeaders(int index, HeaderList headers) => _headers[index] = headers;
+        internal void SetUid(int index, string uid) => _uids[index] = uid;
+        internal void SetSize(int index, long size) => _sizes[index] = size;
+        internal void SetMessage(int index, MimeMessage msg) => _messages[index] = msg;
+
+        public Task<HeaderList> GetMessageHeadersAsync(int index, CancellationToken cancellationToken) =>
+            Task.FromResult(_headers.TryGetValue(index, out var h) ? h : new HeaderList());
+
+        public Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken) =>
+            Task.FromResult(_messages.TryGetValue(index, out var m) ? m : new MimeMessage());
+
+        public Task<string> GetMessageUidAsync(int index, CancellationToken cancellationToken) =>
+            Task.FromResult(_uids.TryGetValue(index, out var u) ? u : $"u{index}");
+
+        public Task<IList<string>> GetMessageUidsAsync(CancellationToken cancellationToken) {
+            if (ThrowUidListNotSupported) {
+                throw new NotSupportedException("uid list not supported");
+            }
+            return Task.FromResult(Uids);
+        }
+
+        public long GetMessageSize(int index, CancellationToken cancellationToken) =>
+            _sizes.TryGetValue(index, out var s) ? s : 0;
+    }
+}
+

--- a/Sources/Mailozaurr/Compatibility/IsExternalInit.cs
+++ b/Sources/Mailozaurr/Compatibility/IsExternalInit.cs
@@ -1,0 +1,8 @@
+// Required to support `init` setters / `record` types when targeting older TFMs.
+// This shim is compiled only for TFMs that don't provide IsExternalInit.
+#if NET472 || NETSTANDARD2_0
+namespace System.Runtime.CompilerServices {
+    internal static class IsExternalInit { }
+}
+#endif
+

--- a/Sources/Mailozaurr/Receive/Pop3MailboxBrowser.cs
+++ b/Sources/Mailozaurr/Receive/Pop3MailboxBrowser.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Pop3;
+using MimeKit;
+using MimeKit.Utils;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Lightweight POP3 mailbox browsing helpers that avoid downloading full messages when possible.
+/// </summary>
+public static class Pop3MailboxBrowser {
+    /// <summary>
+    /// Represents the outcome of resolving a POP3 message request.
+    /// </summary>
+    public enum Pop3MessageResolveStatus {
+        /// <summary>Message was resolved successfully.</summary>
+        Success,
+        /// <summary>Neither index nor uid was provided.</summary>
+        MissingIdentifier,
+        /// <summary>Provided index is invalid (negative).</summary>
+        InvalidIndex,
+        /// <summary>UID lookup is not supported by the POP3 server.</summary>
+        UidLookupUnsupported,
+        /// <summary>Message was not found.</summary>
+        NotFound
+    }
+
+    /// <summary>Summary of a POP3 message derived from message headers.</summary>
+    public sealed record Pop3MessageHeaderSnapshot(
+        int Index,
+        string? Uid,
+        long? MessageSize,
+        string? MessageId,
+        string From,
+        string To,
+        string? Subject,
+        DateTime DateUtc,
+        bool HasAttachmentsHint);
+
+    /// <summary>Response envelope for POP3 header listing.</summary>
+    public sealed record Pop3ListSnapshot(
+        int TotalCount,
+        IReadOnlyList<Pop3MessageHeaderSnapshot> Messages);
+
+    /// <summary>Resolved message snapshot for POP3.</summary>
+    public sealed record Pop3ResolvedMessageSnapshot(
+        int Index,
+        string? Uid,
+        long? MessageSize,
+        MimeMessage Message);
+
+    /// <summary>Result of resolving a POP3 message request.</summary>
+    public sealed record Pop3MessageResolveResult(
+        Pop3MessageResolveStatus Status,
+        Pop3ResolvedMessageSnapshot? Snapshot);
+
+    /// <summary>
+    /// Lists messages as header-only snapshots, starting from the newest message.
+    /// </summary>
+    /// <remarks>
+    /// POP3 servers expose messages using zero-based indices. This method iterates from newest to oldest, applying an offset
+    /// (from the newest message) and returning up to <paramref name="limit"/> messages.
+    /// </remarks>
+    public static Task<Pop3ListSnapshot> ListMessageHeadersAsync(
+        Pop3Client client,
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        return ListMessageHeadersCoreAsync(new MailKitPop3MailboxClient(client), limit, offset, cancellationToken);
+    }
+
+    /// <summary>
+    /// Resolves and downloads a single message by index or UIDL value.
+    /// </summary>
+    public static Task<Pop3MessageResolveResult> ResolveMessageAsync(
+        Pop3Client client,
+        int? requestedIndex,
+        string? requestedUid,
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        return ResolveMessageCoreAsync(new MailKitPop3MailboxClient(client), requestedIndex, requestedUid, cancellationToken);
+    }
+
+    internal interface IPop3MailboxClient {
+        int Count { get; }
+        Task<HeaderList> GetMessageHeadersAsync(int index, CancellationToken cancellationToken);
+        Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken);
+        Task<string> GetMessageUidAsync(int index, CancellationToken cancellationToken);
+        Task<IList<string>> GetMessageUidsAsync(CancellationToken cancellationToken);
+        long GetMessageSize(int index, CancellationToken cancellationToken);
+    }
+
+    internal sealed class MailKitPop3MailboxClient : IPop3MailboxClient {
+        private readonly Pop3Client _client;
+
+        internal MailKitPop3MailboxClient(Pop3Client client) {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        public int Count => _client.Count;
+
+        public Task<HeaderList> GetMessageHeadersAsync(int index, CancellationToken cancellationToken) =>
+            _client.GetMessageHeadersAsync(index, cancellationToken);
+
+        public Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken) =>
+            _client.GetMessageAsync(index, cancellationToken);
+
+        public Task<string> GetMessageUidAsync(int index, CancellationToken cancellationToken) =>
+            _client.GetMessageUidAsync(index, cancellationToken);
+
+        public Task<IList<string>> GetMessageUidsAsync(CancellationToken cancellationToken) =>
+            _client.GetMessageUidsAsync(cancellationToken);
+
+        public long GetMessageSize(int index, CancellationToken cancellationToken) =>
+            _client.GetMessageSize(index, cancellationToken);
+    }
+
+    internal static async Task<Pop3ListSnapshot> ListMessageHeadersCoreAsync(
+        IPop3MailboxClient client,
+        int limit,
+        int offset,
+        CancellationToken cancellationToken) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (limit < 1) {
+            throw new ArgumentOutOfRangeException(nameof(limit));
+        }
+        if (offset < 0) {
+            throw new ArgumentOutOfRangeException(nameof(offset));
+        }
+
+        var totalCount = client.Count;
+        var messages = new List<Pop3MessageHeaderSnapshot>();
+        var start = totalCount - 1 - offset;
+        for (var index = start; index >= 0 && messages.Count < limit; index--) {
+            var headers = await client.GetMessageHeadersAsync(index, cancellationToken).ConfigureAwait(false);
+            var uid = await TryGetMessageUidAsync(client, index, cancellationToken).ConfigureAwait(false);
+            var messageSize = TryGetMessageSize(client, index, cancellationToken);
+
+            messages.Add(new Pop3MessageHeaderSnapshot(
+                Index: index,
+                Uid: uid,
+                MessageSize: messageSize,
+                MessageId: NormalizeMessageIdValue(headers[HeaderId.MessageId]),
+                From: headers[HeaderId.From] ?? string.Empty,
+                To: headers[HeaderId.To] ?? string.Empty,
+                Subject: string.IsNullOrWhiteSpace(headers[HeaderId.Subject]) ? null : headers[HeaderId.Subject],
+                DateUtc: ParseHeaderDateUtc(headers[HeaderId.Date]),
+                HasAttachmentsHint: HasAttachmentHint(headers)));
+        }
+
+        return new Pop3ListSnapshot(totalCount, messages);
+    }
+
+    internal static async Task<Pop3MessageResolveResult> ResolveMessageCoreAsync(
+        IPop3MailboxClient client,
+        int? requestedIndex,
+        string? requestedUid,
+        CancellationToken cancellationToken) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+
+        var uid = NormalizeOptional(requestedUid);
+        if (requestedIndex is null && string.IsNullOrWhiteSpace(uid)) {
+            return new Pop3MessageResolveResult(Pop3MessageResolveStatus.MissingIdentifier, null);
+        }
+
+        if (requestedIndex is not null && requestedIndex.Value < 0) {
+            return new Pop3MessageResolveResult(Pop3MessageResolveStatus.InvalidIndex, null);
+        }
+
+        var resolvedIndex = requestedIndex ?? -1;
+        if (!string.IsNullOrWhiteSpace(uid)) {
+            var lookup = await TryResolveMessageIndexByUidAsync(client, uid!, cancellationToken).ConfigureAwait(false);
+            if (!lookup.Supported) {
+                return new Pop3MessageResolveResult(Pop3MessageResolveStatus.UidLookupUnsupported, null);
+            }
+            if (lookup.Index is null) {
+                return new Pop3MessageResolveResult(Pop3MessageResolveStatus.NotFound, null);
+            }
+            resolvedIndex = lookup.Index.Value;
+        }
+
+        var totalCount = client.Count;
+        if (resolvedIndex < 0 || resolvedIndex >= totalCount) {
+            return new Pop3MessageResolveResult(Pop3MessageResolveStatus.NotFound, null);
+        }
+
+        var resolvedUid = string.IsNullOrWhiteSpace(uid)
+            ? await TryGetMessageUidAsync(client, resolvedIndex, cancellationToken).ConfigureAwait(false)
+            : uid;
+        var messageSize = TryGetMessageSize(client, resolvedIndex, cancellationToken);
+        var message = await client.GetMessageAsync(resolvedIndex, cancellationToken).ConfigureAwait(false);
+
+        return new Pop3MessageResolveResult(
+            Pop3MessageResolveStatus.Success,
+            new Pop3ResolvedMessageSnapshot(resolvedIndex, resolvedUid, messageSize, message));
+    }
+
+    internal static string? NormalizeOptional(string? raw) =>
+        string.IsNullOrWhiteSpace(raw) ? null : raw.Trim();
+
+    internal static string? NormalizeMessageIdValue(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+        var trimmed = value!.Trim();
+        if (trimmed.Length > 1 && trimmed[0] == '<' && trimmed[trimmed.Length - 1] == '>') {
+            trimmed = trimmed.Substring(1, trimmed.Length - 2);
+        }
+        return trimmed;
+    }
+
+    private static DateTime ParseHeaderDateUtc(string? raw) {
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return DateTime.UtcNow;
+        }
+
+        // Prefer RFC822/RFC2822 parsing.
+        if (DateUtils.TryParse(raw, out var parsed)) {
+            return parsed.UtcDateTime;
+        }
+
+        // As a fallback (non-standard servers), attempt a broad parse.
+        if (DateTimeOffset.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var dt)) {
+            return dt.UtcDateTime;
+        }
+
+        return DateTime.UtcNow;
+    }
+
+    private static bool HasAttachmentHint(HeaderList headers) {
+        var contentType = headers[HeaderId.ContentType] ?? string.Empty;
+        var contentDisposition = headers[HeaderId.ContentDisposition] ?? string.Empty;
+        if (contentDisposition.Contains("attachment", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+        if (contentType.Contains("multipart/mixed", StringComparison.OrdinalIgnoreCase) ||
+            contentType.Contains("multipart/related", StringComparison.OrdinalIgnoreCase) ||
+            contentType.Contains("name=", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+        return false;
+    }
+
+    private static async Task<Pop3UidLookupResult> TryResolveMessageIndexByUidAsync(
+        IPop3MailboxClient client,
+        string uid,
+        CancellationToken cancellationToken) {
+        try {
+            var uids = await client.GetMessageUidsAsync(cancellationToken).ConfigureAwait(false);
+            for (var i = 0; i < uids.Count; i++) {
+                if (string.Equals(uids[i], uid, StringComparison.Ordinal)) {
+                    return new Pop3UidLookupResult(true, i);
+                }
+            }
+
+            return new Pop3UidLookupResult(true, null);
+        } catch (NotSupportedException) {
+            return new Pop3UidLookupResult(false, null);
+        }
+    }
+
+    private static async Task<string?> TryGetMessageUidAsync(IPop3MailboxClient client, int index, CancellationToken cancellationToken) {
+        try {
+            return await client.GetMessageUidAsync(index, cancellationToken).ConfigureAwait(false);
+        } catch {
+            return null;
+        }
+    }
+
+    private static long? TryGetMessageSize(IPop3MailboxClient client, int index, CancellationToken cancellationToken) {
+        try {
+            return client.GetMessageSize(index, cancellationToken);
+        } catch {
+            return null;
+        }
+    }
+
+    private sealed record Pop3UidLookupResult(bool Supported, int? Index);
+}

--- a/Sources/Mailozaurr/Receive/Pop3MailboxBrowser.cs
+++ b/Sources/Mailozaurr/Receive/Pop3MailboxBrowser.cs
@@ -209,7 +209,7 @@ public static class Pop3MailboxBrowser {
     }
 
     internal static string? NormalizeOptional(string? raw) =>
-        string.IsNullOrWhiteSpace(raw) ? null : raw.Trim();
+        string.IsNullOrWhiteSpace(raw) ? null : raw!.Trim();
 
     internal static string? NormalizeMessageIdValue(string? value) {
         if (string.IsNullOrWhiteSpace(value)) {


### PR DESCRIPTION
Adds Pop3MailboxBrowser for header-only POP3 listing and index/uid resolution without downloading full messages. Includes unit tests via internal mailbox client abstraction (Mailozaurr.Tests has InternalsVisibleTo).