### PR TITLE
Add mailbox folder listing helpers to Graph and Gmail browsers

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailMailboxBrowserTests.cs
@@ -24,6 +24,30 @@ public sealed class GmailMailboxBrowserTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task ListFoldersAsync_ReturnsSortedLabelFolders() {
+        var labelsJson = "{" +
+                         "\"labels\":[" +
+                         "{\"id\":\"Label_2\",\"name\":\"Zeta\",\"type\":\"user\"}," +
+                         "{\"id\":\"INBOX\",\"name\":\"Inbox\",\"type\":\"system\"}," +
+                         "{\"id\":\"Label_1\",\"name\":\"Alpha\",\"type\":\"user\"}" +
+                         "]" +
+                         "}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(labelsJson) });
+        var browser = CreateBrowser(handler);
+
+        var folders = await browser.ListFoldersAsync();
+
+        Assert.Equal(3, folders.Count);
+        Assert.Equal("Alpha", folders[0].Name);
+        Assert.Equal("Inbox", folders[1].Name);
+        Assert.Equal("Zeta", folders[2].Name);
+        Assert.Equal("INBOX", folders[1].Id);
+        Assert.Equal("system", folders[1].Type);
+        Assert.Single(handler.Requests);
+        Assert.Equal("https://gmail.googleapis.com/gmail/v1/users/me/labels?fields=labels(id,name,type)", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task ListMessagesAsync_UsesListThenLoadsSummaries() {
         var listJson = "{\"messages\":[{\"id\":\"m1\",\"threadId\":\"t1\"},{\"id\":\"m2\",\"threadId\":\"t1\"}],\"resultSizeEstimate\":\"9\"}";
         var m2Json = "{" +

--- a/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
@@ -25,6 +25,40 @@ public class GraphMailboxBrowserTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task ListFoldersAsync_BuildsHierarchicalNames() {
+        var topLevelJson = "{" +
+                           "\"value\":[" +
+                           "{\"id\":\"inbox-id\",\"displayName\":\"Inbox\",\"childFolderCount\":1,\"wellKnownName\":\"inbox\",\"totalItemCount\":10,\"unreadItemCount\":2}," +
+                           "{\"id\":\"archive-id\",\"displayName\":\"Archive\",\"childFolderCount\":0,\"wellKnownName\":\"archive\"}" +
+                           "]" +
+                           "}";
+        var childJson = "{" +
+                        "\"value\":[" +
+                        "{\"id\":\"projects-id\",\"displayName\":\"Projects\",\"parentFolderId\":\"inbox-id\",\"childFolderCount\":0}" +
+                        "]" +
+                        "}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(topLevelJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(childJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var folders = await browser.ListFoldersAsync();
+
+        Assert.Equal(3, folders.Count);
+        Assert.Equal("Archive", folders[0].Name);
+        Assert.Equal("Inbox", folders[1].Name);
+        Assert.Equal("Inbox/Projects", folders[2].Name);
+        Assert.Equal("inbox", folders[1].WellKnownName);
+        Assert.Equal(10, folders[1].TotalItemCount);
+        Assert.Equal(2, folders[1].UnreadItemCount);
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("/me/mailFolders?$top=200", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/me/mailFolders/inbox-id/childFolders?$top=200", handler.Requests[1].RequestUri!.ToString());
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task ListMessagesAsync_ReturnsTotalCount_AndMappedSummaries() {
         var folderJson = "{\"id\":\"inbox\",\"totalItemCount\":12}";
         var listJson = "{\"value\":[{\"id\":\"m1\",\"subject\":\"s\",\"receivedDateTime\":\"2026-02-15T00:00:00Z\",\"internetMessageId\":\"<msg@example.test>\",\"hasAttachments\":true,\"isRead\":false,\"conversationId\":\"conv-1\",\"from\":{\"emailAddress\":{\"address\":\"a@example.test\"}},\"toRecipients\":[{\"emailAddress\":{\"address\":\"b@example.test\"}}],\"flag\":{\"flagStatus\":\"flagged\"}}]}";

--- a/Sources/Mailozaurr/Gmail/GmailMailboxBrowser.cs
+++ b/Sources/Mailozaurr/Gmail/GmailMailboxBrowser.cs
@@ -88,6 +88,39 @@ public sealed class GmailMailboxBrowser {
     }
 
     /// <summary>
+    /// Lists available Gmail labels as mailbox folders.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxFolderSummary>> ListFoldersAsync(
+        CancellationToken cancellationToken = default) {
+        var labels = await _gmail.ListLabelsAsync(_userId, cancellationToken).ConfigureAwait(false);
+        if (labels == null || labels.Count == 0) {
+            return Array.Empty<GmailMailboxFolderSummary>();
+        }
+
+        var output = new List<GmailMailboxFolderSummary>(labels.Count);
+        foreach (var label in labels) {
+            if (label == null) {
+                continue;
+            }
+
+            var id = NormalizeOptional(label.Id);
+            var name = NormalizeOptional(label.Name);
+            if (id == null || name == null) {
+                continue;
+            }
+
+            output.Add(new GmailMailboxFolderSummary {
+                Id = id,
+                Name = name,
+                Type = NormalizeOptional(label.Type)
+            });
+        }
+
+        output.Sort(static (a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+        return output;
+    }
+
+    /// <summary>
     /// Lists messages in a Gmail label.
     /// </summary>
     public async Task<GmailMailboxListResult> ListMessagesAsync(
@@ -1293,6 +1326,20 @@ public sealed class GmailMailboxBrowser {
         } catch (FormatException ex) {
             throw new InvalidDataException("Attachment data is not a valid Base64 string.", ex);
         }
+    }
+
+    /// <summary>
+    /// Gmail mailbox folder summary.
+    /// </summary>
+    public sealed class GmailMailboxFolderSummary {
+        /// <summary>Gmail label id.</summary>
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>Gmail label display name.</summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>Gmail label type (for example, <c>system</c> or <c>user</c>).</summary>
+        public string? Type { get; set; }
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
@@ -29,6 +29,91 @@ public sealed class GraphMailboxBrowser {
     }
 
     /// <summary>
+    /// Lists mailbox folders and returns normalized hierarchical folder names.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphMailboxFolderSummary>> ListFoldersAsync(
+        int top = 200,
+        int maxRequests = 250,
+        CancellationToken cancellationToken = default) {
+        var folders = await _graph.ListMailFoldersRecursiveAsync(
+            top: ClampInt(top, 1, 999),
+            select: "id,displayName,parentFolderId,childFolderCount,wellKnownName,totalItemCount,unreadItemCount",
+            maxRequests: ClampInt(maxRequests, 1, 5000),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var nodes = new Dictionary<string, GraphFolderPathNode>(StringComparer.Ordinal);
+        foreach (var folder in folders) {
+            if (folder == null) {
+                continue;
+            }
+
+            var id = string.IsNullOrWhiteSpace(folder.Id) ? null : folder.Id.Trim();
+            if (id == null) {
+                continue;
+            }
+
+            var displayName = string.IsNullOrWhiteSpace(folder.DisplayName) ? id : folder.DisplayName.Trim();
+            var parentIdRaw = folder.ParentFolderId;
+            string? parentId = null;
+            if (!string.IsNullOrWhiteSpace(parentIdRaw)) {
+                parentId = parentIdRaw!.Trim();
+            }
+            var wellKnownNameRaw = folder.WellKnownName;
+            string? wellKnownName = null;
+            if (!string.IsNullOrWhiteSpace(wellKnownNameRaw)) {
+                wellKnownName = wellKnownNameRaw!.Trim();
+            }
+            nodes[id] = new GraphFolderPathNode(
+                id,
+                displayName,
+                parentId,
+                wellKnownName,
+                folder.TotalItemCount,
+                folder.UnreadItemCount);
+        }
+
+        string BuildPath(string id) {
+            if (!nodes.TryGetValue(id, out var node)) {
+                return id;
+            }
+
+            var parts = new List<string>();
+            var current = node;
+            var guard = 0;
+            while (guard++ < 100) {
+                parts.Add(current.DisplayName);
+                var parentId = current.ParentId;
+                if (string.IsNullOrWhiteSpace(parentId)) {
+                    break;
+                }
+
+                var parentKey = parentId!.Trim();
+                if (!nodes.TryGetValue(parentKey, out current)) {
+                    break;
+                }
+            }
+            parts.Reverse();
+            return string.Join("/", parts);
+        }
+
+        var output = new List<GraphMailboxFolderSummary>(nodes.Count);
+        foreach (var node in nodes.Values) {
+            output.Add(new GraphMailboxFolderSummary {
+                Id = node.Id,
+                Name = BuildPath(node.Id),
+                DisplayName = node.DisplayName,
+                ParentId = node.ParentId,
+                WellKnownName = node.WellKnownName,
+                TotalItemCount = node.TotalItemCount,
+                UnreadItemCount = node.UnreadItemCount
+            });
+        }
+
+        output.Sort(static (a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+        return output;
+    }
+
+    /// <summary>
     /// Lists messages in a Graph folder.
     /// </summary>
     public async Task<GraphMailboxListResult> ListMessagesAsync(
@@ -443,6 +528,30 @@ public sealed class GraphMailboxBrowser {
     private static bool IsFlagged(GraphMailMessageFlag? flag) =>
         string.Equals(flag?.FlagStatus, "flagged", StringComparison.OrdinalIgnoreCase);
 
+    private sealed class GraphFolderPathNode {
+        public GraphFolderPathNode(
+            string id,
+            string displayName,
+            string? parentId,
+            string? wellKnownName,
+            int? totalItemCount,
+            int? unreadItemCount) {
+            Id = id;
+            DisplayName = displayName;
+            ParentId = parentId;
+            WellKnownName = wellKnownName;
+            TotalItemCount = totalItemCount;
+            UnreadItemCount = unreadItemCount;
+        }
+
+        public string Id { get; }
+        public string DisplayName { get; }
+        public string? ParentId { get; }
+        public string? WellKnownName { get; }
+        public int? TotalItemCount { get; }
+        public int? UnreadItemCount { get; }
+    }
+
     private static string JoinRecipients(IReadOnlyList<GraphEmailAddress>? recipients) {
         if (recipients == null || recipients.Count == 0) {
             return string.Empty;
@@ -547,6 +656,32 @@ public sealed class GraphMailboxBrowser {
 
         // Allow callers to pass a Graph folder id directly.
         return folder;
+    }
+
+    /// <summary>
+    /// Graph mailbox folder summary.
+    /// </summary>
+    public sealed class GraphMailboxFolderSummary {
+        /// <summary>Graph folder identifier.</summary>
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>Hierarchical display path (for example, <c>Inbox/Projects</c>).</summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>Folder display name.</summary>
+        public string DisplayName { get; set; } = string.Empty;
+
+        /// <summary>Parent folder id, when available.</summary>
+        public string? ParentId { get; set; }
+
+        /// <summary>Graph well-known folder name, when available.</summary>
+        public string? WellKnownName { get; set; }
+
+        /// <summary>Total item count, when available.</summary>
+        public int? TotalItemCount { get; set; }
+
+        /// <summary>Unread item count, when available.</summary>
+        public int? UnreadItemCount { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add `GraphMailboxBrowser.ListFoldersAsync()` that returns normalized hierarchical folder summaries (`Name` paths like `Inbox/Projects`)
- add `GmailMailboxBrowser.ListFoldersAsync()` that returns sorted label-backed folder summaries
- add focused browser tests for Graph/Gmail folder listing behavior

## Validation
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~GraphMailboxBrowserTests|FullyQualifiedName~GmailMailboxBrowserTests"`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --framework net8.0`
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -f net472`
