### PR TITLE
Add GmailMailboxBrowser high-level mailbox primitives

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailMailboxBrowserTests.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class GmailMailboxBrowserTests {
+    [Fact]
+    public async System.Threading.Tasks.Task ResolveLabelIdAsync_MapsSystemAliases_AndResolvesCustomLabel() {
+        var labelsJson = "{\"labels\":[{\"id\":\"Label_1\",\"name\":\"Project\"}]}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(labelsJson) });
+        var browser = CreateBrowser(handler);
+
+        Assert.Equal("INBOX", await browser.ResolveLabelIdAsync("INBOX"));
+        Assert.Equal("SENT", await browser.ResolveLabelIdAsync("Sent Items"));
+        Assert.Equal("Label_1", await browser.ResolveLabelIdAsync("Project"));
+
+        Assert.Single(handler.Requests);
+        Assert.Equal("https://gmail.googleapis.com/gmail/v1/users/me/labels?fields=labels(id,name,type)", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ListMessagesAsync_UsesListThenLoadsSummaries() {
+        var listJson = "{\"messages\":[{\"id\":\"m1\",\"threadId\":\"t1\"},{\"id\":\"m2\",\"threadId\":\"t1\"}],\"resultSizeEstimate\":\"9\"}";
+        var m2Json = "{" +
+                     "\"id\":\"m2\",\"threadId\":\"t1\",\"internalDate\":\"1739577600000\"," +
+                     "\"labelIds\":[\"INBOX\"]," +
+                     "\"payload\":{\"filename\":\"\",\"headers\":[" +
+                     "{\"name\":\"From\",\"value\":\"a@example.test\"}," +
+                     "{\"name\":\"To\",\"value\":\"b@example.test\"}," +
+                     "{\"name\":\"Subject\",\"value\":\"second\"}," +
+                     "{\"name\":\"Message-Id\",\"value\":\"<m2@example.test>\"}]}}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(listJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(m2Json) });
+        var browser = CreateBrowser(handler);
+
+        var result = await browser.ListMessagesAsync("INBOX", limit: 1, offset: 1);
+
+        Assert.Equal("INBOX", result.ResolvedLabelId);
+        Assert.Equal(9, result.TotalCount);
+        Assert.Single(result.Messages);
+        Assert.Equal("m2", result.Messages[0].NativeId);
+        Assert.Equal("m2@example.test", result.Messages[0].MessageId);
+        Assert.Equal("a@example.test", result.Messages[0].From);
+
+        Assert.Equal(2, handler.Requests.Count);
+        var listUri = handler.Requests[0].RequestUri!;
+        Assert.Contains("/users/me/messages", listUri.ToString());
+        var listQuery = ParseQueryParams(listUri);
+        Assert.Equal("messages(id,threadId),nextPageToken,resultSizeEstimate", Assert.Single(listQuery["fields"]));
+        Assert.Equal("INBOX", Assert.Single(listQuery["labelIds"]));
+
+        var summaryUri = handler.Requests[1].RequestUri!.ToString();
+        Assert.Contains("/users/me/messages/m2?", summaryUri);
+        Assert.Contains("format=full", summaryUri);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SearchMessagesAsync_UsesBuiltQuery_AndSortsByDateDesc() {
+        var listJson = "{\"messages\":[{\"id\":\"m-old\"},{\"id\":\"m-new\"}],\"nextPageToken\":null}";
+        var oldJson = "{" +
+                      "\"id\":\"m-old\",\"threadId\":\"t1\",\"internalDate\":\"1739491200000\"," +
+                      "\"payload\":{\"headers\":[{\"name\":\"Subject\",\"value\":\"old\"}]}}";
+        var newJson = "{" +
+                      "\"id\":\"m-new\",\"threadId\":\"t1\",\"internalDate\":\"1739577600000\"," +
+                      "\"payload\":{\"headers\":[{\"name\":\"Subject\",\"value\":\"new\"}]}}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(listJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(oldJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(newJson) });
+        var browser = CreateBrowser(handler);
+
+        var search = await browser.SearchMessagesAsync(new GmailMailboxBrowser.GmailMailboxSearchRequest {
+            Folder = "INBOX",
+            Query = "urgent",
+            SubjectContains = "invoice",
+            UnseenOnly = true
+        }, max: 20);
+
+        Assert.Equal("INBOX", search.ResolvedLabelId);
+        Assert.Equal(2, search.Messages.Count);
+        Assert.Equal("m-new", search.Messages[0].NativeId);
+        Assert.Equal("m-old", search.Messages[1].NativeId);
+
+        Assert.Equal(3, handler.Requests.Count);
+        var uri = handler.Requests[0].RequestUri!;
+        var query = ParseQueryParams(uri);
+        Assert.Equal("INBOX", Assert.Single(query["labelIds"]));
+        var q = Assert.Single(query["q"]);
+        Assert.Contains("is:unread", q);
+        Assert.Contains("subject:(invoice)", q);
+        Assert.Contains("urgent", q);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ListThreadMessagesAsync_ReturnsSortedSummaries() {
+        var threadJson = "{" +
+                         "\"id\":\"thr-1\",\"messages\":[" +
+                         "{\"id\":\"m1\",\"threadId\":\"thr-1\",\"internalDate\":\"1739491200000\",\"payload\":{\"headers\":[{\"name\":\"Subject\",\"value\":\"first\"}]}}," +
+                         "{\"id\":\"m2\",\"threadId\":\"thr-1\",\"internalDate\":\"1739577600000\",\"payload\":{\"headers\":[{\"name\":\"Subject\",\"value\":\"second\"}]}}" +
+                         "]}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(threadJson) });
+        var browser = CreateBrowser(handler);
+
+        var messages = await browser.ListThreadMessagesAsync("thr-1");
+
+        Assert.Equal(2, messages.Count);
+        Assert.Equal("m2", messages[0].NativeId);
+        Assert.Equal("m1", messages[1].NativeId);
+        Assert.Single(handler.Requests);
+        Assert.Contains("/users/me/threads/thr-1", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetMessageContentAsync_ReturnsMimeAndFlags() {
+        var mime = "From: a@example.test\r\nTo: b@example.test\r\nSubject: Sample\r\nMessage-Id: <m1@example.test>\r\n\r\nhello";
+        var raw = Convert.ToBase64String(Encoding.UTF8.GetBytes(mime)).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+        var rawJson = "{\"id\":\"m1\",\"labelIds\":[\"UNREAD\",\"STARRED\"],\"raw\":\"" + raw + "\"}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(rawJson) });
+        var browser = CreateBrowser(handler);
+
+        var result = await browser.GetMessageContentAsync("m1");
+
+        Assert.NotNull(result.Message);
+        Assert.Equal("Sample", result.Message.Subject);
+        Assert.False(result.Seen);
+        Assert.True(result.Flagged);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task WatchAsync_ResolvesLabels_AndParsesExpiration() {
+        var labelsJson = "{\"labels\":[{\"id\":\"Label_1\",\"name\":\"Project\"}]}";
+        var watchJson = "{\"historyId\":\"77\",\"expiration\":\"1739577600000\"}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(labelsJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(watchJson) });
+        var browser = CreateBrowser(handler);
+
+        var result = await browser.WatchAsync("projects/p/topics/t", new[] { "INBOX", "Project" });
+
+        Assert.Equal("77", result.HistoryId);
+        Assert.NotNull(result.ExpirationUtc);
+        Assert.Contains("INBOX", result.LabelIds);
+        Assert.Contains("Label_1", result.LabelIds);
+
+        Assert.Equal(2, handler.Requests.Count);
+        var body = await handler.Requests[1].Content!.ReadAsStringAsync();
+        Assert.Contains("\"topicName\":\"projects/p/topics/t\"", body);
+        Assert.Contains("INBOX", body);
+        Assert.Contains("Label_1", body);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetHistoryAsync_MapsUpsertsDeletes_AndDropsDeletedFromUpserts() {
+        var historyJson = "{" +
+                          "\"historyId\":\"200\"," +
+                          "\"history\":[" +
+                          "{" +
+                          "\"id\":\"10\"," +
+                          "\"messagesAdded\":[{\"message\":{\"id\":\"m1\"}},{\"message\":{\"id\":\"m2\"}}]," +
+                          "\"messagesDeleted\":[{\"message\":{\"id\":\"m2\"}}]," +
+                          "\"labelsAdded\":[{\"message\":{\"id\":\"m3\"}}]," +
+                          "\"labelsRemoved\":[{\"message\":{\"id\":\"m3\"}}]" +
+                          "}" +
+                          "]" +
+                          "}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(historyJson) });
+        var browser = CreateBrowser(handler);
+
+        var result = await browser.GetHistoryAsync("INBOX", "5", maxChanges: 100);
+
+        Assert.Equal("INBOX", result.ResolvedLabelId);
+        Assert.Equal("200", result.NewHistoryId);
+        Assert.Equal(new[] { "m1" }, result.UpsertNativeIds);
+        Assert.Equal(new[] { "m2", "m3" }, result.DeletedNativeIds);
+
+        Assert.Single(handler.Requests);
+        var uri = handler.Requests[0].RequestUri!;
+        var query = ParseQueryParams(uri);
+        Assert.Equal("5", Assert.Single(query["startHistoryId"]));
+        Assert.Equal("INBOX", Assert.Single(query["labelId"]));
+        Assert.Contains("messageAdded", query["historyTypes"]);
+        Assert.Contains("messageDeleted", query["historyTypes"]);
+        Assert.Contains("labelAdded", query["historyTypes"]);
+        Assert.Contains("labelRemoved", query["historyTypes"]);
+    }
+
+    [Fact]
+    public void BuildSearchQuery_ComposesExpectedTokens() {
+        var query = GmailMailboxBrowser.BuildSearchQuery(new GmailMailboxBrowser.GmailMailboxSearchRequest {
+            Query = "urgent",
+            SubjectContains = "invoice",
+            FromContains = "boss@example.test",
+            ToContains = "team@example.test",
+            BodyContains = "overdue",
+            UnseenOnly = true,
+            HasAttachment = true,
+            SinceUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            BeforeUtc = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc)
+        });
+
+        Assert.Contains("is:unread", query);
+        Assert.Contains("has:attachment", query);
+        Assert.Contains("after:1704067200", query);
+        Assert.Contains("before:1704153600", query);
+        Assert.Contains("subject:(invoice)", query);
+        Assert.Contains("from:(boss@example.test)", query);
+        Assert.Contains("to:(team@example.test)", query);
+        Assert.Contains("overdue", query);
+        Assert.Contains("urgent", query);
+    }
+
+    private static Dictionary<string, List<string>> ParseQueryParams(Uri uri) {
+        var dict = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        var q = uri.Query;
+        if (string.IsNullOrEmpty(q) || q == "?") {
+            return dict;
+        }
+        if (q[0] == '?') {
+            q = q.Substring(1);
+        }
+
+        foreach (var part in q.Split(new[] { '&' }, StringSplitOptions.RemoveEmptyEntries)) {
+            var idx = part.IndexOf('=');
+            string rawKey;
+            string rawValue;
+            if (idx < 0) {
+                rawKey = part;
+                rawValue = string.Empty;
+            } else {
+                rawKey = part.Substring(0, idx);
+                rawValue = part.Substring(idx + 1);
+            }
+
+            var key = Uri.UnescapeDataString(rawKey.Replace("+", " "));
+            var value = Uri.UnescapeDataString(rawValue.Replace("+", " "));
+
+            if (!dict.TryGetValue(key, out var list)) {
+                list = new List<string>();
+                dict[key] = list;
+            }
+            list.Add(value);
+        }
+
+        return dict;
+    }
+
+    private static GmailMailboxBrowser CreateBrowser(HttpMessageHandler handler) {
+        var api = new GmailApiClient(new OAuthCredential { UserName = "me", AccessToken = "token", ExpiresOn = DateTimeOffset.MaxValue });
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(api, new HttpClient(handler) { BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/") });
+        return new GmailMailboxBrowser(api);
+    }
+}

--- a/Sources/Mailozaurr/Gmail/GmailMailboxBrowser.cs
+++ b/Sources/Mailozaurr/Gmail/GmailMailboxBrowser.cs
@@ -1,0 +1,993 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// High-level delegated-token mailbox browsing helpers built on top of <see cref="GmailApiClient"/>.
+/// </summary>
+public sealed class GmailMailboxBrowser {
+    private const string ListFields = "messages(id,threadId),nextPageToken,resultSizeEstimate";
+    private const string MessageSummaryFields = "id,threadId,internalDate,labelIds,payload(headers,name,value,parts,filename,body/attachmentId,body/size,mimeType)";
+    private const string ThreadFields = "id,messages(id,threadId,internalDate,labelIds,payload(headers,name,value,parts,filename,body/attachmentId,body/size,mimeType))";
+    private const string RawFields = "id,internalDate,labelIds,raw";
+    private readonly GmailApiClient _gmail;
+    private readonly string _userId;
+
+    /// <summary>
+    /// Maximum MIME payload size used by <see cref="GetMessageContentAsync"/> when no explicit limit is provided.
+    /// </summary>
+    public const int DefaultMaxMimeBytes = 25 * 1024 * 1024;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GmailMailboxBrowser"/> class.
+    /// </summary>
+    /// <param name="gmail">Gmail API client.</param>
+    /// <param name="userId">Mailbox user id (use <c>me</c> for delegated tokens).</param>
+    public GmailMailboxBrowser(GmailApiClient gmail, string userId = "me") {
+        _gmail = gmail ?? throw new ArgumentNullException(nameof(gmail));
+        _userId = string.IsNullOrWhiteSpace(userId) ? "me" : userId.Trim();
+    }
+
+    /// <summary>
+    /// Resolves a folder/label selector to a Gmail label id.
+    /// </summary>
+    public async Task<string?> ResolveLabelIdAsync(
+        string? folder,
+        CancellationToken cancellationToken = default) {
+        var raw = (folder ?? string.Empty).Trim();
+        if (raw.Length == 0) {
+            return "INBOX";
+        }
+
+        if (TryResolveSystemLabel(raw, out var systemLabelId)) {
+            return systemLabelId;
+        }
+
+        var labels = await _gmail.ListLabelsAsync(_userId, cancellationToken).ConfigureAwait(false);
+        foreach (var label in labels) {
+            if (label == null) {
+                continue;
+            }
+
+            var id = NormalizeOptional(label.Id);
+            var name = NormalizeOptional(label.Name);
+            if (id == null || name == null) {
+                continue;
+            }
+            if (id.Equals(raw, StringComparison.OrdinalIgnoreCase) || name.Equals(raw, StringComparison.OrdinalIgnoreCase)) {
+                return id;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves a folder selector for Gmail watch requests.
+    /// </summary>
+    public async Task<string?> ResolveWatchLabelIdAsync(
+        string folder,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(folder)) {
+            return null;
+        }
+
+        if (TryResolveWatchSystemLabel(folder, out var watchLabelId)) {
+            return watchLabelId;
+        }
+
+        return await ResolveLabelIdAsync(folder, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Lists messages in a Gmail label.
+    /// </summary>
+    public async Task<GmailMailboxListResult> ListMessagesAsync(
+        string? folder,
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default) {
+        var safeLimit = ClampInt(limit, 1, 2000);
+        var skipRemaining = Math.Max(0, offset);
+
+        var resolvedLabelId = NormalizeOptional(await ResolveLabelIdAsync(folder, cancellationToken).ConfigureAwait(false));
+        if (resolvedLabelId == null) {
+            throw new InvalidOperationException("Unable to resolve Gmail folder/label.");
+        }
+
+        string? pageToken = null;
+        long totalEstimate = 0;
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+        var selectedIds = new List<string>();
+
+        while (selectedIds.Count < safeLimit) {
+            var page = await _gmail.ListPageAsync(
+                _userId,
+                query: null,
+                labelIds: new[] { resolvedLabelId },
+                includeSpamTrash: false,
+                maxResults: 100,
+                pageToken: pageToken,
+                fields: ListFields,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (page.ResultSizeEstimate.HasValue && page.ResultSizeEstimate.Value > 0) {
+                totalEstimate = page.ResultSizeEstimate.Value;
+            }
+
+            pageToken = page.NextPageToken;
+            if (page.Messages == null || page.Messages.Count == 0) {
+                break;
+            }
+
+            foreach (var message in page.Messages) {
+                var id = NormalizeOptional(message?.Id);
+                if (id == null || !seenIds.Add(id)) {
+                    continue;
+                }
+
+                if (skipRemaining > 0) {
+                    skipRemaining--;
+                    continue;
+                }
+
+                selectedIds.Add(id);
+                if (selectedIds.Count >= safeLimit) {
+                    break;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(pageToken)) {
+                break;
+            }
+        }
+
+        var summaries = new List<GmailMailboxMessageSummary>(selectedIds.Count);
+        foreach (var id in selectedIds) {
+            var summary = await TryGetMessageSummaryAsync(id, cancellationToken).ConfigureAwait(false);
+            if (summary != null) {
+                summaries.Add(summary);
+            }
+        }
+
+        return new GmailMailboxListResult {
+            ResolvedLabelId = resolvedLabelId,
+            TotalCount = totalEstimate > int.MaxValue ? int.MaxValue : (int)totalEstimate,
+            Messages = summaries
+        };
+    }
+
+    /// <summary>
+    /// Lists messages in a Gmail thread.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxMessageSummary>> ListThreadMessagesAsync(
+        string threadId,
+        int maxItems = 2000,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(threadId)) {
+            throw new ArgumentException("threadId is required.", nameof(threadId));
+        }
+
+        var thread = await _gmail.GetThreadWithOptionsAsync(
+            _userId,
+            threadId.Trim(),
+            format: "full",
+            fields: ThreadFields,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var summaries = MapSummaries(thread.Messages);
+        summaries.Sort(static (a, b) => b.DateUtc.CompareTo(a.DateUtc));
+        var cap = ClampInt(maxItems, 1, 10000);
+        if (summaries.Count > cap) {
+            summaries = summaries.GetRange(0, cap);
+        }
+
+        return summaries;
+    }
+
+    /// <summary>
+    /// Searches messages in a Gmail label.
+    /// </summary>
+    public async Task<GmailMailboxSearchResult> SearchMessagesAsync(
+        GmailMailboxSearchRequest request,
+        int max,
+        CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var safeMax = ClampInt(max, 1, 2000);
+        var resolvedLabelId = NormalizeOptional(await ResolveLabelIdAsync(request.Folder, cancellationToken).ConfigureAwait(false));
+        if (resolvedLabelId == null) {
+            throw new InvalidOperationException("Unable to resolve Gmail folder/label.");
+        }
+
+        var query = BuildSearchQuery(request);
+        var selected = new List<string>();
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+        string? pageToken = null;
+
+        while (selected.Count < safeMax) {
+            var page = await _gmail.ListPageAsync(
+                _userId,
+                query: string.IsNullOrWhiteSpace(query) ? null : query,
+                labelIds: new[] { resolvedLabelId },
+                includeSpamTrash: false,
+                maxResults: 100,
+                pageToken: pageToken,
+                fields: ListFields,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            pageToken = page.NextPageToken;
+            if (page.Messages == null || page.Messages.Count == 0) {
+                break;
+            }
+
+            foreach (var message in page.Messages) {
+                var id = NormalizeOptional(message?.Id);
+                if (id == null || !seenIds.Add(id)) {
+                    continue;
+                }
+
+                selected.Add(id);
+                if (selected.Count >= safeMax) {
+                    break;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(pageToken)) {
+                break;
+            }
+        }
+
+        var summaries = new List<GmailMailboxMessageSummary>(selected.Count);
+        foreach (var id in selected) {
+            var summary = await TryGetMessageSummaryAsync(id, cancellationToken).ConfigureAwait(false);
+            if (summary != null) {
+                summaries.Add(summary);
+            }
+        }
+
+        summaries.Sort(static (a, b) => b.DateUtc.CompareTo(a.DateUtc));
+        return new GmailMailboxSearchResult {
+            ResolvedLabelId = resolvedLabelId,
+            Messages = summaries
+        };
+    }
+
+    /// <summary>
+    /// Builds a Gmail query string from mailbox search filters.
+    /// </summary>
+    public static string BuildSearchQuery(GmailMailboxSearchRequest request) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var parts = new List<string>();
+        void Add(string? value) {
+            var normalized = NormalizeOptional(value);
+            if (normalized != null) {
+                parts.Add(normalized);
+            }
+        }
+
+        if (request.UnseenOnly) {
+            parts.Add("is:unread");
+        }
+        if (request.HasAttachment) {
+            parts.Add("has:attachment");
+        }
+
+        if (request.SinceUtc.HasValue) {
+            var sinceUtc = DateTime.SpecifyKind(request.SinceUtc.Value, DateTimeKind.Utc);
+            var after = new DateTimeOffset(sinceUtc).ToUnixTimeSeconds();
+            parts.Add("after:" + after.ToString(CultureInfo.InvariantCulture));
+        }
+        if (request.BeforeUtc.HasValue) {
+            var beforeUtc = DateTime.SpecifyKind(request.BeforeUtc.Value, DateTimeKind.Utc);
+            var before = new DateTimeOffset(beforeUtc).ToUnixTimeSeconds();
+            parts.Add("before:" + before.ToString(CultureInfo.InvariantCulture));
+        }
+
+        var subjectContains = NormalizeOptional(request.SubjectContains);
+        if (!string.IsNullOrWhiteSpace(subjectContains)) {
+            Add("subject:(" + subjectContains + ")");
+        }
+        var fromContains = NormalizeOptional(request.FromContains);
+        if (!string.IsNullOrWhiteSpace(fromContains)) {
+            Add("from:(" + fromContains + ")");
+        }
+        var toContains = NormalizeOptional(request.ToContains);
+        if (!string.IsNullOrWhiteSpace(toContains)) {
+            Add("to:(" + toContains + ")");
+        }
+        if (!string.IsNullOrWhiteSpace(request.BodyContains)) {
+            Add(request.BodyContains);
+        }
+        if (!string.IsNullOrWhiteSpace(request.Query)) {
+            Add(request.Query);
+        }
+
+        return string.Join(" ", parts);
+    }
+
+    /// <summary>
+    /// Gets one message summary.
+    /// </summary>
+    public async Task<GmailMailboxMessageSummary> GetMessageSummaryAsync(
+        string messageId,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        var message = await _gmail.GetFullAsync(
+            _userId,
+            messageId.Trim(),
+            fields: MessageSummaryFields,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return MapSummary(message);
+    }
+
+    /// <summary>
+    /// Gets one message content by downloading MIME payload and parsing it to <see cref="MimeMessage"/>.
+    /// </summary>
+    public async Task<GmailMailboxGetResult> GetMessageContentAsync(
+        string messageId,
+        int maxMimeBytes = DefaultMaxMimeBytes,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+        if (maxMimeBytes <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxMimeBytes), "maxMimeBytes must be greater than zero.");
+        }
+
+        var message = await _gmail.GetRawAsync(
+            _userId,
+            messageId.Trim(),
+            fields: RawFields,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(message.Raw)) {
+            throw new InvalidDataException("Gmail message response did not contain raw RFC822 payload.");
+        }
+
+        byte[] mimeBytes;
+        try {
+            mimeBytes = Base64UrlDecode(message.Raw!);
+        } catch (Exception ex) {
+            throw new InvalidDataException("Failed to decode Gmail raw MIME payload.", ex);
+        }
+
+        if (mimeBytes.Length > maxMimeBytes) {
+            throw new InvalidOperationException("Gmail raw message exceeds " + maxMimeBytes.ToString(CultureInfo.InvariantCulture) + " bytes.");
+        }
+
+        MimeMessage mimeMessage;
+        try {
+            mimeMessage = MimeMessage.Load(new MemoryStream(mimeBytes, writable: false));
+        } catch (Exception ex) {
+            throw new InvalidDataException("Failed to parse Gmail MIME message.", ex);
+        }
+
+        return new GmailMailboxGetResult {
+            Message = mimeMessage,
+            Seen = !HasLabel(message.LabelIds, "UNREAD"),
+            Flagged = HasLabel(message.LabelIds, "STARRED")
+        };
+    }
+
+    /// <summary>
+    /// Gets mailbox profile.
+    /// </summary>
+    public async Task<GmailMailboxProfileResult> GetProfileAsync(CancellationToken cancellationToken = default) {
+        var profile = await _gmail.GetProfileAsync(_userId, cancellationToken).ConfigureAwait(false);
+        return new GmailMailboxProfileResult {
+            EmailAddress = NormalizeOptional(profile.EmailAddress),
+            MessagesTotal = profile.MessagesTotal,
+            ThreadsTotal = profile.ThreadsTotal,
+            HistoryId = NormalizeOptional(profile.HistoryId)
+        };
+    }
+
+    /// <summary>
+    /// Starts Gmail watch subscription for selected folders.
+    /// </summary>
+    public async Task<GmailMailboxWatchResult> WatchAsync(
+        string topicName,
+        IReadOnlyCollection<string>? folders,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(topicName)) {
+            throw new ArgumentException("topicName is required.", nameof(topicName));
+        }
+
+        var folderInput = folders == null || folders.Count == 0
+            ? new[] { "INBOX" }
+            : folders;
+
+        var labelIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var raw in folderInput) {
+            if (string.IsNullOrWhiteSpace(raw)) {
+                continue;
+            }
+            var labelId = await ResolveWatchLabelIdAsync(raw, cancellationToken).ConfigureAwait(false);
+            var normalizedLabelId = NormalizeOptional(labelId);
+            if (normalizedLabelId != null) {
+                labelIds.Add(normalizedLabelId);
+            }
+        }
+
+        var watch = await _gmail.WatchAsync(
+            _userId,
+            topicName.Trim(),
+            labelIds.Count == 0 ? null : labelIds.ToArray(),
+            cancellationToken).ConfigureAwait(false);
+
+        DateTime? expirationUtc = null;
+        if (watch.Expiration > 0) {
+            expirationUtc = DateTimeOffset.FromUnixTimeMilliseconds(watch.Expiration).UtcDateTime;
+        }
+
+        return new GmailMailboxWatchResult {
+            HistoryId = NormalizeOptional(watch.HistoryId),
+            ExpirationUtc = expirationUtc,
+            LabelIds = labelIds.ToList()
+        };
+    }
+
+    /// <summary>
+    /// Stops Gmail watch subscription.
+    /// </summary>
+    public Task StopWatchAsync(CancellationToken cancellationToken = default) =>
+        _gmail.StopWatchAsync(_userId, cancellationToken);
+
+    /// <summary>
+    /// Gets Gmail history changes for a folder.
+    /// </summary>
+    public async Task<GmailMailboxHistoryResult> GetHistoryAsync(
+        string folder,
+        string startHistoryId,
+        int maxChanges,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(startHistoryId)) {
+            throw new ArgumentException("startHistoryId is required.", nameof(startHistoryId));
+        }
+
+        var resolvedLabelId = NormalizeOptional(await ResolveLabelIdAsync(folder, cancellationToken).ConfigureAwait(false));
+        if (resolvedLabelId == null) {
+            throw new InvalidOperationException("Unable to resolve Gmail folder/label.");
+        }
+
+        var max = ClampInt(maxChanges, 1, 2000);
+        var upserts = new HashSet<string>(StringComparer.Ordinal);
+        var deletes = new HashSet<string>(StringComparer.Ordinal);
+        var historyTypes = new[] { "messageAdded", "messageDeleted", "labelAdded", "labelRemoved" };
+        string? pageToken = null;
+        string? newHistoryId = null;
+        var pageCount = 0;
+
+        while (pageCount++ < 25 && (upserts.Count + deletes.Count) < max) {
+            var history = await _gmail.ListHistoryAsync(
+                _userId,
+                startHistoryId.Trim(),
+                labelId: resolvedLabelId,
+                historyTypes: historyTypes,
+                maxResults: 500,
+                pageToken: pageToken,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            var historyId = NormalizeOptional(history.HistoryId);
+            if (historyId != null) {
+                newHistoryId = historyId;
+            }
+
+            pageToken = NormalizeOptional(history.NextPageToken);
+            if (history.History == null || history.History.Count == 0) {
+                break;
+            }
+
+            foreach (var entry in history.History) {
+                if (entry == null) {
+                    continue;
+                }
+
+                AddHistoryRefs(entry.MessagesAdded, upserts);
+                AddHistoryRefs(entry.LabelsAdded, upserts);
+                AddHistoryRefs(entry.MessagesDeleted, deletes);
+                AddHistoryRefs(entry.LabelsRemoved, deletes);
+            }
+
+            if (string.IsNullOrWhiteSpace(pageToken)) {
+                break;
+            }
+        }
+
+        foreach (var deletedId in deletes) {
+            _ = upserts.Remove(deletedId);
+        }
+
+        var upsertIds = upserts.ToList();
+        upsertIds.Sort(StringComparer.Ordinal);
+        var deleteIds = deletes.ToList();
+        deleteIds.Sort(StringComparer.Ordinal);
+
+        return new GmailMailboxHistoryResult {
+            ResolvedLabelId = resolvedLabelId,
+            NewHistoryId = newHistoryId,
+            UpsertNativeIds = upsertIds,
+            DeletedNativeIds = deleteIds
+        };
+    }
+
+    private static void AddHistoryRefs(
+        IReadOnlyCollection<GmailApiClient.GmailHistoryMessageAdded>? refs,
+        HashSet<string> output) {
+        if (refs == null || refs.Count == 0) {
+            return;
+        }
+
+        foreach (var entry in refs) {
+            var id = NormalizeOptional(entry?.Message?.Id);
+            if (id != null) {
+                output.Add(id);
+            }
+        }
+    }
+
+    private static void AddHistoryRefs(
+        IReadOnlyCollection<GmailApiClient.GmailHistoryLabelAdded>? refs,
+        HashSet<string> output) {
+        if (refs == null || refs.Count == 0) {
+            return;
+        }
+
+        foreach (var entry in refs) {
+            var id = NormalizeOptional(entry?.Message?.Id);
+            if (id != null) {
+                output.Add(id);
+            }
+        }
+    }
+
+    private static void AddHistoryRefs(
+        IReadOnlyCollection<GmailApiClient.GmailHistoryMessageDeleted>? refs,
+        HashSet<string> output) {
+        if (refs == null || refs.Count == 0) {
+            return;
+        }
+
+        foreach (var entry in refs) {
+            var id = NormalizeOptional(entry?.Message?.Id);
+            if (id != null) {
+                output.Add(id);
+            }
+        }
+    }
+
+    private static void AddHistoryRefs(
+        IReadOnlyCollection<GmailApiClient.GmailHistoryLabelRemoved>? refs,
+        HashSet<string> output) {
+        if (refs == null || refs.Count == 0) {
+            return;
+        }
+
+        foreach (var entry in refs) {
+            var id = NormalizeOptional(entry?.Message?.Id);
+            if (id != null) {
+                output.Add(id);
+            }
+        }
+    }
+
+    private async Task<GmailMailboxMessageSummary?> TryGetMessageSummaryAsync(string messageId, CancellationToken cancellationToken) {
+        try {
+            return await GetMessageSummaryAsync(messageId, cancellationToken).ConfigureAwait(false);
+        } catch {
+            return null;
+        }
+    }
+
+    private static bool TryResolveSystemLabel(string raw, out string labelId) {
+        var normalized = raw.Trim();
+        if (normalized.Equals("INBOX", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "INBOX";
+            return true;
+        }
+        if (normalized.Equals("SENT", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("SENTITEMS", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("SENT ITEMS", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("SENT MAIL", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "SENT";
+            return true;
+        }
+        if (normalized.Equals("TRASH", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("DELETED", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("DELETED ITEMS", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("DELETEDITEMS", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "TRASH";
+            return true;
+        }
+        if (normalized.Equals("DRAFT", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("DRAFTS", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "DRAFT";
+            return true;
+        }
+        if (normalized.Equals("SPAM", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("JUNK", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("JUNK EMAIL", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("JUNKEMAIL", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "SPAM";
+            return true;
+        }
+        if (normalized.Equals("STARRED", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "STARRED";
+            return true;
+        }
+        if (normalized.Equals("IMPORTANT", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "IMPORTANT";
+            return true;
+        }
+
+        labelId = string.Empty;
+        return false;
+    }
+
+    private static bool TryResolveWatchSystemLabel(string raw, out string labelId) {
+        if (raw.Equals("INBOX", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "INBOX";
+            return true;
+        }
+        if (raw.Equals("SENT", StringComparison.OrdinalIgnoreCase) ||
+            raw.Equals("SENTITEMS", StringComparison.OrdinalIgnoreCase) ||
+            raw.Equals("SENT ITEMS", StringComparison.OrdinalIgnoreCase) ||
+            raw.Equals("SENT MAIL", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "SENT";
+            return true;
+        }
+        if (raw.Equals("TRASH", StringComparison.OrdinalIgnoreCase) ||
+            raw.Equals("DELETED", StringComparison.OrdinalIgnoreCase) ||
+            raw.Equals("DELETED ITEMS", StringComparison.OrdinalIgnoreCase) ||
+            raw.Equals("DELETEDITEMS", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "TRASH";
+            return true;
+        }
+        if (raw.Equals("SPAM", StringComparison.OrdinalIgnoreCase) ||
+            raw.Equals("JUNK", StringComparison.OrdinalIgnoreCase) ||
+            raw.Equals("JUNK EMAIL", StringComparison.OrdinalIgnoreCase) ||
+            raw.Equals("JUNKEMAIL", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "SPAM";
+            return true;
+        }
+        if (raw.Equals("DRAFT", StringComparison.OrdinalIgnoreCase) ||
+            raw.Equals("DRAFTS", StringComparison.OrdinalIgnoreCase)) {
+            labelId = "DRAFT";
+            return true;
+        }
+
+        labelId = string.Empty;
+        return false;
+    }
+
+    private static int ClampInt(int value, int min, int max) {
+        if (value < min) return min;
+        if (value > max) return max;
+        return value;
+    }
+
+    private static string? NormalizeOptional(string? raw) {
+        var trimmed = raw == null ? string.Empty : raw.Trim();
+        if (trimmed.Length == 0) {
+            return null;
+        }
+        return trimmed;
+    }
+
+    private static DateTime ResolveInternalDateUtc(long? internalDateMs) {
+        if (!internalDateMs.HasValue || internalDateMs.Value <= 0) {
+            return DateTime.UtcNow;
+        }
+
+        try {
+            return DateTimeOffset.FromUnixTimeMilliseconds(internalDateMs.Value).UtcDateTime;
+        } catch {
+            return DateTime.UtcNow;
+        }
+    }
+
+    private static Dictionary<string, string> BuildHeaderMap(GmailMessagePayload? payload) {
+        var output = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var headers = payload?.Headers;
+        if (headers == null || headers.Count == 0) {
+            return output;
+        }
+
+        foreach (var header in headers) {
+            var name = NormalizeOptional(header?.Name);
+            if (name == null) {
+                continue;
+            }
+
+            output[name] = header?.Value ?? string.Empty;
+        }
+
+        return output;
+    }
+
+    private static bool PayloadHasAttachments(GmailMessagePayload? payload) {
+        if (payload == null) {
+            return false;
+        }
+        if (!string.IsNullOrWhiteSpace(payload.Filename) || !string.IsNullOrWhiteSpace(payload.Body?.AttachmentId)) {
+            return true;
+        }
+
+        var parts = payload.Parts;
+        if (parts == null || parts.Count == 0) {
+            return false;
+        }
+
+        foreach (var part in parts) {
+            if (PayloadHasAttachments(part)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasLabel(IReadOnlyCollection<string>? labelIds, string labelId) {
+        if (labelIds == null || labelIds.Count == 0 || string.IsNullOrWhiteSpace(labelId)) {
+            return false;
+        }
+
+        foreach (var current in labelIds) {
+            if (current != null && current.Equals(labelId, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string? NormalizeMessageIdValue(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        var normalized = value == null ? string.Empty : value.Trim();
+        if (normalized.StartsWith("<", StringComparison.Ordinal)) {
+            normalized = normalized.Substring(1);
+        }
+        if (normalized.EndsWith(">", StringComparison.Ordinal)) {
+            normalized = normalized.Substring(0, normalized.Length - 1);
+        }
+
+        normalized = normalized.Trim();
+        return normalized.Length == 0 ? null : normalized;
+    }
+
+    private static GmailMailboxMessageSummary MapSummary(GmailMessage message) {
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var headers = BuildHeaderMap(message.Payload);
+        _ = headers.TryGetValue("From", out var from);
+        _ = headers.TryGetValue("To", out var to);
+        _ = headers.TryGetValue("Subject", out var subject);
+        _ = headers.TryGetValue("Message-Id", out var messageIdHeader);
+
+        return new GmailMailboxMessageSummary {
+            NativeId = NormalizeOptional(message.Id) ?? string.Empty,
+            NativeThreadId = NormalizeOptional(message.ThreadId),
+            MessageId = NormalizeMessageIdValue(messageIdHeader),
+            From = from ?? string.Empty,
+            To = to ?? string.Empty,
+            Subject = NormalizeOptional(subject),
+            DateUtc = ResolveInternalDateUtc(message.InternalDate),
+            HasAttachments = PayloadHasAttachments(message.Payload),
+            Seen = !HasLabel(message.LabelIds, "UNREAD"),
+            Flagged = HasLabel(message.LabelIds, "STARRED")
+        };
+    }
+
+    private static List<GmailMailboxMessageSummary> MapSummaries(IList<GmailMessage>? messages) {
+        if (messages == null || messages.Count == 0) {
+            return new List<GmailMailboxMessageSummary>();
+        }
+
+        var output = new List<GmailMailboxMessageSummary>(messages.Count);
+        foreach (var message in messages) {
+            if (message == null) {
+                continue;
+            }
+            output.Add(MapSummary(message));
+        }
+
+        return output;
+    }
+
+    private static byte[] Base64UrlDecode(string value) {
+        var data = value.Replace('-', '+').Replace('_', '/');
+        if (data.Length % 4 == 1) {
+            throw new InvalidDataException("Attachment data is not a valid Base64 string.");
+        }
+
+        var padding = (4 - data.Length % 4) % 4;
+        if (padding > 0) {
+            data = data.PadRight(data.Length + padding, '=');
+        }
+
+        try {
+            return Convert.FromBase64String(data);
+        } catch (FormatException ex) {
+            throw new InvalidDataException("Attachment data is not a valid Base64 string.", ex);
+        }
+    }
+
+    /// <summary>
+    /// Gmail mailbox list result.
+    /// </summary>
+    public sealed class GmailMailboxListResult {
+        /// <summary>Resolved Gmail label id used for listing.</summary>
+        public string ResolvedLabelId { get; set; } = string.Empty;
+
+        /// <summary>Total item count estimate as reported by Gmail list response.</summary>
+        public int TotalCount { get; set; }
+
+        /// <summary>Message summaries.</summary>
+        public List<GmailMailboxMessageSummary> Messages { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Gmail mailbox search request.
+    /// </summary>
+    public sealed class GmailMailboxSearchRequest {
+        /// <summary>Folder/label filter.</summary>
+        public string? Folder { get; set; }
+
+        /// <summary>Free-form Gmail query text.</summary>
+        public string? Query { get; set; }
+
+        /// <summary>Subject contains filter.</summary>
+        public string? SubjectContains { get; set; }
+
+        /// <summary>From contains filter.</summary>
+        public string? FromContains { get; set; }
+
+        /// <summary>To contains filter.</summary>
+        public string? ToContains { get; set; }
+
+        /// <summary>Body contains filter.</summary>
+        public string? BodyContains { get; set; }
+
+        /// <summary>Unseen-only filter.</summary>
+        public bool UnseenOnly { get; set; }
+
+        /// <summary>Has-attachment filter.</summary>
+        public bool HasAttachment { get; set; }
+
+        /// <summary>Lower bound for message date/time (UTC).</summary>
+        public DateTime? SinceUtc { get; set; }
+
+        /// <summary>Upper bound for message date/time (UTC).</summary>
+        public DateTime? BeforeUtc { get; set; }
+    }
+
+    /// <summary>
+    /// Gmail mailbox search result.
+    /// </summary>
+    public sealed class GmailMailboxSearchResult {
+        /// <summary>Resolved Gmail label id used for searching.</summary>
+        public string ResolvedLabelId { get; set; } = string.Empty;
+
+        /// <summary>Matched messages.</summary>
+        public List<GmailMailboxMessageSummary> Messages { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Gmail mailbox get-message result.
+    /// </summary>
+    public sealed class GmailMailboxGetResult {
+        /// <summary>Parsed MIME message.</summary>
+        public MimeMessage Message { get; set; } = new MimeMessage();
+
+        /// <summary>Read state from Gmail labels.</summary>
+        public bool? Seen { get; set; }
+
+        /// <summary>Flagged state from Gmail labels.</summary>
+        public bool? Flagged { get; set; }
+    }
+
+    /// <summary>
+    /// Gmail mailbox profile result.
+    /// </summary>
+    public sealed class GmailMailboxProfileResult {
+        /// <summary>Email address associated with the mailbox.</summary>
+        public string? EmailAddress { get; set; }
+
+        /// <summary>Total number of messages.</summary>
+        public long MessagesTotal { get; set; }
+
+        /// <summary>Total number of threads.</summary>
+        public long ThreadsTotal { get; set; }
+
+        /// <summary>Current mailbox history id.</summary>
+        public string? HistoryId { get; set; }
+    }
+
+    /// <summary>
+    /// Gmail mailbox watch result.
+    /// </summary>
+    public sealed class GmailMailboxWatchResult {
+        /// <summary>History id returned by watch.</summary>
+        public string? HistoryId { get; set; }
+
+        /// <summary>Watch expiration in UTC when available.</summary>
+        public DateTime? ExpirationUtc { get; set; }
+
+        /// <summary>Resolved label ids used for the watch request.</summary>
+        public List<string> LabelIds { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Gmail mailbox history result.
+    /// </summary>
+    public sealed class GmailMailboxHistoryResult {
+        /// <summary>Resolved Gmail label id used for history query.</summary>
+        public string ResolvedLabelId { get; set; } = string.Empty;
+
+        /// <summary>Newest history id seen while reading history pages.</summary>
+        public string? NewHistoryId { get; set; }
+
+        /// <summary>Message ids that should be upserted.</summary>
+        public List<string> UpsertNativeIds { get; set; } = new();
+
+        /// <summary>Message ids that should be deleted.</summary>
+        public List<string> DeletedNativeIds { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Provider-agnostic Gmail mailbox message summary.
+    /// </summary>
+    public sealed class GmailMailboxMessageSummary {
+        /// <summary>Gmail message id.</summary>
+        public string NativeId { get; set; } = string.Empty;
+
+        /// <summary>Gmail thread id.</summary>
+        public string? NativeThreadId { get; set; }
+
+        /// <summary>Normalized message-id header value.</summary>
+        public string? MessageId { get; set; }
+
+        /// <summary>Sender address.</summary>
+        public string From { get; set; } = string.Empty;
+
+        /// <summary>Recipient list.</summary>
+        public string To { get; set; } = string.Empty;
+
+        /// <summary>Subject line.</summary>
+        public string? Subject { get; set; }
+
+        /// <summary>Message date/time (UTC).</summary>
+        public DateTime DateUtc { get; set; }
+
+        /// <summary>True when message has attachments.</summary>
+        public bool HasAttachments { get; set; }
+
+        /// <summary>True when message is seen.</summary>
+        public bool Seen { get; set; }
+
+        /// <summary>True when message is flagged.</summary>
+        public bool Flagged { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add `GmailMailboxBrowser` as a high-level delegated-token Gmail mailbox wrapper built on top of `GmailApiClient`
- upstream Gmail mailbox browse/search/get/thread/watch/profile/history helpers that BayManager currently duplicates
- add focused tests for label resolution, list/search/thread/get MIME, watch, history, and query building

## Validation
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --filter GmailMailboxBrowserTests`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --filter "FullyQualifiedName~GmailMailboxBrowserTests|FullyQualifiedName~GmailApiClientTests"`

## Notes
- local `dotnet test` without `-f net8.0` aborts on this machine because `mono` is not installed for running `net472` test hosts.
