### PR TITLE
Add Graph bulk mailbox primitives for batch and conversations

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphApiClientMailboxTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphApiClientMailboxTests.cs
@@ -141,4 +141,78 @@ public class GraphApiClientMailboxTests {
         Assert.Contains("\"name\":\"a.txt\"", body);
         Assert.Contains("\"size\":10", body);
     }
+
+    [Fact]
+    public async System.Threading.Tasks.Task BatchSetMessagesIsReadAsync_ReturnsPerMessageStatus() {
+        var batchResponse = "{\"responses\":[{\"id\":\"1\",\"status\":200,\"headers\":{},\"body\":{}},{\"id\":\"2\",\"status\":400,\"headers\":{},\"body\":{\"error\":{\"message\":\"bad-request\"}}}]}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StringContent(batchResponse)
+        });
+        var api = new GraphApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = DateTimeOffset.MaxValue });
+        var field = typeof(GraphApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(api, new HttpClient(handler) { BaseAddress = new Uri("https://graph.microsoft.com/v1.0/") });
+
+        var results = await api.BatchSetMessagesIsReadAsync(new[] { "m-1", "m-2" }, isRead: true);
+
+        Assert.Equal(2, results.Count);
+        Assert.True(results[0].Ok);
+        Assert.Equal("m-1", results[0].Id);
+        Assert.False(results[1].Ok);
+        Assert.Equal("m-2", results[1].Id);
+        Assert.Contains("bad-request", results[1].Error);
+
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Contains("/$batch", handler.Requests[0].RequestUri!.ToString());
+        var body = await handler.Requests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"url\":\"me/messages/m-1\"", body);
+        Assert.Contains("\"isRead\":true", body);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task BatchMoveConversationsAsync_ListsConversationMessages_ThenMovesInBatch() {
+        var listResponse = "{\"value\":[{\"id\":\"m-1\"},{\"id\":\"m-2\"}]}";
+        var batchResponse = "{\"responses\":[{\"id\":\"1\",\"status\":201,\"headers\":{},\"body\":{}},{\"id\":\"2\",\"status\":201,\"headers\":{},\"body\":{}}]}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(listResponse) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(batchResponse) });
+        var api = new GraphApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = DateTimeOffset.MaxValue });
+        var field = typeof(GraphApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(api, new HttpClient(handler) { BaseAddress = new Uri("https://graph.microsoft.com/v1.0/") });
+
+        var results = await api.BatchMoveConversationsAsync(new[] { "conv-1" }, destinationFolderId: "archive");
+
+        Assert.Single(results);
+        Assert.Equal("conv-1", results[0].Id);
+        Assert.True(results[0].Ok);
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+        Assert.Contains("conversationId", handler.Requests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
+        var body = await handler.Requests[1].Content!.ReadAsStringAsync();
+        Assert.Contains("\"url\":\"me/messages/m-1/move\"", body);
+        Assert.Contains("\"url\":\"me/messages/m-2/move\"", body);
+        Assert.Contains("\"destinationId\":\"archive\"", body);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task BatchDeleteMessagesAsync_WhenBatchFails_ReturnsFailurePerMessage() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.InternalServerError) {
+            Content = new StringContent("{\"error\":{\"message\":\"batch-down\"}}")
+        });
+        var api = new GraphApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = DateTimeOffset.MaxValue });
+        var field = typeof(GraphApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(api, new HttpClient(handler) { BaseAddress = new Uri("https://graph.microsoft.com/v1.0/") });
+
+        var results = await api.BatchDeleteMessagesAsync(new[] { "m-1", "m-2" });
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.False(r.Ok));
+        Assert.Contains("Graph batch failed (500).", results[0].Error);
+        Assert.Contains("Graph batch failed (500).", results[1].Error);
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Contains("/$batch", handler.Requests[0].RequestUri!.ToString());
+    }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
@@ -1323,6 +1323,283 @@ public sealed class GraphApiClient : IDisposable {
     }
 
     /// <summary>
+    /// Moves many messages using Graph batch requests.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> BatchMoveMessagesAsync(
+        IEnumerable<string> messageIds,
+        string destinationFolderId,
+        string userId = "me",
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+        if (string.IsNullOrWhiteSpace(destinationFolderId)) {
+            throw new ArgumentException("destinationFolderId is required.", nameof(destinationFolderId));
+        }
+
+        var ids = NormalizeBulkIds(messageIds);
+        if (ids.Count == 0) {
+            return Array.Empty<GraphBulkOperationResult>();
+        }
+
+        var userSegment = BuildUserSegment(userId);
+        var batch = ClampInt(batchSize, 1, 20);
+        var payloadJson = JsonSerializer.Serialize(
+            new GraphDestinationRequest { DestinationId = destinationFolderId.Trim() },
+            MailozaurrJsonContext.Default.GraphDestinationRequest);
+        using var bodyDoc = JsonDocument.Parse(payloadJson);
+        var body = bodyDoc.RootElement.Clone();
+
+        return await ExecuteMessageBatchAsync(
+            ids,
+            batch,
+            messageId => new GraphBatchRequest {
+                Method = GraphHttpMethod.POST,
+                Url = userSegment + "/messages/" + Uri.EscapeDataString(messageId) + "/move",
+                Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Content-Type"] = "application/json" },
+                Body = body
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes many messages using Graph batch requests.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> BatchDeleteMessagesAsync(
+        IEnumerable<string> messageIds,
+        string userId = "me",
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        var ids = NormalizeBulkIds(messageIds);
+        if (ids.Count == 0) {
+            return Array.Empty<GraphBulkOperationResult>();
+        }
+
+        var userSegment = BuildUserSegment(userId);
+        var batch = ClampInt(batchSize, 1, 20);
+        return await ExecuteMessageBatchAsync(
+            ids,
+            batch,
+            messageId => new GraphBatchRequest {
+                Method = GraphHttpMethod.DELETE,
+                Url = userSegment + "/messages/" + Uri.EscapeDataString(messageId)
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets read/unread state for many messages using Graph batch requests.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> BatchSetMessagesIsReadAsync(
+        IEnumerable<string> messageIds,
+        bool isRead,
+        string userId = "me",
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        var ids = NormalizeBulkIds(messageIds);
+        if (ids.Count == 0) {
+            return Array.Empty<GraphBulkOperationResult>();
+        }
+
+        var userSegment = BuildUserSegment(userId);
+        var batch = ClampInt(batchSize, 1, 20);
+        var payloadJson = JsonSerializer.Serialize(
+            new GraphMarkReadRequest { IsRead = isRead },
+            MailozaurrJsonContext.Default.GraphMarkReadRequest);
+        using var bodyDoc = JsonDocument.Parse(payloadJson);
+        var body = bodyDoc.RootElement.Clone();
+
+        return await ExecuteMessageBatchAsync(
+            ids,
+            batch,
+            messageId => new GraphBatchRequest {
+                Method = GraphHttpMethod.PATCH,
+                Url = userSegment + "/messages/" + Uri.EscapeDataString(messageId),
+                Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Content-Type"] = "application/json" },
+                Body = body
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets flagged/unflagged state for many messages using Graph batch requests.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> BatchSetMessagesFlaggedAsync(
+        IEnumerable<string> messageIds,
+        bool flagged,
+        string userId = "me",
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        var ids = NormalizeBulkIds(messageIds);
+        if (ids.Count == 0) {
+            return Array.Empty<GraphBulkOperationResult>();
+        }
+
+        var userSegment = BuildUserSegment(userId);
+        var batch = ClampInt(batchSize, 1, 20);
+        var payloadJson = JsonSerializer.Serialize(
+            new GraphSetFlagRequest { Flag = new GraphSetFlagRequestFlag { FlagStatus = flagged ? "flagged" : "notFlagged" } },
+            MailozaurrJsonContext.Default.GraphSetFlagRequest);
+        using var bodyDoc = JsonDocument.Parse(payloadJson);
+        var body = bodyDoc.RootElement.Clone();
+
+        return await ExecuteMessageBatchAsync(
+            ids,
+            batch,
+            messageId => new GraphBatchRequest {
+                Method = GraphHttpMethod.PATCH,
+                Url = userSegment + "/messages/" + Uri.EscapeDataString(messageId),
+                Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Content-Type"] = "application/json" },
+                Body = body
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves all messages in each conversation using Graph batch requests.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> BatchMoveConversationsAsync(
+        IEnumerable<string> conversationIds,
+        string destinationFolderId,
+        string userId = "me",
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (conversationIds == null) {
+            throw new ArgumentNullException(nameof(conversationIds));
+        }
+        if (string.IsNullOrWhiteSpace(destinationFolderId)) {
+            throw new ArgumentException("destinationFolderId is required.", nameof(destinationFolderId));
+        }
+
+        var conversations = NormalizeBulkIds(conversationIds);
+        if (conversations.Count == 0) {
+            return Array.Empty<GraphBulkOperationResult>();
+        }
+
+        var output = new List<GraphBulkOperationResult>(conversations.Count);
+        foreach (var conversationId in conversations) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            IReadOnlyList<string> messageIds;
+            try {
+                messageIds = await ListConversationMessageIdsAsync(conversationId, userId: userId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                output.Add(new GraphBulkOperationResult {
+                    Id = conversationId,
+                    Ok = false,
+                    Error = ex.Message
+                });
+                continue;
+            }
+
+            if (messageIds.Count == 0) {
+                output.Add(new GraphBulkOperationResult { Id = conversationId, Ok = true });
+                continue;
+            }
+
+            var moved = await BatchMoveMessagesAsync(
+                messageIds,
+                destinationFolderId,
+                userId: userId,
+                batchSize: batchSize,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            var failed = FindFirstFailedBulkResult(moved);
+            if (failed is not null) {
+                output.Add(new GraphBulkOperationResult {
+                    Id = conversationId,
+                    Ok = false,
+                    Error = failed.Error ?? "Graph conversation move failed."
+                });
+                continue;
+            }
+            output.Add(new GraphBulkOperationResult { Id = conversationId, Ok = true });
+        }
+
+        return output;
+    }
+
+    /// <summary>
+    /// Deletes all messages in each conversation using Graph batch requests.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> BatchDeleteConversationsAsync(
+        IEnumerable<string> conversationIds,
+        string userId = "me",
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (conversationIds == null) {
+            throw new ArgumentNullException(nameof(conversationIds));
+        }
+
+        var conversations = NormalizeBulkIds(conversationIds);
+        if (conversations.Count == 0) {
+            return Array.Empty<GraphBulkOperationResult>();
+        }
+
+        var output = new List<GraphBulkOperationResult>(conversations.Count);
+        foreach (var conversationId in conversations) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            IReadOnlyList<string> messageIds;
+            try {
+                messageIds = await ListConversationMessageIdsAsync(conversationId, userId: userId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                output.Add(new GraphBulkOperationResult {
+                    Id = conversationId,
+                    Ok = false,
+                    Error = ex.Message
+                });
+                continue;
+            }
+
+            if (messageIds.Count == 0) {
+                output.Add(new GraphBulkOperationResult { Id = conversationId, Ok = true });
+                continue;
+            }
+
+            var deleted = await BatchDeleteMessagesAsync(
+                messageIds,
+                userId: userId,
+                batchSize: batchSize,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            var failed = FindFirstFailedBulkResult(deleted);
+            if (failed is not null) {
+                output.Add(new GraphBulkOperationResult {
+                    Id = conversationId,
+                    Ok = false,
+                    Error = failed.Error ?? "Graph conversation delete failed."
+                });
+                continue;
+            }
+            output.Add(new GraphBulkOperationResult { Id = conversationId, Ok = true });
+        }
+
+        return output;
+    }
+
+    /// <summary>
     /// Sends a Graph batch request using the current bearer token.
     /// </summary>
     public async Task<IReadOnlyList<GraphBatchResult>> SendBatchAsync(IEnumerable<GraphBatchRequest> requests, CancellationToken cancellationToken = default) {
@@ -1388,7 +1665,7 @@ public sealed class GraphApiClient : IDisposable {
                         result.Headers = h;
                     }
                     if (item.TryGetProperty("body", out var bodyEl)) {
-                        result.Body = bodyEl;
+                        result.Body = bodyEl.Clone();
                     }
                     results.Add(result);
                 }
@@ -1396,6 +1673,153 @@ public sealed class GraphApiClient : IDisposable {
         }
 
         return results;
+    }
+
+    private static List<string> NormalizeBulkIds(IEnumerable<string> ids) {
+        var output = new List<string>();
+        foreach (var raw in ids) {
+            if (string.IsNullOrWhiteSpace(raw)) {
+                continue;
+            }
+            var id = raw.Trim();
+            if (id.Length == 0) {
+                continue;
+            }
+            output.Add(id);
+        }
+        return output;
+    }
+
+    private async Task<IReadOnlyList<GraphBulkOperationResult>> ExecuteMessageBatchAsync(
+        List<string> messageIds,
+        int batchSize,
+        Func<string, GraphBatchRequest> requestFactory,
+        CancellationToken cancellationToken) {
+        var output = new List<GraphBulkOperationResult>(messageIds.Count);
+        var chunkSize = ClampInt(batchSize, 1, 20);
+
+        for (var i = 0; i < messageIds.Count; i += chunkSize) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var count = Math.Min(chunkSize, messageIds.Count - i);
+            var chunk = messageIds.GetRange(i, count);
+            var subIds = new List<string>(chunk.Count);
+            var requests = new List<GraphBatchRequest>(chunk.Count);
+            for (var j = 0; j < chunk.Count; j++) {
+                var subId = (j + 1).ToString(CultureInfo.InvariantCulture);
+                subIds.Add(subId);
+                var req = requestFactory(chunk[j]);
+                req.Id = subId;
+                requests.Add(req);
+            }
+
+            IReadOnlyList<GraphBatchResult> responses;
+            try {
+                responses = await SendBatchAsync(requests, cancellationToken).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                var err = ex.Message;
+                foreach (var id in chunk) {
+                    output.Add(new GraphBulkOperationResult { Id = id, Ok = false, Error = err });
+                }
+                continue;
+            }
+
+            var byId = new Dictionary<string, GraphBatchResult>(StringComparer.Ordinal);
+            foreach (var response in responses) {
+                if (response == null || string.IsNullOrWhiteSpace(response.Id)) {
+                    continue;
+                }
+                byId[response.Id.Trim()] = response;
+            }
+
+            for (var j = 0; j < chunk.Count; j++) {
+                var messageId = chunk[j];
+                var subId = subIds[j];
+                if (!byId.TryGetValue(subId, out var response)) {
+                    output.Add(new GraphBulkOperationResult {
+                        Id = messageId,
+                        Ok = false,
+                        Error = "Graph batch response missing for message id."
+                    });
+                    continue;
+                }
+
+                if (response.Status >= 200 && response.Status <= 299) {
+                    output.Add(new GraphBulkOperationResult { Id = messageId, Ok = true });
+                    continue;
+                }
+
+                output.Add(new GraphBulkOperationResult {
+                    Id = messageId,
+                    Ok = false,
+                    Error = TryExtractBatchErrorMessage(response) ?? ("Graph batch request failed (" + response.Status.ToString(CultureInfo.InvariantCulture) + ").")
+                });
+            }
+        }
+
+        return output;
+    }
+
+    private static GraphBulkOperationResult? FindFirstFailedBulkResult(IReadOnlyList<GraphBulkOperationResult> results) {
+        if (results == null) {
+            return null;
+        }
+        foreach (var result in results) {
+            if (result != null && !result.Ok) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    private static string? TryExtractBatchErrorMessage(GraphBatchResult response) {
+        if (response?.Body == null) {
+            return null;
+        }
+
+        var body = response.Body.Value;
+        if (body.ValueKind != JsonValueKind.Object) {
+            return null;
+        }
+
+        if (body.TryGetProperty("error", out var error)) {
+            if (error.ValueKind == JsonValueKind.String) {
+                var text = error.GetString();
+                if (text != null) {
+                    var trimmed = text.Trim();
+                    if (trimmed.Length > 0) {
+                        return trimmed;
+                    }
+                }
+            }
+
+            if (error.ValueKind == JsonValueKind.Object &&
+                error.TryGetProperty("message", out var messageEl) &&
+                messageEl.ValueKind == JsonValueKind.String) {
+                var msg = messageEl.GetString();
+                if (msg != null) {
+                    var trimmed = msg.Trim();
+                    if (trimmed.Length > 0) {
+                        return trimmed;
+                    }
+                }
+            }
+        }
+
+        if (body.TryGetProperty("message", out var fallbackMessageEl) &&
+            fallbackMessageEl.ValueKind == JsonValueKind.String) {
+            var fallback = fallbackMessageEl.GetString();
+            if (fallback != null) {
+                var trimmed = fallback.Trim();
+                if (trimmed.Length > 0) {
+                    return trimmed;
+                }
+            }
+        }
+
+        return null;
     }
 
     /// <summary>Create subscription request payload.</summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphBulkOperationResult.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphBulkOperationResult.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Result item for Graph bulk mailbox operations.
+/// </summary>
+public sealed class GraphBulkOperationResult {
+    /// <summary>Original message/conversation identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>True when the operation completed successfully for this id.</summary>
+    public bool Ok { get; set; }
+
+    /// <summary>Error text when <see cref="Ok"/> is false.</summary>
+    public string? Error { get; set; }
+}


### PR DESCRIPTION
## Summary
- add upstream Graph mailbox bulk primitives to `GraphApiClient`:
  - message-level batch move/delete/set-read/set-flagged
  - conversation-level batch move/delete (via conversation message expansion)
- add `GraphBulkOperationResult` for per-id success/error reporting
- fix a latent `SendBatchAsync` issue by cloning `body` JSON elements in batch responses
- add mailbox tests for:
  - per-message status mapping
  - conversation move flow (list conversation IDs + batch move)
  - full-batch failure fanout to per-id errors

## Validation
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release -v minimal`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release -f net8.0 -v minimal`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release -f net8.0 --filter GraphApiClientMailboxTests -v minimal`
