### PR TITLE
Add GmailMailboxBrowser action and bulk operation helpers

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailMailboxBrowserTests.cs
@@ -215,6 +215,87 @@ public sealed class GmailMailboxBrowserTests {
         Assert.Contains("urgent", query);
     }
 
+    [Fact]
+    public async System.Threading.Tasks.Task SetMessageSeenAsync_ModifiesMessageLabels() {
+        var modifyJson = "{\"id\":\"m1\",\"threadId\":\"t1\"}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(modifyJson) });
+        var browser = CreateBrowser(handler);
+
+        await browser.SetMessageSeenAsync("m1", seen: true);
+
+        Assert.Single(handler.Requests);
+        Assert.Contains("/users/me/messages/m1/modify", handler.Requests[0].RequestUri!.ToString());
+        var body = await handler.Requests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"removeLabelIds\":[\"UNREAD\"]", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MoveMessageAsync_ResolvesLabels_AndModifiesMessage() {
+        var labelsJson = "{\"labels\":[{\"id\":\"Label_Target\",\"name\":\"Archive\"}]}";
+        var modifyJson = "{\"id\":\"m1\",\"threadId\":\"t1\"}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(labelsJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(modifyJson) });
+        var browser = CreateBrowser(handler);
+
+        await browser.MoveMessageAsync("m1", sourceFolder: "INBOX", targetFolder: "Archive");
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("/users/me/labels", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/users/me/messages/m1/modify", handler.Requests[1].RequestUri!.ToString());
+        var body = await handler.Requests[1].Content!.ReadAsStringAsync();
+        Assert.Contains("\"addLabelIds\":[\"Label_Target\"]", body, StringComparison.Ordinal);
+        Assert.Contains("INBOX", body, StringComparison.Ordinal);
+        Assert.Contains("TRASH", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MoveMessageAsync_ToTrash_UsesTrashEndpoint() {
+        var trashJson = "{\"id\":\"m1\",\"threadId\":\"t1\"}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(trashJson) });
+        var browser = CreateBrowser(handler);
+
+        await browser.MoveMessageAsync("m1", sourceFolder: "INBOX", targetFolder: "TRASH");
+
+        Assert.Single(handler.Requests);
+        Assert.Contains("/users/me/messages/m1/trash", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ArchiveMessagesAsync_UsesBatchModify_AndReturnsPerMessageResults() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) });
+        var browser = CreateBrowser(handler);
+
+        var results = await browser.ArchiveMessagesAsync(new[] { "m1", "m2" });
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, x => Assert.True(x.Ok, x.Error));
+        Assert.Single(handler.Requests);
+        Assert.Contains("/users/me/messages/batchModify", handler.Requests[0].RequestUri!.ToString());
+        var body = await handler.Requests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"ids\":[\"m1\",\"m2\"]", body, StringComparison.Ordinal);
+        Assert.Contains("\"removeLabelIds\":[\"INBOX\",\"TRASH\"]", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task DeleteThreadsAsync_MapsPerThreadFailures() {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.NoContent) { Content = new StringContent(string.Empty) },
+            new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("boom") });
+        var browser = CreateBrowser(handler);
+
+        var results = await browser.DeleteThreadsAsync(new[] { "t1", "t2" });
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("t1", results[0].Id);
+        Assert.True(results[0].Ok, results[0].Error);
+        Assert.Equal("t2", results[1].Id);
+        Assert.False(results[1].Ok);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("/users/me/threads/t1", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/users/me/threads/t2", handler.Requests[1].RequestUri!.ToString());
+    }
+
     private static Dictionary<string, List<string>> ParseQueryParams(Uri uri) {
         var dict = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         var q = uri.Query;

--- a/Sources/Mailozaurr/Gmail/GmailMailboxBrowser.cs
+++ b/Sources/Mailozaurr/Gmail/GmailMailboxBrowser.cs
@@ -13,6 +13,7 @@ namespace Mailozaurr;
 /// High-level delegated-token mailbox browsing helpers built on top of <see cref="GmailApiClient"/>.
 /// </summary>
 public sealed class GmailMailboxBrowser {
+    private const int BatchMaxIds = 1000;
     private const string ListFields = "messages(id,threadId),nextPageToken,resultSizeEstimate";
     private const string MessageSummaryFields = "id,threadId,internalDate,labelIds,payload(headers,name,value,parts,filename,body/attachmentId,body/size,mimeType)";
     private const string ThreadFields = "id,messages(id,threadId,internalDate,labelIds,payload(headers,name,value,parts,filename,body/attachmentId,body/size,mimeType))";
@@ -387,6 +388,370 @@ public sealed class GmailMailboxBrowser {
     }
 
     /// <summary>
+    /// Sets read/unread state on a single message.
+    /// </summary>
+    public async Task SetMessageSeenAsync(
+        string messageId,
+        bool seen,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        await _gmail.ModifyMessageLabelsAsync(
+            _userId,
+            messageId.Trim(),
+            addLabelIds: seen ? Array.Empty<string>() : new[] { "UNREAD" },
+            removeLabelIds: seen ? new[] { "UNREAD" } : Array.Empty<string>(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets flagged/unflagged state on a single message.
+    /// </summary>
+    public async Task SetMessageFlaggedAsync(
+        string messageId,
+        bool flagged,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        await _gmail.ModifyMessageLabelsAsync(
+            _userId,
+            messageId.Trim(),
+            addLabelIds: flagged ? new[] { "STARRED" } : Array.Empty<string>(),
+            removeLabelIds: flagged ? Array.Empty<string>() : new[] { "STARRED" },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves a single message to a target folder/label.
+    /// </summary>
+    public async Task MoveMessageAsync(
+        string messageId,
+        string? sourceFolder,
+        string targetFolder,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+        if (string.IsNullOrWhiteSpace(targetFolder)) {
+            throw new ArgumentException("targetFolder is required.", nameof(targetFolder));
+        }
+
+        var targetLabelId = NormalizeOptional(await ResolveLabelIdAsync(targetFolder, cancellationToken).ConfigureAwait(false));
+        if (targetLabelId == null) {
+            throw new InvalidOperationException("Unable to resolve Gmail target folder/label.");
+        }
+
+        if (targetLabelId.Equals("TRASH", StringComparison.OrdinalIgnoreCase)) {
+            _ = await _gmail.TrashMessageAsync(_userId, messageId.Trim(), cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var remove = new List<string>();
+        var sourceLabelId = NormalizeOptional(await ResolveLabelIdAsync(sourceFolder, cancellationToken).ConfigureAwait(false));
+        if (sourceLabelId != null) {
+            remove.Add(sourceLabelId);
+        }
+        remove.Add("TRASH");
+
+        _ = await _gmail.ModifyMessageLabelsAsync(
+            _userId,
+            messageId.Trim(),
+            addLabelIds: new[] { targetLabelId },
+            removeLabelIds: remove,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Archives a single message (removes INBOX/TRASH labels).
+    /// </summary>
+    public async Task ArchiveMessageAsync(
+        string messageId,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        _ = await _gmail.ModifyMessageLabelsAsync(
+            _userId,
+            messageId.Trim(),
+            addLabelIds: Array.Empty<string>(),
+            removeLabelIds: new[] { "INBOX", "TRASH" },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves a single message to trash.
+    /// </summary>
+    public async Task TrashMessageAsync(
+        string messageId,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        _ = await _gmail.TrashMessageAsync(_userId, messageId.Trim(), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes a single message.
+    /// </summary>
+    public async Task DeleteMessageAsync(
+        string messageId,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        await _gmail.DeleteAsync(_userId, messageId.Trim(), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets read/unread state on many messages.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> SetMessagesSeenAsync(
+        IEnumerable<string> messageIds,
+        bool seen,
+        int batchSize = BatchMaxIds,
+        CancellationToken cancellationToken = default) {
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        return await ExecuteBatchModifyAsync(
+            messageIds,
+            addLabelIds: seen ? Array.Empty<string>() : new[] { "UNREAD" },
+            removeLabelIds: seen ? new[] { "UNREAD" } : Array.Empty<string>(),
+            batchSize,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets flagged/unflagged state on many messages.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> SetMessagesFlaggedAsync(
+        IEnumerable<string> messageIds,
+        bool flagged,
+        int batchSize = BatchMaxIds,
+        CancellationToken cancellationToken = default) {
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        return await ExecuteBatchModifyAsync(
+            messageIds,
+            addLabelIds: flagged ? new[] { "STARRED" } : Array.Empty<string>(),
+            removeLabelIds: flagged ? Array.Empty<string>() : new[] { "STARRED" },
+            batchSize,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves many messages to a target folder/label.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> MoveMessagesAsync(
+        IEnumerable<string> messageIds,
+        string? sourceFolder,
+        string targetFolder,
+        int batchSize = BatchMaxIds,
+        CancellationToken cancellationToken = default) {
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+        if (string.IsNullOrWhiteSpace(targetFolder)) {
+            throw new ArgumentException("targetFolder is required.", nameof(targetFolder));
+        }
+
+        var ids = NormalizeIds(messageIds);
+        if (ids.Count == 0) {
+            return Array.Empty<GmailMailboxBulkOperationResult>();
+        }
+
+        var targetLabelId = NormalizeOptional(await ResolveLabelIdAsync(targetFolder, cancellationToken).ConfigureAwait(false));
+        if (targetLabelId == null) {
+            throw new InvalidOperationException("Unable to resolve Gmail target folder/label.");
+        }
+
+        if (targetLabelId.Equals("TRASH", StringComparison.OrdinalIgnoreCase)) {
+            return await TrashMessagesAsync(ids, cancellationToken).ConfigureAwait(false);
+        }
+
+        var remove = new List<string>();
+        var sourceLabelId = NormalizeOptional(await ResolveLabelIdAsync(sourceFolder, cancellationToken).ConfigureAwait(false));
+        if (sourceLabelId != null) {
+            remove.Add(sourceLabelId);
+        }
+        remove.Add("TRASH");
+
+        return await ExecuteBatchModifyAsync(
+            ids,
+            addLabelIds: new[] { targetLabelId },
+            removeLabelIds: remove,
+            batchSize,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Archives many messages (removes INBOX/TRASH labels).
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> ArchiveMessagesAsync(
+        IEnumerable<string> messageIds,
+        int batchSize = BatchMaxIds,
+        CancellationToken cancellationToken = default) {
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        return await ExecuteBatchModifyAsync(
+            messageIds,
+            addLabelIds: Array.Empty<string>(),
+            removeLabelIds: new[] { "INBOX", "TRASH" },
+            batchSize,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves many messages to trash.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> TrashMessagesAsync(
+        IEnumerable<string> messageIds,
+        CancellationToken cancellationToken = default) {
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        var ids = NormalizeIds(messageIds);
+        if (ids.Count == 0) {
+            return Array.Empty<GmailMailboxBulkOperationResult>();
+        }
+
+        var results = new List<GmailMailboxBulkOperationResult>(ids.Count);
+        foreach (var id in ids) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                _ = await _gmail.TrashMessageAsync(_userId, id, cancellationToken).ConfigureAwait(false);
+                results.Add(new GmailMailboxBulkOperationResult { Id = id, Ok = true });
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                results.Add(new GmailMailboxBulkOperationResult { Id = id, Ok = false, Error = ex.Message });
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Deletes many messages.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> DeleteMessagesAsync(
+        IEnumerable<string> messageIds,
+        int batchSize = BatchMaxIds,
+        CancellationToken cancellationToken = default) {
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        var ids = NormalizeIds(messageIds);
+        if (ids.Count == 0) {
+            return Array.Empty<GmailMailboxBulkOperationResult>();
+        }
+
+        var results = new List<GmailMailboxBulkOperationResult>(ids.Count);
+        foreach (var chunk in Chunk(ids, ClampInt(batchSize, 1, BatchMaxIds))) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                await _gmail.BatchDeleteMessagesAsync(_userId, chunk, cancellationToken).ConfigureAwait(false);
+                foreach (var id in chunk) {
+                    results.Add(new GmailMailboxBulkOperationResult { Id = id, Ok = true });
+                }
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                foreach (var id in chunk) {
+                    results.Add(new GmailMailboxBulkOperationResult { Id = id, Ok = false, Error = ex.Message });
+                }
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Archives a single thread (removes INBOX/TRASH labels).
+    /// </summary>
+    public async Task ArchiveThreadAsync(
+        string threadId,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(threadId)) {
+            throw new ArgumentException("threadId is required.", nameof(threadId));
+        }
+
+        _ = await _gmail.ModifyThreadLabelsAsync(
+            _userId,
+            threadId.Trim(),
+            addLabelIds: Array.Empty<string>(),
+            removeLabelIds: new[] { "INBOX", "TRASH" },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves a single thread to trash.
+    /// </summary>
+    public async Task TrashThreadAsync(
+        string threadId,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(threadId)) {
+            throw new ArgumentException("threadId is required.", nameof(threadId));
+        }
+
+        _ = await _gmail.TrashThreadAsync(_userId, threadId.Trim(), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes a single thread.
+    /// </summary>
+    public async Task DeleteThreadAsync(
+        string threadId,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(threadId)) {
+            throw new ArgumentException("threadId is required.", nameof(threadId));
+        }
+
+        await _gmail.DeleteThreadAsync(_userId, threadId.Trim(), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Archives many threads.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> ArchiveThreadsAsync(
+        IEnumerable<string> threadIds,
+        CancellationToken cancellationToken = default) {
+        return await ExecuteThreadActionAsync(threadIds, ArchiveThreadAsync, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves many threads to trash.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> TrashThreadsAsync(
+        IEnumerable<string> threadIds,
+        CancellationToken cancellationToken = default) {
+        return await ExecuteThreadActionAsync(threadIds, TrashThreadAsync, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes many threads.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> DeleteThreadsAsync(
+        IEnumerable<string> threadIds,
+        CancellationToken cancellationToken = default) {
+        return await ExecuteThreadActionAsync(threadIds, DeleteThreadAsync, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Gets mailbox profile.
     /// </summary>
     public async Task<GmailMailboxProfileResult> GetProfileAsync(CancellationToken cancellationToken = default) {
@@ -526,6 +891,102 @@ public sealed class GmailMailboxBrowser {
             UpsertNativeIds = upsertIds,
             DeletedNativeIds = deleteIds
         };
+    }
+
+    private async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> ExecuteBatchModifyAsync(
+        IEnumerable<string> messageIds,
+        IReadOnlyCollection<string> addLabelIds,
+        IReadOnlyCollection<string> removeLabelIds,
+        int batchSize,
+        CancellationToken cancellationToken) {
+        var ids = NormalizeIds(messageIds);
+        if (ids.Count == 0) {
+            return Array.Empty<GmailMailboxBulkOperationResult>();
+        }
+
+        var results = new List<GmailMailboxBulkOperationResult>(ids.Count);
+        foreach (var chunk in Chunk(ids, ClampInt(batchSize, 1, BatchMaxIds))) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                await _gmail.BatchModifyMessagesAsync(
+                    _userId,
+                    chunk,
+                    addLabelIds: addLabelIds,
+                    removeLabelIds: removeLabelIds,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                foreach (var id in chunk) {
+                    results.Add(new GmailMailboxBulkOperationResult { Id = id, Ok = true });
+                }
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                foreach (var id in chunk) {
+                    results.Add(new GmailMailboxBulkOperationResult { Id = id, Ok = false, Error = ex.Message });
+                }
+            }
+        }
+
+        return results;
+    }
+
+    private async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> ExecuteThreadActionAsync(
+        IEnumerable<string> threadIds,
+        Func<string, CancellationToken, Task> actionAsync,
+        CancellationToken cancellationToken) {
+        if (threadIds == null) {
+            throw new ArgumentNullException(nameof(threadIds));
+        }
+        if (actionAsync == null) {
+            throw new ArgumentNullException(nameof(actionAsync));
+        }
+
+        var ids = NormalizeIds(threadIds);
+        if (ids.Count == 0) {
+            return Array.Empty<GmailMailboxBulkOperationResult>();
+        }
+
+        var results = new List<GmailMailboxBulkOperationResult>(ids.Count);
+        foreach (var id in ids) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                await actionAsync(id, cancellationToken).ConfigureAwait(false);
+                results.Add(new GmailMailboxBulkOperationResult { Id = id, Ok = true });
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                results.Add(new GmailMailboxBulkOperationResult { Id = id, Ok = false, Error = ex.Message });
+            }
+        }
+
+        return results;
+    }
+
+    private static List<string> NormalizeIds(IEnumerable<string> ids) {
+        var output = new List<string>();
+        if (ids == null) {
+            return output;
+        }
+
+        foreach (var raw in ids) {
+            var id = NormalizeOptional(raw);
+            if (id != null) {
+                output.Add(id);
+            }
+        }
+
+        return output;
+    }
+
+    private static IEnumerable<List<string>> Chunk(IReadOnlyList<string> ids, int chunkSize) {
+        var safeChunkSize = chunkSize <= 0 ? 1 : chunkSize;
+        for (var i = 0; i < ids.Count; i += safeChunkSize) {
+            var count = Math.Min(safeChunkSize, ids.Count - i);
+            var chunk = new List<string>(count);
+            for (var j = 0; j < count; j++) {
+                chunk.Add(ids[i + j]);
+            }
+            yield return chunk;
+        }
     }
 
     private static void AddHistoryRefs(
@@ -954,6 +1415,20 @@ public sealed class GmailMailboxBrowser {
 
         /// <summary>Message ids that should be deleted.</summary>
         public List<string> DeletedNativeIds { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Gmail mailbox bulk action result.
+    /// </summary>
+    public sealed class GmailMailboxBulkOperationResult {
+        /// <summary>Message/thread id.</summary>
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>True when action succeeded.</summary>
+        public bool Ok { get; set; }
+
+        /// <summary>Error message when action failed.</summary>
+        public string? Error { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- extend `GmailMailboxBrowser` with high-level delegated-token mailbox action helpers for:
  - single message actions: seen, flagged, move, archive, trash, delete
  - message bulk actions: seen, flagged, move, archive, trash, delete
  - thread actions: archive, trash, delete (single + bulk)
- centralize Gmail batch chunking and per-id bulk result mapping in `GmailMailboxBrowser`
- add focused unit tests for new action endpoints and payload shapes

## Testing
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~GmailMailboxBrowserTests"`
- `dotnet build Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net472`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0`
