### PR TITLE
Upstream IMAP/native mailbox primitives and stale-aware provider semantics

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailMailboxBrowserTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
+using MimeKit;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -141,6 +142,26 @@ public sealed class GmailMailboxBrowserTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task ListThreadMessagesPageAsync_ReturnsPagedSortedSummaries() {
+        var threadJson = "{" +
+                         "\"id\":\"thr-1\",\"messages\":[" +
+                         "{\"id\":\"m1\",\"threadId\":\"thr-1\",\"internalDate\":\"1739491200000\",\"payload\":{\"headers\":[{\"name\":\"Subject\",\"value\":\"first\"}]}}," +
+                         "{\"id\":\"m2\",\"threadId\":\"thr-1\",\"internalDate\":\"1739577600000\",\"payload\":{\"headers\":[{\"name\":\"Subject\",\"value\":\"second\"}]}}" +
+                         "]}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(threadJson) });
+        var browser = CreateBrowser(handler);
+
+        var page = await browser.ListThreadMessagesPageAsync("thr-1", limit: 1, offset: 1);
+
+        Assert.Equal("thr-1", page.ThreadId);
+        Assert.Equal(2, page.TotalCount);
+        Assert.Single(page.Messages);
+        Assert.Equal("m1", page.Messages[0].NativeId);
+        Assert.Single(handler.Requests);
+        Assert.Contains("/users/me/threads/thr-1", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task GetMessageContentAsync_ReturnsMimeAndFlags() {
         var mime = "From: a@example.test\r\nTo: b@example.test\r\nSubject: Sample\r\nMessage-Id: <m1@example.test>\r\n\r\nhello";
         var raw = Convert.ToBase64String(Encoding.UTF8.GetBytes(mime)).Replace('+', '-').Replace('/', '_').TrimEnd('=');
@@ -154,6 +175,63 @@ public sealed class GmailMailboxBrowserTests {
         Assert.Equal("Sample", result.Message.Subject);
         Assert.False(result.Seen);
         Assert.True(result.Flagged);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SendMessageAsync_UsesGmailSendEndpoint() {
+        var sentJson = "{\"id\":\"gmail-sent-id\",\"threadId\":\"gmail-thread-id\"}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(sentJson) });
+        var browser = CreateBrowser(handler);
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.test"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.test"));
+        message.Subject = "Send me";
+        message.Body = new TextPart("plain") { Text = "hello" };
+
+        var result = await browser.SendMessageAsync(message);
+
+        Assert.Equal("gmail-sent-id", result.NativeId);
+        Assert.Equal("gmail-thread-id", result.NativeThreadId);
+        Assert.Single(handler.Requests);
+        Assert.Contains("/users/me/messages/send", handler.Requests[0].RequestUri!.ToString());
+        var body = await handler.Requests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"raw\":\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetThreadingMetadataAsync_ParsesSelectedHeaders() {
+        var json = "{" +
+                   "\"id\":\"m1\"," +
+                   "\"payload\":{\"headers\":[" +
+                   "{\"name\":\"Message-ID\",\"value\":\"<thread-child@example.test>\"}," +
+                   "{\"name\":\"In-Reply-To\",\"value\":\"<thread-parent@example.test>\"}," +
+                   "{\"name\":\"References\",\"value\":\"<thread-root@example.test> <thread-parent@example.test> <thread-root@example.test>\"}," +
+                   "{\"name\":\"Reply-To\",\"value\":\"replies@example.test\"}," +
+                   "{\"name\":\"Cc\",\"value\":\"cc@example.test\"}" +
+                   "]}}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) });
+        var browser = CreateBrowser(handler);
+
+        var result = await browser.GetThreadingMetadataAsync("m1");
+
+        Assert.Equal("thread-child@example.test", result.MessageId);
+        Assert.Equal("thread-parent@example.test", result.InReplyTo);
+        Assert.Equal("replies@example.test", result.ReplyTo);
+        Assert.Equal("cc@example.test", result.Cc);
+        Assert.Equal(2, result.References.Count);
+        Assert.Equal("thread-root@example.test", result.References[0]);
+        Assert.Equal("thread-parent@example.test", result.References[1]);
+
+        Assert.Single(handler.Requests);
+        var uri = handler.Requests[0].RequestUri!;
+        var query = ParseQueryParams(uri);
+        Assert.Equal("metadata", Assert.Single(query["format"]));
+        Assert.Equal("id,payload(headers)", Assert.Single(query["fields"]));
+        Assert.Contains("Message-ID", query["metadataHeaders"]);
+        Assert.Contains("In-Reply-To", query["metadataHeaders"]);
+        Assert.Contains("References", query["metadataHeaders"]);
+        Assert.Contains("Reply-To", query["metadataHeaders"]);
+        Assert.Contains("Cc", query["metadataHeaders"]);
     }
 
     [Fact]
@@ -177,6 +255,27 @@ public sealed class GmailMailboxBrowserTests {
         Assert.Contains("\"topicName\":\"projects/p/topics/t\"", body);
         Assert.Contains("INBOX", body);
         Assert.Contains("Label_1", body);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task StopWatchAsync_ReturnsAlreadyStopped_WhenMissingAndConfigured() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("{\"error\":\"missing\"}") });
+        var browser = CreateBrowser(handler);
+
+        var result = await browser.StopWatchAsync(treatMissingAsSuccess: true);
+
+        Assert.True(result.Stopped);
+        Assert.True(result.AlreadyStopped);
+        Assert.Single(handler.Requests);
+        Assert.Contains("/users/me/stop", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task StopWatchAsync_Throws_WhenMissingAndStrictMode() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("{\"error\":\"missing\"}") });
+        var browser = CreateBrowser(handler);
+
+        await Assert.ThrowsAsync<GmailApiException>(() => browser.StopWatchAsync(treatMissingAsSuccess: false));
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
@@ -210,6 +210,42 @@ public class GraphMailboxBrowserTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task FindMessageByInternetMessageIdAsync_UsesBracketedFilterAndReturnsMatch() {
+        var listJson = "{\"value\":[{\"id\":\"m1\",\"internetMessageId\":\"<msg-123@example.test>\"}]}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(listJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var result = await browser.FindMessageByInternetMessageIdAsync("msg-123@example.test", folder: "Sent Items");
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("sentitems", result.FolderSelector);
+        Assert.Equal("m1", result.NativeId);
+        Assert.Equal("msg-123@example.test", result.MessageId);
+        Assert.Single(handler.Requests);
+        var requestUri = handler.Requests[0].RequestUri!;
+        Assert.Contains("/me/mailFolders/sentitems/messages?", requestUri.ToString());
+        var decodedQuery = Uri.UnescapeDataString(requestUri.Query);
+        Assert.Contains("internetMessageId eq '<msg-123@example.test>'", decodedQuery, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("internetMessageId eq 'msg-123@example.test'", decodedQuery, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task FindMessageByInternetMessageIdAsync_ReturnsNoMatch_WhenResponseContainsDifferentMessageId() {
+        var listJson = "{\"value\":[{\"id\":\"m1\",\"internetMessageId\":\"<other@example.test>\"}]}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(listJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var result = await browser.FindMessageByInternetMessageIdAsync("msg-123@example.test", folder: "Sent Items");
+
+        Assert.False(result.IsMatch);
+        Assert.Equal("sentitems", result.FolderSelector);
+        Assert.Null(result.NativeId);
+        Assert.Null(result.MessageId);
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task SearchMessagesAsync_UsesGraphSearchWhenTextIsProvided() {
         var listJson = "{\"value\":[{\"id\":\"m1\",\"subject\":\"hello\"}]}";
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(listJson) });

--- a/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
+using MimeKit;
 using Xunit;
 
 namespace Mailozaurr.Tests;
@@ -85,6 +86,130 @@ public class GraphMailboxBrowserTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task ListConversationMessagesPageAsync_ReturnsPagedSortedSummaries() {
+        var listJson = "{\"value\":[" +
+                       "{\"id\":\"m1\",\"subject\":\"first\",\"receivedDateTime\":\"2026-02-14T00:00:00Z\",\"conversationId\":\"conv-1\"}," +
+                       "{\"id\":\"m2\",\"subject\":\"second\",\"receivedDateTime\":\"2026-02-15T00:00:00Z\",\"conversationId\":\"conv-1\"}" +
+                       "]}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(listJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var page = await browser.ListConversationMessagesPageAsync("conv-1", limit: 1, offset: 1);
+
+        Assert.Equal("conv-1", page.ConversationId);
+        Assert.Equal(2, page.TotalCount);
+        Assert.Single(page.Messages);
+        Assert.Equal("m1", page.Messages[0].NativeId);
+        Assert.Single(handler.Requests);
+        Assert.Contains("/me/messages?", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("conversationId", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ImportMessageAsync_CreatesMessageInResolvedFolder_AndReturnsResult() {
+        var createdJson = "{\"id\":\"created-id\"}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent(createdJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.test"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.test"));
+        message.Subject = "Imported";
+        message.MessageId = "<imported@example.test>";
+        message.Headers.Replace("X-Idempotency-Key", "idem-123");
+        message.Body = new TextPart("plain") { Text = "hello" };
+
+        var result = await browser.ImportMessageAsync(
+            message,
+            folder: "Sent Items",
+            idempotencyHeaderName: "X-Idempotency-Key");
+
+        Assert.Equal("sentitems", result.FolderSelector);
+        Assert.Equal("created-id", result.NativeId);
+        Assert.Equal("imported@example.test", result.MessageId);
+
+        Assert.Single(handler.Requests);
+        Assert.Contains("/me/mailFolders/sentitems/messages", handler.Requests[0].RequestUri!.ToString());
+        var body = await handler.Requests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"subject\":\"Imported\"", body, StringComparison.Ordinal);
+        Assert.Contains("\"name\":\"X-Idempotency-Key\"", body, StringComparison.Ordinal);
+        Assert.Contains("\"value\":\"idem-123\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ImportMessageAsync_UploadsLargeAttachmentsThroughUploadSession() {
+        var createJson = "{\"id\":\"created-id\"}";
+        var uploadSessionJson = "{\"uploadUrl\":\"https://upload.test/session\"}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent(createJson) },
+            new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent(uploadSessionJson) },
+            new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent(string.Empty) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.test"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.test"));
+        message.Subject = "With attachment";
+        message.MessageId = "<upload@example.test>";
+        var builder = new BodyBuilder { TextBody = "hello" };
+        var attachmentBytes = Encoding.UTF8.GetBytes("hello world");
+        builder.Attachments.Add("notes.txt", attachmentBytes);
+        message.Body = builder.ToMessageBody();
+
+        var result = await browser.ImportMessageAsync(
+            message,
+            folder: "Sent Items",
+            maxInlineAttachmentBytes: 0);
+
+        Assert.Equal("sentitems", result.FolderSelector);
+        Assert.Equal("created-id", result.NativeId);
+        Assert.Equal("upload@example.test", result.MessageId);
+
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Contains("/me/mailFolders/sentitems/messages", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/me/messages/created-id/attachments/createUploadSession", handler.Requests[1].RequestUri!.ToString());
+        Assert.Equal("https://upload.test/session", handler.Requests[2].RequestUri!.ToString());
+        var uploadBody = await handler.Requests[1].Content!.ReadAsStringAsync();
+        Assert.Contains("\"name\":\"notes.txt\"", uploadBody, StringComparison.Ordinal);
+        Assert.Contains("\"size\":11", uploadBody, StringComparison.Ordinal);
+        var range = handler.Requests[2].Content!.Headers.ContentRange;
+        Assert.NotNull(range);
+        Assert.Equal(0L, range!.From);
+        Assert.Equal(10L, range.To);
+        Assert.Equal(11L, range.Length);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SendMessageAsync_CreatesDraftAndSendsIt() {
+        var createJson = "{\"id\":\"draft-id\"}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent(createJson) },
+            new HttpResponseMessage(HttpStatusCode.Accepted) { Content = new StringContent(string.Empty) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.test"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.test"));
+        message.Subject = "Send me";
+        message.MessageId = "<send@example.test>";
+        message.Headers.Replace("X-Idempotency-Key", "idem-send");
+        message.Body = new TextPart("plain") { Text = "hello" };
+
+        var result = await browser.SendMessageAsync(
+            message,
+            idempotencyHeaderName: "X-Idempotency-Key");
+
+        Assert.Equal("draft-id", result.DraftId);
+        Assert.Equal("send@example.test", result.MessageId);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("/me/mailFolders/drafts/messages", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/me/messages/draft-id/send", handler.Requests[1].RequestUri!.ToString());
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task SearchMessagesAsync_UsesGraphSearchWhenTextIsProvided() {
         var listJson = "{\"value\":[{\"id\":\"m1\",\"subject\":\"hello\"}]}";
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(listJson) });
@@ -149,6 +274,117 @@ public class GraphMailboxBrowserTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task GetThreadingMetadataAsync_ParsesHeaderFieldsFromMime() {
+        var mime = "From: a@example.test\r\n" +
+                   "To: b@example.test\r\n" +
+                   "Reply-To: replies@example.test\r\n" +
+                   "Cc: c@example.test\r\n" +
+                   "Message-Id: <thread-child@example.test>\r\n" +
+                   "In-Reply-To: <thread-parent@example.test>\r\n" +
+                   "References: <thread-root@example.test> <thread-parent@example.test> <thread-root@example.test>\r\n" +
+                   "\r\nhello";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(Encoding.UTF8.GetBytes(mime)) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var result = await browser.GetThreadingMetadataAsync("m1");
+
+        Assert.Equal("thread-child@example.test", result.MessageId);
+        Assert.Equal("thread-parent@example.test", result.InReplyTo);
+        Assert.Equal("replies@example.test", result.ReplyTo);
+        Assert.Equal("c@example.test", result.Cc);
+        Assert.Equal(2, result.References.Count);
+        Assert.Equal("thread-root@example.test", result.References[0]);
+        Assert.Equal("thread-parent@example.test", result.References[1]);
+        Assert.Single(handler.Requests);
+        Assert.Contains("/me/messages/m1/$value", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Theory]
+    [InlineData("Archive", "me/mailFolders('archive')/messages")]
+    [InlineData("AAMkADk0Y2Qx", "me/mailFolders('AAMkADk0Y2Qx')/messages")]
+    [InlineData("A'B", "me/mailFolders('A''B')/messages")]
+    public void BuildMessageSubscriptionResource_MapsAndEscapesFolderSelector(string folder, string expected) {
+        var actual = GraphMailboxBrowser.BuildMessageSubscriptionResource(folder);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task CreateMessageSubscriptionAsync_PostsSubscriptionPayloadAndMapsResult() {
+        var json = "{\"id\":\"sub-1\",\"resource\":\"me/mailFolders('archive')/messages\",\"clientState\":\"state-1\",\"expirationDateTime\":\"2026-02-16T01:00:00Z\"}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent(json) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+        var expiration = new DateTimeOffset(new DateTime(2026, 2, 16, 0, 0, 0, DateTimeKind.Utc));
+
+        var result = await browser.CreateMessageSubscriptionAsync(
+            notificationUrl: "https://example.test/webhook",
+            folder: "Archive",
+            expirationDateTime: expiration,
+            changeType: "created,updated,deleted",
+            clientState: "state-1");
+
+        Assert.Equal("sub-1", result.SubscriptionId);
+        Assert.Equal("me/mailFolders('archive')/messages", result.Resource);
+        Assert.Equal("state-1", result.ClientState);
+        Assert.Equal(new DateTimeOffset(new DateTime(2026, 2, 16, 1, 0, 0, DateTimeKind.Utc)), result.ExpirationDateTime);
+        Assert.Single(handler.Requests);
+        Assert.Contains("/subscriptions", handler.Requests[0].RequestUri!.ToString());
+        var body = await handler.Requests[0].Content!.ReadAsStringAsync();
+        using var doc = System.Text.Json.JsonDocument.Parse(body);
+        Assert.Equal("https://example.test/webhook", doc.RootElement.GetProperty("notificationUrl").GetString());
+        Assert.Equal("me/mailFolders('archive')/messages", doc.RootElement.GetProperty("resource").GetString());
+        Assert.Equal("created,updated,deleted", doc.RootElement.GetProperty("changeType").GetString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task RenewSubscriptionAsync_PatchesSubscriptionAndMapsResult() {
+        var json = "{\"id\":\"sub-renew\",\"resource\":\"me/mailFolders('inbox')/messages\",\"clientState\":\"state-2\",\"expirationDateTime\":\"2026-02-16T01:00:00Z\"}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+        var expiration = new DateTimeOffset(new DateTime(2026, 2, 16, 0, 0, 0, DateTimeKind.Utc));
+
+        var result = await browser.RenewSubscriptionAsync("sub-renew", expiration);
+
+        Assert.Equal("sub-renew", result.SubscriptionId);
+        Assert.Equal(new DateTimeOffset(new DateTime(2026, 2, 16, 1, 0, 0, DateTimeKind.Utc)), result.ExpirationDateTime);
+        Assert.Single(handler.Requests);
+        Assert.Equal(new HttpMethod("PATCH"), handler.Requests[0].Method);
+        Assert.Contains("/subscriptions/sub-renew", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task RenewSubscriptionSafeAsync_ReturnsMissing_WhenSubscriptionIsGone() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("{\"error\":\"missing\"}") });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+        var expiration = new DateTimeOffset(new DateTime(2026, 2, 16, 0, 0, 0, DateTimeKind.Utc));
+
+        var result = await browser.RenewSubscriptionSafeAsync("sub-renew-missing", expiration, treatMissingAsStale: true);
+
+        Assert.False(result.Renewed);
+        Assert.True(result.Missing);
+        Assert.Null(result.Subscription);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task DeleteSubscriptionAsync_ReturnsAlreadyDeleted_WhenMissingAndConfigured() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("{\"error\":\"missing\"}") });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var result = await browser.DeleteSubscriptionAsync("sub-missing", treatMissingAsSuccess: true);
+
+        Assert.True(result.Deleted);
+        Assert.True(result.AlreadyDeleted);
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Delete, handler.Requests[0].Method);
+        Assert.Contains("/subscriptions/sub-missing", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task SetMessageSeenAsync_PatchesReadState() {
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) });
         var client = CreateClient(handler);
@@ -200,6 +436,40 @@ public class GraphMailboxBrowserTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task ArchiveMessageAsync_UsesArchiveDestinationAlias() {
+        var folderJson = "{\"id\":\"archive-id\"}";
+        var movedJson = "{\"id\":\"m1\"}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(folderJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(movedJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        await browser.ArchiveMessageAsync("m1");
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("/me/mailFolders/archive?$select=id", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/me/messages/m1/move", handler.Requests[1].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task TrashMessageAsync_UsesTrashDestinationAlias() {
+        var folderJson = "{\"id\":\"trash-id\"}";
+        var movedJson = "{\"id\":\"m1\"}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(folderJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(movedJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        await browser.TrashMessageAsync("m1");
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("/me/mailFolders/deleteditems?$select=id", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/me/messages/m1/move", handler.Requests[1].RequestUri!.ToString());
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task DeleteMessageAsync_UsesDeleteEndpoint() {
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.NoContent) { Content = new StringContent(string.Empty) });
         var client = CreateClient(handler);
@@ -232,6 +502,32 @@ public class GraphMailboxBrowserTests {
         var body = await handler.Requests[1].Content!.ReadAsStringAsync();
         Assert.Contains("me/messages/m1/move", body, StringComparison.Ordinal);
         Assert.Contains("me/messages/m2/move", body, StringComparison.Ordinal);
+        Assert.Contains("\"destinationId\":\"archive-id\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ArchiveConversationsAsync_UsesArchiveDestinationAlias() {
+        var folderJson = "{\"id\":\"archive-id\"}";
+        var listJson = "{\"value\":[{\"id\":\"m1\"}]}";
+        var batchJson = "{\"responses\":[{\"id\":\"1\",\"status\":201}]}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(folderJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(listJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(batchJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var results = await browser.ArchiveConversationsAsync(new[] { "conv-1" });
+
+        Assert.Single(results);
+        Assert.All(results, r => Assert.True(r.Ok, r.Error));
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Contains("/me/mailFolders/archive?$select=id", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/me/messages?", handler.Requests[1].RequestUri!.ToString());
+        Assert.Contains("conversationId", handler.Requests[1].RequestUri!.ToString());
+        Assert.Contains("/$batch", handler.Requests[2].RequestUri!.ToString());
+        var body = await handler.Requests[2].Content!.ReadAsStringAsync();
+        Assert.Contains("me/messages/m1/move", body, StringComparison.Ordinal);
         Assert.Contains("\"destinationId\":\"archive-id\"", body, StringComparison.Ordinal);
     }
 

--- a/Sources/Mailozaurr.Tests/ImapBulkFlagOperationsTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapBulkFlagOperationsTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ImapBulkFlagOperationsTests {
+    [Fact]
+    public async Task SetFlagsAsync_UsesBulkPath_WhenBulkSucceeds() {
+        var folder = new FakeFolder();
+
+        var result = await ImapBulkFlagOperations.SetFlagsAsync(
+            folder,
+            new[] { new UniqueId(1), new UniqueId(2), new UniqueId(2) },
+            MessageFlags.Seen,
+            add: true);
+
+        Assert.Equal(2, result.Requested);
+        Assert.Equal(2, result.Updated);
+        Assert.Equal(2, result.SuccessfulUids.Count);
+        Assert.All(result.Results, x => Assert.True(x.Ok));
+        Assert.Equal(1, folder.BulkAddCalls);
+        Assert.Equal(0, folder.SingleAddCalls);
+    }
+
+    [Fact]
+    public async Task SetFlagsAsync_FallsBackPerItem_WhenBulkFails() {
+        var folder = new FakeFolder {
+            ThrowOnBulkRemove = true,
+            FailSingleRemoveFor = new HashSet<uint> { 2 }
+        };
+
+        var result = await ImapBulkFlagOperations.SetFlagsAsync(
+            folder,
+            new[] { new UniqueId(1), new UniqueId(2) },
+            MessageFlags.Flagged,
+            add: false,
+            sanitizeError: message => "sanitized: " + message);
+
+        Assert.Equal(2, result.Requested);
+        Assert.Equal(1, result.Updated);
+        Assert.Single(result.SuccessfulUids);
+        Assert.Equal((uint)1, result.SuccessfulUids[0].Id);
+        Assert.Equal(2, result.Results.Count);
+        Assert.True(result.Results[0].Ok);
+        Assert.False(result.Results[1].Ok);
+        Assert.Equal("sanitized: uid 2 failed", result.Results[1].Error);
+        Assert.Equal(1, folder.BulkRemoveCalls);
+        Assert.Equal(2, folder.SingleRemoveCalls);
+    }
+
+    private sealed class FakeFolder : ImapBulkFlagOperations.IImapFolder {
+        internal bool ThrowOnBulkRemove { get; set; }
+        internal HashSet<uint> FailSingleRemoveFor { get; set; } = new();
+        internal int BulkAddCalls { get; private set; }
+        internal int BulkRemoveCalls { get; private set; }
+        internal int SingleAddCalls { get; private set; }
+        internal int SingleRemoveCalls { get; private set; }
+
+        public Task AddFlagsAsync(IReadOnlyCollection<UniqueId> uids, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) {
+            _ = uids ?? throw new ArgumentNullException(nameof(uids));
+            _ = flags;
+            _ = silent;
+            _ = cancellationToken;
+            BulkAddCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveFlagsAsync(IReadOnlyCollection<UniqueId> uids, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) {
+            _ = uids ?? throw new ArgumentNullException(nameof(uids));
+            _ = flags;
+            _ = silent;
+            _ = cancellationToken;
+            BulkRemoveCalls++;
+            if (ThrowOnBulkRemove) {
+                throw new InvalidOperationException("bulk failed");
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task AddFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) {
+            _ = uid;
+            _ = flags;
+            _ = silent;
+            _ = cancellationToken;
+            SingleAddCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) {
+            _ = flags;
+            _ = silent;
+            _ = cancellationToken;
+            SingleRemoveCalls++;
+            if (FailSingleRemoveFor.Contains(uid.Id)) {
+                throw new InvalidOperationException($"uid {uid.Id} failed");
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ImapDeleteOperationsTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapDeleteOperationsTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ImapDeleteOperationsTests {
+    [Fact]
+    public async Task DeleteAsync_Expunges_WhenRequestedAndAtLeastOneDeleteSucceeds() {
+        var folder = new FakeDeleteFolder {
+            ThrowOnBulkAdd = true,
+            FailSingleAddFor = new HashSet<uint> { 2 }
+        };
+
+        var result = await ImapDeleteOperations.DeleteAsync(
+            folder,
+            new[] { new UniqueId(1), new UniqueId(2) },
+            expunge: true,
+            sanitizeError: message => "sanitized: " + message);
+
+        Assert.Equal(2, result.Requested);
+        Assert.Equal(1, result.Deleted);
+        Assert.True(result.Expunged);
+        Assert.Equal(1, folder.ExpungeCalls);
+        Assert.Single(result.DeletedUids);
+        Assert.Equal((uint)1, result.DeletedUids[0].Id);
+        Assert.Equal(2, result.Results.Count);
+        Assert.True(result.Results[0].Ok);
+        Assert.False(result.Results[1].Ok);
+        Assert.Equal("sanitized: uid 2 failed", result.Results[1].Error);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_DoesNotExpunge_WhenNoDeleteSucceeds() {
+        var folder = new FakeDeleteFolder {
+            ThrowOnBulkAdd = true,
+            FailSingleAddFor = new HashSet<uint> { 1 }
+        };
+
+        var result = await ImapDeleteOperations.DeleteAsync(
+            folder,
+            new[] { new UniqueId(1) },
+            expunge: true);
+
+        Assert.Equal(1, result.Requested);
+        Assert.Equal(0, result.Deleted);
+        Assert.False(result.Expunged);
+        Assert.Equal(0, folder.ExpungeCalls);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_DoesNotExpunge_WhenNotRequested() {
+        var folder = new FakeDeleteFolder();
+
+        var result = await ImapDeleteOperations.DeleteAsync(
+            folder,
+            new[] { new UniqueId(1) },
+            expunge: false);
+
+        Assert.Equal(1, result.Requested);
+        Assert.Equal(1, result.Deleted);
+        Assert.False(result.Expunged);
+        Assert.Equal(0, folder.ExpungeCalls);
+    }
+
+    private sealed class FakeDeleteFolder : ImapDeleteOperations.IImapDeleteFolder {
+        internal bool ThrowOnBulkAdd { get; set; }
+        internal HashSet<uint> FailSingleAddFor { get; set; } = new();
+        internal int ExpungeCalls { get; private set; }
+
+        public string FullName => "INBOX";
+
+        public Task AddFlagsAsync(IReadOnlyCollection<UniqueId> uids, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) {
+            _ = uids ?? throw new ArgumentNullException(nameof(uids));
+            _ = flags;
+            _ = silent;
+            _ = cancellationToken;
+            if (ThrowOnBulkAdd) {
+                throw new InvalidOperationException("bulk failed");
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveFlagsAsync(IReadOnlyCollection<UniqueId> uids, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) {
+            _ = uids;
+            _ = flags;
+            _ = silent;
+            _ = cancellationToken;
+            return Task.CompletedTask;
+        }
+
+        public Task AddFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) {
+            _ = flags;
+            _ = silent;
+            _ = cancellationToken;
+            if (FailSingleAddFor.Contains(uid.Id)) {
+                throw new InvalidOperationException($"uid {uid.Id} failed");
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) {
+            _ = uid;
+            _ = flags;
+            _ = silent;
+            _ = cancellationToken;
+            return Task.CompletedTask;
+        }
+
+        public Task ExpungeAsync(CancellationToken cancellationToken = default) {
+            _ = cancellationToken;
+            ExpungeCalls++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ImapMailboxSearchQueryBuilderTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapMailboxSearchQueryBuilderTests.cs
@@ -1,0 +1,37 @@
+using MailKit.Search;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ImapMailboxSearchQueryBuilderTests {
+    [Fact]
+    public void Tokenize_ReturnsEmpty_ForNullOrWhitespace() {
+        Assert.Empty(ImapMailboxSearchQueryBuilder.Tokenize(null));
+        Assert.Empty(ImapMailboxSearchQueryBuilder.Tokenize(string.Empty));
+        Assert.Empty(ImapMailboxSearchQueryBuilder.Tokenize(" \t \r\n "));
+    }
+
+    [Fact]
+    public void Tokenize_SplitsOnWhitespaceAndTrims() {
+        var tokens = ImapMailboxSearchQueryBuilder.Tokenize(" alpha\tbeta \r\ngamma  ");
+
+        Assert.Equal(3, tokens.Count);
+        Assert.Equal("alpha", tokens[0]);
+        Assert.Equal("beta", tokens[1]);
+        Assert.Equal("gamma", tokens[2]);
+    }
+
+    [Fact]
+    public void Build_ReturnsSearchQuery() {
+        var query = ImapMailboxSearchQueryBuilder.Build(
+            unseenOnly: true,
+            subjectContains: "subject",
+            fromContains: "sender",
+            toContains: "recipient",
+            bodyContains: "body",
+            query: "token");
+
+        Assert.NotNull(query);
+        Assert.IsAssignableFrom<SearchQuery>(query);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ImapMoveOperationsTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapMoveOperationsTests.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ImapMoveOperationsTests {
+    [Fact]
+    public async Task MoveAsync_ReturnsNoOp_WhenSourceAndTargetAreSame() {
+        var folder = new FakeFolder("INBOX");
+
+        var result = await ImapMoveOperations.MoveAsync(
+            folder,
+            folder,
+            new[] { new UniqueId(1), new UniqueId(1), new UniqueId(2) });
+
+        Assert.Equal(2, result.Requested);
+        Assert.Equal(2, result.Moved);
+        Assert.Equal(2, result.Results.Count);
+        Assert.All(result.Results, x => Assert.True(x.Ok));
+        Assert.All(result.Results, x => Assert.False(x.UsedCopyFallback));
+        Assert.Equal(0, folder.OpenCalls);
+        Assert.Equal(0, folder.MoveCalls);
+    }
+
+    [Fact]
+    public async Task MoveAsync_UsesCopyFallbackAndUidMapping_WhenMoveNotSupported() {
+        var source = new FakeFolder("INBOX") {
+            NotSupportedMoveUids = new HashSet<uint> { 7 },
+            MessageIdHeaders = new Dictionary<uint, string?> {
+                [7] = "  <id-7@example>  "
+            },
+            CopyMap = new Dictionary<uint, uint> {
+                [7] = 701
+            }
+        };
+        var target = new FakeFolder("Archive");
+
+        var result = await ImapMoveOperations.MoveAsync(
+            source,
+            target,
+            new[] { new UniqueId(7) });
+
+        Assert.Equal(1, result.Requested);
+        Assert.Equal(1, result.Moved);
+        var item = Assert.Single(result.Results);
+        Assert.True(item.Ok);
+        Assert.True(item.UsedCopyFallback);
+        Assert.Equal(701, item.TargetUid);
+        Assert.Equal("id-7@example", item.MessageId);
+        Assert.Equal(1, source.AddFlagsCalls);
+        Assert.Equal(1, source.ExpungeCalls);
+    }
+
+    [Fact]
+    public async Task MoveAsync_UsesSearchLookup_WhenFallbackMapMissing() {
+        var source = new FakeFolder("INBOX") {
+            NotSupportedMoveUids = new HashSet<uint> { 5 },
+            ThrowOnCopyWithMap = true,
+            MessageIdHeaders = new Dictionary<uint, string?> {
+                [5] = "<lookup-5@example>"
+            }
+        };
+        var target = new FakeFolder("Archive") {
+            SearchByMessageId = new Dictionary<string, List<UniqueId>>(StringComparer.OrdinalIgnoreCase) {
+                ["lookup-5@example"] = new List<UniqueId> { new UniqueId(5001) }
+            }
+        };
+
+        var result = await ImapMoveOperations.MoveAsync(
+            source,
+            target,
+            new[] { new UniqueId(5) });
+
+        var item = Assert.Single(result.Results);
+        Assert.True(item.Ok);
+        Assert.True(item.UsedCopyFallback);
+        Assert.Equal(5001, item.TargetUid);
+        Assert.Equal(1, source.CopySingleCalls);
+        Assert.Equal(1, source.ExpungeCalls);
+    }
+
+    [Fact]
+    public async Task MoveAsync_ReturnsPerItemFailures_WithSanitizedErrors() {
+        var source = new FakeFolder("INBOX") {
+            ThrowOnMoveUids = new HashSet<uint> { 2 }
+        };
+        var target = new FakeFolder("Archive");
+
+        var result = await ImapMoveOperations.MoveAsync(
+            source,
+            target,
+            new[] { new UniqueId(1), new UniqueId(2) },
+            sanitizeError: message => "sanitized: " + message);
+
+        Assert.Equal(2, result.Requested);
+        Assert.Equal(1, result.Moved);
+        Assert.True(result.Results[0].Ok);
+        Assert.False(result.Results[1].Ok);
+        Assert.Equal("sanitized: move failed for uid 2", result.Results[1].Error);
+    }
+
+    [Fact]
+    public async Task MoveAsync_PropagatesCancellation_WhenOpenIsCanceled() {
+        var source = new FakeFolder("INBOX") {
+            ThrowOnOpenWhenCancellationRequested = true
+        };
+        var target = new FakeFolder("Archive");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            ImapMoveOperations.MoveAsync(
+                source,
+                target,
+                new[] { new UniqueId(1) },
+                cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task MoveAsync_RecoversWhenCloseFails_DuringAccessUpgrade() {
+        var source = new FakeFolder("INBOX") {
+            StartOpen = true,
+            StartAccess = FolderAccess.ReadOnly,
+            ThrowOnClose = true
+        };
+        var target = new FakeFolder("Archive");
+
+        var result = await ImapMoveOperations.MoveAsync(
+            source,
+            target,
+            new[] { new UniqueId(1) });
+
+        var item = Assert.Single(result.Results);
+        Assert.True(item.Ok);
+        Assert.Equal(1, source.CloseCalls);
+        Assert.Equal(1, source.OpenCalls);
+    }
+
+    private sealed class FakeFolder : ImapMoveOperations.IImapMoveFolder {
+        internal FakeFolder(string fullName) {
+            FullName = fullName;
+        }
+
+        public string FullName { get; }
+
+        private bool _isOpen;
+        private FolderAccess _access;
+
+        public bool IsOpen => StartOpen || _isOpen;
+
+        public FolderAccess Access => StartOpen ? StartAccess : _access;
+
+        internal int OpenCalls { get; private set; }
+        internal int CloseCalls { get; private set; }
+        internal int MoveCalls { get; private set; }
+        internal int AddFlagsCalls { get; private set; }
+        internal int ExpungeCalls { get; private set; }
+        internal int CopySingleCalls { get; private set; }
+
+        internal bool StartOpen { get; set; }
+        internal FolderAccess StartAccess { get; set; }
+        internal bool ThrowOnOpenWhenCancellationRequested { get; set; }
+        internal bool ThrowOnClose { get; set; }
+        internal HashSet<uint> NotSupportedMoveUids { get; set; } = new();
+        internal HashSet<uint> ThrowOnMoveUids { get; set; } = new();
+        internal bool ThrowOnCopyWithMap { get; set; }
+        internal Dictionary<uint, string?> MessageIdHeaders { get; set; } = new();
+        internal Dictionary<uint, uint> CopyMap { get; set; } = new();
+        internal Dictionary<string, List<UniqueId>> SearchByMessageId { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task OpenAsync(FolderAccess access, CancellationToken cancellationToken = default) {
+            if (ThrowOnOpenWhenCancellationRequested) {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            OpenCalls++;
+            StartOpen = false;
+            _isOpen = true;
+            _access = access;
+            return Task.CompletedTask;
+        }
+
+        public Task CloseAsync(bool expunge, CancellationToken cancellationToken = default) {
+            _ = expunge;
+            _ = cancellationToken;
+            CloseCalls++;
+            if (ThrowOnClose) {
+                throw new InvalidOperationException("close failed");
+            }
+
+            StartOpen = false;
+            _isOpen = false;
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> GetMessageIdHeaderAsync(UniqueId uid, CancellationToken cancellationToken = default) {
+            _ = cancellationToken;
+            MessageIdHeaders.TryGetValue(uid.Id, out var value);
+            return Task.FromResult(value);
+        }
+
+        public Task MoveToAsync(UniqueId uid, ImapMoveOperations.IImapMoveFolder destination, CancellationToken cancellationToken = default) {
+            _ = destination;
+            _ = cancellationToken;
+            MoveCalls++;
+
+            if (ThrowOnMoveUids.Contains(uid.Id)) {
+                throw new InvalidOperationException($"move failed for uid {uid.Id}");
+            }
+            if (NotSupportedMoveUids.Contains(uid.Id)) {
+                throw new NotSupportedException("MOVE is not supported");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<IDictionary<UniqueId, UniqueId>?> CopyToWithMapAsync(IReadOnlyCollection<UniqueId> uids, ImapMoveOperations.IImapMoveFolder destination, CancellationToken cancellationToken = default) {
+            _ = destination;
+            _ = cancellationToken;
+            if (ThrowOnCopyWithMap) {
+                throw new InvalidOperationException("copy map failed");
+            }
+
+            var map = new Dictionary<UniqueId, UniqueId>();
+            foreach (var uid in uids) {
+                if (CopyMap.TryGetValue(uid.Id, out var targetUid)) {
+                    map[uid] = new UniqueId(targetUid);
+                }
+            }
+            return Task.FromResult<IDictionary<UniqueId, UniqueId>?>(map);
+        }
+
+        public Task CopyToAsync(UniqueId uid, ImapMoveOperations.IImapMoveFolder destination, CancellationToken cancellationToken = default) {
+            _ = uid;
+            _ = destination;
+            _ = cancellationToken;
+            CopySingleCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task AddFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) {
+            _ = uid;
+            _ = flags;
+            _ = silent;
+            _ = cancellationToken;
+            AddFlagsCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task ExpungeAsync(CancellationToken cancellationToken = default) {
+            _ = cancellationToken;
+            ExpungeCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task<IList<UniqueId>> SearchByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+            _ = cancellationToken;
+            if (SearchByMessageId.TryGetValue(messageId, out var hits)) {
+                return Task.FromResult<IList<UniqueId>>(hits);
+            }
+
+            return Task.FromResult<IList<UniqueId>>(Array.Empty<UniqueId>());
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ImapSentFolderResolverTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapSentFolderResolverTests.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ImapSentFolderResolverTests {
+    [Fact]
+    public void ResolveSentFolderName_UsesRequestedFolder_WhenProvided() {
+        var resolved = ImapSentFolderResolver.ResolveSentFolderName(
+            requestedFolder: " Custom/Sent ",
+            folders: new[] {
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Sent", Name = "Sent", IsSent = true }
+            });
+
+        Assert.Equal("Custom/Sent", resolved);
+    }
+
+    [Fact]
+    public void ResolveSentFolderName_UsesConfiguredFolder_WhenRequestedIsMissing() {
+        var resolved = ImapSentFolderResolver.ResolveSentFolderName(
+            requestedFolder: null,
+            configuredFolder: " Team/Sent ",
+            folders: new[] {
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Sent", Name = "Sent", IsSent = true }
+            });
+
+        Assert.Equal("Team/Sent", resolved);
+    }
+
+    [Fact]
+    public void ResolveSentFolderName_PrefersAttributeTaggedSentFolder() {
+        var resolved = ImapSentFolderResolver.ResolveSentFolderName(
+            requestedFolder: null,
+            configuredFolder: null,
+            folders: new[] {
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "INBOX", Name = "INBOX" },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Sent Items", Name = "Sent Items", IsSent = true }
+            });
+
+        Assert.Equal("Sent Items", resolved);
+    }
+
+    [Fact]
+    public void ResolveSentFolderName_UsesSentHeuristic_WhenNoAttributeMatch() {
+        var resolved = ImapSentFolderResolver.ResolveSentFolderName(
+            requestedFolder: null,
+            configuredFolder: null,
+            folders: new[] {
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "INBOX", Name = "INBOX" },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Sent Mail", Name = "Sent Mail" }
+            });
+
+        Assert.Equal("Sent Mail", resolved);
+    }
+
+    [Fact]
+    public void ResolveSentFolderName_IgnoresArchiveAndDraftLikeNames() {
+        var resolved = ImapSentFolderResolver.ResolveSentFolderName(
+            requestedFolder: null,
+            configuredFolder: null,
+            folders: new[] {
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Archive", Name = "Archive" },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Draft Sent Ideas", Name = "Draft Sent Ideas" },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Sent", Name = "Sent" }
+            });
+
+        Assert.Equal("Sent", resolved);
+    }
+
+    [Fact]
+    public void ResolveSentFolderName_UsesFallback_WhenNoCandidatesExist() {
+        var resolved = ImapSentFolderResolver.ResolveSentFolderName(
+            requestedFolder: null,
+            configuredFolder: null,
+            folders: new List<ImapSentFolderResolver.ImapFolderInfo>(),
+            fallbackFolder: "Sent");
+
+        Assert.Equal("Sent", resolved);
+    }
+
+    [Fact]
+    public void ResolveDraftsFolderName_PrefersConfiguredOverride_WhenProvided() {
+        var resolved = ImapSentFolderResolver.ResolveDraftsFolderName(
+            requestedFolder: null,
+            configuredFolder: " Team Drafts ",
+            folders: new[] {
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Drafts", Name = "Drafts", IsDrafts = true }
+            });
+
+        Assert.Equal("Team Drafts", resolved);
+    }
+
+    [Fact]
+    public void ResolveDraftsFolderName_UsesHeuristic_WhenNoAttributeFlag() {
+        var resolved = ImapSentFolderResolver.ResolveDraftsFolderName(
+            requestedFolder: null,
+            configuredFolder: null,
+            folders: new[] {
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "INBOX", Name = "INBOX" },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "[Gmail]/Drafts", Name = "Drafts" }
+            });
+
+        Assert.Equal("[Gmail]/Drafts", resolved);
+    }
+
+    [Fact]
+    public void ResolveTrashFolderName_UsesSpecialUseFlag() {
+        var resolved = ImapSentFolderResolver.ResolveTrashFolderName(
+            requestedFolder: null,
+            configuredFolder: null,
+            folders: new[] {
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Deleted Items", Name = "Deleted Items", IsTrash = true },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Junk", Name = "Junk", IsJunk = true }
+            });
+
+        Assert.Equal("Deleted Items", resolved);
+    }
+
+    [Fact]
+    public void ResolveArchiveFolderName_UsesHeuristic() {
+        var resolved = ImapSentFolderResolver.ResolveArchiveFolderName(
+            requestedFolder: null,
+            configuredFolder: null,
+            folders: new[] {
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "INBOX", Name = "INBOX" },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "[Gmail]/All Mail", Name = "All Mail" }
+            });
+
+        Assert.Equal("[Gmail]/All Mail", resolved);
+    }
+
+    [Fact]
+    public void ResolveJunkFolderName_UsesConfiguredOverride_WhenProvided() {
+        var resolved = ImapSentFolderResolver.ResolveJunkFolderName(
+            requestedFolder: null,
+            configuredFolder: "Spam Box",
+            folders: new[] {
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Junk", Name = "Junk", IsJunk = true }
+            });
+
+        Assert.Equal("Spam Box", resolved);
+    }
+
+    [Fact]
+    public void ResolveSpecialFolderMappings_UsesOverridesBeforeDetection() {
+        var mappings = ImapSentFolderResolver.ResolveSpecialFolderMappings(
+            configuredInboxFolder: "INBOX.Client",
+            configuredSentFolder: "Sent.Custom",
+            configuredDraftsFolder: "Drafts.Custom",
+            configuredTrashFolder: null,
+            configuredArchiveFolder: null,
+            configuredJunkFolder: null,
+            folders: new[] {
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Inbox", Name = "Inbox" },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Sent Items", Name = "Sent Items", IsSent = true },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Drafts", Name = "Drafts", IsDrafts = true },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Deleted Items", Name = "Deleted Items", IsTrash = true },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Archive", Name = "Archive", IsArchive = true },
+                new ImapSentFolderResolver.ImapFolderInfo { FullName = "Spam", Name = "Spam", IsJunk = true }
+            },
+            configuredImapFolder: "INBOX");
+
+        Assert.Equal("INBOX.Client", mappings.Inbox);
+        Assert.Equal("Sent.Custom", mappings.Sent);
+        Assert.Equal("Drafts.Custom", mappings.Drafts);
+        Assert.Equal("Deleted Items", mappings.Trash);
+        Assert.Equal("Archive", mappings.Archive);
+        Assert.Equal("Spam", mappings.Junk);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ImapSentMessageOperationsTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapSentMessageOperationsTests.cs
@@ -97,6 +97,42 @@ public sealed class ImapSentMessageOperationsTests {
     }
 
     [Fact]
+    public async Task FindSentDuplicateAsync_NoMatch_ReturnsDistinctInstances() {
+        var folderA = new FakeImapSentFolder {
+            FullNameValue = "Sent-A",
+            IsOpenValue = true,
+            AccessValue = FolderAccess.ReadOnly
+        };
+        folderA.SearchResults.Enqueue(new List<UniqueId>());
+
+        var folderB = new FakeImapSentFolder {
+            FullNameValue = "Sent-B",
+            IsOpenValue = true,
+            AccessValue = FolderAccess.ReadOnly
+        };
+        folderB.SearchResults.Enqueue(new List<UniqueId>());
+
+        var resultA = await ImapSentMessageOperations.FindSentDuplicateAsync(
+            folderA,
+            idempotencyHeaderName: "X-BayManager-Idempotency-Key",
+            idempotencyKey: "idem-123",
+            messageIdToken: null);
+        var resultB = await ImapSentMessageOperations.FindSentDuplicateAsync(
+            folderB,
+            idempotencyHeaderName: "X-BayManager-Idempotency-Key",
+            idempotencyKey: "idem-123",
+            messageIdToken: null);
+
+        Assert.False(resultA.IsMatch);
+        Assert.False(resultB.IsMatch);
+        Assert.NotSame(resultA, resultB);
+        Assert.Null(resultA.Folder);
+        Assert.Null(resultB.Folder);
+        Assert.Null(resultA.MessageId);
+        Assert.Null(resultB.MessageId);
+    }
+
+    [Fact]
     public async Task GetThreadingMetadataAsync_ReturnsFolderMetadata() {
         var uid = new UniqueId(777);
         var folder = new FakeImapSentFolder {

--- a/Sources/Mailozaurr.Tests/ImapSentMessageOperationsTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapSentMessageOperationsTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Search;
+using MimeKit;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ImapSentMessageOperationsTests {
+    [Fact]
+    public async Task AppendToSentAsync_EnsuresReadWriteAndAppendsSeen() {
+        var folder = new FakeImapSentFolder {
+            FullNameValue = "Sent",
+            IsOpenValue = true,
+            AccessValue = FolderAccess.ReadOnly
+        };
+        var message = BuildMessage();
+
+        var result = await ImapSentMessageOperations.AppendToSentAsync(folder, message);
+
+        Assert.True(result.Appended);
+        Assert.Equal("Sent", result.Folder);
+        Assert.Equal(1, folder.CloseCount);
+        Assert.Equal(1, folder.OpenCount);
+        Assert.Equal(FolderAccess.ReadWrite, folder.LastOpenAccess);
+        Assert.Equal(1, folder.AppendCount);
+        Assert.Equal(MessageFlags.Seen, folder.LastAppendFlags);
+    }
+
+    [Fact]
+    public async Task FindSentDuplicateAsync_ReturnsMatchFromIdempotencyHeaderSearch() {
+        var uid = new UniqueId(123);
+        var folder = new FakeImapSentFolder {
+            FullNameValue = "Sent",
+            IsOpenValue = true,
+            AccessValue = FolderAccess.ReadOnly
+        };
+        folder.SearchResults.Enqueue(new List<UniqueId> { uid });
+        folder.EnvelopeMessageIds[uid] = "matched@example.test";
+
+        var result = await ImapSentMessageOperations.FindSentDuplicateAsync(
+            folder,
+            idempotencyHeaderName: "X-BayManager-Idempotency-Key",
+            idempotencyKey: "idem-123",
+            messageIdToken: "fallback@example.test");
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("Sent", result.Folder);
+        Assert.Equal("matched@example.test", result.MessageId);
+        Assert.Single(folder.SearchQueries);
+    }
+
+    [Fact]
+    public async Task FindSentDuplicateAsync_FallsBackToMessageIdSearch() {
+        var uid = new UniqueId(345);
+        var folder = new FakeImapSentFolder {
+            FullNameValue = "Sent",
+            IsOpenValue = true,
+            AccessValue = FolderAccess.ReadOnly
+        };
+        folder.SearchResults.Enqueue(new List<UniqueId>());
+        folder.SearchResults.Enqueue(new List<UniqueId> { uid });
+        folder.EnvelopeMessageIds[uid] = "found-by-message-id@example.test";
+
+        var result = await ImapSentMessageOperations.FindSentDuplicateAsync(
+            folder,
+            idempotencyHeaderName: "X-BayManager-Idempotency-Key",
+            idempotencyKey: "idem-123",
+            messageIdToken: "<msg-123@example.test>");
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("found-by-message-id@example.test", result.MessageId);
+        Assert.Equal(2, folder.SearchQueries.Count);
+    }
+
+    [Fact]
+    public async Task FindSentDuplicateAsync_ReturnsNoneWhenNoMatch() {
+        var folder = new FakeImapSentFolder {
+            FullNameValue = "Sent",
+            IsOpenValue = true,
+            AccessValue = FolderAccess.ReadOnly
+        };
+        folder.SearchResults.Enqueue(new List<UniqueId>());
+
+        var result = await ImapSentMessageOperations.FindSentDuplicateAsync(
+            folder,
+            idempotencyHeaderName: "X-BayManager-Idempotency-Key",
+            idempotencyKey: "idem-123",
+            messageIdToken: null);
+
+        Assert.False(result.IsMatch);
+        Assert.Null(result.MessageId);
+        Assert.Single(folder.SearchQueries);
+    }
+
+    [Fact]
+    public async Task GetThreadingMetadataAsync_ReturnsFolderMetadata() {
+        var uid = new UniqueId(777);
+        var folder = new FakeImapSentFolder {
+            FullNameValue = "INBOX",
+            IsOpenValue = false,
+            AccessValue = FolderAccess.ReadOnly
+        };
+        folder.ThreadingMetadataByUid[uid] = new ImapSentMessageOperations.ImapThreadingMetadataResult {
+            MessageId = "child@example.test",
+            InReplyTo = "parent@example.test",
+            ReplyTo = "reply@example.test",
+            Cc = "cc@example.test",
+            References = new List<string> { "root@example.test", "parent@example.test" }
+        };
+
+        var result = await ImapSentMessageOperations.GetThreadingMetadataAsync(folder, uid);
+
+        Assert.NotNull(result);
+        Assert.Equal("child@example.test", result!.MessageId);
+        Assert.Equal("parent@example.test", result.InReplyTo);
+        Assert.Equal("reply@example.test", result.ReplyTo);
+        Assert.Equal("cc@example.test", result.Cc);
+        Assert.Equal(2, result.References!.Count);
+        Assert.Equal(1, folder.OpenCount);
+        Assert.Equal(FolderAccess.ReadOnly, folder.LastOpenAccess);
+    }
+
+    [Theory]
+    [InlineData("<abc@example.test>", "abc@example.test")]
+    [InlineData(" abc@example.test ", "abc@example.test")]
+    [InlineData("", null)]
+    [InlineData("   ", null)]
+    public void NormalizeMessageIdToken_NormalizesExpectedValues(string input, string? expected) {
+        var actual = ImapSentMessageOperations.NormalizeMessageIdToken(input);
+        Assert.Equal(expected, actual);
+    }
+
+    private static MimeMessage BuildMessage() {
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.test"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.test"));
+        message.Subject = "subject";
+        message.Body = new TextPart("plain") { Text = "body" };
+        return message;
+    }
+
+    private sealed class FakeImapSentFolder : ImapSentMessageOperations.IImapSentFolder {
+        public string FullNameValue { get; set; } = "INBOX";
+        public bool IsOpenValue { get; set; }
+        public FolderAccess AccessValue { get; set; }
+        public int OpenCount { get; private set; }
+        public int CloseCount { get; private set; }
+        public int AppendCount { get; private set; }
+        public FolderAccess LastOpenAccess { get; private set; } = FolderAccess.ReadOnly;
+        public MessageFlags LastAppendFlags { get; private set; } = MessageFlags.None;
+        public Queue<IList<UniqueId>> SearchResults { get; } = new();
+        public List<SearchQuery> SearchQueries { get; } = new();
+        public Dictionary<UniqueId, string?> EnvelopeMessageIds { get; } = new();
+        public Dictionary<UniqueId, ImapSentMessageOperations.ImapThreadingMetadataResult?> ThreadingMetadataByUid { get; } = new();
+
+        public string FullName => FullNameValue;
+        public bool IsOpen => IsOpenValue;
+        public FolderAccess Access => AccessValue;
+
+        public Task OpenAsync(FolderAccess access, CancellationToken cancellationToken = default) {
+            OpenCount++;
+            LastOpenAccess = access;
+            AccessValue = access;
+            IsOpenValue = true;
+            return Task.CompletedTask;
+        }
+
+        public Task CloseAsync(bool expunge, CancellationToken cancellationToken = default) {
+            CloseCount++;
+            IsOpenValue = false;
+            return Task.CompletedTask;
+        }
+
+        public Task AppendAsync(MimeMessage message, MessageFlags flags, CancellationToken cancellationToken = default) {
+            _ = message ?? throw new ArgumentNullException(nameof(message));
+            AppendCount++;
+            LastAppendFlags = flags;
+            return Task.CompletedTask;
+        }
+
+        public Task<IList<UniqueId>> SearchAsync(SearchQuery query, CancellationToken cancellationToken = default) {
+            SearchQueries.Add(query);
+            if (SearchResults.Count > 0) {
+                return Task.FromResult(SearchResults.Dequeue());
+            }
+            return Task.FromResult<IList<UniqueId>>(new List<UniqueId>());
+        }
+
+        public Task<string?> FetchEnvelopeMessageIdAsync(UniqueId uid, CancellationToken cancellationToken = default) {
+            EnvelopeMessageIds.TryGetValue(uid, out var value);
+            return Task.FromResult(value);
+        }
+
+        public Task<ImapSentMessageOperations.ImapThreadingMetadataResult?> FetchThreadingMetadataAsync(UniqueId uid, CancellationToken cancellationToken = default) {
+            ThreadingMetadataByUid.TryGetValue(uid, out var value);
+            return Task.FromResult(value);
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/NativeMailboxThreadingMetadataOperationsTests.cs
+++ b/Sources/Mailozaurr.Tests/NativeMailboxThreadingMetadataOperationsTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class NativeMailboxThreadingMetadataOperationsTests {
+    [Fact]
+    public void Normalize_FromRawValues_NormalizesAndDeduplicates() {
+        var metadata = NativeMailboxThreadingMetadataOperations.Normalize(
+            messageId: " <child@example.test> ",
+            replyTo: " reply@example.test ",
+            cc: " cc@example.test ",
+            inReplyTo: " <parent@example.test> ",
+            references: new[] {
+                "<root@example.test>",
+                "parent@example.test",
+                " <ROOT@example.test> ",
+                "  "
+            });
+
+        Assert.Equal("child@example.test", metadata.MessageId);
+        Assert.Equal("reply@example.test", metadata.ReplyTo);
+        Assert.Equal("cc@example.test", metadata.Cc);
+        Assert.Equal("parent@example.test", metadata.InReplyTo);
+        Assert.NotNull(metadata.References);
+        Assert.Equal(2, metadata.References!.Count);
+        Assert.Equal("root@example.test", metadata.References[0]);
+        Assert.Equal("parent@example.test", metadata.References[1]);
+    }
+
+    [Fact]
+    public void Normalize_FromGraphResult_UsesSharedNormalization() {
+        var graph = new GraphMailboxBrowser.GraphMailboxThreadingMetadataResult {
+            MessageId = " <graph@example.test> ",
+            ReplyTo = " graph-reply@example.test ",
+            Cc = " graph-cc@example.test ",
+            InReplyTo = " <graph-parent@example.test> ",
+            References = new List<string> {
+                "<graph-root@example.test>",
+                "graph-parent@example.test",
+                "<GRAPH-ROOT@example.test>"
+            }
+        };
+
+        var metadata = NativeMailboxThreadingMetadataOperations.Normalize(graph);
+
+        Assert.Equal("graph@example.test", metadata.MessageId);
+        Assert.Equal("graph-reply@example.test", metadata.ReplyTo);
+        Assert.Equal("graph-cc@example.test", metadata.Cc);
+        Assert.Equal("graph-parent@example.test", metadata.InReplyTo);
+        Assert.NotNull(metadata.References);
+        Assert.Equal(2, metadata.References!.Count);
+    }
+
+    [Fact]
+    public void Normalize_FromGmailResult_UsesSharedNormalization() {
+        var gmail = new GmailMailboxBrowser.GmailMailboxThreadingMetadataResult {
+            MessageId = " <gmail@example.test> ",
+            ReplyTo = " gmail-reply@example.test ",
+            Cc = " gmail-cc@example.test ",
+            InReplyTo = " <gmail-parent@example.test> ",
+            References = new List<string> {
+                "<gmail-root@example.test>",
+                "gmail-parent@example.test",
+                "<GMAIL-ROOT@example.test>"
+            }
+        };
+
+        var metadata = NativeMailboxThreadingMetadataOperations.Normalize(gmail);
+
+        Assert.Equal("gmail@example.test", metadata.MessageId);
+        Assert.Equal("gmail-reply@example.test", metadata.ReplyTo);
+        Assert.Equal("gmail-cc@example.test", metadata.Cc);
+        Assert.Equal("gmail-parent@example.test", metadata.InReplyTo);
+        Assert.NotNull(metadata.References);
+        Assert.Equal(2, metadata.References!.Count);
+    }
+
+    [Fact]
+    public void Normalize_EmptyReferences_ReturnsNullReferences() {
+        var metadata = NativeMailboxThreadingMetadataOperations.Normalize(
+            messageId: null,
+            replyTo: null,
+            cc: null,
+            inReplyTo: null,
+            references: new[] { " ", "\t" });
+
+        Assert.Null(metadata.MessageId);
+        Assert.Null(metadata.ReplyTo);
+        Assert.Null(metadata.Cc);
+        Assert.Null(metadata.InReplyTo);
+        Assert.Null(metadata.References);
+    }
+}

--- a/Sources/Mailozaurr.Tests/NativeSentMailboxOperationsTests.cs
+++ b/Sources/Mailozaurr.Tests/NativeSentMailboxOperationsTests.cs
@@ -1,0 +1,67 @@
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class NativeSentMailboxOperationsTests {
+    [Fact]
+    public void ResolveGraphSentFolderName_PrefersRequestedFolder() {
+        var folder = NativeSentMailboxOperations.ResolveGraphSentFolderName(
+            requestedSentFolder: " Team/Sent ",
+            configuredSentFolder: "ConfigSent");
+
+        Assert.Equal("Team/Sent", folder);
+    }
+
+    [Fact]
+    public void ResolveGraphSentFolderName_UsesConfiguredWhenRequestedMissing() {
+        var folder = NativeSentMailboxOperations.ResolveGraphSentFolderName(
+            requestedSentFolder: null,
+            configuredSentFolder: " ConfigSent ");
+
+        Assert.Equal("ConfigSent", folder);
+    }
+
+    [Fact]
+    public void ResolveGraphSentFolderName_UsesFallbackWhenOverridesMissing() {
+        var folder = NativeSentMailboxOperations.ResolveGraphSentFolderName(
+            requestedSentFolder: null,
+            configuredSentFolder: null);
+
+        Assert.Equal(NativeSentMailboxOperations.DefaultGraphSentFolder, folder);
+    }
+
+    [Fact]
+    public void ResolveGraphSentFolderSelector_UsesGraphFolderSelectorRules() {
+        var selector = NativeSentMailboxOperations.ResolveGraphSentFolderSelector(
+            requestedSentFolder: null,
+            configuredSentFolder: "Sent Items");
+
+        Assert.Equal(GraphMailboxBrowser.ResolveFolderSelector("Sent Items"), selector);
+    }
+
+    [Fact]
+    public void ResolveGmailSentLabelId_IsAlwaysSystemSentLabel() {
+        var label = NativeSentMailboxOperations.ResolveGmailSentLabelId(
+            requestedSentFolder: "CustomSent",
+            configuredSentFolder: "ConfiguredSent");
+
+        Assert.Equal(NativeSentMailboxOperations.DefaultGmailSentLabelId, label);
+    }
+
+    [Fact]
+    public void ResolveGmailSentFolderName_PrefersRequestedThenConfiguredThenFallback() {
+        var requested = NativeSentMailboxOperations.ResolveGmailSentFolderName(
+            requestedSentFolder: " Requested ",
+            configuredSentFolder: "Configured");
+        var configured = NativeSentMailboxOperations.ResolveGmailSentFolderName(
+            requestedSentFolder: null,
+            configuredSentFolder: " Configured ");
+        var fallback = NativeSentMailboxOperations.ResolveGmailSentFolderName(
+            requestedSentFolder: null,
+            configuredSentFolder: null);
+
+        Assert.Equal("Requested", requested);
+        Assert.Equal("Configured", configured);
+        Assert.Equal(NativeSentMailboxOperations.DefaultGmailSentLabelId, fallback);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ProtocolAuthTests.cs
+++ b/Sources/Mailozaurr.Tests/ProtocolAuthTests.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ProtocolAuthTests {
+    [Theory]
+    [InlineData(null, ProtocolAuthMode.Basic)]
+    [InlineData("", ProtocolAuthMode.Basic)]
+    [InlineData(" ", ProtocolAuthMode.Basic)]
+    [InlineData("basic", ProtocolAuthMode.Basic)]
+    [InlineData("BASIC", ProtocolAuthMode.Basic)]
+    [InlineData("oauth2", ProtocolAuthMode.OAuth2)]
+    [InlineData("oauth", ProtocolAuthMode.OAuth2)]
+    [InlineData("xoauth2", ProtocolAuthMode.OAuth2)]
+    [InlineData("unexpected", ProtocolAuthMode.Basic)]
+    public void ParseMode_ParsesExpectedValues(string? raw, ProtocolAuthMode expected) {
+        var mode = ProtocolAuth.ParseMode(raw);
+        Assert.Equal(expected, mode);
+    }
+
+    [Fact]
+    public void ParseMode_UsesProvidedFallbackForUnknownValue() {
+        var mode = ProtocolAuth.ParseMode("unexpected", fallback: ProtocolAuthMode.OAuth2);
+        Assert.Equal(ProtocolAuthMode.OAuth2, mode);
+    }
+}

--- a/Sources/Mailozaurr.Tests/SmtpSentFolderSessionPipelineTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSentFolderSessionPipelineTests.cs
@@ -110,4 +110,59 @@ public class SmtpSentFolderSessionPipelineTests {
                 resolveSentFolderAsync: (_, _) => Task.FromResult(Mock.Of<IMailFolder>()),
                 message: null!));
     }
+
+    [Fact]
+    public async Task TryGetThreadingMetadataAsync_UsesConnectedSession_AndDisconnects() {
+        var connectCalls = 0;
+        var metadataCalls = 0;
+        var disconnectCalls = 0;
+        var expected = new ImapSentMessageOperations.ImapThreadingMetadataResult {
+            MessageId = "child@example.test",
+            InReplyTo = "parent@example.test"
+        };
+
+        var actual = await SmtpSentFolderSessionPipeline.TryGetThreadingMetadataAsync(
+            connectAsync: _ => {
+                connectCalls++;
+                return Task.FromResult(new ImapClient());
+            },
+            folder: "INBOX",
+            uid: 42,
+            getMetadataAsync: (_, folder, uid, _) => {
+                metadataCalls++;
+                Assert.Equal("INBOX", folder);
+                Assert.Equal((uint)42, uid);
+                return Task.FromResult<ImapSentMessageOperations.ImapThreadingMetadataResult?>(expected);
+            },
+            disconnectAsync: (_, _) => {
+                disconnectCalls++;
+                return Task.CompletedTask;
+            });
+
+        Assert.Same(expected, actual);
+        Assert.Equal(1, connectCalls);
+        Assert.Equal(1, metadataCalls);
+        Assert.Equal(1, disconnectCalls);
+    }
+
+    [Fact]
+    public async Task TryGetThreadingMetadataAsync_Throws_ForInvalidArguments() {
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            SmtpSentFolderSessionPipeline.TryGetThreadingMetadataAsync(
+                connectAsync: null!,
+                folder: "INBOX",
+                uid: 1));
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            SmtpSentFolderSessionPipeline.TryGetThreadingMetadataAsync(
+                connectAsync: _ => Task.FromResult(new ImapClient()),
+                folder: " ",
+                uid: 1));
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            SmtpSentFolderSessionPipeline.TryGetThreadingMetadataAsync(
+                connectAsync: _ => Task.FromResult(new ImapClient()),
+                folder: "INBOX",
+                uid: 0));
+    }
 }

--- a/Sources/Mailozaurr/Connections/ProtocolAuth.cs
+++ b/Sources/Mailozaurr/Connections/ProtocolAuth.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Imap;
+using MailKit.Net.Pop3;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Protocol authentication mode used by IMAP/POP3/SMTP connectors.
+/// </summary>
+public enum ProtocolAuthMode {
+    /// <summary>Username/password authentication.</summary>
+    Basic = 0,
+
+    /// <summary>OAuth2 (XOAUTH2) token authentication.</summary>
+    OAuth2 = 1
+}
+
+/// <summary>
+/// Shared protocol authentication helpers for IMAP/POP3/SMTP clients.
+/// </summary>
+public static class ProtocolAuth {
+    /// <summary>
+    /// Parses protocol auth mode text.
+    /// </summary>
+    public static ProtocolAuthMode ParseMode(string? raw, ProtocolAuthMode fallback = ProtocolAuthMode.Basic) {
+        var value = (raw ?? string.Empty).Trim();
+        if (value.Length == 0) {
+            return fallback;
+        }
+        if (value.Equals("basic", StringComparison.OrdinalIgnoreCase)) {
+            return ProtocolAuthMode.Basic;
+        }
+        if (value.Equals("oauth2", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("xoauth2", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("oauth", StringComparison.OrdinalIgnoreCase)) {
+            return ProtocolAuthMode.OAuth2;
+        }
+
+        return fallback;
+    }
+
+    /// <summary>
+    /// Authenticates an IMAP client using selected auth mode.
+    /// </summary>
+    public static Task AuthenticateImapAsync(
+        ImapClient client,
+        string userName,
+        string secret,
+        ProtocolAuthMode mode,
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (string.IsNullOrWhiteSpace(userName)) {
+            throw new InvalidOperationException("IMAP username is required.");
+        }
+        if (string.IsNullOrWhiteSpace(secret)) {
+            throw new InvalidOperationException("IMAP secret/token is required.");
+        }
+
+        var normalizedUser = userName.Trim();
+        var normalizedSecret = secret.Trim();
+        if (mode == ProtocolAuthMode.OAuth2) {
+            return client.AuthenticateAsync(new SaslMechanismOAuth2(normalizedUser, normalizedSecret), cancellationToken);
+        }
+
+        return client.AuthenticateAsync(new NetworkCredential(normalizedUser, normalizedSecret), cancellationToken);
+    }
+
+    /// <summary>
+    /// Authenticates an SMTP client using selected auth mode.
+    /// </summary>
+    public static Task AuthenticateSmtpAsync(
+        SmtpClient client,
+        string userName,
+        string secret,
+        ProtocolAuthMode mode,
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (string.IsNullOrWhiteSpace(userName)) {
+            throw new InvalidOperationException("SMTP username is required.");
+        }
+        if (string.IsNullOrWhiteSpace(secret)) {
+            throw new InvalidOperationException("SMTP secret/token is required.");
+        }
+
+        var normalizedUser = userName.Trim();
+        if (mode == ProtocolAuthMode.OAuth2) {
+            return client.AuthenticateAsync(new SaslMechanismOAuth2(normalizedUser, secret.Trim()), cancellationToken);
+        }
+
+        return client.AuthenticateAsync(normalizedUser, secret, cancellationToken);
+    }
+
+    /// <summary>
+    /// Authenticates a POP3 client using selected auth mode.
+    /// </summary>
+    public static Task AuthenticatePop3Async(
+        Pop3Client client,
+        string userName,
+        string secret,
+        ProtocolAuthMode mode,
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (string.IsNullOrWhiteSpace(userName)) {
+            throw new InvalidOperationException("POP3 username is required.");
+        }
+        if (string.IsNullOrWhiteSpace(secret)) {
+            throw new InvalidOperationException("POP3 secret/token is required.");
+        }
+
+        var normalizedUser = userName.Trim();
+        if (mode == ProtocolAuthMode.OAuth2) {
+            return client.AuthenticateAsync(new SaslMechanismOAuth2(normalizedUser, secret.Trim()), cancellationToken);
+        }
+
+        return client.AuthenticateAsync(normalizedUser, secret, cancellationToken);
+    }
+}

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -888,7 +888,17 @@ public sealed class GmailApiClient : IDisposable {
         }
         using var response = await _client.PostAsync($"users/{userId}/stop", new StringContent("{}", Encoding.UTF8, "application/json"), cancellationToken).ConfigureAwait(false);
         await ThrowIfAuthErrorAsync(response, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode) {
+#if NET5_0_OR_GREATER
+            var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+            throw new GmailApiException(
+                response.StatusCode,
+                $"Gmail users.stop failed ({(int)response.StatusCode}).",
+                content);
+        }
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/Gmail/GmailApiException.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 
 namespace Mailozaurr;
 
@@ -6,6 +7,11 @@ namespace Mailozaurr;
 /// Exception thrown when Gmail API returns an unexpected response.
 /// </summary>
 public class GmailApiException : Exception {
+    /// <summary>
+    /// HTTP status code returned by the Gmail API when available.
+    /// </summary>
+    public HttpStatusCode? StatusCode { get; }
+
     /// <summary>
     /// Raw response content returned by the Gmail API.
     /// </summary>
@@ -19,7 +25,19 @@ public class GmailApiException : Exception {
     /// <param name="innerException">The original exception.</param>
     public GmailApiException(string message, string responseContent, Exception innerException)
         : base(message, innerException) {
+        StatusCode = null;
+        ResponseContent = responseContent;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GmailApiException"/> class.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <param name="message">The error message.</param>
+    /// <param name="responseContent">Raw response content from the server.</param>
+    public GmailApiException(HttpStatusCode statusCode, string message, string responseContent)
+        : base(message) {
+        StatusCode = statusCode;
         ResponseContent = responseContent;
     }
 }
-

--- a/Sources/Mailozaurr/Gmail/GmailMailboxBrowser.cs
+++ b/Sources/Mailozaurr/Gmail/GmailMailboxBrowser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using MimeKit;
@@ -227,6 +228,32 @@ public sealed class GmailMailboxBrowser {
     }
 
     /// <summary>
+    /// Lists a paged slice of messages in a Gmail thread.
+    /// </summary>
+    public async Task<GmailMailboxThreadListResult> ListThreadMessagesPageAsync(
+        string threadId,
+        int limit,
+        int offset,
+        int maxItems = 2000,
+        CancellationToken cancellationToken = default) {
+        var messages = await ListThreadMessagesAsync(
+            threadId,
+            maxItems: maxItems,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var total = messages.Count;
+        var skip = Math.Max(0, offset);
+        var take = ClampInt(limit, 1, 1000);
+        var page = messages.Skip(skip).Take(take).ToList();
+
+        return new GmailMailboxThreadListResult {
+            ThreadId = threadId.Trim(),
+            TotalCount = total,
+            Messages = page
+        };
+    }
+
+    /// <summary>
     /// Searches messages in a Gmail label.
     /// </summary>
     public async Task<GmailMailboxSearchResult> SearchMessagesAsync(
@@ -369,6 +396,172 @@ public sealed class GmailMailboxBrowser {
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return MapSummary(message);
+    }
+
+    /// <summary>
+    /// Imports a MIME message into Gmail with a target label (typically <c>SENT</c>).
+    /// </summary>
+    /// <param name="message">MIME message to import.</param>
+    /// <param name="labelId">Target label id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Import result.</returns>
+    public async Task<GmailMailboxImportResult> ImportMessageAsync(
+        MimeMessage message,
+        string labelId = "SENT",
+        CancellationToken cancellationToken = default) {
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+        if (string.IsNullOrWhiteSpace(labelId)) {
+            throw new ArgumentException("labelId is required.", nameof(labelId));
+        }
+
+        string raw;
+        using (var ms = new MemoryStream()) {
+            await message.WriteToAsync(ms, cancellationToken).ConfigureAwait(false);
+            raw = Base64UrlEncode(ms.ToArray());
+        }
+
+        var imported = await _gmail.ImportAsync(
+            _userId,
+            raw,
+            labelIds: new[] { labelId.Trim() },
+            internalDateSource: "dateHeader",
+            neverMarkSpam: true,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new GmailMailboxImportResult {
+            LabelId = labelId.Trim(),
+            NativeId = NormalizeOptional(imported.Id),
+            NativeThreadId = NormalizeOptional(imported.ThreadId)
+        };
+    }
+
+    /// <summary>
+    /// Sends a MIME message through Gmail.
+    /// </summary>
+    /// <param name="message">MIME message to send.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Send result metadata.</returns>
+    public async Task<GmailMailboxSendResult> SendMessageAsync(
+        MimeMessage message,
+        CancellationToken cancellationToken = default) {
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var sent = await _gmail.SendAsync(_userId, message, cancellationToken).ConfigureAwait(false);
+        return new GmailMailboxSendResult {
+            NativeId = NormalizeOptional(sent.Id),
+            NativeThreadId = NormalizeOptional(sent.ThreadId)
+        };
+    }
+
+    /// <summary>
+    /// Probes a Gmail label for a message with a matching RFC822 <c>Message-Id</c> token.
+    /// </summary>
+    /// <param name="messageIdToken">Message-Id token (with or without angle brackets).</param>
+    /// <param name="sentLabelId">Label id to probe. Defaults to <c>SENT</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Duplicate probe result.</returns>
+    public async Task<GmailMailboxDuplicateProbeResult> FindSentMessageByRfc822MessageIdAsync(
+        string messageIdToken,
+        string sentLabelId = "SENT",
+        CancellationToken cancellationToken = default) {
+        var normalizedToken = NormalizeMessageIdValue(messageIdToken);
+        if (normalizedToken == null) {
+            throw new ArgumentException("messageIdToken is required.", nameof(messageIdToken));
+        }
+
+        var query = "rfc822msgid:" + normalizedToken;
+        var page = await _gmail.ListPageAsync(
+            _userId,
+            query: query,
+            labelIds: new[] { sentLabelId },
+            includeSpamTrash: false,
+            maxResults: 1,
+            pageToken: null,
+            fields: ListFields,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var first = page.Messages?.FirstOrDefault();
+        if (first == null) {
+            return new GmailMailboxDuplicateProbeResult {
+                IsMatch = false,
+                LabelId = sentLabelId
+            };
+        }
+
+        return new GmailMailboxDuplicateProbeResult {
+            IsMatch = true,
+            LabelId = sentLabelId,
+            NativeId = NormalizeOptional(first.Id),
+            NativeThreadId = NormalizeOptional(first.ThreadId),
+            MessageId = normalizedToken
+        };
+    }
+
+    /// <summary>
+    /// Reads provider threading metadata for a single message.
+    /// </summary>
+    /// <param name="messageId">Gmail message id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Threading metadata parsed from selected headers.</returns>
+    public async Task<GmailMailboxThreadingMetadataResult> GetThreadingMetadataAsync(
+        string messageId,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+
+        var message = await _gmail.GetMessageWithOptionsAsync(
+            _userId,
+            messageId.Trim(),
+            format: "metadata",
+            metadataHeaders: new[] { "Message-ID", "In-Reply-To", "References", "Reply-To", "Cc" },
+            fields: "id,payload(headers)",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var headers = message.Payload?.Headers;
+        if (headers == null || headers.Count == 0) {
+            return new GmailMailboxThreadingMetadataResult();
+        }
+
+        string? messageIdHeader = null;
+        string? inReplyTo = null;
+        string? referencesRaw = null;
+        string? replyTo = null;
+        string? cc = null;
+
+        foreach (var header in headers) {
+            var name = header?.Name;
+            var value = header?.Value;
+            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(value)) {
+                continue;
+            }
+
+            var headerName = name!.Trim();
+            var headerValue = value!.Trim();
+            if (headerName.Equals("Message-ID", StringComparison.OrdinalIgnoreCase)) {
+                messageIdHeader = NormalizeMessageIdValue(headerValue);
+            } else if (headerName.Equals("In-Reply-To", StringComparison.OrdinalIgnoreCase)) {
+                inReplyTo = NormalizeMessageIdValue(headerValue);
+            } else if (headerName.Equals("References", StringComparison.OrdinalIgnoreCase)) {
+                referencesRaw = headerValue;
+            } else if (headerName.Equals("Reply-To", StringComparison.OrdinalIgnoreCase)) {
+                replyTo = NormalizeOptional(headerValue);
+            } else if (headerName.Equals("Cc", StringComparison.OrdinalIgnoreCase)) {
+                cc = NormalizeOptional(headerValue);
+            }
+        }
+
+        return new GmailMailboxThreadingMetadataResult {
+            MessageId = messageIdHeader,
+            ReplyTo = replyTo,
+            Cc = cc,
+            InReplyTo = inReplyTo,
+            References = SplitMessageIdTokens(referencesRaw)
+        };
     }
 
     /// <summary>
@@ -847,6 +1040,26 @@ public sealed class GmailMailboxBrowser {
     /// </summary>
     public Task StopWatchAsync(CancellationToken cancellationToken = default) =>
         _gmail.StopWatchAsync(_userId, cancellationToken);
+
+    /// <summary>
+    /// Stops Gmail watch subscription with stale-remote handling.
+    /// </summary>
+    public async Task<GmailMailboxStopWatchResult> StopWatchAsync(
+        bool treatMissingAsSuccess,
+        CancellationToken cancellationToken = default) {
+        try {
+            await _gmail.StopWatchAsync(_userId, cancellationToken).ConfigureAwait(false);
+            return new GmailMailboxStopWatchResult {
+                Stopped = true
+            };
+        } catch (GmailApiException ex) when (treatMissingAsSuccess &&
+                                             (ex.StatusCode == HttpStatusCode.NotFound || ex.StatusCode == HttpStatusCode.Gone)) {
+            return new GmailMailboxStopWatchResult {
+                Stopped = true,
+                AlreadyStopped = true
+            };
+        }
+    }
 
     /// <summary>
     /// Gets Gmail history changes for a folder.
@@ -1328,6 +1541,29 @@ public sealed class GmailMailboxBrowser {
         }
     }
 
+    private static string Base64UrlEncode(byte[] bytes) {
+        var base64 = Convert.ToBase64String(bytes);
+        return base64.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
+    private static List<string> SplitMessageIdTokens(string? raw) {
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return new List<string>();
+        }
+
+        var output = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var tokens = raw!.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var token in tokens) {
+            var normalized = NormalizeMessageIdValue(token);
+            if (normalized == null || !seen.Add(normalized)) {
+                continue;
+            }
+            output.Add(normalized);
+        }
+        return output;
+    }
+
     /// <summary>
     /// Gmail mailbox folder summary.
     /// </summary>
@@ -1353,6 +1589,20 @@ public sealed class GmailMailboxBrowser {
         public int TotalCount { get; set; }
 
         /// <summary>Message summaries.</summary>
+        public List<GmailMailboxMessageSummary> Messages { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Gmail mailbox thread list result.
+    /// </summary>
+    public sealed class GmailMailboxThreadListResult {
+        /// <summary>Gmail thread id used for listing.</summary>
+        public string ThreadId { get; set; } = string.Empty;
+
+        /// <summary>Total number of messages available in the thread slice source.</summary>
+        public int TotalCount { get; set; }
+
+        /// <summary>Paged thread message summaries.</summary>
         public List<GmailMailboxMessageSummary> Messages { get; set; } = new();
     }
 
@@ -1403,6 +1653,71 @@ public sealed class GmailMailboxBrowser {
     }
 
     /// <summary>
+    /// Gmail mailbox import result.
+    /// </summary>
+    public sealed class GmailMailboxImportResult {
+        /// <summary>Label id used for import.</summary>
+        public string? LabelId { get; set; }
+
+        /// <summary>Imported Gmail native message id, when available.</summary>
+        public string? NativeId { get; set; }
+
+        /// <summary>Imported Gmail native thread id, when available.</summary>
+        public string? NativeThreadId { get; set; }
+    }
+
+    /// <summary>
+    /// Gmail mailbox send result.
+    /// </summary>
+    public sealed class GmailMailboxSendResult {
+        /// <summary>Sent Gmail native message id, when available.</summary>
+        public string? NativeId { get; set; }
+
+        /// <summary>Sent Gmail native thread id, when available.</summary>
+        public string? NativeThreadId { get; set; }
+    }
+
+    /// <summary>
+    /// Gmail mailbox duplicate probe result.
+    /// </summary>
+    public sealed class GmailMailboxDuplicateProbeResult {
+        /// <summary>True when a matching message was found.</summary>
+        public bool IsMatch { get; set; }
+
+        /// <summary>Label id used for probing.</summary>
+        public string? LabelId { get; set; }
+
+        /// <summary>Matched Gmail native message id, when available.</summary>
+        public string? NativeId { get; set; }
+
+        /// <summary>Matched Gmail native thread id, when available.</summary>
+        public string? NativeThreadId { get; set; }
+
+        /// <summary>Matched normalized RFC822 Message-Id.</summary>
+        public string? MessageId { get; set; }
+    }
+
+    /// <summary>
+    /// Gmail mailbox threading metadata.
+    /// </summary>
+    public sealed class GmailMailboxThreadingMetadataResult {
+        /// <summary>Normalized RFC822 Message-Id.</summary>
+        public string? MessageId { get; set; }
+
+        /// <summary>Reply-To header value.</summary>
+        public string? ReplyTo { get; set; }
+
+        /// <summary>Cc header value.</summary>
+        public string? Cc { get; set; }
+
+        /// <summary>Normalized RFC822 In-Reply-To value.</summary>
+        public string? InReplyTo { get; set; }
+
+        /// <summary>Normalized RFC822 References tokens.</summary>
+        public List<string> References { get; set; } = new();
+    }
+
+    /// <summary>
     /// Gmail mailbox get-message result.
     /// </summary>
     public sealed class GmailMailboxGetResult {
@@ -1448,6 +1763,17 @@ public sealed class GmailMailboxBrowser {
     }
 
     /// <summary>
+    /// Gmail mailbox stop-watch result.
+    /// </summary>
+    public sealed class GmailMailboxStopWatchResult {
+        /// <summary>True when stop call succeeded.</summary>
+        public bool Stopped { get; set; }
+
+        /// <summary>True when stop succeeded because watch was already missing.</summary>
+        public bool AlreadyStopped { get; set; }
+    }
+
+    /// <summary>
     /// Gmail mailbox history result.
     /// </summary>
     public sealed class GmailMailboxHistoryResult {
@@ -1467,16 +1793,7 @@ public sealed class GmailMailboxBrowser {
     /// <summary>
     /// Gmail mailbox bulk action result.
     /// </summary>
-    public sealed class GmailMailboxBulkOperationResult {
-        /// <summary>Message/thread id.</summary>
-        public string Id { get; set; } = string.Empty;
-
-        /// <summary>True when action succeeded.</summary>
-        public bool Ok { get; set; }
-
-        /// <summary>Error message when action failed.</summary>
-        public string? Error { get; set; }
-    }
+    public sealed class GmailMailboxBulkOperationResult : MailboxBulkOperationResult;
 
     /// <summary>
     /// Provider-agnostic Gmail mailbox message summary.

--- a/Sources/Mailozaurr/MailboxBulkOperationResult.cs
+++ b/Sources/Mailozaurr/MailboxBulkOperationResult.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Provider-agnostic result item for mailbox bulk operations.
+/// </summary>
+public class MailboxBulkOperationResult {
+    /// <summary>Original message/thread/conversation identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>True when the operation completed successfully for this identifier.</summary>
+    public bool Ok { get; set; }
+
+    /// <summary>Error text when <see cref="Ok"/> is false.</summary>
+    public string? Error { get; set; }
+}

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphBulkOperationResult.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphBulkOperationResult.cs
@@ -3,13 +3,4 @@ namespace Mailozaurr;
 /// <summary>
 /// Result item for Graph bulk mailbox operations.
 /// </summary>
-public sealed class GraphBulkOperationResult {
-    /// <summary>Original message/conversation identifier.</summary>
-    public string Id { get; set; } = string.Empty;
-
-    /// <summary>True when the operation completed successfully for this id.</summary>
-    public bool Ok { get; set; }
-
-    /// <summary>Error text when <see cref="Ok"/> is false.</summary>
-    public string? Error { get; set; }
-}
+public sealed class GraphBulkOperationResult : MailboxBulkOperationResult;

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
@@ -429,7 +429,9 @@ public sealed class GraphMailboxBrowser {
         }
 
         var folderSelector = ResolveFolderSelector(folder);
-        var filter = "internetMessageId eq '" + EscapeODataStringLiteral(normalizedToken) + "'";
+        var bracketedToken = "<" + normalizedToken + ">";
+        var filter = "internetMessageId eq '" + EscapeODataStringLiteral(bracketedToken) +
+                     "' or internetMessageId eq '" + EscapeODataStringLiteral(normalizedToken) + "'";
         var page = await _graph.ListMessagesAsync(
             folderSelector,
             top: 1,
@@ -440,7 +442,11 @@ public sealed class GraphMailboxBrowser {
             search: null,
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        var match = page.Items.FirstOrDefault(x => NormalizeMessageIdValue(x.InternetMessageId) != null);
+        var match = page.Items.FirstOrDefault(x =>
+            string.Equals(
+                NormalizeMessageIdValue(x.InternetMessageId),
+                normalizedToken,
+                StringComparison.OrdinalIgnoreCase));
         if (match == null) {
             return new GraphMailboxDuplicateProbeResult {
                 IsMatch = false,

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,12 +14,19 @@ namespace Mailozaurr;
 /// </summary>
 public sealed class GraphMailboxBrowser {
     private const string SummarySelect = "id,subject,receivedDateTime,from,toRecipients,internetMessageId,hasAttachments,isRead,flag,conversationId";
+    // Must be a multiple of 320 KiB (except last chunk).
+    private const int LargeAttachmentChunkSize = 327_680 * 32; // 10 MiB
     private readonly GraphApiClient _graph;
 
     /// <summary>
     /// Maximum MIME payload size used by <see cref="GetMessageContentAsync"/> when no explicit limit is provided.
     /// </summary>
     public const int DefaultMaxMimeBytes = 25 * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum MIME payload size used by <see cref="GetThreadingMetadataAsync"/> when no explicit limit is provided.
+    /// </summary>
+    public const int DefaultThreadingMetadataMaxMimeBytes = 2 * 1024 * 1024;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GraphMailboxBrowser"/> class.
@@ -176,6 +184,36 @@ public sealed class GraphMailboxBrowser {
     }
 
     /// <summary>
+    /// Lists a paged slice of messages in a Graph conversation.
+    /// </summary>
+    public async Task<GraphMailboxConversationListResult> ListConversationMessagesPageAsync(
+        string conversationId,
+        int limit,
+        int offset,
+        int top = 100,
+        int maxPages = 25,
+        int maxItems = 2000,
+        CancellationToken cancellationToken = default) {
+        var messages = await ListConversationMessagesAsync(
+            conversationId,
+            top: top,
+            maxPages: maxPages,
+            maxItems: maxItems,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var total = messages.Count;
+        var skip = Math.Max(0, offset);
+        var take = ClampInt(limit, 1, 1000);
+        var page = messages.Skip(skip).Take(take).ToList();
+
+        return new GraphMailboxConversationListResult {
+            ConversationId = conversationId.Trim(),
+            TotalCount = total,
+            Messages = page
+        };
+    }
+
+    /// <summary>
     /// Searches messages in a Graph folder.
     /// </summary>
     public async Task<GraphMailboxSearchResult> SearchMessagesAsync(
@@ -287,6 +325,281 @@ public sealed class GraphMailboxBrowser {
     }
 
     /// <summary>
+    /// Imports a MIME message into a Graph folder (typically <c>sentitems</c>).
+    /// </summary>
+    /// <param name="message">MIME message to import.</param>
+    /// <param name="folder">Folder alias/id. Defaults to <c>Sent Items</c>.</param>
+    /// <param name="maxInlineAttachmentBytes">Maximum inline-attachment budget in bytes.</param>
+    /// <param name="idempotencyHeaderName">Optional idempotency header name to preserve.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Import result.</returns>
+    public async Task<GraphMailboxImportResult> ImportMessageAsync(
+        MimeMessage message,
+        string? folder = "Sent Items",
+        int maxInlineAttachmentBytes = GraphMimePreparation.DefaultMaxInlineAttachmentBytes,
+        string? idempotencyHeaderName = null,
+        CancellationToken cancellationToken = default) {
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+        if (maxInlineAttachmentBytes < 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxInlineAttachmentBytes), "maxInlineAttachmentBytes must be zero or greater.");
+        }
+
+        var folderSelector = ResolveFolderSelector(folder);
+        var prepared = GraphMimePreparation.PrepareMessage(
+            message,
+            maxInlineAttachmentBytes: maxInlineAttachmentBytes,
+            idempotencyHeaderName: idempotencyHeaderName);
+        try {
+            var created = await _graph.CreateMessageAsync(
+                prepared.Message,
+                folderIdOrWellKnownName: folderSelector,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            var nativeId = NormalizeOptional(created.Id);
+            if (nativeId == null) {
+                throw new InvalidDataException("Graph returned an invalid created message response (missing id).");
+            }
+
+            if (prepared.UploadAttachments.Count > 0) {
+                await UploadLargeAttachmentsAsync(
+                    nativeId,
+                    prepared.UploadAttachments,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return new GraphMailboxImportResult {
+                FolderSelector = folderSelector,
+                NativeId = nativeId,
+                MessageId = NormalizeMessageIdValue(message.MessageId)
+            };
+        } finally {
+            foreach (var attachment in prepared.UploadAttachments) {
+                attachment.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sends a MIME message by creating a Graph draft and dispatching it.
+    /// </summary>
+    /// <param name="message">MIME message to send.</param>
+    /// <param name="maxInlineAttachmentBytes">Maximum inline-attachment budget in bytes.</param>
+    /// <param name="idempotencyHeaderName">Optional idempotency header name to preserve.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Send result metadata.</returns>
+    public async Task<GraphMailboxSendResult> SendMessageAsync(
+        MimeMessage message,
+        int maxInlineAttachmentBytes = GraphMimePreparation.DefaultMaxInlineAttachmentBytes,
+        string? idempotencyHeaderName = null,
+        CancellationToken cancellationToken = default) {
+        var draft = await ImportMessageAsync(
+            message,
+            folder: "Drafts",
+            maxInlineAttachmentBytes: maxInlineAttachmentBytes,
+            idempotencyHeaderName: idempotencyHeaderName,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var draftId = NormalizeOptional(draft.NativeId);
+        if (draftId == null) {
+            throw new InvalidDataException("Graph draft created but response did not include message id.");
+        }
+
+        await _graph.SendDraftMessageAsync(draftId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return new GraphMailboxSendResult {
+            DraftId = draftId,
+            MessageId = draft.MessageId
+        };
+    }
+
+    /// <summary>
+    /// Probes a Graph folder for a message with a matching RFC822 <c>Message-Id</c> token.
+    /// </summary>
+    /// <param name="messageIdToken">Message-Id token (with or without angle brackets).</param>
+    /// <param name="folder">Folder alias/id. Defaults to <c>Sent Items</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Duplicate probe result.</returns>
+    public async Task<GraphMailboxDuplicateProbeResult> FindMessageByInternetMessageIdAsync(
+        string messageIdToken,
+        string? folder = "Sent Items",
+        CancellationToken cancellationToken = default) {
+        var normalizedToken = NormalizeMessageIdValue(messageIdToken);
+        if (normalizedToken == null) {
+            throw new ArgumentException("messageIdToken is required.", nameof(messageIdToken));
+        }
+
+        var folderSelector = ResolveFolderSelector(folder);
+        var filter = "internetMessageId eq '" + EscapeODataStringLiteral(normalizedToken) + "'";
+        var page = await _graph.ListMessagesAsync(
+            folderSelector,
+            top: 1,
+            skip: null,
+            select: "id,internetMessageId",
+            orderBy: null,
+            filter: filter,
+            search: null,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var match = page.Items.FirstOrDefault(x => NormalizeMessageIdValue(x.InternetMessageId) != null);
+        if (match == null) {
+            return new GraphMailboxDuplicateProbeResult {
+                IsMatch = false,
+                FolderSelector = folderSelector
+            };
+        }
+
+        return new GraphMailboxDuplicateProbeResult {
+            IsMatch = true,
+            FolderSelector = folderSelector,
+            NativeId = NormalizeOptional(match.Id),
+            MessageId = NormalizeMessageIdValue(match.InternetMessageId)
+        };
+    }
+
+    /// <summary>
+    /// Creates a Graph webhook subscription for message changes in a selected folder.
+    /// </summary>
+    public async Task<GraphMailboxSubscriptionResult> CreateMessageSubscriptionAsync(
+        string notificationUrl,
+        string folder = "INBOX",
+        DateTimeOffset? expirationDateTime = null,
+        string changeType = "created,updated,deleted",
+        string? clientState = null,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(notificationUrl)) {
+            throw new ArgumentException("notificationUrl is required.", nameof(notificationUrl));
+        }
+        if (string.IsNullOrWhiteSpace(changeType)) {
+            throw new ArgumentException("changeType is required.", nameof(changeType));
+        }
+
+        var resource = BuildMessageSubscriptionResource(folder);
+        var request = new GraphApiClient.GraphCreateSubscriptionRequest {
+            ChangeType = changeType.Trim(),
+            NotificationUrl = notificationUrl.Trim(),
+            Resource = resource,
+            ExpirationDateTime = expirationDateTime ?? DateTimeOffset.UtcNow.AddHours(8),
+            ClientState = string.IsNullOrWhiteSpace(clientState) ? null : clientState!.Trim()
+        };
+
+        var created = await _graph.CreateSubscriptionAsync(request, cancellationToken).ConfigureAwait(false);
+        return MapSubscription(created, resource);
+    }
+
+    /// <summary>
+    /// Renews an existing Graph webhook subscription.
+    /// </summary>
+    public async Task<GraphMailboxSubscriptionResult> RenewSubscriptionAsync(
+        string subscriptionId,
+        DateTimeOffset expirationDateTime,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(subscriptionId)) {
+            throw new ArgumentException("subscriptionId is required.", nameof(subscriptionId));
+        }
+
+        var renewed = await _graph.RenewSubscriptionAsync(
+            subscriptionId.Trim(),
+            expirationDateTime,
+            cancellationToken).ConfigureAwait(false);
+        return MapSubscription(renewed, NormalizeOptional(renewed.Resource));
+    }
+
+    /// <summary>
+    /// Renews an existing Graph webhook subscription with stale-remote handling.
+    /// </summary>
+    public async Task<GraphMailboxSubscriptionRenewResult> RenewSubscriptionSafeAsync(
+        string subscriptionId,
+        DateTimeOffset expirationDateTime,
+        bool treatMissingAsStale = true,
+        CancellationToken cancellationToken = default) {
+        try {
+            var renewed = await RenewSubscriptionAsync(subscriptionId, expirationDateTime, cancellationToken).ConfigureAwait(false);
+            return new GraphMailboxSubscriptionRenewResult {
+                Renewed = true,
+                Missing = false,
+                Subscription = renewed
+            };
+        } catch (GraphApiException ex) when (treatMissingAsStale &&
+                                             (ex.StatusCode == HttpStatusCode.NotFound || ex.StatusCode == HttpStatusCode.Gone)) {
+            return new GraphMailboxSubscriptionRenewResult {
+                Renewed = false,
+                Missing = true,
+                Subscription = null
+            };
+        }
+    }
+
+    /// <summary>
+    /// Deletes an existing Graph webhook subscription.
+    /// </summary>
+    public async Task<GraphMailboxSubscriptionDeleteResult> DeleteSubscriptionAsync(
+        string subscriptionId,
+        bool treatMissingAsSuccess = true,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(subscriptionId)) {
+            throw new ArgumentException("subscriptionId is required.", nameof(subscriptionId));
+        }
+
+        try {
+            await _graph.DeleteSubscriptionAsync(subscriptionId.Trim(), cancellationToken).ConfigureAwait(false);
+            return new GraphMailboxSubscriptionDeleteResult { Deleted = true };
+        } catch (GraphApiException ex) when (treatMissingAsSuccess &&
+                                             (ex.StatusCode == HttpStatusCode.NotFound || ex.StatusCode == HttpStatusCode.Gone)) {
+            return new GraphMailboxSubscriptionDeleteResult {
+                Deleted = true,
+                AlreadyDeleted = true
+            };
+        }
+    }
+
+    /// <summary>
+    /// Builds Graph subscription resource for folder message notifications.
+    /// </summary>
+    public static string BuildMessageSubscriptionResource(string folder) {
+        var selector = ResolveFolderSelector(folder);
+        return "me/mailFolders('" + EscapeGraphLiteral(selector) + "')/messages";
+    }
+
+    /// <summary>
+    /// Reads provider threading metadata for a single message.
+    /// </summary>
+    /// <param name="messageId">Graph message id.</param>
+    /// <param name="maxMimeBytes">Maximum MIME payload size to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Threading metadata parsed from MIME headers.</returns>
+    public async Task<GraphMailboxThreadingMetadataResult> GetThreadingMetadataAsync(
+        string messageId,
+        int maxMimeBytes = DefaultThreadingMetadataMaxMimeBytes,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("messageId is required.", nameof(messageId));
+        }
+        if (maxMimeBytes <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxMimeBytes), "maxMimeBytes must be greater than zero.");
+        }
+
+        var mimeBytes = await _graph.GetMessageMimeAsync(
+            messageId.Trim(),
+            maxBytes: maxMimeBytes,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        MimeMessage message;
+        try {
+            message = MimeMessage.Load(new MemoryStream(mimeBytes, writable: false));
+        } catch (Exception ex) {
+            throw new InvalidDataException("Failed to parse Graph MIME message.", ex);
+        }
+
+        return new GraphMailboxThreadingMetadataResult {
+            MessageId = NormalizeMessageIdValue(message.MessageId),
+            ReplyTo = NormalizeOptional(message.ReplyTo?.ToString()),
+            Cc = NormalizeOptional(message.Cc?.ToString()),
+            InReplyTo = NormalizeMessageIdValue(message.InReplyTo),
+            References = NormalizeMessageIdValues(message.References)
+        };
+    }
+
+    /// <summary>
     /// Gets one message content by downloading MIME payload and parsing it to <see cref="MimeMessage"/>.
     /// </summary>
     public async Task<GraphMailboxGetResult> GetMessageContentAsync(
@@ -367,6 +680,24 @@ public sealed class GraphMailboxBrowser {
     }
 
     /// <summary>
+    /// Archives a single message.
+    /// </summary>
+    public Task ArchiveMessageAsync(
+        string messageId,
+        CancellationToken cancellationToken = default) {
+        return MoveMessageAsync(messageId, "Archive", cancellationToken);
+    }
+
+    /// <summary>
+    /// Moves a single message to trash.
+    /// </summary>
+    public Task TrashMessageAsync(
+        string messageId,
+        CancellationToken cancellationToken = default) {
+        return MoveMessageAsync(messageId, "Trash", cancellationToken);
+    }
+
+    /// <summary>
     /// Deletes a message.
     /// </summary>
     public async Task DeleteMessageAsync(
@@ -399,6 +730,26 @@ public sealed class GraphMailboxBrowser {
             destinationId,
             batchSize: batchSize,
             cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Archives many messages.
+    /// </summary>
+    public Task<IReadOnlyList<GraphBulkOperationResult>> ArchiveMessagesAsync(
+        IEnumerable<string> messageIds,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        return MoveMessagesAsync(messageIds, "Archive", batchSize, cancellationToken);
+    }
+
+    /// <summary>
+    /// Moves many messages to trash.
+    /// </summary>
+    public Task<IReadOnlyList<GraphBulkOperationResult>> TrashMessagesAsync(
+        IEnumerable<string> messageIds,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        return MoveMessagesAsync(messageIds, "Trash", batchSize, cancellationToken);
     }
 
     /// <summary>
@@ -477,6 +828,26 @@ public sealed class GraphMailboxBrowser {
     }
 
     /// <summary>
+    /// Archives many conversations.
+    /// </summary>
+    public Task<IReadOnlyList<GraphBulkOperationResult>> ArchiveConversationsAsync(
+        IEnumerable<string> conversationIds,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        return MoveConversationsAsync(conversationIds, "Archive", batchSize, cancellationToken);
+    }
+
+    /// <summary>
+    /// Moves many conversations to trash.
+    /// </summary>
+    public Task<IReadOnlyList<GraphBulkOperationResult>> TrashConversationsAsync(
+        IEnumerable<string> conversationIds,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        return MoveConversationsAsync(conversationIds, "Trash", batchSize, cancellationToken);
+    }
+
+    /// <summary>
     /// Deletes many conversations.
     /// </summary>
     public async Task<IReadOnlyList<GraphBulkOperationResult>> DeleteConversationsAsync(
@@ -491,6 +862,102 @@ public sealed class GraphMailboxBrowser {
             conversationIds,
             batchSize: batchSize,
             cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task UploadLargeAttachmentsAsync(
+        string messageId,
+        IReadOnlyList<DecodedMimeAttachment> attachments,
+        CancellationToken cancellationToken) {
+        foreach (var attachment in attachments) {
+            if (attachment == null) {
+                continue;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await UploadLargeAttachmentAsync(messageId, attachment, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task UploadLargeAttachmentAsync(
+        string messageId,
+        DecodedMimeAttachment attachment,
+        CancellationToken cancellationToken) {
+        if (attachment.Length <= 0) {
+            throw new InvalidDataException(
+                $"Graph upload failed: attachment '{attachment.Name}' length is {attachment.Length.ToString(CultureInfo.InvariantCulture)}.");
+        }
+
+        var uploadSession = await _graph.CreateAttachmentUploadSessionAsync(
+            messageId,
+            BuildAttachmentItem(attachment),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        var uploadUrl = NormalizeOptional(uploadSession.UploadUrl);
+        if (uploadUrl == null) {
+            throw new InvalidDataException("Graph upload session creation failed (empty uploadUrl).");
+        }
+
+        using var stream = attachment.OpenRead();
+        long offset = 0;
+        while (offset < attachment.Length) {
+            cancellationToken.ThrowIfCancellationRequested();
+            var remaining = attachment.Length - offset;
+            var chunkLen = (int)Math.Min(LargeAttachmentChunkSize, remaining);
+            var buffer = new byte[chunkLen];
+
+            var read = 0;
+            while (read < chunkLen) {
+#if NET5_0_OR_GREATER
+                var count = await stream.ReadAsync(buffer.AsMemory(read, chunkLen - read), cancellationToken).ConfigureAwait(false);
+#else
+                var count = await stream.ReadAsync(buffer, read, chunkLen - read, cancellationToken).ConfigureAwait(false);
+#endif
+                if (count <= 0) {
+                    break;
+                }
+
+                read += count;
+            }
+
+            if (read <= 0) {
+                throw new InvalidDataException(
+                    $"Graph upload failed: unexpected end of stream for '{attachment.Name}' at {offset.ToString(CultureInfo.InvariantCulture)}.");
+            }
+
+            var start = offset;
+            var end = offset + read - 1;
+            if (read == buffer.Length) {
+                await _graph.UploadAttachmentChunkAsync(
+                    uploadUrl,
+                    buffer,
+                    start,
+                    end,
+                    attachment.Length,
+                    cancellationToken).ConfigureAwait(false);
+            } else {
+                var trimmed = new byte[read];
+                Buffer.BlockCopy(buffer, 0, trimmed, 0, read);
+                await _graph.UploadAttachmentChunkAsync(
+                    uploadUrl,
+                    trimmed,
+                    start,
+                    end,
+                    attachment.Length,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            offset += read;
+        }
+    }
+
+    private static GraphAttachmentItem BuildAttachmentItem(DecodedMimeAttachment attachment) {
+        var item = new GraphAttachmentItem("file", attachment.Name, attachment.Length) {
+            ContentType = NormalizeOptional(attachment.ContentType)
+        };
+        if (attachment.IsInline) {
+            item.IsInline = true;
+            item.ContentId = NormalizeOptional(attachment.ContentId);
+        }
+        return item;
     }
 
     private async Task<string> ResolveFolderIdAsync(string targetFolder, CancellationToken cancellationToken) {
@@ -564,6 +1031,17 @@ public sealed class GraphMailboxBrowser {
         return items.Count == 0 ? string.Empty : string.Join(", ", items);
     }
 
+    private static string? NormalizeOptional(string? raw) {
+        var trimmed = (raw ?? string.Empty).Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+
+    private static string EscapeGraphLiteral(string value) =>
+        (value ?? string.Empty).Replace("'", "''");
+
+    private static string EscapeODataStringLiteral(string value) =>
+        (value ?? string.Empty).Replace("'", "''");
+
     private static string? NormalizeMessageIdValue(string? value) {
         if (string.IsNullOrWhiteSpace(value)) {
             return null;
@@ -578,6 +1056,23 @@ public sealed class GraphMailboxBrowser {
         }
         normalized = normalized.Trim();
         return normalized.Length == 0 ? null : normalized;
+    }
+
+    private static List<string> NormalizeMessageIdValues(IEnumerable<string>? values) {
+        if (values == null) {
+            return new List<string>();
+        }
+
+        var output = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in values) {
+            var normalized = NormalizeMessageIdValue(value);
+            if (normalized == null || !seen.Add(normalized)) {
+                continue;
+            }
+            output.Add(normalized);
+        }
+        return output;
     }
 
     private static GraphMailboxMessageSummary MapSummary(GraphMailMessage message) {
@@ -612,6 +1107,19 @@ public sealed class GraphMailboxBrowser {
             output.Add(MapSummary(message));
         }
         return output;
+    }
+
+    private static GraphMailboxSubscriptionResult MapSubscription(GraphApiClient.GraphSubscription subscription, string? resource) {
+        if (subscription == null) {
+            throw new ArgumentNullException(nameof(subscription));
+        }
+
+        return new GraphMailboxSubscriptionResult {
+            SubscriptionId = NormalizeOptional(subscription.Id),
+            Resource = NormalizeOptional(resource ?? subscription.Resource),
+            ClientState = NormalizeOptional(subscription.ClientState),
+            ExpirationDateTime = subscription.ExpirationDateTime
+        };
     }
 
     /// <summary>
@@ -699,6 +1207,20 @@ public sealed class GraphMailboxBrowser {
     }
 
     /// <summary>
+    /// Graph mailbox conversation list result.
+    /// </summary>
+    public sealed class GraphMailboxConversationListResult {
+        /// <summary>Graph conversation id used for listing.</summary>
+        public string ConversationId { get; set; } = string.Empty;
+
+        /// <summary>Total number of messages available in the conversation slice source.</summary>
+        public int TotalCount { get; set; }
+
+        /// <summary>Paged conversation message summaries.</summary>
+        public List<GraphMailboxMessageSummary> Messages { get; set; } = new();
+    }
+
+    /// <summary>
     /// Graph mailbox search request.
     /// </summary>
     public sealed class GraphMailboxSearchRequest {
@@ -742,6 +1264,110 @@ public sealed class GraphMailboxBrowser {
 
         /// <summary>Matched messages.</summary>
         public List<GraphMailboxMessageSummary> Messages { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Graph mailbox import result.
+    /// </summary>
+    public sealed class GraphMailboxImportResult {
+        /// <summary>Resolved Graph folder selector used for import.</summary>
+        public string FolderSelector { get; set; } = string.Empty;
+
+        /// <summary>Created Graph native message id.</summary>
+        public string? NativeId { get; set; }
+
+        /// <summary>Normalized RFC822 Message-Id used for import.</summary>
+        public string? MessageId { get; set; }
+    }
+
+    /// <summary>
+    /// Graph mailbox send result.
+    /// </summary>
+    public sealed class GraphMailboxSendResult {
+        /// <summary>Graph draft id that was sent.</summary>
+        public string? DraftId { get; set; }
+
+        /// <summary>Normalized RFC822 Message-Id used for send.</summary>
+        public string? MessageId { get; set; }
+    }
+
+    /// <summary>
+    /// Graph mailbox duplicate probe result.
+    /// </summary>
+    public sealed class GraphMailboxDuplicateProbeResult {
+        /// <summary>True when a matching message was found.</summary>
+        public bool IsMatch { get; set; }
+
+        /// <summary>Resolved Graph folder selector used for probing.</summary>
+        public string? FolderSelector { get; set; }
+
+        /// <summary>Matched Graph native message id, when available.</summary>
+        public string? NativeId { get; set; }
+
+        /// <summary>Matched normalized RFC822 Message-Id.</summary>
+        public string? MessageId { get; set; }
+    }
+
+    /// <summary>
+    /// Graph mailbox webhook subscription result.
+    /// </summary>
+    public sealed class GraphMailboxSubscriptionResult {
+        /// <summary>Graph subscription id.</summary>
+        public string? SubscriptionId { get; set; }
+
+        /// <summary>Subscription resource path.</summary>
+        public string? Resource { get; set; }
+
+        /// <summary>Client-state value when provided.</summary>
+        public string? ClientState { get; set; }
+
+        /// <summary>Subscription expiration value.</summary>
+        public DateTimeOffset ExpirationDateTime { get; set; }
+    }
+
+    /// <summary>
+    /// Graph mailbox webhook delete result.
+    /// </summary>
+    public sealed class GraphMailboxSubscriptionDeleteResult {
+        /// <summary>True when delete operation succeeded.</summary>
+        public bool Deleted { get; set; }
+
+        /// <summary>True when delete succeeded because subscription was already gone.</summary>
+        public bool AlreadyDeleted { get; set; }
+    }
+
+    /// <summary>
+    /// Graph mailbox webhook renew result.
+    /// </summary>
+    public sealed class GraphMailboxSubscriptionRenewResult {
+        /// <summary>True when renew operation succeeded.</summary>
+        public bool Renewed { get; set; }
+
+        /// <summary>True when renew failed because subscription was already missing.</summary>
+        public bool Missing { get; set; }
+
+        /// <summary>Renewed subscription payload when available.</summary>
+        public GraphMailboxSubscriptionResult? Subscription { get; set; }
+    }
+
+    /// <summary>
+    /// Graph mailbox threading metadata.
+    /// </summary>
+    public sealed class GraphMailboxThreadingMetadataResult {
+        /// <summary>Normalized RFC822 Message-Id.</summary>
+        public string? MessageId { get; set; }
+
+        /// <summary>Reply-To header value.</summary>
+        public string? ReplyTo { get; set; }
+
+        /// <summary>Cc header value.</summary>
+        public string? Cc { get; set; }
+
+        /// <summary>Normalized RFC822 In-Reply-To value.</summary>
+        public string? InReplyTo { get; set; }
+
+        /// <summary>Normalized RFC822 References tokens.</summary>
+        public List<string> References { get; set; } = new();
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/NativeMailboxThreadingMetadataOperations.cs
+++ b/Sources/Mailozaurr/NativeMailboxThreadingMetadataOperations.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Shared normalization/retrieval helpers for native-provider threading metadata.
+/// </summary>
+public static class NativeMailboxThreadingMetadataOperations {
+    /// <summary>
+    /// Provider-agnostic threading metadata shape.
+    /// </summary>
+    public sealed class NativeMailboxThreadingMetadataResult {
+        /// <summary>Normalized RFC822 Message-Id.</summary>
+        public string? MessageId { get; set; }
+
+        /// <summary>Reply-To header value.</summary>
+        public string? ReplyTo { get; set; }
+
+        /// <summary>Cc header value.</summary>
+        public string? Cc { get; set; }
+
+        /// <summary>Normalized RFC822 In-Reply-To value.</summary>
+        public string? InReplyTo { get; set; }
+
+        /// <summary>Normalized RFC822 References tokens.</summary>
+        public List<string>? References { get; set; }
+    }
+
+    /// <summary>
+    /// Reads and normalizes Graph threading metadata for a message.
+    /// </summary>
+    public static async Task<NativeMailboxThreadingMetadataResult> GetGraphThreadingMetadataAsync(
+        GraphMailboxBrowser browser,
+        string nativeId,
+        int maxMimeBytes = GraphMailboxBrowser.DefaultThreadingMetadataMaxMimeBytes,
+        CancellationToken cancellationToken = default) {
+        if (browser == null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+        if (string.IsNullOrWhiteSpace(nativeId)) {
+            throw new ArgumentException("nativeId is required.", nameof(nativeId));
+        }
+
+        var metadata = await browser.GetThreadingMetadataAsync(
+            nativeId.Trim(),
+            maxMimeBytes: maxMimeBytes,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        return Normalize(metadata);
+    }
+
+    /// <summary>
+    /// Reads and normalizes Gmail threading metadata for a message.
+    /// </summary>
+    public static async Task<NativeMailboxThreadingMetadataResult> GetGmailThreadingMetadataAsync(
+        GmailMailboxBrowser browser,
+        string nativeId,
+        CancellationToken cancellationToken = default) {
+        if (browser == null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+        if (string.IsNullOrWhiteSpace(nativeId)) {
+            throw new ArgumentException("nativeId is required.", nameof(nativeId));
+        }
+
+        var metadata = await browser.GetThreadingMetadataAsync(
+            nativeId.Trim(),
+            cancellationToken).ConfigureAwait(false);
+        return Normalize(metadata);
+    }
+
+    /// <summary>
+    /// Normalizes provider-agnostic threading metadata values.
+    /// </summary>
+    public static NativeMailboxThreadingMetadataResult Normalize(
+        string? messageId,
+        string? replyTo,
+        string? cc,
+        string? inReplyTo,
+        IEnumerable<string>? references) {
+        var normalizedReferences = NormalizeMessageIdList(references);
+        return new NativeMailboxThreadingMetadataResult {
+            MessageId = ImapSentMessageOperations.NormalizeMessageIdToken(messageId),
+            ReplyTo = NormalizeOptional(replyTo),
+            Cc = NormalizeOptional(cc),
+            InReplyTo = ImapSentMessageOperations.NormalizeMessageIdToken(inReplyTo),
+            References = normalizedReferences
+        };
+    }
+
+    /// <summary>
+    /// Normalizes Graph threading metadata values.
+    /// </summary>
+    public static NativeMailboxThreadingMetadataResult Normalize(
+        GraphMailboxBrowser.GraphMailboxThreadingMetadataResult metadata) {
+        if (metadata == null) {
+            throw new ArgumentNullException(nameof(metadata));
+        }
+
+        return Normalize(
+            metadata.MessageId,
+            metadata.ReplyTo,
+            metadata.Cc,
+            metadata.InReplyTo,
+            metadata.References);
+    }
+
+    /// <summary>
+    /// Normalizes Gmail threading metadata values.
+    /// </summary>
+    public static NativeMailboxThreadingMetadataResult Normalize(
+        GmailMailboxBrowser.GmailMailboxThreadingMetadataResult metadata) {
+        if (metadata == null) {
+            throw new ArgumentNullException(nameof(metadata));
+        }
+
+        return Normalize(
+            metadata.MessageId,
+            metadata.ReplyTo,
+            metadata.Cc,
+            metadata.InReplyTo,
+            metadata.References);
+    }
+
+    private static List<string>? NormalizeMessageIdList(IEnumerable<string>? references) {
+        if (references == null) {
+            return null;
+        }
+
+        var output = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var reference in references) {
+            var normalized = ImapSentMessageOperations.NormalizeMessageIdToken(reference);
+            if (normalized == null || !seen.Add(normalized)) {
+                continue;
+            }
+            output.Add(normalized);
+        }
+
+        return output.Count == 0 ? null : output;
+    }
+
+    private static string? NormalizeOptional(string? value) {
+        var trimmed = (value ?? string.Empty).Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapBulkFlagOperations.cs
+++ b/Sources/Mailozaurr/Receive/ImapBulkFlagOperations.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Executes bulk IMAP flag updates with per-item fallback when server bulk operations fail.
+/// </summary>
+public static class ImapBulkFlagOperations {
+    /// <summary>
+    /// Abstraction over IMAP flag operations for testability.
+    /// </summary>
+    public interface IImapFolder {
+        /// <summary>Adds flags for a batch of UIDs.</summary>
+        Task AddFlagsAsync(IReadOnlyCollection<UniqueId> uids, MessageFlags flags, bool silent, CancellationToken cancellationToken = default);
+
+        /// <summary>Removes flags for a batch of UIDs.</summary>
+        Task RemoveFlagsAsync(IReadOnlyCollection<UniqueId> uids, MessageFlags flags, bool silent, CancellationToken cancellationToken = default);
+
+        /// <summary>Adds flags for one UID.</summary>
+        Task AddFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default);
+
+        /// <summary>Removes flags for one UID.</summary>
+        Task RemoveFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default);
+    }
+
+    private sealed class MailKitFolderAdapter : IImapFolder {
+        private readonly IMailFolder _folder;
+
+        internal MailKitFolderAdapter(IMailFolder folder) {
+            _folder = folder ?? throw new ArgumentNullException(nameof(folder));
+        }
+
+        public Task AddFlagsAsync(IReadOnlyCollection<UniqueId> uids, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) =>
+            _folder.AddFlagsAsync(new List<UniqueId>(uids), flags, silent, cancellationToken);
+
+        public Task RemoveFlagsAsync(IReadOnlyCollection<UniqueId> uids, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) =>
+            _folder.RemoveFlagsAsync(new List<UniqueId>(uids), flags, silent, cancellationToken);
+
+        public Task AddFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) =>
+            _folder.AddFlagsAsync(uid, flags, silent, cancellationToken);
+
+        public Task RemoveFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) =>
+            _folder.RemoveFlagsAsync(uid, flags, silent, cancellationToken);
+    }
+
+    /// <summary>
+    /// One bulk-flag item result.
+    /// </summary>
+    public sealed class ImapBulkFlagResultItem {
+        /// <summary>Message UID.</summary>
+        public UniqueId Uid { get; set; }
+
+        /// <summary>True when update succeeded.</summary>
+        public bool Ok { get; set; }
+
+        /// <summary>Error text for failed updates.</summary>
+        public string? Error { get; set; }
+    }
+
+    /// <summary>
+    /// Bulk-flag operation result.
+    /// </summary>
+    public sealed class ImapBulkFlagResult {
+        /// <summary>Total unique UIDs requested.</summary>
+        public int Requested { get; set; }
+
+        /// <summary>Count of successful updates.</summary>
+        public int Updated { get; set; }
+
+        /// <summary>Per-item results in request order.</summary>
+        public List<ImapBulkFlagResultItem> Results { get; set; } = new();
+
+        /// <summary>UIDs successfully updated.</summary>
+        public List<UniqueId> SuccessfulUids { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Sets or clears IMAP flags for many UIDs with per-item fallback when bulk call fails.
+    /// </summary>
+    /// <param name="folder">Opened IMAP folder with write access.</param>
+    /// <param name="uids">Message UIDs to update.</param>
+    /// <param name="flags">Flags to set/clear.</param>
+    /// <param name="add">True to add flags, false to remove flags.</param>
+    /// <param name="sanitizeError">Optional error sanitizer for per-item failures.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Bulk operation result.</returns>
+    public static async Task<ImapBulkFlagResult> SetFlagsAsync(
+        IMailFolder folder,
+        IReadOnlyCollection<UniqueId> uids,
+        MessageFlags flags,
+        bool add,
+        Func<string, string>? sanitizeError = null,
+        CancellationToken cancellationToken = default) {
+        if (folder == null) {
+            throw new ArgumentNullException(nameof(folder));
+        }
+
+        return await SetFlagsAsync(
+            new MailKitFolderAdapter(folder),
+            uids,
+            flags,
+            add,
+            sanitizeError,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets or clears IMAP flags for many UIDs with per-item fallback when bulk call fails.
+    /// </summary>
+    public static async Task<ImapBulkFlagResult> SetFlagsAsync(
+        IImapFolder folder,
+        IReadOnlyCollection<UniqueId> uids,
+        MessageFlags flags,
+        bool add,
+        Func<string, string>? sanitizeError = null,
+        CancellationToken cancellationToken = default) {
+        if (folder == null) {
+            throw new ArgumentNullException(nameof(folder));
+        }
+        if (uids == null) {
+            throw new ArgumentNullException(nameof(uids));
+        }
+
+        var unique = Deduplicate(uids);
+        var result = new ImapBulkFlagResult {
+            Requested = unique.Count,
+            Results = new List<ImapBulkFlagResultItem>(unique.Count),
+            SuccessfulUids = new List<UniqueId>(unique.Count)
+        };
+        if (unique.Count == 0) {
+            return result;
+        }
+
+        try {
+            if (add) {
+                await folder.AddFlagsAsync(unique, flags, silent: true, cancellationToken).ConfigureAwait(false);
+            } else {
+                await folder.RemoveFlagsAsync(unique, flags, silent: true, cancellationToken).ConfigureAwait(false);
+            }
+
+            foreach (var uid in unique) {
+                result.Updated++;
+                result.SuccessfulUids.Add(uid);
+                result.Results.Add(new ImapBulkFlagResultItem { Uid = uid, Ok = true });
+            }
+            return result;
+        } catch (OperationCanceledException) {
+            throw;
+        } catch {
+            // Fallback path handled below.
+        }
+
+        foreach (var uid in unique) {
+            try {
+                if (add) {
+                    await folder.AddFlagsAsync(uid, flags, silent: true, cancellationToken).ConfigureAwait(false);
+                } else {
+                    await folder.RemoveFlagsAsync(uid, flags, silent: true, cancellationToken).ConfigureAwait(false);
+                }
+
+                result.Updated++;
+                result.SuccessfulUids.Add(uid);
+                result.Results.Add(new ImapBulkFlagResultItem { Uid = uid, Ok = true });
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                var error = ex.Message;
+                if (sanitizeError != null) {
+                    try {
+                        error = sanitizeError(error);
+                    } catch {
+                        // Ignore sanitizer failures.
+                    }
+                }
+                result.Results.Add(new ImapBulkFlagResultItem { Uid = uid, Ok = false, Error = error });
+            }
+        }
+
+        return result;
+    }
+
+    private static List<UniqueId> Deduplicate(IReadOnlyCollection<UniqueId> uids) {
+        var output = new List<UniqueId>(uids.Count);
+        var seen = new HashSet<uint>();
+        foreach (var uid in uids) {
+            var id = uid.Id;
+            if (id == 0 || !seen.Add(id)) {
+                continue;
+            }
+            output.Add(uid);
+        }
+        return output;
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapDeleteOperations.cs
+++ b/Sources/Mailozaurr/Receive/ImapDeleteOperations.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Executes IMAP delete operations with per-item results and optional expunge.
+/// </summary>
+public static class ImapDeleteOperations {
+    /// <summary>
+    /// Abstraction over IMAP delete operations for testability.
+    /// </summary>
+    public interface IImapDeleteFolder : ImapBulkFlagOperations.IImapFolder {
+        /// <summary>Folder full name.</summary>
+        string FullName { get; }
+
+        /// <summary>Expunges messages flagged as deleted.</summary>
+        Task ExpungeAsync(CancellationToken cancellationToken = default);
+    }
+
+    private sealed class MailKitDeleteFolderAdapter : IImapDeleteFolder {
+        private readonly IMailFolder _folder;
+
+        internal MailKitDeleteFolderAdapter(IMailFolder folder) {
+            _folder = folder ?? throw new ArgumentNullException(nameof(folder));
+        }
+
+        public string FullName => _folder.FullName;
+
+        public Task AddFlagsAsync(IReadOnlyCollection<UniqueId> uids, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) =>
+            _folder.AddFlagsAsync(new List<UniqueId>(uids), flags, silent, cancellationToken);
+
+        public Task RemoveFlagsAsync(IReadOnlyCollection<UniqueId> uids, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) =>
+            _folder.RemoveFlagsAsync(new List<UniqueId>(uids), flags, silent, cancellationToken);
+
+        public Task AddFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) =>
+            _folder.AddFlagsAsync(uid, flags, silent, cancellationToken);
+
+        public Task RemoveFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) =>
+            _folder.RemoveFlagsAsync(uid, flags, silent, cancellationToken);
+
+        public Task ExpungeAsync(CancellationToken cancellationToken = default) =>
+            _folder.ExpungeAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Per-message delete result.
+    /// </summary>
+    public sealed class ImapDeleteResultItem {
+        /// <summary>Message UID.</summary>
+        public UniqueId Uid { get; set; }
+
+        /// <summary>True when delete flag update succeeded.</summary>
+        public bool Ok { get; set; }
+
+        /// <summary>Error text when <see cref="Ok"/> is false.</summary>
+        public string? Error { get; set; }
+    }
+
+    /// <summary>
+    /// Aggregate delete result.
+    /// </summary>
+    public sealed class ImapDeleteResult {
+        /// <summary>Resolved folder full name.</summary>
+        public string? Folder { get; set; }
+
+        /// <summary>Total unique UIDs requested.</summary>
+        public int Requested { get; set; }
+
+        /// <summary>Count of successful delete flag updates.</summary>
+        public int Deleted { get; set; }
+
+        /// <summary>True when expunge was executed.</summary>
+        public bool Expunged { get; set; }
+
+        /// <summary>Per-item results in request order.</summary>
+        public List<ImapDeleteResultItem> Results { get; set; } = new();
+
+        /// <summary>UIDs successfully marked deleted.</summary>
+        public List<UniqueId> DeletedUids { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Marks messages deleted and optionally expunges the folder.
+    /// </summary>
+    public static Task<ImapDeleteResult> DeleteAsync(
+        IMailFolder folder,
+        IReadOnlyCollection<UniqueId> uids,
+        bool expunge,
+        Func<string, string>? sanitizeError = null,
+        CancellationToken cancellationToken = default) {
+        if (folder == null) {
+            throw new ArgumentNullException(nameof(folder));
+        }
+
+        return DeleteAsync(new MailKitDeleteFolderAdapter(folder), uids, expunge, sanitizeError, cancellationToken);
+    }
+
+    /// <summary>
+    /// Marks messages deleted and optionally expunges the folder.
+    /// </summary>
+    public static async Task<ImapDeleteResult> DeleteAsync(
+        IImapDeleteFolder folder,
+        IReadOnlyCollection<UniqueId> uids,
+        bool expunge,
+        Func<string, string>? sanitizeError = null,
+        CancellationToken cancellationToken = default) {
+        if (folder == null) {
+            throw new ArgumentNullException(nameof(folder));
+        }
+        if (uids == null) {
+            throw new ArgumentNullException(nameof(uids));
+        }
+
+        var operation = await ImapBulkFlagOperations.SetFlagsAsync(
+            folder,
+            uids,
+            MessageFlags.Deleted,
+            add: true,
+            sanitizeError: sanitizeError,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var result = new ImapDeleteResult {
+            Folder = folder.FullName,
+            Requested = operation.Requested,
+            Deleted = operation.Updated,
+            Results = new List<ImapDeleteResultItem>(operation.Results.Count),
+            DeletedUids = new List<UniqueId>(operation.SuccessfulUids.Count)
+        };
+
+        foreach (var item in operation.Results) {
+            result.Results.Add(new ImapDeleteResultItem {
+                Uid = item.Uid,
+                Ok = item.Ok,
+                Error = item.Error
+            });
+        }
+
+        result.DeletedUids.AddRange(operation.SuccessfulUids);
+
+        if (expunge && result.Deleted > 0) {
+            await folder.ExpungeAsync(cancellationToken).ConfigureAwait(false);
+            result.Expunged = true;
+        }
+
+        return result;
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapMailboxSearchQueryBuilder.cs
+++ b/Sources/Mailozaurr/Receive/ImapMailboxSearchQueryBuilder.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using MailKit.Search;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Builds IMAP <see cref="SearchQuery"/> instances from common mailbox search filters.
+/// </summary>
+public static class ImapMailboxSearchQueryBuilder {
+    /// <summary>
+    /// Builds IMAP search query with optional field filters and free-text tokens.
+    /// </summary>
+    public static SearchQuery Build(
+        bool unseenOnly = false,
+        string? subjectContains = null,
+        string? fromContains = null,
+        string? toContains = null,
+        string? bodyContains = null,
+        DateTime? sinceUtc = null,
+        DateTime? beforeUtc = null,
+        string? query = null) {
+        var search = SearchQuery.All;
+        if (unseenOnly) {
+            search = search.And(SearchQuery.NotSeen);
+        }
+
+        var subject = NormalizeOptional(subjectContains);
+        if (subject != null) {
+            search = search.And(SearchQuery.SubjectContains(subject));
+        }
+
+        var from = NormalizeOptional(fromContains);
+        if (from != null) {
+            search = search.And(SearchQuery.FromContains(from));
+        }
+
+        var to = NormalizeOptional(toContains);
+        if (to != null) {
+            search = search.And(SearchQuery.ToContains(to));
+        }
+
+        var body = NormalizeOptional(bodyContains);
+        if (body != null) {
+            search = search.And(SearchQuery.BodyContains(body));
+        }
+
+        if (sinceUtc.HasValue) {
+            search = search.And(SearchQuery.SentSince(sinceUtc.Value));
+        }
+        if (beforeUtc.HasValue) {
+            search = search.And(SearchQuery.SentBefore(beforeUtc.Value));
+        }
+
+        var tokens = Tokenize(query);
+        foreach (var token in tokens) {
+            // Pragmatic OR across common fields, AND'ed across tokens.
+            var tokenQuery = SearchQuery.SubjectContains(token)
+                .Or(SearchQuery.FromContains(token))
+                .Or(SearchQuery.ToContains(token))
+                .Or(SearchQuery.BodyContains(token));
+            search = search.And(tokenQuery);
+        }
+
+        return search;
+    }
+
+    /// <summary>
+    /// Splits free-text query into non-empty whitespace-delimited terms.
+    /// </summary>
+    public static IReadOnlyList<string> Tokenize(string? query) {
+        var normalized = NormalizeOptional(query);
+        if (normalized == null) {
+            return Array.Empty<string>();
+        }
+
+        return normalized.Split(
+            new[] { ' ', '\t', '\r', '\n' },
+            StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static string? NormalizeOptional(string? value) {
+        var trimmed = (value ?? string.Empty).Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapMoveOperations.cs
+++ b/Sources/Mailozaurr/Receive/ImapMoveOperations.cs
@@ -1,0 +1,378 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Search;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Executes IMAP move operations with portable fallback for servers without MOVE support.
+/// </summary>
+public static class ImapMoveOperations {
+    /// <summary>
+    /// Abstraction over IMAP folder move operations for testability.
+    /// </summary>
+    public interface IImapMoveFolder {
+        /// <summary>Folder full name.</summary>
+        string FullName { get; }
+
+        /// <summary>True when folder is open.</summary>
+        bool IsOpen { get; }
+
+        /// <summary>Current folder access when opened.</summary>
+        FolderAccess Access { get; }
+
+        /// <summary>Opens the folder with requested access.</summary>
+        Task OpenAsync(FolderAccess access, CancellationToken cancellationToken = default);
+
+        /// <summary>Closes the folder.</summary>
+        Task CloseAsync(bool expunge, CancellationToken cancellationToken = default);
+
+        /// <summary>Fetches raw Message-Id header value for a message UID.</summary>
+        Task<string?> GetMessageIdHeaderAsync(UniqueId uid, CancellationToken cancellationToken = default);
+
+        /// <summary>Moves one UID to destination folder.</summary>
+        Task MoveToAsync(UniqueId uid, IImapMoveFolder destination, CancellationToken cancellationToken = default);
+
+        /// <summary>Copies UIDs to destination and returns UID mapping when available.</summary>
+        Task<IDictionary<UniqueId, UniqueId>?> CopyToWithMapAsync(IReadOnlyCollection<UniqueId> uids, IImapMoveFolder destination, CancellationToken cancellationToken = default);
+
+        /// <summary>Copies one UID to destination folder.</summary>
+        Task CopyToAsync(UniqueId uid, IImapMoveFolder destination, CancellationToken cancellationToken = default);
+
+        /// <summary>Adds flags to one UID.</summary>
+        Task AddFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default);
+
+        /// <summary>Expunges the folder.</summary>
+        Task ExpungeAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>Searches destination for Message-Id matches.</summary>
+        Task<IList<UniqueId>> SearchByMessageIdAsync(string messageId, CancellationToken cancellationToken = default);
+    }
+
+    private sealed class MailKitMoveFolderAdapter : IImapMoveFolder {
+        private readonly IMailFolder _folder;
+
+        internal MailKitMoveFolderAdapter(IMailFolder folder) {
+            _folder = folder ?? throw new ArgumentNullException(nameof(folder));
+        }
+
+        public string FullName => _folder.FullName;
+
+        public bool IsOpen => _folder.IsOpen;
+
+        public FolderAccess Access => _folder.Access;
+
+        public Task OpenAsync(FolderAccess access, CancellationToken cancellationToken = default) =>
+            _folder.OpenAsync(access, cancellationToken);
+
+        public Task CloseAsync(bool expunge, CancellationToken cancellationToken = default) =>
+            _folder.CloseAsync(expunge, cancellationToken);
+
+        public async Task<string?> GetMessageIdHeaderAsync(UniqueId uid, CancellationToken cancellationToken = default) {
+            var headers = await _folder.GetHeadersAsync(uid, cancellationToken).ConfigureAwait(false);
+            return headers[HeaderId.MessageId];
+        }
+
+        public Task MoveToAsync(UniqueId uid, IImapMoveFolder destination, CancellationToken cancellationToken = default) =>
+            _folder.MoveToAsync(uid, AsMailKitFolder(destination), cancellationToken);
+
+        public async Task<IDictionary<UniqueId, UniqueId>?> CopyToWithMapAsync(IReadOnlyCollection<UniqueId> uids, IImapMoveFolder destination, CancellationToken cancellationToken = default) {
+            var map = await _folder.CopyToAsync(new List<UniqueId>(uids), AsMailKitFolder(destination), cancellationToken).ConfigureAwait(false);
+            if (map == null) {
+                return null;
+            }
+
+            var resolved = new Dictionary<UniqueId, UniqueId>(uids.Count);
+            foreach (var uid in uids) {
+                if (map.TryGetValue(uid, out var mapped)) {
+                    resolved[uid] = mapped;
+                }
+            }
+            return resolved;
+        }
+
+        public Task CopyToAsync(UniqueId uid, IImapMoveFolder destination, CancellationToken cancellationToken = default) =>
+            _folder.CopyToAsync(uid, AsMailKitFolder(destination), cancellationToken);
+
+        public Task AddFlagsAsync(UniqueId uid, MessageFlags flags, bool silent, CancellationToken cancellationToken = default) =>
+            _folder.AddFlagsAsync(uid, flags, silent, cancellationToken);
+
+        public Task ExpungeAsync(CancellationToken cancellationToken = default) =>
+            _folder.ExpungeAsync(cancellationToken);
+
+        public Task<IList<UniqueId>> SearchByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) =>
+            _folder.SearchAsync(SearchQuery.HeaderContains("Message-Id", messageId), cancellationToken);
+
+        private static IMailFolder AsMailKitFolder(IImapMoveFolder folder) {
+            if (folder is not MailKitMoveFolderAdapter adapter) {
+                throw new ArgumentException("folder adapter type is not supported for MailKit operations.", nameof(folder));
+            }
+
+            return adapter._folder;
+        }
+    }
+
+    /// <summary>
+    /// Per-message result item for IMAP move operations.
+    /// </summary>
+    public sealed class ImapMoveResultItem {
+        /// <summary>Source message UID.</summary>
+        public UniqueId Uid { get; set; }
+
+        /// <summary>True when move succeeded for this UID.</summary>
+        public bool Ok { get; set; }
+
+        /// <summary>Destination UID when available.</summary>
+        public long? TargetUid { get; set; }
+
+        /// <summary>Normalized Message-Id used for destination lookup.</summary>
+        public string? MessageId { get; set; }
+
+        /// <summary>True when MOVE fell back to COPY + DELETE.</summary>
+        public bool UsedCopyFallback { get; set; }
+
+        /// <summary>Failure reason when <see cref="Ok"/> is false.</summary>
+        public string? Error { get; set; }
+    }
+
+    /// <summary>
+    /// Aggregate result for IMAP move operations.
+    /// </summary>
+    public sealed class ImapMoveResult {
+        /// <summary>Resolved source folder full name.</summary>
+        public string? SourceFolder { get; set; }
+
+        /// <summary>Resolved target folder full name.</summary>
+        public string? TargetFolder { get; set; }
+
+        /// <summary>Total unique UIDs requested.</summary>
+        public int Requested { get; set; }
+
+        /// <summary>Count of successful moves.</summary>
+        public int Moved { get; set; }
+
+        /// <summary>Per-item results in request order.</summary>
+        public List<ImapMoveResultItem> Results { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Moves one or many UIDs between folders using an IMAP client.
+    /// </summary>
+    public static async Task<ImapMoveResult> MoveAsync(
+        ImapClient client,
+        string sourceFolder,
+        string targetFolder,
+        IReadOnlyCollection<UniqueId> uids,
+        Func<string, string>? sanitizeError = null,
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (string.IsNullOrWhiteSpace(sourceFolder)) {
+            throw new ArgumentException("sourceFolder is required.", nameof(sourceFolder));
+        }
+        if (string.IsNullOrWhiteSpace(targetFolder)) {
+            throw new ArgumentException("targetFolder is required.", nameof(targetFolder));
+        }
+
+        var source = new MailKitMoveFolderAdapter(client.GetFolder(sourceFolder));
+        var destination = new MailKitMoveFolderAdapter(client.GetFolder(targetFolder));
+        return await MoveAsync(source, destination, uids, sanitizeError, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves one or many UIDs between folders using abstract folders.
+    /// </summary>
+    public static async Task<ImapMoveResult> MoveAsync(
+        IImapMoveFolder source,
+        IImapMoveFolder destination,
+        IReadOnlyCollection<UniqueId> uids,
+        Func<string, string>? sanitizeError = null,
+        CancellationToken cancellationToken = default) {
+        if (source == null) {
+            throw new ArgumentNullException(nameof(source));
+        }
+        if (destination == null) {
+            throw new ArgumentNullException(nameof(destination));
+        }
+        if (uids == null) {
+            throw new ArgumentNullException(nameof(uids));
+        }
+
+        var unique = Deduplicate(uids);
+        var result = new ImapMoveResult {
+            SourceFolder = source.FullName,
+            TargetFolder = destination.FullName,
+            Requested = unique.Count,
+            Results = new List<ImapMoveResultItem>(unique.Count)
+        };
+
+        if (unique.Count == 0) {
+            return result;
+        }
+
+        if (source.FullName.Equals(destination.FullName, StringComparison.OrdinalIgnoreCase)) {
+            foreach (var uid in unique) {
+                result.Moved++;
+                result.Results.Add(new ImapMoveResultItem {
+                    Uid = uid,
+                    Ok = true,
+                    TargetUid = uid.Id,
+                    MessageId = null,
+                    UsedCopyFallback = false
+                });
+            }
+            return result;
+        }
+
+        await EnsureFolderAccessAsync(source, FolderAccess.ReadWrite, cancellationToken).ConfigureAwait(false);
+        await EnsureFolderAccessAsync(destination, FolderAccess.ReadWrite, cancellationToken).ConfigureAwait(false);
+
+        result.SourceFolder = source.FullName;
+        result.TargetFolder = destination.FullName;
+
+        var sourceNeedsExpunge = false;
+        foreach (var uid in unique) {
+            string? messageId = null;
+            long? targetUid = null;
+            var usedCopyFallback = false;
+
+            try {
+                try {
+                    var raw = await source.GetMessageIdHeaderAsync(uid, cancellationToken).ConfigureAwait(false);
+                    messageId = NormalizeMessageIdHeader(raw);
+                } catch {
+                    // best-effort
+                    messageId = null;
+                }
+
+                try {
+                    await source.MoveToAsync(uid, destination, cancellationToken).ConfigureAwait(false);
+                } catch (NotSupportedException) {
+                    usedCopyFallback = true;
+
+                    try {
+                        var map = await source.CopyToWithMapAsync(new[] { uid }, destination, cancellationToken).ConfigureAwait(false);
+                        if (map != null && map.TryGetValue(uid, out var mapped)) {
+                            targetUid = mapped.Id;
+                        }
+                    } catch {
+                        await source.CopyToAsync(uid, destination, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    await source.AddFlagsAsync(uid, MessageFlags.Deleted, silent: true, cancellationToken).ConfigureAwait(false);
+                    sourceNeedsExpunge = true;
+                }
+
+                if (!targetUid.HasValue && !string.IsNullOrWhiteSpace(messageId)) {
+                    try {
+                        var lookupMessageId = messageId!;
+                        var matches = await destination.SearchByMessageIdAsync(lookupMessageId, cancellationToken).ConfigureAwait(false);
+                        if (matches.Count > 0) {
+                            targetUid = matches[matches.Count - 1].Id;
+                        }
+                    } catch {
+                        // best-effort
+                    }
+                }
+
+                result.Moved++;
+                result.Results.Add(new ImapMoveResultItem {
+                    Uid = uid,
+                    Ok = true,
+                    TargetUid = targetUid,
+                    MessageId = messageId,
+                    UsedCopyFallback = usedCopyFallback
+                });
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                var error = ex.Message;
+                if (sanitizeError != null) {
+                    try {
+                        error = sanitizeError(error);
+                    } catch {
+                        // Ignore sanitizer failures.
+                    }
+                }
+
+                result.Results.Add(new ImapMoveResultItem {
+                    Uid = uid,
+                    Ok = false,
+                    TargetUid = targetUid,
+                    MessageId = messageId,
+                    UsedCopyFallback = usedCopyFallback,
+                    Error = error
+                });
+            }
+        }
+
+        if (sourceNeedsExpunge) {
+            try {
+                await source.ExpungeAsync(cancellationToken).ConfigureAwait(false);
+            } catch {
+                // best-effort: copies already exist in destination.
+            }
+        }
+
+        return result;
+    }
+
+    private static async Task EnsureFolderAccessAsync(IImapMoveFolder folder, FolderAccess access, CancellationToken cancellationToken) {
+        if (folder.IsOpen && folder.Access != access) {
+            try {
+                await folder.CloseAsync(expunge: false, cancellationToken).ConfigureAwait(false);
+            } catch {
+                // best-effort
+            }
+        }
+
+        if (!folder.IsOpen || folder.Access != access) {
+            await folder.OpenAsync(access, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!folder.IsOpen || folder.Access != access) {
+            throw new InvalidOperationException($"Folder is not currently open in {access} mode.");
+        }
+    }
+
+    private static List<UniqueId> Deduplicate(IReadOnlyCollection<UniqueId> uids) {
+        var output = new List<UniqueId>(uids.Count);
+        var seen = new HashSet<uint>();
+        foreach (var uid in uids) {
+            var id = uid.Id;
+            if (id == 0 || !seen.Add(id)) {
+                continue;
+            }
+
+            output.Add(uid);
+        }
+
+        return output;
+    }
+
+    private static string? NormalizeMessageIdHeader(string? rawHeaderValue) {
+        if (string.IsNullOrWhiteSpace(rawHeaderValue)) {
+            return null;
+        }
+
+        var first = ExtractFirstMessageId(rawHeaderValue);
+        return ImapSentMessageOperations.NormalizeMessageIdToken(first);
+    }
+
+    private static string? ExtractFirstMessageId(string? raw) {
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+
+        var parts = raw!.Split(
+            new[] { ' ', '\t', '\r', '\n' },
+            StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length == 0 ? null : parts[0];
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapSentFolderResolver.cs
+++ b/Sources/Mailozaurr/Receive/ImapSentFolderResolver.cs
@@ -1,0 +1,615 @@
+using MailKit;
+using MailKit.Net.Imap;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Resolves IMAP Sent-folder names using explicit overrides, server attributes, and name heuristics.
+/// </summary>
+public static class ImapSentFolderResolver {
+    /// <summary>
+    /// Lightweight IMAP folder metadata used by resolver heuristics.
+    /// </summary>
+    public sealed class ImapFolderInfo {
+        /// <summary>Folder full name as used by IMAP.</summary>
+        public string FullName { get; set; } = string.Empty;
+
+        /// <summary>Folder display name.</summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>True when folder has the IMAP <see cref="FolderAttributes.Sent"/> attribute.</summary>
+        public bool IsSent { get; set; }
+
+        /// <summary>True when folder has the IMAP <see cref="FolderAttributes.Trash"/> attribute.</summary>
+        public bool IsTrash { get; set; }
+
+        /// <summary>True when folder has the IMAP <see cref="FolderAttributes.Archive"/> attribute.</summary>
+        public bool IsArchive { get; set; }
+
+        /// <summary>True when folder has the IMAP <see cref="FolderAttributes.Junk"/> attribute.</summary>
+        public bool IsJunk { get; set; }
+
+        /// <summary>True when folder has the IMAP <see cref="FolderAttributes.Drafts"/> attribute.</summary>
+        public bool IsDrafts { get; set; }
+    }
+
+    /// <summary>
+    /// Resolved special-folder mappings for IMAP.
+    /// </summary>
+    public sealed class ImapSpecialFolderMappings {
+        /// <summary>Inbox folder name.</summary>
+        public string Inbox { get; set; } = "INBOX";
+
+        /// <summary>Sent folder name.</summary>
+        public string Sent { get; set; } = "Sent";
+
+        /// <summary>Drafts folder name, when resolved.</summary>
+        public string? Drafts { get; set; }
+
+        /// <summary>Trash folder name, when resolved.</summary>
+        public string? Trash { get; set; }
+
+        /// <summary>Archive folder name, when resolved.</summary>
+        public string? Archive { get; set; }
+
+        /// <summary>Junk folder name, when resolved.</summary>
+        public string? Junk { get; set; }
+    }
+
+    /// <summary>
+    /// Resolves Sent folder name by enumerating folders from an IMAP client.
+    /// </summary>
+    public static async Task<string> ResolveSentFolderNameAsync(
+        ImapClient client,
+        string? requestedFolder,
+        string? configuredFolder = null,
+        string fallbackFolder = "Sent",
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+
+        var requested = NormalizeOptionalFolder(requestedFolder);
+        if (requested != null) {
+            return requested;
+        }
+
+        var configured = NormalizeOptionalFolder(configuredFolder);
+        if (configured != null) {
+            return configured;
+        }
+
+        try {
+            var folders = await GetFoldersInfoAsync(client, cancellationToken).ConfigureAwait(false);
+            return ResolveSentFolderName(
+                requestedFolder: null,
+                configuredFolder: null,
+                folders: folders,
+                fallbackFolder: fallbackFolder);
+        } catch {
+            // Best-effort fallback for servers/providers that fail folder enumeration.
+            return NormalizeOptionalFolder(fallbackFolder) ?? "Sent";
+        }
+    }
+
+    /// <summary>
+    /// Resolves Sent folder name from known folder metadata.
+    /// </summary>
+    public static string ResolveSentFolderName(
+        string? requestedFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string fallbackFolder = "Sent") {
+        return ResolveSentFolderName(
+            requestedFolder: requestedFolder,
+            configuredFolder: null,
+            folders: folders,
+            fallbackFolder: fallbackFolder);
+    }
+
+    /// <summary>
+    /// Resolves Sent folder name from known folder metadata.
+    /// </summary>
+    public static string ResolveSentFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string fallbackFolder = "Sent") {
+        var resolved = ResolveSpecialFolderName(
+            requestedFolder: requestedFolder,
+            configuredFolder: configuredFolder,
+            folders: folders,
+            attributePredicate: x => x.IsSent,
+            looksLikePredicate: LooksLikeSentFolder,
+            heuristicScoreSelector: SentFolderHeuristicScore,
+            fallbackFolder: fallbackFolder);
+        return resolved ?? ResolveFolderName(null, null, fallbackFolder);
+    }
+
+    /// <summary>
+    /// Resolves Drafts folder name from known folder metadata.
+    /// </summary>
+    public static string? ResolveDraftsFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string? fallbackFolder = null) {
+        return ResolveSpecialFolderName(
+            requestedFolder: requestedFolder,
+            configuredFolder: configuredFolder,
+            folders: folders,
+            attributePredicate: x => x.IsDrafts,
+            looksLikePredicate: LooksLikeDraftsFolder,
+            heuristicScoreSelector: DraftsFolderHeuristicScore,
+            fallbackFolder: fallbackFolder);
+    }
+
+    /// <summary>
+    /// Resolves Trash folder name from known folder metadata.
+    /// </summary>
+    public static string? ResolveTrashFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string? fallbackFolder = null) {
+        return ResolveSpecialFolderName(
+            requestedFolder: requestedFolder,
+            configuredFolder: configuredFolder,
+            folders: folders,
+            attributePredicate: x => x.IsTrash,
+            looksLikePredicate: LooksLikeTrashFolder,
+            heuristicScoreSelector: TrashFolderHeuristicScore,
+            fallbackFolder: fallbackFolder);
+    }
+
+    /// <summary>
+    /// Resolves Archive folder name from known folder metadata.
+    /// </summary>
+    public static string? ResolveArchiveFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string? fallbackFolder = null) {
+        return ResolveSpecialFolderName(
+            requestedFolder: requestedFolder,
+            configuredFolder: configuredFolder,
+            folders: folders,
+            attributePredicate: x => x.IsArchive,
+            looksLikePredicate: LooksLikeArchiveFolder,
+            heuristicScoreSelector: ArchiveFolderHeuristicScore,
+            fallbackFolder: fallbackFolder);
+    }
+
+    /// <summary>
+    /// Resolves Junk folder name from known folder metadata.
+    /// </summary>
+    public static string? ResolveJunkFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string? fallbackFolder = null) {
+        return ResolveSpecialFolderName(
+            requestedFolder: requestedFolder,
+            configuredFolder: configuredFolder,
+            folders: folders,
+            attributePredicate: x => x.IsJunk,
+            looksLikePredicate: LooksLikeJunkFolder,
+            heuristicScoreSelector: JunkFolderHeuristicScore,
+            fallbackFolder: fallbackFolder);
+    }
+
+    /// <summary>
+    /// Resolves all primary special folders using configuration overrides, attributes, and heuristics.
+    /// </summary>
+    public static ImapSpecialFolderMappings ResolveSpecialFolderMappings(
+        string? configuredInboxFolder,
+        string? configuredSentFolder,
+        string? configuredDraftsFolder,
+        string? configuredTrashFolder,
+        string? configuredArchiveFolder,
+        string? configuredJunkFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string? configuredImapFolder) {
+        var inboxFallback = ResolveFolderName(null, configuredImapFolder, "INBOX");
+        return new ImapSpecialFolderMappings {
+            Inbox = ResolveFolderName(requestedFolder: null, configuredFolder: configuredInboxFolder, fallbackFolder: inboxFallback),
+            Sent = ResolveSentFolderName(requestedFolder: null, configuredFolder: configuredSentFolder, folders: folders, fallbackFolder: "Sent"),
+            Drafts = ResolveDraftsFolderName(requestedFolder: null, configuredFolder: configuredDraftsFolder, folders: folders),
+            Trash = ResolveTrashFolderName(requestedFolder: null, configuredFolder: configuredTrashFolder, folders: folders),
+            Archive = ResolveArchiveFolderName(requestedFolder: null, configuredFolder: configuredArchiveFolder, folders: folders),
+            Junk = ResolveJunkFolderName(requestedFolder: null, configuredFolder: configuredJunkFolder, folders: folders)
+        };
+    }
+
+    /// <summary>
+    /// Lists IMAP folders with metadata suitable for special-folder resolution.
+    /// </summary>
+    public static async Task<IReadOnlyList<ImapFolderInfo>> ListFoldersInfoAsync(
+        ImapClient client,
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+
+        var folders = await GetFoldersInfoAsync(client, cancellationToken).ConfigureAwait(false);
+        folders.Sort((a, b) => string.Compare(a.FullName, b.FullName, StringComparison.OrdinalIgnoreCase));
+        return folders;
+    }
+
+    /// <summary>
+    /// Lists IMAP folder full names.
+    /// </summary>
+    public static async Task<IReadOnlyList<string>> ListFoldersAsync(
+        ImapClient client,
+        CancellationToken cancellationToken = default) {
+        var folders = await ListFoldersInfoAsync(client, cancellationToken).ConfigureAwait(false);
+        var output = new List<string>(folders.Count);
+        foreach (var folder in folders) {
+            if (string.IsNullOrWhiteSpace(folder.FullName)) {
+                continue;
+            }
+
+            output.Add(folder.FullName);
+        }
+        return output;
+    }
+
+    private static async Task<List<ImapFolderInfo>> GetFoldersInfoAsync(ImapClient client, CancellationToken cancellationToken) {
+        var output = new List<ImapFolderInfo>();
+        if (client.PersonalNamespaces.Count > 0) {
+            foreach (var ns in client.PersonalNamespaces) {
+                var root = client.GetFolder(ns);
+                await CollectFoldersInfoAsync(root, output, cancellationToken).ConfigureAwait(false);
+            }
+        } else {
+            await CollectFoldersInfoAsync(client.Inbox, output, cancellationToken).ConfigureAwait(false);
+        }
+        return output;
+    }
+
+    private static async Task CollectFoldersInfoAsync(IMailFolder folder, List<ImapFolderInfo> output, CancellationToken cancellationToken) {
+        if (folder == null) {
+            return;
+        }
+
+        try {
+            var full = folder.FullName ?? folder.Name ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(full) &&
+                !output.Exists(x => string.Equals(x.FullName, full, StringComparison.OrdinalIgnoreCase))) {
+                output.Add(new ImapFolderInfo {
+                    FullName = full,
+                    Name = folder.Name ?? full,
+                    IsSent = folder.Attributes.HasFlag(FolderAttributes.Sent),
+                    IsTrash = folder.Attributes.HasFlag(FolderAttributes.Trash),
+                    IsArchive = folder.Attributes.HasFlag(FolderAttributes.Archive),
+                    IsJunk = folder.Attributes.HasFlag(FolderAttributes.Junk),
+                    IsDrafts = folder.Attributes.HasFlag(FolderAttributes.Drafts)
+                });
+            }
+        } catch {
+            // Best effort.
+        }
+
+        IList<IMailFolder> subfolders;
+        try {
+            subfolders = await folder.GetSubfoldersAsync(false, cancellationToken).ConfigureAwait(false);
+        } catch {
+            return;
+        }
+
+        foreach (var sub in subfolders) {
+            await CollectFoldersInfoAsync(sub, output, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static bool LooksLikeSentFolder(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        var lower = (value ?? string.Empty).Trim().ToLowerInvariant();
+        if (lower.Length == 0) {
+            return false;
+        }
+        if (lower.Contains("draft", StringComparison.Ordinal) ||
+            lower.Contains("trash", StringComparison.Ordinal) ||
+            lower.Contains("junk", StringComparison.Ordinal) ||
+            lower.Contains("spam", StringComparison.Ordinal) ||
+            lower.Contains("archive", StringComparison.Ordinal)) {
+            return false;
+        }
+
+        var normalized = new string(lower.Select(ch => char.IsLetterOrDigit(ch) ? ch : ' ').ToArray());
+        var tokens = normalized
+            .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(token => token.Trim())
+            .Where(token => token.Length > 0);
+        foreach (var token in tokens) {
+            if (token == "sent" || token == "sentitems" || token == "sentmail") {
+                return true;
+            }
+        }
+
+        return lower.Contains("/sent", StringComparison.Ordinal) ||
+               lower.Contains(".sent", StringComparison.Ordinal) ||
+               lower.Contains("sent", StringComparison.Ordinal);
+    }
+
+    private static int SentFolderHeuristicScore(ImapFolderInfo folder) {
+        var name = (folder.Name ?? string.Empty).Trim().ToLowerInvariant();
+        var full = (folder.FullName ?? string.Empty).Trim().ToLowerInvariant();
+
+        if (name == "sent" ||
+            full == "sent" ||
+            full.EndsWith("/sent", StringComparison.Ordinal) ||
+            full.EndsWith(".sent", StringComparison.Ordinal)) {
+            return 0;
+        }
+
+        if (name is "sent items" or "sent mail" ||
+            full.Contains("/sent items", StringComparison.Ordinal) ||
+            full.Contains("/sent mail", StringComparison.Ordinal)) {
+            return 1;
+        }
+
+        if (full.Contains("sent", StringComparison.Ordinal) || name.Contains("sent", StringComparison.Ordinal)) {
+            return 2;
+        }
+
+        return 1000;
+    }
+
+    private static int DraftsFolderHeuristicScore(ImapFolderInfo folder) {
+        var name = (folder.Name ?? string.Empty).Trim().ToLowerInvariant();
+        var full = (folder.FullName ?? string.Empty).Trim().ToLowerInvariant();
+
+        if (name == "drafts" ||
+            full == "drafts" ||
+            full.EndsWith("/drafts", StringComparison.Ordinal) ||
+            full.EndsWith(".drafts", StringComparison.Ordinal)) {
+            return 0;
+        }
+        if (name == "draft" ||
+            full.EndsWith("/draft", StringComparison.Ordinal) ||
+            full.EndsWith(".draft", StringComparison.Ordinal)) {
+            return 1;
+        }
+        if (name.Contains("draft", StringComparison.Ordinal) || full.Contains("draft", StringComparison.Ordinal)) {
+            return 2;
+        }
+
+        return 1000;
+    }
+
+    private static int TrashFolderHeuristicScore(ImapFolderInfo folder) {
+        var name = (folder.Name ?? string.Empty).Trim().ToLowerInvariant();
+        var full = (folder.FullName ?? string.Empty).Trim().ToLowerInvariant();
+
+        if (name == "trash" ||
+            name == "bin" ||
+            full == "trash" ||
+            full.EndsWith("/trash", StringComparison.Ordinal) ||
+            full.EndsWith(".trash", StringComparison.Ordinal)) {
+            return 0;
+        }
+        if (name is "deleted items" or "deleted messages" ||
+            full.Contains("/deleted items", StringComparison.Ordinal) ||
+            full.Contains("/deleted messages", StringComparison.Ordinal)) {
+            return 1;
+        }
+        if (name.Contains("trash", StringComparison.Ordinal) || full.Contains("trash", StringComparison.Ordinal) ||
+            name.Contains("deleted", StringComparison.Ordinal) || full.Contains("deleted", StringComparison.Ordinal) ||
+            name.Contains("bin", StringComparison.Ordinal) || full.Contains("/bin", StringComparison.Ordinal)) {
+            return 2;
+        }
+
+        return 1000;
+    }
+
+    private static int ArchiveFolderHeuristicScore(ImapFolderInfo folder) {
+        var name = (folder.Name ?? string.Empty).Trim().ToLowerInvariant();
+        var full = (folder.FullName ?? string.Empty).Trim().ToLowerInvariant();
+
+        if (name == "archive" ||
+            full == "archive" ||
+            full.EndsWith("/archive", StringComparison.Ordinal) ||
+            full.EndsWith(".archive", StringComparison.Ordinal)) {
+            return 0;
+        }
+        if (name == "all mail" ||
+            full.EndsWith("/all mail", StringComparison.Ordinal) ||
+            full.EndsWith(".all mail", StringComparison.Ordinal)) {
+            return 1;
+        }
+        if (name.Contains("archive", StringComparison.Ordinal) || full.Contains("archive", StringComparison.Ordinal) ||
+            name.Contains("all mail", StringComparison.Ordinal) || full.Contains("all mail", StringComparison.Ordinal)) {
+            return 2;
+        }
+
+        return 1000;
+    }
+
+    private static int JunkFolderHeuristicScore(ImapFolderInfo folder) {
+        var name = (folder.Name ?? string.Empty).Trim().ToLowerInvariant();
+        var full = (folder.FullName ?? string.Empty).Trim().ToLowerInvariant();
+
+        if (name == "junk" ||
+            name == "spam" ||
+            full == "junk" ||
+            full.EndsWith("/junk", StringComparison.Ordinal) ||
+            full.EndsWith(".junk", StringComparison.Ordinal)) {
+            return 0;
+        }
+        if (name == "junk e-mail" || full.Contains("/junk e-mail", StringComparison.Ordinal)) {
+            return 1;
+        }
+        if (name.Contains("junk", StringComparison.Ordinal) || full.Contains("junk", StringComparison.Ordinal) ||
+            name.Contains("spam", StringComparison.Ordinal) || full.Contains("spam", StringComparison.Ordinal) ||
+            name.Contains("bulk", StringComparison.Ordinal) || full.Contains("bulk", StringComparison.Ordinal)) {
+            return 2;
+        }
+
+        return 1000;
+    }
+
+    private static bool LooksLikeDraftsFolder(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        var lower = (value ?? string.Empty).Trim().ToLowerInvariant();
+        if (lower.Length == 0) {
+            return false;
+        }
+        if (lower.Contains("sent", StringComparison.Ordinal) ||
+            lower.Contains("trash", StringComparison.Ordinal) ||
+            lower.Contains("junk", StringComparison.Ordinal) ||
+            lower.Contains("spam", StringComparison.Ordinal) ||
+            lower.Contains("archive", StringComparison.Ordinal)) {
+            return false;
+        }
+
+        return lower.Contains("draft", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeTrashFolder(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        var lower = (value ?? string.Empty).Trim().ToLowerInvariant();
+        if (lower.Length == 0) {
+            return false;
+        }
+        if (lower.Contains("sent", StringComparison.Ordinal) ||
+            lower.Contains("draft", StringComparison.Ordinal) ||
+            lower.Contains("junk", StringComparison.Ordinal) ||
+            lower.Contains("spam", StringComparison.Ordinal) ||
+            lower.Contains("archive", StringComparison.Ordinal)) {
+            return false;
+        }
+
+        return lower.Contains("trash", StringComparison.Ordinal) ||
+               lower.Contains("deleted", StringComparison.Ordinal) ||
+               lower.Contains("bin", StringComparison.Ordinal) ||
+               lower.Contains("waste", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeArchiveFolder(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        var lower = (value ?? string.Empty).Trim().ToLowerInvariant();
+        if (lower.Length == 0) {
+            return false;
+        }
+        if (lower.Contains("sent", StringComparison.Ordinal) ||
+            lower.Contains("draft", StringComparison.Ordinal) ||
+            lower.Contains("trash", StringComparison.Ordinal) ||
+            lower.Contains("junk", StringComparison.Ordinal) ||
+            lower.Contains("spam", StringComparison.Ordinal)) {
+            return false;
+        }
+
+        return lower.Contains("archive", StringComparison.Ordinal) ||
+               lower.Contains("all mail", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeJunkFolder(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        var lower = (value ?? string.Empty).Trim().ToLowerInvariant();
+        if (lower.Length == 0) {
+            return false;
+        }
+        if (lower.Contains("sent", StringComparison.Ordinal) ||
+            lower.Contains("draft", StringComparison.Ordinal) ||
+            lower.Contains("trash", StringComparison.Ordinal) ||
+            lower.Contains("archive", StringComparison.Ordinal)) {
+            return false;
+        }
+
+        return lower.Contains("junk", StringComparison.Ordinal) ||
+               lower.Contains("spam", StringComparison.Ordinal) ||
+               lower.Contains("bulk", StringComparison.Ordinal);
+    }
+
+    private static string? ResolveSpecialFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        Func<ImapFolderInfo, bool> attributePredicate,
+        Func<string?, bool> looksLikePredicate,
+        Func<ImapFolderInfo, int> heuristicScoreSelector,
+        string? fallbackFolder) {
+        var requested = NormalizeOptionalFolder(requestedFolder);
+        if (requested != null) {
+            return requested;
+        }
+
+        var configured = NormalizeOptionalFolder(configuredFolder);
+        if (configured != null) {
+            return configured;
+        }
+
+        var available = folders?
+            .Where(x => !string.IsNullOrWhiteSpace(x.FullName))
+            .Select(x => new ImapFolderInfo {
+                FullName = x.FullName.Trim(),
+                Name = (x.Name ?? string.Empty).Trim(),
+                IsSent = x.IsSent,
+                IsTrash = x.IsTrash,
+                IsArchive = x.IsArchive,
+                IsJunk = x.IsJunk,
+                IsDrafts = x.IsDrafts
+            })
+            .ToList() ?? new List<ImapFolderInfo>();
+
+        if (available.Count == 0) {
+            return NormalizeOptionalFolder(fallbackFolder);
+        }
+
+        var byAttribute = available.FirstOrDefault(attributePredicate);
+        if (byAttribute != null) {
+            return byAttribute.FullName;
+        }
+
+        var byHeuristic = available
+            .Where(x => looksLikePredicate(x.Name) || looksLikePredicate(x.FullName))
+            .OrderBy(heuristicScoreSelector)
+            .ThenBy(x => x.FullName.Length)
+            .FirstOrDefault();
+        if (byHeuristic != null) {
+            return byHeuristic.FullName;
+        }
+
+        return NormalizeOptionalFolder(fallbackFolder);
+    }
+
+    private static string ResolveFolderName(string? requestedFolder, string? configuredFolder, string fallbackFolder = "INBOX") {
+        var requested = NormalizeOptionalFolder(requestedFolder);
+        if (requested != null) {
+            return requested;
+        }
+
+        var configured = NormalizeOptionalFolder(configuredFolder);
+        if (configured != null) {
+            return configured;
+        }
+
+        var fallback = NormalizeOptionalFolder(fallbackFolder);
+        return fallback ?? "INBOX";
+    }
+
+    private static string? NormalizeOptionalFolder(string? value) {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapSentMessageOperations.cs
+++ b/Sources/Mailozaurr/Receive/ImapSentMessageOperations.cs
@@ -1,0 +1,359 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Search;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// IMAP helper operations used by send/idempotency pipelines around Sent-folder behavior.
+/// </summary>
+public static class ImapSentMessageOperations {
+    /// <summary>
+    /// Abstraction over IMAP sent-folder operations for testability.
+    /// </summary>
+    public interface IImapSentFolder {
+        /// <summary>Folder full name.</summary>
+        string FullName { get; }
+
+        /// <summary>True when folder is open.</summary>
+        bool IsOpen { get; }
+
+        /// <summary>Current folder access when opened.</summary>
+        FolderAccess Access { get; }
+
+        /// <summary>Opens the folder with requested access.</summary>
+        Task OpenAsync(FolderAccess access, CancellationToken cancellationToken = default);
+
+        /// <summary>Closes the folder.</summary>
+        Task CloseAsync(bool expunge, CancellationToken cancellationToken = default);
+
+        /// <summary>Appends a MIME message.</summary>
+        Task AppendAsync(MimeMessage message, MessageFlags flags, CancellationToken cancellationToken = default);
+
+        /// <summary>Searches for matching message UIDs.</summary>
+        Task<IList<UniqueId>> SearchAsync(SearchQuery query, CancellationToken cancellationToken = default);
+
+        /// <summary>Fetches envelope message-id for a single UID.</summary>
+        Task<string?> FetchEnvelopeMessageIdAsync(UniqueId uid, CancellationToken cancellationToken = default);
+
+        /// <summary>Fetches threading metadata for a single UID.</summary>
+        Task<ImapThreadingMetadataResult?> FetchThreadingMetadataAsync(UniqueId uid, CancellationToken cancellationToken = default);
+    }
+
+    private sealed class MailKitSentFolderAdapter : IImapSentFolder {
+        private readonly IMailFolder _folder;
+
+        internal MailKitSentFolderAdapter(IMailFolder folder) {
+            _folder = folder ?? throw new ArgumentNullException(nameof(folder));
+        }
+
+        public string FullName => _folder.FullName;
+
+        public bool IsOpen => _folder.IsOpen;
+
+        public FolderAccess Access => _folder.Access;
+
+        public Task OpenAsync(FolderAccess access, CancellationToken cancellationToken = default) =>
+            _folder.OpenAsync(access, cancellationToken);
+
+        public Task CloseAsync(bool expunge, CancellationToken cancellationToken = default) =>
+            _folder.CloseAsync(expunge, cancellationToken);
+
+        public Task AppendAsync(MimeMessage message, MessageFlags flags, CancellationToken cancellationToken = default) =>
+            _folder.AppendAsync(message, flags, cancellationToken);
+
+        public Task<IList<UniqueId>> SearchAsync(SearchQuery query, CancellationToken cancellationToken = default) =>
+            _folder.SearchAsync(query, cancellationToken);
+
+        public async Task<string?> FetchEnvelopeMessageIdAsync(UniqueId uid, CancellationToken cancellationToken = default) {
+            var summaries = await _folder.FetchAsync(new[] { uid }, MessageSummaryItems.Envelope, cancellationToken).ConfigureAwait(false);
+            if (summaries == null || summaries.Count == 0) {
+                return null;
+            }
+
+            return NormalizeOptional(summaries[0].Envelope?.MessageId);
+        }
+
+        public async Task<ImapThreadingMetadataResult?> FetchThreadingMetadataAsync(UniqueId uid, CancellationToken cancellationToken = default) {
+            var summaries = await _folder.FetchAsync(
+                new[] { uid },
+                MessageSummaryItems.Envelope | MessageSummaryItems.References | MessageSummaryItems.UniqueId,
+                cancellationToken).ConfigureAwait(false);
+            if (summaries == null || summaries.Count == 0) {
+                return null;
+            }
+
+            var summary = summaries[0];
+            var env = summary.Envelope;
+            return new ImapThreadingMetadataResult {
+                MessageId = NormalizeOptional(env?.MessageId),
+                ReplyTo = NormalizeOptional(env?.ReplyTo?.ToString()),
+                Cc = NormalizeOptional(env?.Cc?.ToString()),
+                InReplyTo = NormalizeOptional(env?.InReplyTo),
+                References = summary.References is null ? null : new List<string>(summary.References)
+            };
+        }
+    }
+
+    /// <summary>
+    /// Result of Sent-folder append attempt.
+    /// </summary>
+    public sealed class ImapSentAppendResult {
+        /// <summary>True when append succeeded.</summary>
+        public bool Appended { get; set; }
+
+        /// <summary>Resolved folder name where message was appended.</summary>
+        public string? Folder { get; set; }
+    }
+
+    /// <summary>
+    /// Result of duplicate probe in Sent folder.
+    /// </summary>
+    public sealed class ImapSentDuplicateProbeResult {
+        /// <summary>True when duplicate was found.</summary>
+        public bool IsMatch { get; set; }
+
+        /// <summary>Resolved folder name that was probed.</summary>
+        public string? Folder { get; set; }
+
+        /// <summary>Matched message-id when available.</summary>
+        public string? MessageId { get; set; }
+
+        /// <summary>Non-match helper value.</summary>
+        public static ImapSentDuplicateProbeResult None { get; } = new();
+    }
+
+    /// <summary>
+    /// Threading metadata fetched from IMAP summary headers.
+    /// </summary>
+    public sealed class ImapThreadingMetadataResult {
+        /// <summary>Message-Id value.</summary>
+        public string? MessageId { get; set; }
+
+        /// <summary>Reply-To value.</summary>
+        public string? ReplyTo { get; set; }
+
+        /// <summary>Cc value.</summary>
+        public string? Cc { get; set; }
+
+        /// <summary>In-Reply-To value.</summary>
+        public string? InReplyTo { get; set; }
+
+        /// <summary>References values.</summary>
+        public List<string>? References { get; set; }
+    }
+
+    /// <summary>
+    /// Appends a MIME message to Sent using resolved Sent-folder selection.
+    /// </summary>
+    public static async Task<ImapSentAppendResult> AppendToSentAsync(
+        ImapClient client,
+        MimeMessage message,
+        string? requestedSentFolder = null,
+        string? configuredSentFolder = null,
+        string fallbackFolder = "Sent",
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var sentFolder = await ImapSentFolderResolver.ResolveSentFolderNameAsync(
+            client,
+            requestedSentFolder,
+            configuredSentFolder,
+            fallbackFolder,
+            cancellationToken).ConfigureAwait(false);
+        var folder = new MailKitSentFolderAdapter(client.GetCachedFolder(sentFolder, FolderAccess.ReadOnly));
+        return await AppendToSentAsync(folder, message, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Appends a MIME message to Sent using an abstract folder.
+    /// </summary>
+    public static async Task<ImapSentAppendResult> AppendToSentAsync(
+        IImapSentFolder folder,
+        MimeMessage message,
+        CancellationToken cancellationToken = default) {
+        if (folder == null) {
+            throw new ArgumentNullException(nameof(folder));
+        }
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        await EnsureFolderAccessAsync(folder, FolderAccess.ReadWrite, cancellationToken).ConfigureAwait(false);
+        await folder.AppendAsync(message, MessageFlags.Seen, cancellationToken).ConfigureAwait(false);
+        return new ImapSentAppendResult {
+            Appended = true,
+            Folder = folder.FullName
+        };
+    }
+
+    /// <summary>
+    /// Probes Sent for duplicate send marker by idempotency header, with optional Message-Id fallback.
+    /// </summary>
+    public static async Task<ImapSentDuplicateProbeResult> FindSentDuplicateAsync(
+        ImapClient client,
+        string idempotencyHeaderName,
+        string idempotencyKey,
+        string? messageIdToken,
+        string? requestedSentFolder = null,
+        string? configuredSentFolder = null,
+        string fallbackFolder = "Sent",
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+
+        var sentFolder = await ImapSentFolderResolver.ResolveSentFolderNameAsync(
+            client,
+            requestedSentFolder,
+            configuredSentFolder,
+            fallbackFolder,
+            cancellationToken).ConfigureAwait(false);
+        var folder = new MailKitSentFolderAdapter(client.GetCachedFolder(sentFolder, FolderAccess.ReadOnly));
+        var result = await FindSentDuplicateAsync(
+            folder,
+            idempotencyHeaderName,
+            idempotencyKey,
+            messageIdToken,
+            cancellationToken).ConfigureAwait(false);
+        result.Folder = sentFolder;
+        return result;
+    }
+
+    /// <summary>
+    /// Probes Sent for duplicate send marker by idempotency header, with optional Message-Id fallback.
+    /// </summary>
+    public static async Task<ImapSentDuplicateProbeResult> FindSentDuplicateAsync(
+        IImapSentFolder folder,
+        string idempotencyHeaderName,
+        string idempotencyKey,
+        string? messageIdToken,
+        CancellationToken cancellationToken = default) {
+        if (folder == null) {
+            throw new ArgumentNullException(nameof(folder));
+        }
+        if (string.IsNullOrWhiteSpace(idempotencyHeaderName)) {
+            throw new ArgumentException("idempotencyHeaderName is required.", nameof(idempotencyHeaderName));
+        }
+        if (string.IsNullOrWhiteSpace(idempotencyKey)) {
+            throw new ArgumentException("idempotencyKey is required.", nameof(idempotencyKey));
+        }
+
+        await EnsureFolderAccessAsync(folder, FolderAccess.ReadOnly, cancellationToken).ConfigureAwait(false);
+
+        var uids = await folder.SearchAsync(
+            SearchQuery.HeaderContains(idempotencyHeaderName.Trim(), idempotencyKey.Trim()),
+            cancellationToken).ConfigureAwait(false);
+        if (uids.Count == 0) {
+            var normalizedMessageId = NormalizeMessageIdToken(messageIdToken);
+            if (!string.IsNullOrWhiteSpace(normalizedMessageId)) {
+                uids = await folder.SearchAsync(
+                    SearchQuery.HeaderContains("Message-Id", normalizedMessageId),
+                    cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        if (uids.Count == 0) {
+            return ImapSentDuplicateProbeResult.None;
+        }
+
+        var matchedMessageId = await folder.FetchEnvelopeMessageIdAsync(uids[0], cancellationToken).ConfigureAwait(false);
+        return new ImapSentDuplicateProbeResult {
+            IsMatch = true,
+            Folder = folder.FullName,
+            MessageId = string.IsNullOrWhiteSpace(matchedMessageId) ? messageIdToken : matchedMessageId
+        };
+    }
+
+    /// <summary>
+    /// Gets threading metadata for a message identified by folder + UID.
+    /// </summary>
+    public static async Task<ImapThreadingMetadataResult?> GetThreadingMetadataAsync(
+        ImapClient client,
+        string folder,
+        uint uid,
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (string.IsNullOrWhiteSpace(folder)) {
+            throw new ArgumentException("folder is required.", nameof(folder));
+        }
+        if (uid == 0) {
+            throw new ArgumentOutOfRangeException(nameof(uid), "uid must be greater than zero.");
+        }
+
+        var mailFolder = new MailKitSentFolderAdapter(client.GetCachedFolder(folder, FolderAccess.ReadOnly));
+        return await GetThreadingMetadataAsync(mailFolder, new UniqueId(uid), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Gets threading metadata for a message in an abstract folder.
+    /// </summary>
+    public static async Task<ImapThreadingMetadataResult?> GetThreadingMetadataAsync(
+        IImapSentFolder folder,
+        UniqueId uid,
+        CancellationToken cancellationToken = default) {
+        if (folder == null) {
+            throw new ArgumentNullException(nameof(folder));
+        }
+
+        await EnsureFolderAccessAsync(folder, FolderAccess.ReadOnly, cancellationToken).ConfigureAwait(false);
+        return await folder.FetchThreadingMetadataAsync(uid, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Normalizes a message-id token by trimming whitespace and angle brackets.
+    /// </summary>
+    public static string? NormalizeMessageIdToken(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        var token = value!.Trim();
+        if (token.StartsWith("<", StringComparison.Ordinal)) {
+            token = token.Substring(1);
+        }
+        if (token.EndsWith(">", StringComparison.Ordinal)) {
+            token = token.Substring(0, token.Length - 1);
+        }
+        token = token.Trim();
+        return token.Length == 0 ? null : token;
+    }
+
+    private static async Task EnsureFolderAccessAsync(
+        IImapSentFolder folder,
+        FolderAccess access,
+        CancellationToken cancellationToken) {
+        if (folder.IsOpen && folder.Access != access) {
+            try {
+                await folder.CloseAsync(expunge: false, cancellationToken).ConfigureAwait(false);
+            } catch {
+                // best-effort
+            }
+        }
+
+        if (!folder.IsOpen || folder.Access != access) {
+            await folder.OpenAsync(access, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!folder.IsOpen || folder.Access != access) {
+            throw new InvalidOperationException($"Folder is not currently open in {access} mode.");
+        }
+    }
+
+    private static string? NormalizeOptional(string? value) {
+        var trimmed = (value ?? string.Empty).Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapSentMessageOperations.cs
+++ b/Sources/Mailozaurr/Receive/ImapSentMessageOperations.cs
@@ -123,9 +123,6 @@ public static class ImapSentMessageOperations {
 
         /// <summary>Matched message-id when available.</summary>
         public string? MessageId { get; set; }
-
-        /// <summary>Non-match helper value.</summary>
-        public static ImapSentDuplicateProbeResult None { get; } = new();
     }
 
     /// <summary>
@@ -264,7 +261,7 @@ public static class ImapSentMessageOperations {
         }
 
         if (uids.Count == 0) {
-            return ImapSentDuplicateProbeResult.None;
+            return new ImapSentDuplicateProbeResult();
         }
 
         var matchedMessageId = await folder.FetchEnvelopeMessageIdAsync(uids[0], cancellationToken).ConfigureAwait(false);

--- a/Sources/Mailozaurr/Receive/MessageRemover.cs
+++ b/Sources/Mailozaurr/Receive/MessageRemover.cs
@@ -34,12 +34,27 @@ public static class MessageRemover {
         bool dryRun,
         string? folder = null,
         CancellationToken cancellationToken = default) {
+        await DeleteAsync(client, uid, dryRun, folder, expunge: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes a single message from an IMAP folder, optionally simulating the change and controlling expunge behavior.
+    /// </summary>
+    public static async Task DeleteAsync(
+        ImapClient client,
+        UniqueId uid,
+        bool dryRun,
+        string? folder,
+        bool expunge,
+        CancellationToken cancellationToken = default) {
         if (dryRun) {
             return;
         }
         var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadWrite);
         await mailFolder.AddFlagsAsync(uid, MessageFlags.Deleted, true, cancellationToken).ConfigureAwait(false);
-        await mailFolder.ExpungeAsync(cancellationToken).ConfigureAwait(false);
+        if (expunge) {
+            await mailFolder.ExpungeAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <summary>
@@ -65,6 +80,19 @@ public static class MessageRemover {
         bool dryRun,
         string? folder = null,
         CancellationToken cancellationToken = default) {
+        await DeleteAsync(client, uids, dryRun, folder, expunge: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes multiple messages from an IMAP folder, optionally simulating the change and controlling expunge behavior.
+    /// </summary>
+    public static async Task DeleteAsync(
+        ImapClient client,
+        IEnumerable<UniqueId> uids,
+        bool dryRun,
+        string? folder,
+        bool expunge,
+        CancellationToken cancellationToken = default) {
         if (dryRun) {
             return;
         }
@@ -74,7 +102,9 @@ public static class MessageRemover {
         }
         var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadWrite);
         await mailFolder.AddFlagsAsync(list, MessageFlags.Deleted, true, cancellationToken).ConfigureAwait(false);
-        await mailFolder.ExpungeAsync(cancellationToken).ConfigureAwait(false);
+        if (expunge) {
+            await mailFolder.ExpungeAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/Smtp/NativeSentMailboxOperations.cs
+++ b/Sources/Mailozaurr/Smtp/NativeSentMailboxOperations.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Shared native-provider helpers for Sent-folder append and duplicate detection.
+/// </summary>
+public static class NativeSentMailboxOperations {
+    /// <summary>
+    /// Default Graph folder used for Sent copy operations.
+    /// </summary>
+    public const string DefaultGraphSentFolder = "Sent Items";
+
+    /// <summary>
+    /// Default Gmail system Sent label id.
+    /// </summary>
+    public const string DefaultGmailSentLabelId = "SENT";
+
+    /// <summary>
+    /// Result of native Sent append operation.
+    /// </summary>
+    public sealed class NativeSentAppendResult {
+        /// <summary>True when append succeeded.</summary>
+        public bool Appended { get; set; }
+
+        /// <summary>Resolved folder/label display name.</summary>
+        public string? Folder { get; set; }
+
+        /// <summary>Resolved provider message id when available.</summary>
+        public string? MessageId { get; set; }
+    }
+
+    /// <summary>
+    /// Result of native Sent duplicate probe.
+    /// </summary>
+    public sealed class NativeSentDuplicateProbeResult {
+        /// <summary>True when duplicate message was found.</summary>
+        public bool IsMatch { get; set; }
+
+        /// <summary>Resolved folder/label display name.</summary>
+        public string? Folder { get; set; }
+
+        /// <summary>Matched message-id token.</summary>
+        public string? MessageId { get; set; }
+
+        /// <summary>Non-match helper value.</summary>
+        public static NativeSentDuplicateProbeResult None { get; } = new();
+    }
+
+    /// <summary>
+    /// Resolves Graph Sent folder name using request override, account override, and fallback.
+    /// </summary>
+    public static string ResolveGraphSentFolderName(
+        string? requestedSentFolder,
+        string? configuredSentFolder,
+        string fallbackFolder = DefaultGraphSentFolder) {
+        return ResolveFolderName(requestedSentFolder, configuredSentFolder, fallbackFolder);
+    }
+
+    /// <summary>
+    /// Resolves Graph Sent folder selector value accepted by Graph APIs.
+    /// </summary>
+    public static string ResolveGraphSentFolderSelector(
+        string? requestedSentFolder,
+        string? configuredSentFolder,
+        string fallbackFolder = DefaultGraphSentFolder) {
+        var folderName = ResolveGraphSentFolderName(requestedSentFolder, configuredSentFolder, fallbackFolder);
+        return GraphMailboxBrowser.ResolveFolderSelector(folderName);
+    }
+
+    /// <summary>
+    /// Resolves Gmail Sent label id for native Sent copy operations.
+    /// </summary>
+    public static string ResolveGmailSentLabelId(
+        string? requestedSentFolder = null,
+        string? configuredSentFolder = null) {
+        _ = requestedSentFolder;
+        _ = configuredSentFolder;
+        return DefaultGmailSentLabelId;
+    }
+
+    /// <summary>
+    /// Resolves Gmail Sent folder display value used for caller metadata.
+    /// </summary>
+    public static string ResolveGmailSentFolderName(
+        string? requestedSentFolder,
+        string? configuredSentFolder,
+        string fallbackFolder = DefaultGmailSentLabelId) {
+        return ResolveFolderName(requestedSentFolder, configuredSentFolder, fallbackFolder);
+    }
+
+    /// <summary>
+    /// Imports a MIME message into Graph Sent folder.
+    /// </summary>
+    public static async Task<NativeSentAppendResult> AppendToGraphSentAsync(
+        GraphMailboxBrowser browser,
+        MimeMessage message,
+        string? requestedSentFolder = null,
+        string? configuredSentFolder = null,
+        int maxInlineAttachmentBytes = GraphMimePreparation.DefaultMaxInlineAttachmentBytes,
+        string? idempotencyHeaderName = null,
+        CancellationToken cancellationToken = default) {
+        if (browser == null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+        if (maxInlineAttachmentBytes < 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxInlineAttachmentBytes), "maxInlineAttachmentBytes must be zero or greater.");
+        }
+
+        var folder = ResolveGraphSentFolderName(requestedSentFolder, configuredSentFolder);
+        var imported = await browser.ImportMessageAsync(
+            message,
+            folder: folder,
+            maxInlineAttachmentBytes: maxInlineAttachmentBytes,
+            idempotencyHeaderName: idempotencyHeaderName,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new NativeSentAppendResult {
+            Appended = true,
+            Folder = folder,
+            MessageId = NormalizeOptional(imported.MessageId)
+        };
+    }
+
+    /// <summary>
+    /// Imports a MIME message into Gmail Sent label.
+    /// </summary>
+    public static async Task<NativeSentAppendResult> AppendToGmailSentAsync(
+        GmailMailboxBrowser browser,
+        MimeMessage message,
+        string? requestedSentFolder = null,
+        string? configuredSentFolder = null,
+        CancellationToken cancellationToken = default) {
+        if (browser == null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var labelId = ResolveGmailSentLabelId(requestedSentFolder, configuredSentFolder);
+        _ = await browser.ImportMessageAsync(
+            message,
+            labelId: labelId,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new NativeSentAppendResult {
+            Appended = true,
+            Folder = ResolveGmailSentFolderName(requestedSentFolder, configuredSentFolder),
+            MessageId = NormalizeMessageIdToken(message.MessageId)
+        };
+    }
+
+    /// <summary>
+    /// Probes Graph Sent folder for duplicate RFC822 message-id.
+    /// </summary>
+    public static async Task<NativeSentDuplicateProbeResult> FindGraphSentDuplicateAsync(
+        GraphMailboxBrowser browser,
+        string messageIdToken,
+        string? requestedSentFolder = null,
+        string? configuredSentFolder = null,
+        CancellationToken cancellationToken = default) {
+        if (browser == null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+
+        var normalizedToken = NormalizeMessageIdToken(messageIdToken);
+        if (normalizedToken == null) {
+            throw new ArgumentException("messageIdToken is required.", nameof(messageIdToken));
+        }
+
+        var folder = ResolveGraphSentFolderName(requestedSentFolder, configuredSentFolder);
+        var probe = await browser.FindMessageByInternetMessageIdAsync(
+            normalizedToken,
+            folder: folder,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!probe.IsMatch) {
+            return NativeSentDuplicateProbeResult.None;
+        }
+
+        return new NativeSentDuplicateProbeResult {
+            IsMatch = true,
+            Folder = folder,
+            MessageId = NormalizeMessageIdToken(probe.MessageId) ?? normalizedToken
+        };
+    }
+
+    /// <summary>
+    /// Probes Gmail Sent label for duplicate RFC822 message-id.
+    /// </summary>
+    public static async Task<NativeSentDuplicateProbeResult> FindGmailSentDuplicateAsync(
+        GmailMailboxBrowser browser,
+        string messageIdToken,
+        string? requestedSentFolder = null,
+        string? configuredSentFolder = null,
+        CancellationToken cancellationToken = default) {
+        if (browser == null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+
+        var normalizedToken = NormalizeMessageIdToken(messageIdToken);
+        if (normalizedToken == null) {
+            throw new ArgumentException("messageIdToken is required.", nameof(messageIdToken));
+        }
+
+        var labelId = ResolveGmailSentLabelId(requestedSentFolder, configuredSentFolder);
+        var probe = await browser.FindSentMessageByRfc822MessageIdAsync(
+            normalizedToken,
+            sentLabelId: labelId,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!probe.IsMatch) {
+            return NativeSentDuplicateProbeResult.None;
+        }
+
+        return new NativeSentDuplicateProbeResult {
+            IsMatch = true,
+            Folder = ResolveGmailSentFolderName(requestedSentFolder, configuredSentFolder),
+            MessageId = NormalizeMessageIdToken(probe.MessageId) ?? normalizedToken
+        };
+    }
+
+    private static string ResolveFolderName(string? requestedFolder, string? configuredFolder, string fallbackFolder) {
+        var requested = NormalizeOptional(requestedFolder);
+        if (requested != null) {
+            return requested;
+        }
+
+        var configured = NormalizeOptional(configuredFolder);
+        if (configured != null) {
+            return configured;
+        }
+
+        var fallback = NormalizeOptional(fallbackFolder);
+        return fallback ?? DefaultGraphSentFolder;
+    }
+
+    private static string? NormalizeOptional(string? value) {
+        var trimmed = (value ?? string.Empty).Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+
+    private static string? NormalizeMessageIdToken(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        var token = value!.Trim();
+        if (token.StartsWith("<", StringComparison.Ordinal)) {
+            token = token.Substring(1);
+        }
+        if (token.EndsWith(">", StringComparison.Ordinal)) {
+            token = token.Substring(0, token.Length - 1);
+        }
+
+        token = token.Trim();
+        return token.Length == 0 ? null : token;
+    }
+}

--- a/Sources/Mailozaurr/Smtp/SmtpSentFolderSessionPipeline.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpSentFolderSessionPipeline.cs
@@ -108,6 +108,51 @@ public static class SmtpSentFolderSessionPipeline {
         }
     }
 
+    /// <summary>
+    /// Connects IMAP session, reads threading metadata for a folder + UID, and disconnects.
+    /// </summary>
+    /// <param name="connectAsync">Callback used to create and connect IMAP client.</param>
+    /// <param name="folder">Folder name containing the message.</param>
+    /// <param name="uid">Message UID in the folder.</param>
+    /// <param name="getMetadataAsync">Optional metadata callback override.</param>
+    /// <param name="disconnectAsync">Optional disconnect callback override.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Threading metadata when found; otherwise null.</returns>
+    public static async Task<ImapSentMessageOperations.ImapThreadingMetadataResult?> TryGetThreadingMetadataAsync(
+        Func<CancellationToken, Task<ImapClient>> connectAsync,
+        string folder,
+        uint uid,
+        Func<ImapClient, string, uint, CancellationToken, Task<ImapSentMessageOperations.ImapThreadingMetadataResult?>>? getMetadataAsync = null,
+        Func<ImapClient, CancellationToken, Task>? disconnectAsync = null,
+        CancellationToken cancellationToken = default) {
+        if (connectAsync is null) {
+            throw new ArgumentNullException(nameof(connectAsync));
+        }
+        if (string.IsNullOrWhiteSpace(folder)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(folder));
+        }
+        if (uid == 0) {
+            throw new ArgumentOutOfRangeException(nameof(uid), "uid must be greater than zero.");
+        }
+
+        var client = await connectAsync(cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Connected IMAP client is required.");
+
+        try {
+            if (getMetadataAsync is null) {
+                return await ImapSentMessageOperations.GetThreadingMetadataAsync(
+                    client,
+                    folder,
+                    uid,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return await getMetadataAsync(client, folder, uid, cancellationToken).ConfigureAwait(false);
+        } finally {
+            await DisconnectAndDisposeAsync(client, disconnectAsync, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
     private static async Task DisconnectAndDisposeAsync(
         ImapClient client,
         Func<ImapClient, CancellationToken, Task>? disconnectAsync,


### PR DESCRIPTION
## Summary
- add shared IMAP primitives for bulk flagging, delete (with expunge control), move (MOVE + COPY fallback), sent-folder resolution, sent-duplicate probing, and search query building
- add shared native-provider helpers for sent duplicate/append and threading metadata normalization
- add shared protocol auth helper for IMAP/POP3/SMTP auth-mode handling
- add stale-aware provider semantics for push/watch operations:
  - Graph subscription renew/delete safe result contracts (404/410 stale handling)
  - Gmail watch stop stale-aware result contract
- extend tests across IMAP/Graph/Gmail/SMTP/native primitives and contracts

## Validation
-   Determining projects to restore...
  All projects are up-to-date for restore.
  Mailozaurr -> /Users/przemyslawklys/Documents/GitHub/Mailozaurr.worktrees/native-sent-duplicate-upstream/Sources/Mailozaurr/bin/Debug/net8.0/Mailozaurr.dll
  Mailozaurr.Msg -> /Users/przemyslawklys/Documents/GitHub/Mailozaurr.worktrees/native-sent-duplicate-upstream/Sources/Mailozaurr.Msg/bin/Debug/net8.0/Mailozaurr.Msg.dll
  Mailozaurr.PowerShell -> /Users/przemyslawklys/Documents/GitHub/Mailozaurr.worktrees/native-sent-duplicate-upstream/Sources/Mailozaurr.PowerShell/bin/Debug/net8.0/Mailozaurr.PowerShell.dll
  Mailozaurr.Examples -> /Users/przemyslawklys/Documents/GitHub/Mailozaurr.worktrees/native-sent-duplicate-upstream/Sources/Mailozaurr.Examples/bin/Debug/net8.0/Mailozaurr.Examples.dll
  Mailozaurr.Tests -> /Users/przemyslawklys/Documents/GitHub/Mailozaurr.worktrees/native-sent-duplicate-upstream/Sources/Mailozaurr.Tests/bin/Debug/net8.0/Mailozaurr.Tests.dll
Test run for /Users/przemyslawklys/Documents/GitHub/Mailozaurr.worktrees/native-sent-duplicate-upstream/Sources/Mailozaurr.Tests/bin/Debug/net8.0/Mailozaurr.Tests.dll (.NETCoreApp,Version=v8.0)
VSTest version 18.0.1 (arm64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
[xUnit.net 00:00:03.80]     Mailozaurr.Tests.TemporaryPgpKeyPairTests.KeyPair_CanSignAndEncryptMessage [SKIP]
  Skipped Mailozaurr.Tests.TemporaryPgpKeyPairTests.KeyPair_CanSignAndEncryptMessage [1 ms]

Passed!  - Failed:     0, Passed:   661, Skipped:     1, Total:   662, Duration: 11 s - Mailozaurr.Tests.dll (net8.0) (662 total, 661 passed, 1 skipped)
-   Determining projects to restore...
  All projects are up-to-date for restore.
  Mailozaurr -> /Users/przemyslawklys/Documents/GitHub/Mailozaurr.worktrees/native-sent-duplicate-upstream/Sources/Mailozaurr/bin/Debug/net472/Mailozaurr.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:00.11 (succeeded)
