### PR TITLE
Add Graph draft/upload helpers and POP3 attachment payload builder

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphApiClientMailboxTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphApiClientMailboxTests.cs
@@ -79,4 +79,66 @@ public class GraphApiClientMailboxTests {
         Assert.Contains("\"url\":\"me/messages/123\"", body);
         Assert.Contains("\"method\":\"DELETE\"", body);
     }
+
+    [Fact]
+    public async System.Threading.Tasks.Task CreateMessageAsync_CreatesDraftInFolder() {
+        var json = "{\"id\":\"m-created\",\"subject\":\"s\"}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StringContent(json)
+        });
+        var api = new GraphApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = DateTimeOffset.MaxValue });
+        var field = typeof(GraphApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(api, new HttpClient(handler) { BaseAddress = new Uri("https://graph.microsoft.com/v1.0/") });
+
+        var created = await api.CreateMessageAsync(
+            new GraphMessage {
+                Subject = "s",
+                Body = new GraphContent { Type = "Text", Content = "body" }
+            },
+            folderIdOrWellKnownName: "sentitems");
+
+        Assert.Equal("m-created", created.Id);
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Contains("/me/mailFolders/sentitems/messages", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SendDraftMessageAsync_PostsToSendEndpoint() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.Accepted) {
+            Content = new StringContent(string.Empty)
+        });
+        var api = new GraphApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = DateTimeOffset.MaxValue });
+        var field = typeof(GraphApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(api, new HttpClient(handler) { BaseAddress = new Uri("https://graph.microsoft.com/v1.0/") });
+
+        await api.SendDraftMessageAsync("m123");
+
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Contains("/me/messages/m123/send", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task CreateAttachmentUploadSessionAsync_UsesAttachmentItemEnvelope() {
+        var json = "{\"uploadUrl\":\"https://upload.example/session\"}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StringContent(json)
+        });
+        var api = new GraphApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = DateTimeOffset.MaxValue });
+        var field = typeof(GraphApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(api, new HttpClient(handler) { BaseAddress = new Uri("https://graph.microsoft.com/v1.0/") });
+
+        var session = await api.CreateAttachmentUploadSessionAsync(
+            "m123",
+            new GraphAttachmentItem("file", "a.txt", 10));
+
+        Assert.Equal("https://upload.example/session", session.UploadUrl);
+        Assert.Single(handler.Requests);
+        var body = await handler.Requests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"attachmentItem\"", body);
+        Assert.Contains("\"attachmentType\":\"file\"", body);
+        Assert.Contains("\"name\":\"a.txt\"", body);
+        Assert.Contains("\"size\":10", body);
+    }
 }

--- a/Sources/Mailozaurr.Tests/Pop3AttachmentPayloadBuilderTests.cs
+++ b/Sources/Mailozaurr.Tests/Pop3AttachmentPayloadBuilderTests.cs
@@ -1,0 +1,49 @@
+using MimeKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class Pop3AttachmentPayloadBuilderTests {
+    [Fact]
+    public void Build_ReturnsNotFound_WhenIndexOutOfRange() {
+        var message = new MimeMessage {
+            Body = new TextPart("plain") { Text = "body" }
+        };
+
+        var result = Pop3AttachmentPayloadBuilder.Build(message, attachmentIndex: 0, maxBytes: 1024);
+
+        Assert.Equal(Pop3AttachmentBuildStatus.NotFound, result.Status);
+        Assert.False(result.Success);
+        Assert.Null(result.Payload);
+    }
+
+    [Fact]
+    public void Build_ReturnsSizeLimitExceeded_WhenPayloadTooLarge() {
+        var message = new MimeMessage();
+        var body = new BodyBuilder { TextBody = "body" };
+        body.Attachments.Add("a.txt", new byte[64]);
+        message.Body = body.ToMessageBody();
+
+        var result = Pop3AttachmentPayloadBuilder.Build(message, attachmentIndex: 0, maxBytes: 8);
+
+        Assert.Equal(Pop3AttachmentBuildStatus.SizeLimitExceeded, result.Status);
+        Assert.False(result.Success);
+        Assert.Null(result.Payload);
+    }
+
+    [Fact]
+    public void Build_ReturnsPayload_ForMimePart() {
+        var message = new MimeMessage();
+        var body = new BodyBuilder { TextBody = "body" };
+        body.Attachments.Add("a.txt", new byte[] { 1, 2, 3, 4 });
+        message.Body = body.ToMessageBody();
+
+        var result = Pop3AttachmentPayloadBuilder.Build(message, attachmentIndex: 0, maxBytes: 1024);
+
+        Assert.Equal(Pop3AttachmentBuildStatus.Success, result.Status);
+        Assert.True(result.Success);
+        Assert.NotNull(result.Payload);
+        Assert.Equal("a.txt", result.Payload!.FileName);
+        Assert.Equal(4, result.Payload.Bytes.Length);
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
@@ -906,6 +906,215 @@ public sealed class GraphApiClient : IDisposable {
     }
 
     /// <summary>
+    /// Creates a message draft, optionally under a specific folder.
+    /// </summary>
+    public async Task<GraphMessage> CreateMessageAsync(
+        GraphMessage message,
+        string userId = "me",
+        string? folderIdOrWellKnownName = null,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var userSegment = BuildUserSegment(userId);
+        string? trimmedFolderId = null;
+        if (folderIdOrWellKnownName != null) {
+            var candidate = folderIdOrWellKnownName.Trim();
+            if (candidate.Length > 0) {
+                trimmedFolderId = candidate;
+            }
+        }
+        var url = trimmedFolderId == null
+            ? userSegment + "/messages"
+            : userSegment + "/mailFolders/" + Uri.EscapeDataString(trimmedFolderId) + "/messages";
+        var payload = JsonSerializer.Serialize(message, MailozaurrJsonContext.Default.GraphMessage);
+        using var req = new HttpRequestMessage(HttpMethod.Post, url) {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json")
+        };
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph message create failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+
+        GraphMessage? created;
+        try {
+            created = JsonSerializer.Deserialize(body, MailozaurrJsonContext.Default.GraphMessage);
+        } catch (JsonException ex) {
+            throw new InvalidDataException("Failed to parse Graph message create response.", ex);
+        }
+        if (created == null || string.IsNullOrWhiteSpace(created.Id)) {
+            throw new InvalidDataException("Graph returned an invalid created message response.");
+        }
+        return created;
+    }
+
+    /// <summary>
+    /// Sends an existing draft message.
+    /// </summary>
+    public async Task SendDraftMessageAsync(
+        string messageId,
+        string userId = "me",
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        var userSegment = BuildUserSegment(userId);
+        var selector = Uri.EscapeDataString(messageId.Trim());
+        using var req = new HttpRequestMessage(HttpMethod.Post, userSegment + "/messages/" + selector + "/send");
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph draft send failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+    }
+
+    /// <summary>
+    /// Creates attachment upload session for an existing draft message.
+    /// </summary>
+    public async Task<GraphUploadSessionResult> CreateAttachmentUploadSessionAsync(
+        string messageId,
+        GraphAttachmentItem attachmentItem,
+        string userId = "me",
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+        if (attachmentItem == null) {
+            throw new ArgumentNullException(nameof(attachmentItem));
+        }
+        if (string.IsNullOrWhiteSpace(attachmentItem.Name)) {
+            throw new ArgumentException("attachmentItem.Name is required.", nameof(attachmentItem));
+        }
+        if (attachmentItem.Size <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(attachmentItem), "attachmentItem.Size must be > 0.");
+        }
+
+        var userSegment = BuildUserSegment(userId);
+        var selector = Uri.EscapeDataString(messageId.Trim());
+        var url = userSegment + "/messages/" + selector + "/attachments/createUploadSession";
+
+        var payload = BuildCreateUploadSessionPayload(attachmentItem);
+        using var req = new HttpRequestMessage(HttpMethod.Post, url) {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json")
+        };
+        ApplyAuthHeader(req);
+        using var resp = await _client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        await ThrowIfAuthErrorAsync(resp, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            throw new GraphApiException(resp.StatusCode, $"Graph upload session create failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+        }
+
+        GraphUploadSessionResult? result;
+        try {
+            result = JsonSerializer.Deserialize(body, MailozaurrJsonContext.Default.GraphUploadSessionResult);
+        } catch (JsonException ex) {
+            throw new InvalidDataException("Failed to parse Graph upload session response.", ex);
+        }
+        if (result == null || string.IsNullOrWhiteSpace(result.UploadUrl)) {
+            throw new InvalidDataException("Graph returned an invalid upload session response.");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Uploads one attachment chunk to a Graph upload session URL.
+    /// </summary>
+    public async Task UploadAttachmentChunkAsync(
+        string uploadUrl,
+        byte[] chunk,
+        long startInclusive,
+        long endInclusive,
+        long totalLength,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(uploadUrl)) {
+            throw new ArgumentException("uploadUrl is required.", nameof(uploadUrl));
+        }
+        if (chunk == null) {
+            throw new ArgumentNullException(nameof(chunk));
+        }
+        if (chunk.Length == 0) {
+            throw new ArgumentException("chunk must not be empty.", nameof(chunk));
+        }
+
+        using var req = new HttpRequestMessage(HttpMethod.Put, uploadUrl);
+        req.Content = new ByteArrayContent(chunk);
+        req.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        req.Content.Headers.ContentRange = new ContentRangeHeaderValue(startInclusive, endInclusive, totalLength);
+
+        using var resp = await _client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (resp.IsSuccessStatusCode || (int)resp.StatusCode == 202) {
+            return;
+        }
+
+        throw new GraphApiException(resp.StatusCode, $"Graph attachment chunk upload failed ({(int)resp.StatusCode}).", body, TryGetRetryAfter(resp));
+    }
+
+    private static string BuildCreateUploadSessionPayload(GraphAttachmentItem attachmentItem) {
+        static string JsonString(string value) =>
+            "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+
+        var sb = new StringBuilder();
+        sb.Append("{\"attachmentItem\":{");
+        sb.Append("\"attachmentType\":").Append(JsonString(string.IsNullOrWhiteSpace(attachmentItem.AttachmentType) ? "file" : attachmentItem.AttachmentType.Trim())).Append(',');
+        sb.Append("\"name\":").Append(JsonString(attachmentItem.Name.Trim())).Append(',');
+        sb.Append("\"size\":").Append(attachmentItem.Size.ToString(CultureInfo.InvariantCulture));
+        string? contentType = null;
+        if (attachmentItem.ContentType != null) {
+            var candidate = attachmentItem.ContentType.Trim();
+            if (candidate.Length > 0) {
+                contentType = candidate;
+            }
+        }
+        if (contentType != null) {
+            sb.Append(",\"contentType\":").Append(JsonString(contentType));
+        }
+        if (attachmentItem.IsInline.HasValue && attachmentItem.IsInline.Value) {
+            sb.Append(",\"isInline\":true");
+            string? contentId = null;
+            if (attachmentItem.ContentId != null) {
+                var candidate = attachmentItem.ContentId.Trim();
+                if (candidate.Length > 0) {
+                    contentId = candidate;
+                }
+            }
+            if (contentId != null) {
+                sb.Append(",\"contentId\":").Append(JsonString(contentId));
+            }
+        }
+        sb.Append("}}");
+        return sb.ToString();
+    }
+
+    /// <summary>
     /// Retrieves a delta page for messages in a folder.
     /// </summary>
     /// <remarks>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachment.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachment.cs
@@ -21,6 +21,13 @@ public class GraphAttachment {
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets attachment content type.
+    /// </summary>
+    [JsonPropertyName("contentType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ContentType { get; set; }
+
+    /// <summary>
     /// Gets or sets the file content encoded as a Base64 string.
     /// </summary>
     [JsonPropertyName("contentBytes")]

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentItem.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphAttachmentItem.cs
@@ -26,6 +26,27 @@ public class GraphAttachmentItem {
     [JsonPropertyName("size")]
     public long Size { get; set; }
 
+    /// <summary>
+    /// Gets or sets optional content type.
+    /// </summary>
+    [JsonPropertyName("contentType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ContentType { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether attachment should be rendered inline.
+    /// </summary>
+    [JsonPropertyName("isInline")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? IsInline { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional content identifier for inline attachments.
+    /// </summary>
+    [JsonPropertyName("contentId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ContentId { get; set; }
+
     /// <summary>Creates a new attachment item.</summary>
     /// <param name="attachmentType">Type of the attachment.</param>
     /// <param name="name">File name.</param>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphEmail.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphEmail.cs
@@ -9,4 +9,11 @@ public class GraphEmail {
     /// </summary>
     [JsonPropertyName("address")]
     public string Address { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the optional display name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Name { get; set; }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphLargeAttachmentUploader.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphLargeAttachmentUploader.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Uploads Graph attachments via upload sessions.
+/// </summary>
+public static class GraphLargeAttachmentUploader {
+    // Must be a multiple of 320 KiB (except last chunk).
+    private const int ChunkSize = 327_680 * 32; // 10 MiB
+
+    /// <summary>
+    /// Uploads decoded attachments to an existing draft message.
+    /// </summary>
+    /// <returns>Error text when upload fails; otherwise null.</returns>
+    public static async Task<string?> UploadAsync(
+        HttpClient client,
+        string accessToken,
+        string messageId,
+        IReadOnlyList<DecodedMimeAttachment> attachments,
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (string.IsNullOrWhiteSpace(accessToken)) {
+            throw new ArgumentException("accessToken is required.", nameof(accessToken));
+        }
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+        if (attachments == null) {
+            throw new ArgumentNullException(nameof(attachments));
+        }
+
+        foreach (var attachment in attachments) {
+            if (attachment == null) {
+                continue;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var uploadUrl = await CreateUploadSessionAsync(client, accessToken, messageId, attachment, cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(uploadUrl)) {
+                return "Graph upload session creation failed (empty uploadUrl).";
+            }
+
+            var uploadError = await UploadToSessionAsync(client, uploadUrl!, attachment, cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(uploadError)) {
+                return uploadError;
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<string?> CreateUploadSessionAsync(
+        HttpClient client,
+        string accessToken,
+        string messageId,
+        DecodedMimeAttachment attachment,
+        CancellationToken cancellationToken) {
+        var url = "https://graph.microsoft.com/v1.0/me/messages/" + Uri.EscapeDataString(messageId) + "/attachments/createUploadSession";
+        using var req = new HttpRequestMessage(HttpMethod.Post, url);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        req.Content = new StringContent(BuildUploadSessionRequestJson(attachment), Encoding.UTF8, "application/json");
+
+        using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!resp.IsSuccessStatusCode) {
+            var trimmed = (body ?? string.Empty).Replace('\r', ' ').Replace('\n', ' ').Trim();
+            if (trimmed.Length > 500) {
+                trimmed = trimmed.Substring(0, 500) + "...";
+            }
+            return $"Graph upload session creation failed (HTTP {((int)resp.StatusCode).ToString(CultureInfo.InvariantCulture)}): {trimmed}";
+        }
+
+        try {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("uploadUrl", out var uploadUrlEl)) {
+                var uploadUrl = uploadUrlEl.GetString();
+                var uploadUrlTrimmed = uploadUrl == null ? null : uploadUrl.Trim();
+                return string.IsNullOrWhiteSpace(uploadUrlTrimmed) ? null : uploadUrlTrimmed;
+            }
+        } catch {
+            // ignore parse errors, caller gets null
+        }
+
+        return null;
+    }
+
+    private static string BuildUploadSessionRequestJson(DecodedMimeAttachment attachment) {
+        static string JsonString(string value) =>
+            "\"" + (value ?? string.Empty).Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+
+        var sb = new StringBuilder();
+        sb.Append("{\"attachmentItem\":{");
+        sb.Append("\"attachmentType\":\"file\",");
+        sb.Append("\"name\":").Append(JsonString(attachment.Name)).Append(",");
+        sb.Append("\"size\":").Append(attachment.Length.ToString(CultureInfo.InvariantCulture));
+        var contentType = attachment.ContentType;
+        if (contentType != null && contentType.Trim().Length > 0) {
+            sb.Append(",\"contentType\":").Append(JsonString(contentType));
+        }
+        if (attachment.IsInline) {
+            sb.Append(",\"isInline\":true");
+            var contentId = attachment.ContentId;
+            if (contentId != null && contentId.Trim().Length > 0) {
+                sb.Append(",\"contentId\":").Append(JsonString(contentId));
+            }
+        }
+        sb.Append("}}");
+        return sb.ToString();
+    }
+
+    private static async Task<string?> UploadToSessionAsync(
+        HttpClient client,
+        string uploadUrl,
+        DecodedMimeAttachment attachment,
+        CancellationToken cancellationToken) {
+        if (attachment.Length <= 0) {
+            return $"Graph upload failed: attachment '{attachment.Name}' length is {attachment.Length.ToString(CultureInfo.InvariantCulture)}.";
+        }
+
+        long offset = 0;
+        using var stream = attachment.OpenRead();
+        if (!stream.CanSeek) {
+            return $"Graph upload failed: attachment '{attachment.Name}' stream is not seekable.";
+        }
+
+        while (offset < attachment.Length) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var remaining = attachment.Length - offset;
+            var chunkLen = (int)Math.Min(ChunkSize, remaining);
+            var buffer = new byte[chunkLen];
+            var read = 0;
+            while (read < chunkLen) {
+#if NET5_0_OR_GREATER
+                var n = await stream.ReadAsync(buffer.AsMemory(read, chunkLen - read), cancellationToken).ConfigureAwait(false);
+#else
+                var n = await stream.ReadAsync(buffer, read, chunkLen - read, cancellationToken).ConfigureAwait(false);
+#endif
+                if (n <= 0) {
+                    break;
+                }
+                read += n;
+            }
+
+            if (read <= 0) {
+                return $"Graph upload failed: unexpected end of stream for '{attachment.Name}' at {offset.ToString(CultureInfo.InvariantCulture)}.";
+            }
+
+            var start = offset;
+            var end = offset + read - 1;
+            using var req = new HttpRequestMessage(HttpMethod.Put, uploadUrl);
+            req.Content = new ByteArrayContent(buffer, 0, read);
+            req.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            req.Content.Headers.ContentRange = new ContentRangeHeaderValue(start, end, attachment.Length);
+
+            using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            if (resp.IsSuccessStatusCode || (int)resp.StatusCode == 202) {
+                offset += read;
+                continue;
+            }
+
+#if NET5_0_OR_GREATER
+            var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+            var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+            var trimmed = (body ?? string.Empty).Replace('\r', ' ').Replace('\n', ' ').Trim();
+            if (trimmed.Length > 500) {
+                trimmed = trimmed.Substring(0, 500) + "...";
+            }
+            return $"Graph upload failed (HTTP {(int)resp.StatusCode}) for '{attachment.Name}': {trimmed}";
+        }
+
+        return null;
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMimePreparation.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMimePreparation.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Helpers for preparing MimeKit messages for Microsoft Graph APIs.
+/// </summary>
+public static class GraphMimePreparation {
+    /// <summary>
+    /// Default maximum attachment bytes kept inline in Graph JSON payload.
+    /// </summary>
+    public const int DefaultMaxInlineAttachmentBytes = 3 * 1024 * 1024;
+
+    /// <summary>
+    /// Encodes bytes into base64url.
+    /// </summary>
+    public static string Base64UrlEncode(byte[] bytes) {
+        var base64 = Convert.ToBase64String(bytes);
+        return base64.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
+    /// <summary>
+    /// Prepares a MIME message for Graph create-message APIs.
+    /// </summary>
+    public static GraphPreparedMessage PrepareMessage(
+        MimeMessage message,
+        int maxInlineAttachmentBytes = DefaultMaxInlineAttachmentBytes,
+        string? idempotencyHeaderName = null) {
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+        if (maxInlineAttachmentBytes < 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxInlineAttachmentBytes));
+        }
+
+        var inlineAttachments = new List<GraphAttachment>();
+        var uploadAttachments = new List<DecodedMimeAttachment>();
+        var inlineBytes = 0L;
+
+        foreach (var entity in message.Attachments) {
+            if (entity is not MimePart part) {
+                continue;
+            }
+
+            var decoded = DecodedMimeAttachment.DecodeToTempFile(part);
+            if (decoded.Length <= maxInlineAttachmentBytes &&
+                inlineBytes + decoded.Length <= maxInlineAttachmentBytes) {
+                byte[] bytes;
+                try {
+                    bytes = decoded.ReadAllBytes();
+                } finally {
+                    decoded.Dispose();
+                }
+
+                inlineBytes += bytes.Length;
+                inlineAttachments.Add(new GraphAttachment {
+                    ODataType = "#microsoft.graph.fileAttachment",
+                    Name = decoded.Name,
+                    ContentType = decoded.ContentType,
+                    ContentBytes = Convert.ToBase64String(bytes),
+                    IsInline = decoded.IsInline,
+                    ContentId = decoded.IsInline ? decoded.ContentId : null
+                });
+            } else {
+                uploadAttachments.Add(decoded);
+            }
+        }
+
+        var graphMessage = ConvertToGraphMessage(
+            message,
+            inlineAttachments.Count == 0 ? null : inlineAttachments,
+            idempotencyHeaderName);
+        return new GraphPreparedMessage(graphMessage, uploadAttachments);
+    }
+
+    /// <summary>
+    /// Converts a MIME message to Graph message payload.
+    /// </summary>
+    public static GraphMessage ConvertToGraphMessage(
+        MimeMessage message,
+        List<GraphAttachment>? attachments = null,
+        string? idempotencyHeaderName = null) {
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var html = message.HtmlBody;
+        var text = message.TextBody;
+        var bodyContentType = string.IsNullOrWhiteSpace(html) ? "Text" : "HTML";
+        var bodyContent = string.IsNullOrWhiteSpace(html) ? (text ?? string.Empty) : html!;
+
+        var headers = new List<GraphInternetMessageHeader>();
+        AddHeader(headers, "Message-Id", message.MessageId);
+        AddHeader(headers, "In-Reply-To", message.InReplyTo);
+        if (message.References != null && message.References.Count > 0) {
+            AddHeader(headers, "References", string.Join(" ", message.References));
+        }
+
+        if (idempotencyHeaderName != null) {
+            var trimmedIdempotencyHeaderName = idempotencyHeaderName.Trim();
+            if (trimmedIdempotencyHeaderName.Length > 0) {
+                AddHeader(headers, trimmedIdempotencyHeaderName, message.Headers[trimmedIdempotencyHeaderName]);
+            }
+        }
+
+        return new GraphMessage {
+            Subject = message.Subject ?? string.Empty,
+            Body = new GraphContent { Type = bodyContentType, Content = bodyContent },
+            To = ConvertRecipients(message.To),
+            Cc = ConvertRecipients(message.Cc),
+            Bcc = ConvertRecipients(message.Bcc),
+            ReplyTo = ConvertRecipients(message.ReplyTo),
+            InternetMessageHeaders = headers.Count == 0 ? null : headers,
+            Attachments = attachments
+        };
+    }
+
+    private static List<GraphEmailAddress>? ConvertRecipients(InternetAddressList? list) {
+        if (list == null) {
+            return null;
+        }
+
+        var recipients = new List<GraphEmailAddress>();
+        foreach (var mailbox in list.Mailboxes) {
+            var address = (mailbox.Address ?? string.Empty).Trim();
+            if (address.Length == 0) {
+                continue;
+            }
+
+            recipients.Add(new GraphEmailAddress {
+                Email = new GraphEmail {
+                    Address = address,
+                    Name = string.IsNullOrWhiteSpace(mailbox.Name) ? null : mailbox.Name.Trim()
+                }
+            });
+        }
+
+        return recipients.Count == 0 ? null : recipients;
+    }
+
+    private static void AddHeader(List<GraphInternetMessageHeader> headers, string name, string? value) {
+        var trimmed = (value ?? string.Empty).Trim();
+        if (trimmed.Length == 0) {
+            return;
+        }
+
+        headers.Add(new GraphInternetMessageHeader {
+            Name = name,
+            Value = trimmed
+        });
+    }
+}
+
+/// <summary>
+/// Result of graph MIME preparation.
+/// </summary>
+public sealed record GraphPreparedMessage(
+    GraphMessage Message,
+    IReadOnlyList<DecodedMimeAttachment> UploadAttachments);
+
+/// <summary>
+/// Decoded attachment materialized into a temp file.
+/// </summary>
+public sealed class DecodedMimeAttachment : IDisposable {
+    private readonly string _tempPath;
+
+    private DecodedMimeAttachment(
+        string tempPath,
+        string name,
+        string? contentType,
+        bool isInline,
+        string? contentId,
+        long length) {
+        _tempPath = tempPath;
+        Name = name;
+        ContentType = contentType;
+        IsInline = isInline;
+        ContentId = contentId;
+        Length = length;
+    }
+
+    /// <summary>Attachment display name.</summary>
+    public string Name { get; }
+    /// <summary>Optional MIME content type.</summary>
+    public string? ContentType { get; }
+    /// <summary>True when attachment is inline.</summary>
+    public bool IsInline { get; }
+    /// <summary>Inline content id (cid).</summary>
+    public string? ContentId { get; }
+    /// <summary>Attachment length in bytes.</summary>
+    public long Length { get; }
+
+    /// <summary>
+    /// Decodes a MIME part into a temp-file backed attachment.
+    /// </summary>
+    public static DecodedMimeAttachment DecodeToTempFile(MimePart part) {
+        if (part == null) {
+            throw new ArgumentNullException(nameof(part));
+        }
+
+        var fileName = (part.FileName ?? string.Empty).Trim();
+        if (fileName.Length == 0) {
+            fileName = "attachment";
+        }
+
+        var isInline = part.ContentDisposition?.Disposition?.Equals(ContentDisposition.Inline, StringComparison.OrdinalIgnoreCase) == true;
+        var contentType = part.ContentType?.MimeType;
+        var contentId = isInline ? part.ContentId : null;
+        var tempPath = Path.Combine(Path.GetTempPath(), $"mailozaurr-mime-{Guid.NewGuid():N}.bin");
+
+        try {
+            using var fs = new FileStream(tempPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
+            part.Content.DecodeTo(fs);
+            fs.Flush(true);
+            return new DecodedMimeAttachment(tempPath, fileName, contentType, isInline, contentId, fs.Length);
+        } catch {
+            TryDelete(tempPath);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Opens attachment content as a readable stream.
+    /// </summary>
+    public Stream OpenRead() {
+        return new FileStream(_tempPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+    }
+
+    /// <summary>
+    /// Reads all attachment bytes.
+    /// </summary>
+    public byte[] ReadAllBytes() {
+        return File.ReadAllBytes(_tempPath);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        TryDelete(_tempPath);
+        GC.SuppressFinalize(this);
+    }
+
+    private static void TryDelete(string path) {
+        try {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        } catch {
+            // best-effort cleanup
+        }
+    }
+}

--- a/Sources/Mailozaurr/Receive/Pop3AttachmentPayloadBuilder.cs
+++ b/Sources/Mailozaurr/Receive/Pop3AttachmentPayloadBuilder.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Status of POP3 attachment payload build operation.
+/// </summary>
+public enum Pop3AttachmentBuildStatus {
+    /// <summary>Attachment payload was built.</summary>
+    Success,
+    /// <summary>Attachment index was not found.</summary>
+    NotFound,
+    /// <summary>Attachment exceeded maximum allowed payload size.</summary>
+    SizeLimitExceeded
+}
+
+/// <summary>
+/// Materialized POP3 attachment payload.
+/// </summary>
+public sealed record Pop3AttachmentPayload(
+    string FileName,
+    string ContentType,
+    byte[] Bytes);
+
+/// <summary>
+/// Result of POP3 attachment payload build operation.
+/// </summary>
+public sealed record Pop3AttachmentBuildResult(
+    Pop3AttachmentBuildStatus Status,
+    Pop3AttachmentPayload? Payload,
+    string? Error) {
+    /// <summary>True when payload was produced.</summary>
+    public bool Success => Payload != null;
+}
+
+/// <summary>
+/// Builds binary attachment payload from MIME messages retrieved over POP3.
+/// </summary>
+public static class Pop3AttachmentPayloadBuilder {
+    /// <summary>
+    /// Builds attachment payload by index.
+    /// </summary>
+    public static Pop3AttachmentBuildResult Build(MimeMessage message, int attachmentIndex, long maxBytes) {
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+        if (maxBytes < 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxBytes));
+        }
+
+        var attachments = new List<MimeEntity>();
+        foreach (var attachment in message.Attachments) {
+            attachments.Add(attachment);
+        }
+
+        if (attachmentIndex < 0 || attachmentIndex >= attachments.Count) {
+            return new Pop3AttachmentBuildResult(
+                Pop3AttachmentBuildStatus.NotFound,
+                null,
+                "Attachment not found.");
+        }
+
+        var entity = attachments[attachmentIndex];
+        string fileName;
+        string contentType;
+        if (entity is MimePart part) {
+            fileName = part.FileName ?? part.ContentDisposition?.FileName ?? part.ContentType?.Name ?? string.Empty;
+            contentType = part.ContentType?.MimeType ?? "application/octet-stream";
+        } else if (entity is MessagePart messagePart) {
+            fileName = messagePart.ContentDisposition?.FileName ?? messagePart.ContentType?.Name ?? "message.eml";
+            contentType = "message/rfc822";
+        } else {
+            fileName = "attachment";
+            contentType = "application/octet-stream";
+        }
+
+        using var ms = new MemoryStream();
+        try {
+            using var limited = new SizeLimitedWriteStream(ms, maxBytes);
+            if (entity is MimePart mimePart) {
+                mimePart.Content.DecodeTo(limited);
+            } else if (entity is MessagePart nestedMessagePart) {
+                nestedMessagePart.Message.WriteTo(limited);
+            } else {
+                entity.WriteTo(limited);
+            }
+        } catch (InvalidDataException ex) {
+            return new Pop3AttachmentBuildResult(
+                Pop3AttachmentBuildStatus.SizeLimitExceeded,
+                null,
+                ex.Message);
+        }
+
+        fileName = string.IsNullOrWhiteSpace(fileName) ? $"attachment-{attachmentIndex}" : fileName.Trim();
+        return new Pop3AttachmentBuildResult(
+            Pop3AttachmentBuildStatus.Success,
+            new Pop3AttachmentPayload(fileName, contentType, ms.ToArray()),
+            null);
+    }
+
+    private sealed class SizeLimitedWriteStream : Stream {
+        private readonly Stream _inner;
+        private readonly long _maxBytes;
+        private long _writtenBytes;
+
+        internal SizeLimitedWriteStream(Stream inner, long maxBytes) {
+            _inner = inner;
+            _maxBytes = maxBytes;
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => _inner.Length;
+        public override long Position {
+            get => _inner.Position;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) {
+            if (count < 0) {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            if (_maxBytes >= 0 && _writtenBytes + count > _maxBytes) {
+                throw new InvalidDataException($"Attachment exceeds max allowed size of {_maxBytes} bytes.");
+            }
+
+            _inner.Write(buffer, offset, count);
+            _writtenBytes += count;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Graph MIME preparation helper (`GraphMimePreparation`) for Graph draft payload generation and large-attachment separation
- add Graph large attachment upload helper (`GraphLargeAttachmentUploader`) for upload-session chunking
- extend `GraphApiClient` with draft/send/upload-session/chunk operations
- add upstream POP3 attachment payload primitive (`Pop3AttachmentPayloadBuilder`) with status/result model
- extend Graph models with optional email/attachment metadata used by the new APIs

## Tests
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release -f net8.0`

## Notes
- net472/netstandard2.0 compatibility is preserved (no unsupported API usage).
