### PR TITLE
Add POP3 mailbox browser delete primitive

### DIFF
--- a/Sources/Mailozaurr.Tests/Pop3MailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/Pop3MailboxBrowserTests.cs
@@ -86,6 +86,39 @@ public sealed class Pop3MailboxBrowserTests {
     }
 
     [Fact]
+    public async Task DeleteMessageCoreAsync_ResolvesByUid_AndDeletesResolvedIndex() {
+        var fake = new FakePop3Client(count: 3);
+        fake.Uids = new List<string> { "u0", "u1", "u2" };
+        fake.SetMessage(1, new MimeMessage { Subject = "x" });
+        fake.SetUid(1, "u1");
+
+        var result = await Pop3MailboxBrowser.DeleteMessageCoreAsync(fake, requestedIndex: null, requestedUid: "u1", CancellationToken.None);
+
+        Assert.Equal(Pop3MailboxBrowser.Pop3MessageResolveStatus.Success, result.Status);
+        Assert.Equal(1, result.DeletedIndex);
+        Assert.Equal("u1", result.DeletedUid);
+        Assert.Equal(new[] { 1 }, fake.DeletedIndices);
+    }
+
+    [Fact]
+    public async Task DeleteMessageCoreAsync_MissingIdentifier_ReturnsMissingIdentifier() {
+        var fake = new FakePop3Client(count: 1);
+        var result = await Pop3MailboxBrowser.DeleteMessageCoreAsync(fake, requestedIndex: null, requestedUid: null, CancellationToken.None);
+
+        Assert.Equal(Pop3MailboxBrowser.Pop3MessageResolveStatus.MissingIdentifier, result.Status);
+        Assert.Empty(fake.DeletedIndices);
+    }
+
+    [Fact]
+    public async Task DeleteMessageCoreAsync_UidLookupUnsupported_ReturnsUidLookupUnsupported() {
+        var fake = new FakePop3Client(count: 1) { ThrowUidListNotSupported = true };
+        var result = await Pop3MailboxBrowser.DeleteMessageCoreAsync(fake, requestedIndex: null, requestedUid: "u1", CancellationToken.None);
+
+        Assert.Equal(Pop3MailboxBrowser.Pop3MessageResolveStatus.UidLookupUnsupported, result.Status);
+        Assert.Empty(fake.DeletedIndices);
+    }
+
+    [Fact]
     public void NormalizeMessageIdValue_StripsAngleBrackets() {
         Assert.Equal("x@y", Pop3MailboxBrowser.NormalizeMessageIdValue("<x@y>"));
         Assert.Equal("x@y", Pop3MailboxBrowser.NormalizeMessageIdValue("x@y"));
@@ -115,6 +148,7 @@ public sealed class Pop3MailboxBrowserTests {
         public int Count { get; }
         public bool ThrowUidListNotSupported { get; set; }
         public IList<string> Uids { get; set; } = new List<string>();
+        public List<int> DeletedIndices { get; } = new();
 
         internal void SetHeaders(int index, HeaderList headers) => _headers[index] = headers;
         internal void SetUid(int index, string uid) => _uids[index] = uid;
@@ -137,8 +171,12 @@ public sealed class Pop3MailboxBrowserTests {
             return Task.FromResult(Uids);
         }
 
+        public Task DeleteMessageAsync(int index, CancellationToken cancellationToken) {
+            DeletedIndices.Add(index);
+            return Task.CompletedTask;
+        }
+
         public long GetMessageSize(int index, CancellationToken cancellationToken) =>
             _sizes.TryGetValue(index, out var s) ? s : 0;
     }
 }
-

--- a/Sources/Mailozaurr/Receive/Pop3MailboxBrowser.cs
+++ b/Sources/Mailozaurr/Receive/Pop3MailboxBrowser.cs
@@ -58,6 +58,12 @@ public static class Pop3MailboxBrowser {
         Pop3MessageResolveStatus Status,
         Pop3ResolvedMessageSnapshot? Snapshot);
 
+    /// <summary>Result of deleting a POP3 message by index/UIDL identifier.</summary>
+    public sealed record Pop3MessageDeleteResult(
+        Pop3MessageResolveStatus Status,
+        int? DeletedIndex,
+        string? DeletedUid);
+
     /// <summary>
     /// Lists messages as header-only snapshots, starting from the newest message.
     /// </summary>
@@ -90,12 +96,27 @@ public static class Pop3MailboxBrowser {
         return ResolveMessageCoreAsync(new MailKitPop3MailboxClient(client), requestedIndex, requestedUid, cancellationToken);
     }
 
+    /// <summary>
+    /// Resolves a POP3 message by index or UIDL and marks it for deletion.
+    /// </summary>
+    public static Task<Pop3MessageDeleteResult> DeleteMessageAsync(
+        Pop3Client client,
+        int? requestedIndex,
+        string? requestedUid,
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        return DeleteMessageCoreAsync(new MailKitPop3MailboxClient(client), requestedIndex, requestedUid, cancellationToken);
+    }
+
     internal interface IPop3MailboxClient {
         int Count { get; }
         Task<HeaderList> GetMessageHeadersAsync(int index, CancellationToken cancellationToken);
         Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken);
         Task<string> GetMessageUidAsync(int index, CancellationToken cancellationToken);
         Task<IList<string>> GetMessageUidsAsync(CancellationToken cancellationToken);
+        Task DeleteMessageAsync(int index, CancellationToken cancellationToken);
         long GetMessageSize(int index, CancellationToken cancellationToken);
     }
 
@@ -119,6 +140,9 @@ public static class Pop3MailboxBrowser {
 
         public Task<IList<string>> GetMessageUidsAsync(CancellationToken cancellationToken) =>
             _client.GetMessageUidsAsync(cancellationToken);
+
+        public Task DeleteMessageAsync(int index, CancellationToken cancellationToken) =>
+            _client.DeleteMessageAsync(index, cancellationToken);
 
         public long GetMessageSize(int index, CancellationToken cancellationToken) =>
             _client.GetMessageSize(index, cancellationToken);
@@ -206,6 +230,20 @@ public static class Pop3MailboxBrowser {
         return new Pop3MessageResolveResult(
             Pop3MessageResolveStatus.Success,
             new Pop3ResolvedMessageSnapshot(resolvedIndex, resolvedUid, messageSize, message));
+    }
+
+    internal static async Task<Pop3MessageDeleteResult> DeleteMessageCoreAsync(
+        IPop3MailboxClient client,
+        int? requestedIndex,
+        string? requestedUid,
+        CancellationToken cancellationToken) {
+        var resolved = await ResolveMessageCoreAsync(client, requestedIndex, requestedUid, cancellationToken).ConfigureAwait(false);
+        if (resolved.Status != Pop3MessageResolveStatus.Success || resolved.Snapshot is null) {
+            return new Pop3MessageDeleteResult(resolved.Status, null, null);
+        }
+
+        await client.DeleteMessageAsync(resolved.Snapshot.Index, cancellationToken).ConfigureAwait(false);
+        return new Pop3MessageDeleteResult(Pop3MessageResolveStatus.Success, resolved.Snapshot.Index, resolved.Snapshot.Uid);
     }
 
     internal static string? NormalizeOptional(string? raw) =>


### PR DESCRIPTION
## Summary
- add `Pop3MailboxBrowser.DeleteMessageAsync(Pop3Client, int? requestedIndex, string? requestedUid, CancellationToken)`
- add internal `DeleteMessageCoreAsync` primitive using existing resolve-by-index/UIDL flow
- extend internal POP3 client abstraction with `DeleteMessageAsync` to support unit testing
- add `Pop3MessageDeleteResult` with resolved delete metadata (`DeletedIndex`, `DeletedUid`)
- add focused tests for success + missing identifier + UID lookup unsupported delete scenarios

## Validation
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --filter "FullyQualifiedName~Pop3MailboxBrowserTests" -f net8.0 -v minimal`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 -v minimal`
