### PR TITLE
Add GraphMailboxBrowser action and bulk conversation helpers

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
@@ -116,7 +116,7 @@ public class GraphMailboxBrowserTests {
 
     [Fact]
     public async System.Threading.Tasks.Task SetMessageSeenAsync_PatchesReadState() {
-        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) });
         var client = CreateClient(handler);
         var browser = new GraphMailboxBrowser(client);
 
@@ -132,7 +132,7 @@ public class GraphMailboxBrowserTests {
 
     [Fact]
     public async System.Threading.Tasks.Task SetMessageFlaggedAsync_PatchesFlagState() {
-        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) });
         var client = CreateClient(handler);
         var browser = new GraphMailboxBrowser(client);
 
@@ -167,7 +167,7 @@ public class GraphMailboxBrowserTests {
 
     [Fact]
     public async System.Threading.Tasks.Task DeleteMessageAsync_UsesDeleteEndpoint() {
-        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.NoContent) { Content = new StringContent(string.Empty) });
         var client = CreateClient(handler);
         var browser = new GraphMailboxBrowser(client);
 

--- a/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
@@ -114,6 +114,117 @@ public class GraphMailboxBrowserTests {
         Assert.Contains("/me/messages/m1/$value", handler.Requests[1].RequestUri!.ToString());
     }
 
+    [Fact]
+    public async System.Threading.Tasks.Task SetMessageSeenAsync_PatchesReadState() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        await browser.SetMessageSeenAsync("m1", seen: true);
+
+        Assert.Single(handler.Requests);
+        var request = handler.Requests[0];
+        Assert.Equal(new HttpMethod("PATCH"), request.Method);
+        Assert.Contains("/me/messages/m1", request.RequestUri!.ToString());
+        var body = await request.Content!.ReadAsStringAsync();
+        Assert.Contains("\"isRead\":true", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SetMessageFlaggedAsync_PatchesFlagState() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        await browser.SetMessageFlaggedAsync("m1", flagged: true);
+
+        Assert.Single(handler.Requests);
+        var request = handler.Requests[0];
+        Assert.Equal(new HttpMethod("PATCH"), request.Method);
+        Assert.Contains("/me/messages/m1", request.RequestUri!.ToString());
+        var body = await request.Content!.ReadAsStringAsync();
+        Assert.Contains("\"flagStatus\":\"flagged\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MoveMessageAsync_ResolvesFolderAliasAndUsesDestinationId() {
+        var folderJson = "{\"id\":\"archive-id\"}";
+        var movedJson = "{\"id\":\"m1\"}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(folderJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(movedJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        await browser.MoveMessageAsync("m1", "Archive");
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("/me/mailFolders/archive?$select=id", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/me/messages/m1/move", handler.Requests[1].RequestUri!.ToString());
+        var body = await handler.Requests[1].Content!.ReadAsStringAsync();
+        Assert.Contains("\"destinationId\":\"archive-id\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task DeleteMessageAsync_UsesDeleteEndpoint() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        await browser.DeleteMessageAsync("m1");
+
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Delete, handler.Requests[0].Method);
+        Assert.Contains("/me/messages/m1", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MoveMessagesAsync_ResolvesFolderAliasAndBatchesMoveRequests() {
+        var folderJson = "{\"id\":\"archive-id\"}";
+        var batchJson = "{\"responses\":[{\"id\":\"1\",\"status\":201},{\"id\":\"2\",\"status\":201}]}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(folderJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(batchJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var results = await browser.MoveMessagesAsync(new[] { "m1", "m2" }, "Archive");
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.True(r.Ok, r.Error));
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("/me/mailFolders/archive?$select=id", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/$batch", handler.Requests[1].RequestUri!.ToString());
+        var body = await handler.Requests[1].Content!.ReadAsStringAsync();
+        Assert.Contains("me/messages/m1/move", body, StringComparison.Ordinal);
+        Assert.Contains("me/messages/m2/move", body, StringComparison.Ordinal);
+        Assert.Contains("\"destinationId\":\"archive-id\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task DeleteConversationsAsync_ExpandsAndDeletesConversationMessages() {
+        var listJson = "{\"value\":[{\"id\":\"m1\"},{\"id\":\"m2\"}]}";
+        var batchJson = "{\"responses\":[{\"id\":\"1\",\"status\":204},{\"id\":\"2\",\"status\":204}]}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(listJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(batchJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var results = await browser.DeleteConversationsAsync(new[] { "conv-1" });
+
+        Assert.Single(results);
+        Assert.True(results[0].Ok, results[0].Error);
+        Assert.Equal("conv-1", results[0].Id);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("/me/messages?", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("conversationId", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/$batch", handler.Requests[1].RequestUri!.ToString());
+        var body = await handler.Requests[1].Content!.ReadAsStringAsync();
+        Assert.Contains("me/messages/m1", body, StringComparison.Ordinal);
+        Assert.Contains("me/messages/m2", body, StringComparison.Ordinal);
+    }
+
     private static GraphApiClient CreateClient(HttpMessageHandler handler) {
         var api = new GraphApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = DateTimeOffset.MaxValue });
         var field = typeof(GraphApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
@@ -229,6 +229,202 @@ public sealed class GraphMailboxBrowser {
         }
     }
 
+    /// <summary>
+    /// Sets message read/unread state.
+    /// </summary>
+    public async Task SetMessageSeenAsync(
+        string messageId,
+        bool seen,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        await _graph.SetMessageIsReadAsync(
+            messageId.Trim(),
+            seen,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets message flagged/unflagged state.
+    /// </summary>
+    public async Task SetMessageFlaggedAsync(
+        string messageId,
+        bool flagged,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        await _graph.SetMessageFlaggedAsync(
+            messageId.Trim(),
+            flagged,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves a message to a target folder alias/id.
+    /// </summary>
+    public async Task MoveMessageAsync(
+        string messageId,
+        string targetFolder,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        var destinationId = await ResolveFolderIdAsync(targetFolder, cancellationToken).ConfigureAwait(false);
+        await _graph.MoveMessageAsync(
+            messageId.Trim(),
+            destinationId,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes a message.
+    /// </summary>
+    public async Task DeleteMessageAsync(
+        string messageId,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        await _graph.DeleteMessageAsync(
+            messageId.Trim(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves many messages to a target folder alias/id.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> MoveMessagesAsync(
+        IEnumerable<string> messageIds,
+        string targetFolder,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        var destinationId = await ResolveFolderIdAsync(targetFolder, cancellationToken).ConfigureAwait(false);
+        return await _graph.BatchMoveMessagesAsync(
+            messageIds,
+            destinationId,
+            batchSize: batchSize,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes many messages.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> DeleteMessagesAsync(
+        IEnumerable<string> messageIds,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        return await _graph.BatchDeleteMessagesAsync(
+            messageIds,
+            batchSize: batchSize,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets read/unread state on many messages.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> SetMessagesSeenAsync(
+        IEnumerable<string> messageIds,
+        bool seen,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        return await _graph.BatchSetMessagesIsReadAsync(
+            messageIds,
+            seen,
+            batchSize: batchSize,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets flagged/unflagged state on many messages.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> SetMessagesFlaggedAsync(
+        IEnumerable<string> messageIds,
+        bool flagged,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        return await _graph.BatchSetMessagesFlaggedAsync(
+            messageIds,
+            flagged,
+            batchSize: batchSize,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves many conversations to a target folder alias/id.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> MoveConversationsAsync(
+        IEnumerable<string> conversationIds,
+        string targetFolder,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        if (conversationIds == null) {
+            throw new ArgumentNullException(nameof(conversationIds));
+        }
+
+        var destinationId = await ResolveFolderIdAsync(targetFolder, cancellationToken).ConfigureAwait(false);
+        return await _graph.BatchMoveConversationsAsync(
+            conversationIds,
+            destinationId,
+            batchSize: batchSize,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes many conversations.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> DeleteConversationsAsync(
+        IEnumerable<string> conversationIds,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        if (conversationIds == null) {
+            throw new ArgumentNullException(nameof(conversationIds));
+        }
+
+        return await _graph.BatchDeleteConversationsAsync(
+            conversationIds,
+            batchSize: batchSize,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<string> ResolveFolderIdAsync(string targetFolder, CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(targetFolder)) {
+            throw new ArgumentException("targetFolder is required.", nameof(targetFolder));
+        }
+
+        var folderSelector = ResolveFolderSelector(targetFolder);
+        var folder = await _graph.GetMailFolderAsync(
+            folderSelector,
+            select: "id",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        var id = (folder.Id ?? string.Empty).Trim();
+        if (id.Length == 0) {
+            throw new InvalidOperationException($"Graph folder id resolution returned an empty id for selector '{folderSelector}'.");
+        }
+        return id;
+    }
+
     private static int ClampInt(int value, int min, int max) {
         if (value < min) return min;
         if (value > max) return max;


### PR DESCRIPTION
## Summary
- extend `GraphMailboxBrowser` with high-level delegated-token action helpers for:
  - single message actions: seen, flagged, move, delete
  - message bulk actions: seen, flagged, move, delete
  - conversation bulk actions: move, delete
- centralize Graph folder alias/id resolution for move actions in `GraphMailboxBrowser`
- add focused unit tests validating request shapes and folder-resolution behavior for the new browser actions

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~GraphMailboxBrowserTests"`
- `dotnet build Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net472`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0`

## Notes
- Running `dotnet test` for `net472` in this local macOS environment is blocked by missing Mono test host, but the `net472` test assembly builds successfully.
