### PR TITLE
Add shared auth/IMAP/native primitives for BayManager engine convergence

### DIFF
--- a/Sources/Mailozaurr.Tests/ImapSentFolderResolverTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapSentFolderResolverTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ImapSentFolderResolverTests {
+    [Fact]
+    public void ResolveSentFolderName_PrefersConfiguredFolder() {
+        var folders = new List<ImapSentFolderResolver.ImapFolderInfo> {
+            new() { FullName = "INBOX", Name = "INBOX" },
+            new() { FullName = "Sent", Name = "Sent", IsSent = true }
+        };
+
+        var resolved = ImapSentFolderResolver.ResolveSentFolderName(
+            requestedFolder: null,
+            configuredFolder: "CustomSent",
+            folders: folders,
+            fallbackFolder: "Sent");
+
+        Assert.Equal("CustomSent", resolved);
+    }
+
+    [Fact]
+    public void ResolveSentFolderName_UsesHeuristic_WhenNoConfiguredFolder() {
+        var folders = new List<ImapSentFolderResolver.ImapFolderInfo> {
+            new() { FullName = "INBOX", Name = "INBOX" },
+            new() { FullName = "Sent Items", Name = "Sent Items" }
+        };
+
+        var resolved = ImapSentFolderResolver.ResolveSentFolderName(
+            requestedFolder: null,
+            configuredFolder: null,
+            folders: folders,
+            fallbackFolder: "Sent");
+
+        Assert.Equal("Sent Items", resolved);
+    }
+
+    [Fact]
+    public void ResolveSpecialFolderMappings_AppliesConfiguredOverrides() {
+        var folders = new List<ImapSentFolderResolver.ImapFolderInfo> {
+            new() { FullName = "INBOX", Name = "INBOX" },
+            new() { FullName = "Sent", Name = "Sent", IsSent = true },
+            new() { FullName = "Drafts", Name = "Drafts", IsDrafts = true },
+            new() { FullName = "Trash", Name = "Trash", IsTrash = true }
+        };
+
+        var mappings = ImapSentFolderResolver.ResolveSpecialFolderMappings(
+            configuredInboxFolder: "InboxOverride",
+            configuredSentFolder: "SentOverride",
+            configuredDraftsFolder: "DraftsOverride",
+            configuredTrashFolder: null,
+            configuredArchiveFolder: null,
+            configuredJunkFolder: null,
+            folders: folders,
+            configuredImapFolder: null);
+
+        Assert.Equal("InboxOverride", mappings.Inbox);
+        Assert.Equal("SentOverride", mappings.Sent);
+        Assert.Equal("DraftsOverride", mappings.Drafts);
+        Assert.Equal("Trash", mappings.Trash);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ImapSentMessageOperationsTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapSentMessageOperationsTests.cs
@@ -1,0 +1,28 @@
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ImapSentMessageOperationsTests {
+    [Theory]
+    [InlineData("<id@example.test>", "id@example.test")]
+    [InlineData("  <id@example.test>  ", "id@example.test")]
+    [InlineData("id@example.test", "id@example.test")]
+    [InlineData("<id@example.test", "id@example.test")]
+    [InlineData("id@example.test>", "id@example.test")]
+    public void NormalizeMessageIdToken_NormalizesBracketsAndWhitespace(string input, string expected) {
+        var normalized = ImapSentMessageOperations.NormalizeMessageIdToken(input);
+
+        Assert.Equal(expected, normalized);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("<>")]
+    public void NormalizeMessageIdToken_ReturnsNull_ForEmptyInput(string? input) {
+        var normalized = ImapSentMessageOperations.NormalizeMessageIdToken(input);
+
+        Assert.Null(normalized);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ProtocolAuthTests.cs
+++ b/Sources/Mailozaurr.Tests/ProtocolAuthTests.cs
@@ -1,0 +1,28 @@
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ProtocolAuthTests {
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("basic")]
+    [InlineData("unknown")]
+    public void ParseMode_ReturnsBasic_ForDefaultOrUnknownValues(string? value) {
+        var mode = ProtocolAuth.ParseMode(value);
+
+        Assert.Equal(ProtocolAuthMode.Basic, mode);
+    }
+
+    [Theory]
+    [InlineData("oauth2")]
+    [InlineData("xoauth2")]
+    [InlineData("oauth")]
+    [InlineData(" OAUTH2 ")]
+    public void ParseMode_ReturnsOAuth2_ForAliases(string value) {
+        var mode = ProtocolAuth.ParseMode(value);
+
+        Assert.Equal(ProtocolAuthMode.OAuth2, mode);
+    }
+}

--- a/Sources/Mailozaurr/Connections/ProtocolAuth.cs
+++ b/Sources/Mailozaurr/Connections/ProtocolAuth.cs
@@ -1,0 +1,108 @@
+#pragma warning disable CS1591
+#pragma warning disable CS8600,CS8601,CS8602,CS8603,CS8604,CS8618,CS8625
+#nullable enable
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Imap;
+using MailKit.Net.Pop3;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+
+namespace Mailozaurr;
+
+public enum ProtocolAuthMode {
+    Basic = 0,
+    OAuth2 = 1
+}
+
+public static class ProtocolAuth {
+    public static ProtocolAuthMode ParseMode(string? raw) {
+        var value = (raw ?? string.Empty).Trim();
+        if (value.Length == 0) {
+            return ProtocolAuthMode.Basic;
+        }
+
+        if (value.Equals("basic", StringComparison.OrdinalIgnoreCase)) {
+            return ProtocolAuthMode.Basic;
+        }
+
+        if (value.Equals("oauth2", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("xoauth2", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("oauth", StringComparison.OrdinalIgnoreCase)) {
+            return ProtocolAuthMode.OAuth2;
+        }
+
+        return ProtocolAuthMode.Basic;
+    }
+
+    public static Task AuthenticateImapAsync(
+        ImapClient client,
+        string userName,
+        string secret,
+        ProtocolAuthMode mode,
+        CancellationToken ct) {
+        if (client is null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (string.IsNullOrWhiteSpace(userName)) {
+            throw new InvalidOperationException("IMAP username is required.");
+        }
+        if (string.IsNullOrWhiteSpace(secret)) {
+            throw new InvalidOperationException("IMAP secret/token is required.");
+        }
+
+        if (mode == ProtocolAuthMode.OAuth2) {
+            return client.AuthenticateAsync(new SaslMechanismOAuth2(userName.Trim(), secret.Trim()), ct);
+        }
+
+        return client.AuthenticateAsync(new NetworkCredential(userName.Trim(), secret), ct);
+    }
+
+    public static Task AuthenticateSmtpAsync(
+        SmtpClient client,
+        string userName,
+        string secret,
+        ProtocolAuthMode mode,
+        CancellationToken ct) {
+        if (client is null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (string.IsNullOrWhiteSpace(userName)) {
+            throw new InvalidOperationException("SMTP username is required.");
+        }
+        if (string.IsNullOrWhiteSpace(secret)) {
+            throw new InvalidOperationException("SMTP secret/token is required.");
+        }
+
+        if (mode == ProtocolAuthMode.OAuth2) {
+            return client.AuthenticateAsync(new SaslMechanismOAuth2(userName.Trim(), secret.Trim()), ct);
+        }
+
+        return client.AuthenticateAsync(userName.Trim(), secret, ct);
+    }
+
+    public static Task AuthenticatePop3Async(
+        Pop3Client client,
+        string userName,
+        string secret,
+        ProtocolAuthMode mode,
+        CancellationToken ct) {
+        if (client is null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (string.IsNullOrWhiteSpace(userName)) {
+            throw new InvalidOperationException("POP3 username is required.");
+        }
+        if (string.IsNullOrWhiteSpace(secret)) {
+            throw new InvalidOperationException("POP3 secret/token is required.");
+        }
+
+        if (mode == ProtocolAuthMode.OAuth2) {
+            return client.AuthenticateAsync(new SaslMechanismOAuth2(userName.Trim(), secret.Trim()), ct);
+        }
+
+        return client.AuthenticateAsync(userName.Trim(), secret, ct);
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapBulkFlagOperations.cs
+++ b/Sources/Mailozaurr/Receive/ImapBulkFlagOperations.cs
@@ -1,0 +1,94 @@
+#pragma warning disable CS1591
+#pragma warning disable CS8600,CS8601,CS8602,CS8603,CS8604,CS8618,CS8625
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+
+namespace Mailozaurr;
+
+public static class ImapBulkFlagOperations {
+    public sealed class ImapBulkFlagResultItem {
+        public UniqueId Uid { get; init; }
+        public bool Ok { get; init; }
+        public string? Error { get; init; }
+    }
+
+    public sealed class ImapBulkFlagResult {
+        public int Requested { get; init; }
+        public int Updated { get; set; }
+        public List<UniqueId> SuccessfulUids { get; init; } = new();
+        public List<ImapBulkFlagResultItem> Results { get; init; } = new();
+    }
+
+    public static async Task<ImapBulkFlagResult> SetFlagsAsync(
+        IMailFolder folder,
+        IReadOnlyCollection<UniqueId> uids,
+        MessageFlags flags,
+        bool add,
+        Func<string, string>? sanitizeError,
+        CancellationToken cancellationToken) {
+        if (folder is null) {
+            throw new ArgumentNullException(nameof(folder));
+        }
+        if (uids is null) {
+            throw new ArgumentNullException(nameof(uids));
+        }
+
+        sanitizeError ??= static message => message;
+        await EnsureFolderAccessAsync(folder, FolderAccess.ReadWrite, cancellationToken).ConfigureAwait(false);
+
+        var result = new ImapBulkFlagResult { Requested = uids.Count };
+        var uidList = new List<UniqueId>(uids.Count);
+        uidList.AddRange(uids);
+
+        try {
+            if (add) {
+                await folder.AddFlagsAsync(uidList, flags, silent: true, cancellationToken).ConfigureAwait(false);
+            } else {
+                await folder.RemoveFlagsAsync(uidList, flags, silent: true, cancellationToken).ConfigureAwait(false);
+            }
+
+            foreach (var uid in uidList) {
+                result.Updated++;
+                result.SuccessfulUids.Add(uid);
+                result.Results.Add(new ImapBulkFlagResultItem { Uid = uid, Ok = true });
+            }
+        } catch {
+            foreach (var uid in uidList) {
+                try {
+                    if (add) {
+                        await folder.AddFlagsAsync(uid, flags, silent: true, cancellationToken).ConfigureAwait(false);
+                    } else {
+                        await folder.RemoveFlagsAsync(uid, flags, silent: true, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    result.Updated++;
+                    result.SuccessfulUids.Add(uid);
+                    result.Results.Add(new ImapBulkFlagResultItem { Uid = uid, Ok = true });
+                } catch (Exception ex) {
+                    result.Results.Add(new ImapBulkFlagResultItem {
+                        Uid = uid,
+                        Ok = false,
+                        Error = sanitizeError(ex.Message)
+                    });
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static async Task EnsureFolderAccessAsync(IMailFolder folder, FolderAccess access, CancellationToken cancellationToken) {
+        if (!folder.IsOpen) {
+            await folder.OpenAsync(access, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (folder.Access != access && access == FolderAccess.ReadWrite) {
+            await folder.OpenAsync(access, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapDeleteOperations.cs
+++ b/Sources/Mailozaurr/Receive/ImapDeleteOperations.cs
@@ -1,0 +1,95 @@
+#pragma warning disable CS1591
+#pragma warning disable CS8600,CS8601,CS8602,CS8603,CS8604,CS8618,CS8625
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+
+namespace Mailozaurr;
+
+public static class ImapDeleteOperations {
+    public sealed class ImapDeleteResult {
+        public string Folder { get; init; } = string.Empty;
+        public int Requested { get; init; }
+        public int Deleted { get; set; }
+        public bool Expunged { get; set; }
+        public List<UniqueId> DeletedUids { get; init; } = new();
+        public List<ImapDeleteResultItem> Results { get; init; } = new();
+    }
+
+    public sealed class ImapDeleteResultItem {
+        public UniqueId Uid { get; init; }
+        public bool Ok { get; init; }
+        public string? Error { get; init; }
+    }
+
+    public static async Task<ImapDeleteResult> DeleteAsync(
+        IMailFolder folder,
+        IReadOnlyCollection<UniqueId> uids,
+        bool expunge,
+        Func<string, string>? sanitizeError,
+        CancellationToken cancellationToken) {
+        if (folder is null) {
+            throw new ArgumentNullException(nameof(folder));
+        }
+        if (uids is null) {
+            throw new ArgumentNullException(nameof(uids));
+        }
+
+        sanitizeError ??= static message => message;
+        await EnsureFolderAccessAsync(folder, FolderAccess.ReadWrite, cancellationToken).ConfigureAwait(false);
+
+        var result = new ImapDeleteResult {
+            Folder = folder.FullName,
+            Requested = uids.Count,
+            Expunged = false
+        };
+
+        var uidList = new List<UniqueId>(uids.Count);
+        uidList.AddRange(uids);
+
+        try {
+            await folder.AddFlagsAsync(uidList, MessageFlags.Deleted, silent: true, cancellationToken).ConfigureAwait(false);
+            foreach (var uid in uidList) {
+                result.Deleted++;
+                result.DeletedUids.Add(uid);
+                result.Results.Add(new ImapDeleteResultItem { Uid = uid, Ok = true });
+            }
+        } catch {
+            foreach (var uid in uidList) {
+                try {
+                    await folder.AddFlagsAsync(uid, MessageFlags.Deleted, silent: true, cancellationToken).ConfigureAwait(false);
+                    result.Deleted++;
+                    result.DeletedUids.Add(uid);
+                    result.Results.Add(new ImapDeleteResultItem { Uid = uid, Ok = true });
+                } catch (Exception ex) {
+                    result.Results.Add(new ImapDeleteResultItem {
+                        Uid = uid,
+                        Ok = false,
+                        Error = sanitizeError(ex.Message)
+                    });
+                }
+            }
+        }
+
+        if (expunge && result.Deleted > 0) {
+            await folder.ExpungeAsync(cancellationToken).ConfigureAwait(false);
+            result.Expunged = true;
+        }
+
+        return result;
+    }
+
+    private static async Task EnsureFolderAccessAsync(IMailFolder folder, FolderAccess access, CancellationToken cancellationToken) {
+        if (!folder.IsOpen) {
+            await folder.OpenAsync(access, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (folder.Access != access && access == FolderAccess.ReadWrite) {
+            await folder.OpenAsync(access, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapMailboxSearchQueryBuilder.cs
+++ b/Sources/Mailozaurr/Receive/ImapMailboxSearchQueryBuilder.cs
@@ -1,0 +1,57 @@
+#pragma warning disable CS1591
+#pragma warning disable CS8600,CS8601,CS8602,CS8603,CS8604,CS8618,CS8625
+#nullable enable
+using System;
+using MailKit.Search;
+
+namespace Mailozaurr;
+
+public static class ImapMailboxSearchQueryBuilder {
+    public static SearchQuery Build(
+        bool unseenOnly,
+        string? subjectContains,
+        string? fromContains,
+        string? toContains,
+        string? bodyContains,
+        DateTime? sinceUtc,
+        DateTime? beforeUtc,
+        string? query) {
+        SearchQuery? combined = null;
+
+        static void Add(ref SearchQuery? current, SearchQuery part) {
+            current = current is null ? part : current.And(part);
+        }
+
+        if (unseenOnly) {
+            Add(ref combined, SearchQuery.NotSeen);
+        }
+        if (!string.IsNullOrWhiteSpace(subjectContains)) {
+            Add(ref combined, SearchQuery.SubjectContains(subjectContains.Trim()));
+        }
+        if (!string.IsNullOrWhiteSpace(fromContains)) {
+            Add(ref combined, SearchQuery.FromContains(fromContains.Trim()));
+        }
+        if (!string.IsNullOrWhiteSpace(toContains)) {
+            Add(ref combined, SearchQuery.ToContains(toContains.Trim()));
+        }
+        if (!string.IsNullOrWhiteSpace(bodyContains)) {
+            Add(ref combined, SearchQuery.BodyContains(bodyContains.Trim()));
+        }
+        if (sinceUtc.HasValue) {
+            Add(ref combined, SearchQuery.DeliveredAfter(sinceUtc.Value.ToUniversalTime()));
+        }
+        if (beforeUtc.HasValue) {
+            Add(ref combined, SearchQuery.DeliveredBefore(beforeUtc.Value.ToUniversalTime()));
+        }
+        if (!string.IsNullOrWhiteSpace(query)) {
+            var q = query.Trim();
+            var freeText = SearchQuery.SubjectContains(q)
+                .Or(SearchQuery.BodyContains(q))
+                .Or(SearchQuery.FromContains(q))
+                .Or(SearchQuery.ToContains(q));
+            Add(ref combined, freeText);
+        }
+
+        return combined ?? SearchQuery.All;
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapMoveOperations.cs
+++ b/Sources/Mailozaurr/Receive/ImapMoveOperations.cs
@@ -1,0 +1,198 @@
+#pragma warning disable CS1591
+#pragma warning disable CS8600,CS8601,CS8602,CS8603,CS8604,CS8618,CS8625
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Search;
+using MimeKit;
+
+namespace Mailozaurr;
+
+public static class ImapMoveOperations {
+    public sealed class ImapMoveResult {
+        public string? SourceFolder { get; init; }
+        public string? TargetFolder { get; init; }
+        public int Requested { get; init; }
+        public int Moved { get; set; }
+        public List<ImapMoveResultItem> Results { get; init; } = new();
+    }
+
+    public sealed class ImapMoveResultItem {
+        public UniqueId Uid { get; init; }
+        public bool Ok { get; set; }
+        public long? TargetUid { get; set; }
+        public string? MessageId { get; set; }
+        public bool UsedCopyFallback { get; set; }
+        public string? Error { get; set; }
+    }
+
+    public static async Task<ImapMoveResult> MoveAsync(
+        ImapClient client,
+        string sourceFolder,
+        string targetFolder,
+        IReadOnlyCollection<UniqueId> uids,
+        Func<string, string>? sanitizeError,
+        CancellationToken cancellationToken) {
+        if (client is null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (string.IsNullOrWhiteSpace(sourceFolder)) {
+            throw new ArgumentException("sourceFolder is required.", nameof(sourceFolder));
+        }
+        if (string.IsNullOrWhiteSpace(targetFolder)) {
+            throw new ArgumentException("targetFolder is required.", nameof(targetFolder));
+        }
+        if (uids is null) {
+            throw new ArgumentNullException(nameof(uids));
+        }
+
+        sanitizeError ??= static message => message;
+
+        var source = client.GetFolder(sourceFolder);
+        await EnsureFolderAccessAsync(source, FolderAccess.ReadWrite, cancellationToken).ConfigureAwait(false);
+
+        var destination = client.GetFolder(targetFolder);
+        await EnsureFolderAccessAsync(destination, FolderAccess.ReadWrite, cancellationToken).ConfigureAwait(false);
+
+        var result = new ImapMoveResult {
+            SourceFolder = source.FullName,
+            TargetFolder = destination.FullName,
+            Requested = uids.Count
+        };
+
+        var sourceNeedsExpunge = false;
+        foreach (var uid in uids) {
+            var item = new ImapMoveResultItem { Uid = uid };
+            try {
+                item.MessageId = await TryGetNormalizedMessageIdAsync(source, uid, cancellationToken).ConfigureAwait(false);
+
+                try {
+                    var map = await source.MoveToAsync(new List<UniqueId> { uid }, destination, cancellationToken).ConfigureAwait(false);
+                    if (map.TryGetValue(uid, out var mappedUid)) {
+                        item.TargetUid = mappedUid.Id;
+                    }
+                } catch (NotSupportedException) {
+                    item.UsedCopyFallback = true;
+                    await CopyWithFallbackAsync(source, destination, uid, cancellationToken, item).ConfigureAwait(false);
+                    await source.AddFlagsAsync(uid, MessageFlags.Deleted, silent: true, cancellationToken).ConfigureAwait(false);
+                    sourceNeedsExpunge = true;
+                }
+
+                if (!item.TargetUid.HasValue && !string.IsNullOrWhiteSpace(item.MessageId)) {
+                    item.TargetUid = await TryResolveTargetUidByMessageIdAsync(destination, item.MessageId, cancellationToken).ConfigureAwait(false);
+                }
+
+                item.Ok = true;
+                result.Moved++;
+            } catch (Exception ex) {
+                item.Ok = false;
+                item.Error = sanitizeError(ex.Message);
+            }
+
+            result.Results.Add(item);
+        }
+
+        if (sourceNeedsExpunge) {
+            try {
+                await source.ExpungeAsync(cancellationToken).ConfigureAwait(false);
+            } catch {
+                // best-effort; successful copies were already placed in destination
+            }
+        }
+
+        return result;
+    }
+
+    private static async Task CopyWithFallbackAsync(
+        IMailFolder source,
+        IMailFolder destination,
+        UniqueId uid,
+        CancellationToken cancellationToken,
+        ImapMoveResultItem item) {
+        try {
+            var map = await source.CopyToAsync(new List<UniqueId> { uid }, destination, cancellationToken).ConfigureAwait(false);
+            if (map.TryGetValue(uid, out var mappedUid)) {
+                item.TargetUid = mappedUid.Id;
+                return;
+            }
+        } catch {
+            // fall through to copy without mapping
+        }
+
+        await source.CopyToAsync(uid, destination, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<string?> TryGetNormalizedMessageIdAsync(IMailFolder source, UniqueId uid, CancellationToken cancellationToken) {
+        try {
+            var headers = await source.GetHeadersAsync(uid, cancellationToken).ConfigureAwait(false);
+            var raw = headers[HeaderId.MessageId];
+            return NormalizeMessageId(ExtractFirstToken(raw));
+        } catch {
+            return null;
+        }
+    }
+
+    private static async Task<long?> TryResolveTargetUidByMessageIdAsync(IMailFolder destination, string messageId, CancellationToken cancellationToken) {
+        try {
+            var matches = await destination.SearchAsync(SearchQuery.HeaderContains("Message-Id", messageId), cancellationToken).ConfigureAwait(false);
+            if (matches.Count == 0) {
+                return null;
+            }
+            return matches[matches.Count - 1].Id;
+        } catch {
+            return null;
+        }
+    }
+
+    private static async Task EnsureFolderAccessAsync(IMailFolder folder, FolderAccess access, CancellationToken cancellationToken) {
+        if (!folder.IsOpen) {
+            await folder.OpenAsync(access, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (folder.Access != access && access == FolderAccess.ReadWrite) {
+            await folder.OpenAsync(access, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static string? NormalizeMessageId(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0) {
+            return null;
+        }
+
+        var start = 0;
+        var end = trimmed.Length;
+        if (trimmed[start] == '<') {
+            start++;
+        }
+        if (end > start && trimmed[end - 1] == '>') {
+            end--;
+        }
+
+        var normalized = trimmed.Substring(start, end - start).Trim();
+        return normalized.Length == 0 ? null : normalized;
+    }
+
+    private static string? ExtractFirstToken(string? raw) {
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+
+        var parts = raw.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var part in parts) {
+            var token = part.Trim();
+            if (token.Length > 0) {
+                return token;
+            }
+        }
+        return null;
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapSentFolderResolver.cs
+++ b/Sources/Mailozaurr/Receive/ImapSentFolderResolver.cs
@@ -1,0 +1,431 @@
+#pragma warning disable CS1591
+#pragma warning disable CS8600,CS8601,CS8602,CS8603,CS8604,CS8618,CS8625
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Net.Imap;
+
+namespace Mailozaurr;
+
+public static class ImapSentFolderResolver {
+    public sealed class ImapFolderInfo {
+        public string FullName { get; init; } = string.Empty;
+        public string Name { get; init; } = string.Empty;
+        public bool IsSent { get; init; }
+        public bool IsTrash { get; init; }
+        public bool IsArchive { get; init; }
+        public bool IsJunk { get; init; }
+        public bool IsDrafts { get; init; }
+    }
+
+    public sealed class ImapSpecialFolderMappings {
+        public string Inbox { get; init; } = "INBOX";
+        public string Sent { get; init; } = "Sent";
+        public string? Drafts { get; init; }
+        public string? Trash { get; init; }
+        public string? Archive { get; init; }
+        public string? Junk { get; init; }
+    }
+
+    public static async Task<IReadOnlyList<string>> ListFoldersAsync(ImapClient client, CancellationToken cancellationToken) {
+        var folders = await ListFoldersInfoAsync(client, cancellationToken).ConfigureAwait(false);
+        var output = new List<string>(folders.Count);
+        foreach (var folder in folders) {
+            if (!string.IsNullOrWhiteSpace(folder.FullName)) {
+                output.Add(folder.FullName);
+            }
+        }
+        return output;
+    }
+
+    public static Task<List<ImapFolderInfo>> ListFoldersInfoAsync(ImapClient client, CancellationToken cancellationToken) {
+        if (client is null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        return GetFoldersInfoAsync(client, cancellationToken);
+    }
+
+    public static async Task<string> ResolveSentFolderNameAsync(
+        ImapClient client,
+        string? requestedFolder,
+        string? configuredFolder,
+        string fallbackFolder,
+        CancellationToken cancellationToken) {
+        if (client is null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+
+        var requested = NormalizeOptionalFolder(requestedFolder);
+        if (!string.IsNullOrWhiteSpace(requested)) {
+            return requested;
+        }
+
+        var configured = NormalizeOptionalFolder(configuredFolder);
+        if (!string.IsNullOrWhiteSpace(configured)) {
+            return configured;
+        }
+
+        try {
+            var folders = await ListFoldersInfoAsync(client, cancellationToken).ConfigureAwait(false);
+            return ResolveSentFolderName(
+                requestedFolder: null,
+                configuredFolder: null,
+                folders: folders,
+                fallbackFolder: fallbackFolder);
+        } catch {
+            return string.IsNullOrWhiteSpace(fallbackFolder) ? "Sent" : fallbackFolder.Trim();
+        }
+    }
+
+    public static string ResolveSentFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string fallbackFolder = "Sent") {
+        var resolved = ResolveSpecialFolderName(
+            requestedFolder: requestedFolder,
+            configuredFolder: configuredFolder,
+            folders: folders,
+            attributePredicate: f => f.IsSent,
+            looksLikePredicate: LooksLikeSentFolder,
+            heuristicScoreSelector: SentFolderHeuristicScore,
+            fallbackFolder: fallbackFolder);
+        return resolved ?? (string.IsNullOrWhiteSpace(fallbackFolder) ? "Sent" : fallbackFolder.Trim());
+    }
+
+    public static string? ResolveDraftsFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string? fallbackFolder = null) {
+        return ResolveSpecialFolderName(
+            requestedFolder: requestedFolder,
+            configuredFolder: configuredFolder,
+            folders: folders,
+            attributePredicate: f => f.IsDrafts,
+            looksLikePredicate: LooksLikeDraftsFolder,
+            heuristicScoreSelector: DraftsFolderHeuristicScore,
+            fallbackFolder: fallbackFolder);
+    }
+
+    public static string? ResolveTrashFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string? fallbackFolder = null) {
+        return ResolveSpecialFolderName(
+            requestedFolder: requestedFolder,
+            configuredFolder: configuredFolder,
+            folders: folders,
+            attributePredicate: f => f.IsTrash,
+            looksLikePredicate: LooksLikeTrashFolder,
+            heuristicScoreSelector: TrashFolderHeuristicScore,
+            fallbackFolder: fallbackFolder);
+    }
+
+    public static string? ResolveArchiveFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string? fallbackFolder = null) {
+        return ResolveSpecialFolderName(
+            requestedFolder: requestedFolder,
+            configuredFolder: configuredFolder,
+            folders: folders,
+            attributePredicate: f => f.IsArchive,
+            looksLikePredicate: LooksLikeArchiveFolder,
+            heuristicScoreSelector: ArchiveFolderHeuristicScore,
+            fallbackFolder: fallbackFolder);
+    }
+
+    public static string? ResolveJunkFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string? fallbackFolder = null) {
+        return ResolveSpecialFolderName(
+            requestedFolder: requestedFolder,
+            configuredFolder: configuredFolder,
+            folders: folders,
+            attributePredicate: f => f.IsJunk,
+            looksLikePredicate: LooksLikeJunkFolder,
+            heuristicScoreSelector: JunkFolderHeuristicScore,
+            fallbackFolder: fallbackFolder);
+    }
+
+    public static ImapSpecialFolderMappings ResolveSpecialFolderMappings(
+        string? configuredInboxFolder,
+        string? configuredSentFolder,
+        string? configuredDraftsFolder,
+        string? configuredTrashFolder,
+        string? configuredArchiveFolder,
+        string? configuredJunkFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        string? configuredImapFolder) {
+        var inboxFallback = ResolveFolderName(configuredInboxFolder, configuredImapFolder, "INBOX");
+        return new ImapSpecialFolderMappings {
+            Inbox = inboxFallback,
+            Sent = ResolveSentFolderName(
+                requestedFolder: null,
+                configuredFolder: configuredSentFolder,
+                folders: folders,
+                fallbackFolder: "Sent"),
+            Drafts = ResolveDraftsFolderName(
+                requestedFolder: null,
+                configuredFolder: configuredDraftsFolder,
+                folders: folders),
+            Trash = ResolveTrashFolderName(
+                requestedFolder: null,
+                configuredFolder: configuredTrashFolder,
+                folders: folders),
+            Archive = ResolveArchiveFolderName(
+                requestedFolder: null,
+                configuredFolder: configuredArchiveFolder,
+                folders: folders),
+            Junk = ResolveJunkFolderName(
+                requestedFolder: null,
+                configuredFolder: configuredJunkFolder,
+                folders: folders)
+        };
+    }
+
+    private static async Task<List<ImapFolderInfo>> GetFoldersInfoAsync(ImapClient client, CancellationToken cancellationToken) {
+        var output = new List<ImapFolderInfo>();
+        if (client.PersonalNamespaces.Count > 0) {
+            foreach (var ns in client.PersonalNamespaces) {
+                var root = client.GetFolder(ns);
+                await CollectFoldersInfoAsync(root, output, cancellationToken).ConfigureAwait(false);
+            }
+        } else {
+            await CollectFoldersInfoAsync(client.Inbox, output, cancellationToken).ConfigureAwait(false);
+        }
+        return output;
+    }
+
+    private static async Task CollectFoldersInfoAsync(IMailFolder folder, List<ImapFolderInfo> output, CancellationToken cancellationToken) {
+        if (folder is null) {
+            return;
+        }
+
+        try {
+            var full = folder.FullName ?? folder.Name ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(full) &&
+                !output.Exists(f => string.Equals(f.FullName, full, StringComparison.OrdinalIgnoreCase))) {
+                output.Add(new ImapFolderInfo {
+                    FullName = full,
+                    Name = folder.Name ?? full,
+                    IsSent = folder.Attributes.HasFlag(FolderAttributes.Sent),
+                    IsTrash = folder.Attributes.HasFlag(FolderAttributes.Trash),
+                    IsArchive = folder.Attributes.HasFlag(FolderAttributes.Archive),
+                    IsJunk = folder.Attributes.HasFlag(FolderAttributes.Junk),
+                    IsDrafts = folder.Attributes.HasFlag(FolderAttributes.Drafts)
+                });
+            }
+        } catch {
+            // best-effort
+        }
+
+        IList<IMailFolder> subfolders;
+        try {
+            subfolders = await folder.GetSubfoldersAsync(false, cancellationToken).ConfigureAwait(false);
+        } catch {
+            return;
+        }
+
+        foreach (var subfolder in subfolders) {
+            await CollectFoldersInfoAsync(subfolder, output, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static string? ResolveSpecialFolderName(
+        string? requestedFolder,
+        string? configuredFolder,
+        IEnumerable<ImapFolderInfo>? folders,
+        Func<ImapFolderInfo, bool> attributePredicate,
+        Func<string?, bool> looksLikePredicate,
+        Func<ImapFolderInfo, int> heuristicScoreSelector,
+        string? fallbackFolder) {
+        var requested = NormalizeOptionalFolder(requestedFolder);
+        if (!string.IsNullOrWhiteSpace(requested)) {
+            return requested;
+        }
+
+        var configured = NormalizeOptionalFolder(configuredFolder);
+        if (!string.IsNullOrWhiteSpace(configured)) {
+            return configured;
+        }
+
+        var available = folders?
+            .Where(f => !string.IsNullOrWhiteSpace(f.FullName))
+            .Select(f => new ImapFolderInfo {
+                FullName = f.FullName.Trim(),
+                Name = (f.Name ?? string.Empty).Trim(),
+                IsSent = f.IsSent,
+                IsTrash = f.IsTrash,
+                IsArchive = f.IsArchive,
+                IsJunk = f.IsJunk,
+                IsDrafts = f.IsDrafts
+            })
+            .ToList() ?? new List<ImapFolderInfo>();
+
+        if (available.Count == 0) {
+            return NormalizeOptionalFolder(fallbackFolder);
+        }
+
+        var byAttribute = available.FirstOrDefault(attributePredicate);
+        if (byAttribute is not null) {
+            return byAttribute.FullName;
+        }
+
+        var byHeuristic = available
+            .Where(f => looksLikePredicate(f.Name) || looksLikePredicate(f.FullName))
+            .OrderBy(heuristicScoreSelector)
+            .ThenBy(f => f.FullName.Length)
+            .FirstOrDefault();
+        if (byHeuristic is not null) {
+            return byHeuristic.FullName;
+        }
+
+        return NormalizeOptionalFolder(fallbackFolder);
+    }
+
+    private static string ResolveFolderName(string? configuredInboxFolder, string? configuredImapFolder, string fallbackFolder) {
+        var inbox = NormalizeOptionalFolder(configuredInboxFolder);
+        if (!string.IsNullOrWhiteSpace(inbox)) {
+            return inbox;
+        }
+        var configured = NormalizeOptionalFolder(configuredImapFolder);
+        if (!string.IsNullOrWhiteSpace(configured)) {
+            return configured;
+        }
+        return fallbackFolder;
+    }
+
+    private static int SentFolderHeuristicScore(ImapFolderInfo folder) {
+        var name = (folder.Name ?? string.Empty).Trim().ToLowerInvariant();
+        var full = (folder.FullName ?? string.Empty).Trim().ToLowerInvariant();
+        if (name == "sent" || full == "sent" || full.EndsWith("/sent", StringComparison.Ordinal) || full.EndsWith(".sent", StringComparison.Ordinal)) return 0;
+        if (name is "sent items" or "sent mail" || full.Contains("/sent items", StringComparison.Ordinal) || full.Contains("/sent mail", StringComparison.Ordinal)) return 1;
+        if (full.Contains("sent", StringComparison.Ordinal) || name.Contains("sent", StringComparison.Ordinal)) return 2;
+        return 1000;
+    }
+
+    private static int DraftsFolderHeuristicScore(ImapFolderInfo folder) {
+        var name = (folder.Name ?? string.Empty).Trim().ToLowerInvariant();
+        var full = (folder.FullName ?? string.Empty).Trim().ToLowerInvariant();
+        if (name == "drafts" || full == "drafts" || full.EndsWith("/drafts", StringComparison.Ordinal) || full.EndsWith(".drafts", StringComparison.Ordinal)) return 0;
+        if (name == "draft" || full.EndsWith("/draft", StringComparison.Ordinal) || full.EndsWith(".draft", StringComparison.Ordinal)) return 1;
+        if (name.Contains("draft", StringComparison.Ordinal) || full.Contains("draft", StringComparison.Ordinal)) return 2;
+        return 1000;
+    }
+
+    private static int TrashFolderHeuristicScore(ImapFolderInfo folder) {
+        var name = (folder.Name ?? string.Empty).Trim().ToLowerInvariant();
+        var full = (folder.FullName ?? string.Empty).Trim().ToLowerInvariant();
+        if (name == "trash" || name == "bin" || full == "trash" || full.EndsWith("/trash", StringComparison.Ordinal) || full.EndsWith(".trash", StringComparison.Ordinal)) return 0;
+        if (name is "deleted items" or "deleted messages" || full.Contains("/deleted items", StringComparison.Ordinal) || full.Contains("/deleted messages", StringComparison.Ordinal)) return 1;
+        if (name.Contains("trash", StringComparison.Ordinal) || full.Contains("trash", StringComparison.Ordinal) ||
+            name.Contains("deleted", StringComparison.Ordinal) || full.Contains("deleted", StringComparison.Ordinal) ||
+            name.Contains("bin", StringComparison.Ordinal) || full.Contains("/bin", StringComparison.Ordinal)) return 2;
+        return 1000;
+    }
+
+    private static int ArchiveFolderHeuristicScore(ImapFolderInfo folder) {
+        var name = (folder.Name ?? string.Empty).Trim().ToLowerInvariant();
+        var full = (folder.FullName ?? string.Empty).Trim().ToLowerInvariant();
+        if (name == "archive" || full == "archive" || full.EndsWith("/archive", StringComparison.Ordinal) || full.EndsWith(".archive", StringComparison.Ordinal)) return 0;
+        if (name == "all mail" || full.EndsWith("/all mail", StringComparison.Ordinal) || full.EndsWith(".all mail", StringComparison.Ordinal)) return 1;
+        if (name.Contains("archive", StringComparison.Ordinal) || full.Contains("archive", StringComparison.Ordinal) ||
+            name.Contains("all mail", StringComparison.Ordinal) || full.Contains("all mail", StringComparison.Ordinal)) return 2;
+        return 1000;
+    }
+
+    private static int JunkFolderHeuristicScore(ImapFolderInfo folder) {
+        var name = (folder.Name ?? string.Empty).Trim().ToLowerInvariant();
+        var full = (folder.FullName ?? string.Empty).Trim().ToLowerInvariant();
+        if (name == "junk" || name == "spam" || full == "junk" || full.EndsWith("/junk", StringComparison.Ordinal) || full.EndsWith(".junk", StringComparison.Ordinal)) return 0;
+        if (name == "junk e-mail" || full.Contains("/junk e-mail", StringComparison.Ordinal)) return 1;
+        if (name.Contains("junk", StringComparison.Ordinal) || full.Contains("junk", StringComparison.Ordinal) ||
+            name.Contains("spam", StringComparison.Ordinal) || full.Contains("spam", StringComparison.Ordinal) ||
+            name.Contains("bulk", StringComparison.Ordinal) || full.Contains("bulk", StringComparison.Ordinal)) return 2;
+        return 1000;
+    }
+
+    private static bool LooksLikeSentFolder(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        var lower = value.Trim().ToLowerInvariant();
+        if (lower.Contains("draft", StringComparison.Ordinal) ||
+            lower.Contains("trash", StringComparison.Ordinal) ||
+            lower.Contains("junk", StringComparison.Ordinal) ||
+            lower.Contains("spam", StringComparison.Ordinal) ||
+            lower.Contains("archive", StringComparison.Ordinal)) {
+            return false;
+        }
+        return lower.Contains("sent", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeDraftsFolder(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        var lower = value.Trim().ToLowerInvariant();
+        if (lower.Contains("sent", StringComparison.Ordinal) ||
+            lower.Contains("trash", StringComparison.Ordinal) ||
+            lower.Contains("junk", StringComparison.Ordinal) ||
+            lower.Contains("spam", StringComparison.Ordinal) ||
+            lower.Contains("archive", StringComparison.Ordinal)) {
+            return false;
+        }
+        return lower.Contains("draft", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeTrashFolder(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        var lower = value.Trim().ToLowerInvariant();
+        if (lower.Contains("sent", StringComparison.Ordinal) ||
+            lower.Contains("draft", StringComparison.Ordinal) ||
+            lower.Contains("junk", StringComparison.Ordinal) ||
+            lower.Contains("spam", StringComparison.Ordinal) ||
+            lower.Contains("archive", StringComparison.Ordinal)) {
+            return false;
+        }
+        return lower.Contains("trash", StringComparison.Ordinal) ||
+               lower.Contains("deleted", StringComparison.Ordinal) ||
+               lower.Contains("bin", StringComparison.Ordinal) ||
+               lower.Contains("waste", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeArchiveFolder(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        var lower = value.Trim().ToLowerInvariant();
+        if (lower.Contains("sent", StringComparison.Ordinal) ||
+            lower.Contains("draft", StringComparison.Ordinal) ||
+            lower.Contains("trash", StringComparison.Ordinal) ||
+            lower.Contains("junk", StringComparison.Ordinal) ||
+            lower.Contains("spam", StringComparison.Ordinal)) {
+            return false;
+        }
+        return lower.Contains("archive", StringComparison.Ordinal) || lower.Contains("all mail", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeJunkFolder(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        var lower = value.Trim().ToLowerInvariant();
+        if (lower.Contains("sent", StringComparison.Ordinal) ||
+            lower.Contains("draft", StringComparison.Ordinal) ||
+            lower.Contains("trash", StringComparison.Ordinal) ||
+            lower.Contains("archive", StringComparison.Ordinal)) {
+            return false;
+        }
+        return lower.Contains("junk", StringComparison.Ordinal) ||
+               lower.Contains("spam", StringComparison.Ordinal) ||
+               lower.Contains("bulk", StringComparison.Ordinal);
+    }
+
+    private static string? NormalizeOptionalFolder(string? value) {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/ImapSentMessageOperations.cs
+++ b/Sources/Mailozaurr/SentMessages/ImapSentMessageOperations.cs
@@ -1,0 +1,29 @@
+#pragma warning disable CS1591
+#pragma warning disable CS8600,CS8601,CS8602,CS8603,CS8604,CS8618,CS8625
+#nullable enable
+using System;
+
+namespace Mailozaurr;
+
+public static class ImapSentMessageOperations {
+    public static string? NormalizeMessageIdToken(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0) {
+            return null;
+        }
+
+        if (trimmed.StartsWith("<", StringComparison.Ordinal)) {
+            trimmed = trimmed.Substring(1);
+        }
+        if (trimmed.EndsWith(">", StringComparison.Ordinal)) {
+            trimmed = trimmed.Substring(0, trimmed.Length - 1);
+        }
+
+        trimmed = trimmed.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/NativeMailboxThreadingMetadataOperations.cs
+++ b/Sources/Mailozaurr/SentMessages/NativeMailboxThreadingMetadataOperations.cs
@@ -1,0 +1,191 @@
+#pragma warning disable CS1591
+#pragma warning disable CS8600,CS8601,CS8602,CS8603,CS8604,CS8618,CS8625
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Mailozaurr;
+using MimeKit;
+
+namespace Mailozaurr;
+
+public static class NativeMailboxThreadingMetadataOperations {
+    public sealed class NativeMailboxThreadingMetadataResult {
+        public string? MessageId { get; init; }
+        public string? ReplyTo { get; init; }
+        public string? Cc { get; init; }
+        public string? InReplyTo { get; init; }
+        public List<string>? References { get; init; }
+    }
+
+    public static async Task<NativeMailboxThreadingMetadataResult> GetGraphThreadingMetadataAsync(
+        GraphMailboxBrowser browser,
+        string nativeId,
+        int maxMimeBytes,
+        CancellationToken cancellationToken) {
+        if (browser is null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+        if (string.IsNullOrWhiteSpace(nativeId)) {
+            throw new ArgumentException("nativeId is required.", nameof(nativeId));
+        }
+
+        var message = await browser.GetMessageContentAsync(
+            nativeId,
+            maxMimeBytes: maxMimeBytes,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        return NormalizeFromMessage(message.Message);
+    }
+
+    public static async Task<NativeMailboxThreadingMetadataResult> GetGmailThreadingMetadataAsync(
+        GmailMailboxBrowser browser,
+        string nativeId,
+        CancellationToken cancellationToken) {
+        if (browser is null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+        if (string.IsNullOrWhiteSpace(nativeId)) {
+            throw new ArgumentException("nativeId is required.", nameof(nativeId));
+        }
+
+        var message = await browser.GetMessageContentAsync(
+            nativeId,
+            maxMimeBytes: GmailMailboxBrowser.DefaultMaxMimeBytes,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        return NormalizeFromMessage(message.Message);
+    }
+
+    public static NativeMailboxThreadingMetadataResult Normalize(
+        string? messageId,
+        string? replyTo,
+        string? cc,
+        string? inReplyTo,
+        IReadOnlyCollection<string>? references) {
+        var normalizedMessageId = NormalizeMessageId(messageId);
+        var normalizedReplyTo = NormalizeOptional(replyTo);
+        var normalizedCc = NormalizeOptional(cc);
+        var normalizedInReplyTo = NormalizeMessageId(inReplyTo);
+        var normalizedReferences = NormalizeReferences(references);
+
+        return new NativeMailboxThreadingMetadataResult {
+            MessageId = normalizedMessageId,
+            ReplyTo = normalizedReplyTo,
+            Cc = normalizedCc,
+            InReplyTo = normalizedInReplyTo,
+            References = normalizedReferences
+        };
+    }
+
+    private static NativeMailboxThreadingMetadataResult NormalizeFromMessage(MimeMessage message) {
+        if (message is null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var messageId = NormalizeMessageId(message.MessageId ?? ExtractFirstToken(message.Headers[HeaderId.MessageId]));
+        var replyTo = JoinAddresses(message.ReplyTo);
+        var cc = JoinAddresses(message.Cc);
+        var inReplyTo = NormalizeMessageId(ExtractFirstToken(message.Headers[HeaderId.InReplyTo]));
+        var references = NormalizeReferences(ExtractTokens(message.Headers[HeaderId.References]));
+
+        return new NativeMailboxThreadingMetadataResult {
+            MessageId = messageId,
+            ReplyTo = replyTo,
+            Cc = cc,
+            InReplyTo = inReplyTo,
+            References = references
+        };
+    }
+
+    private static string? JoinAddresses(InternetAddressList addresses) {
+        if (addresses is null || addresses.Count == 0) {
+            return null;
+        }
+
+        var joined = string.Join(", ", addresses.Select(a => a.ToString()));
+        return NormalizeOptional(joined);
+    }
+
+    private static List<string>? NormalizeReferences(IEnumerable<string>? values) {
+        if (values is null) {
+            return null;
+        }
+
+        var normalized = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in values) {
+            var token = NormalizeMessageId(value);
+            if (string.IsNullOrWhiteSpace(token)) {
+                continue;
+            }
+            if (seen.Add(token)) {
+                normalized.Add(token);
+            }
+        }
+
+        return normalized.Count == 0 ? null : normalized;
+    }
+
+    private static IEnumerable<string> ExtractTokens(string? raw) {
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return Array.Empty<string>();
+        }
+
+        var parts = raw.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        var output = new List<string>(parts.Length);
+        foreach (var part in parts) {
+            var token = part.Trim();
+            if (token.Length > 0) {
+                output.Add(token);
+            }
+        }
+        return output;
+    }
+
+    private static string? ExtractFirstToken(string? raw) {
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+
+        var parts = raw.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var part in parts) {
+            var token = part.Trim();
+            if (token.Length > 0) {
+                return token;
+            }
+        }
+        return null;
+    }
+
+    private static string? NormalizeMessageId(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0) {
+            return null;
+        }
+
+        var start = 0;
+        var end = trimmed.Length;
+        if (trimmed[start] == '<') {
+            start++;
+        }
+        if (end > start && trimmed[end - 1] == '>') {
+            end--;
+        }
+
+        var normalized = trimmed.Substring(start, end - start).Trim();
+        return normalized.Length == 0 ? null : normalized;
+    }
+
+    private static string? NormalizeOptional(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+        var trimmed = value.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/NativeSentMailboxOperations.cs
+++ b/Sources/Mailozaurr/SentMessages/NativeSentMailboxOperations.cs
@@ -1,0 +1,286 @@
+#pragma warning disable CS1591
+#pragma warning disable CS8600,CS8601,CS8602,CS8603,CS8604,CS8618,CS8625
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Mailozaurr;
+using MimeKit;
+
+namespace Mailozaurr;
+
+public static class NativeSentMailboxOperations {
+    private const int GraphUploadChunkSize = 5 * 1024 * 1024;
+
+    public sealed class NativeSentAppendResult {
+        public bool Appended { get; init; }
+        public string? Folder { get; init; }
+    }
+
+    public sealed class NativeSentDuplicateProbeResult {
+        public bool IsMatch { get; init; }
+        public string? Folder { get; init; }
+        public string? MessageId { get; init; }
+    }
+
+    public static async Task<NativeSentAppendResult> AppendToGraphSentAsync(
+        GraphMailboxBrowser browser,
+        MimeMessage message,
+        string? requestedSentFolder,
+        string? configuredSentFolder,
+        int maxInlineAttachmentBytes,
+        string? idempotencyHeaderName,
+        CancellationToken cancellationToken) {
+        if (browser is null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+        if (message is null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var graph = GetGraphApiClient(browser);
+        var resolvedFolder = ResolveGraphFolder(requestedSentFolder, configuredSentFolder, fallback: "sentitems");
+        var prepared = GraphMimePreparation.PrepareMessage(message, maxInlineAttachmentBytes, idempotencyHeaderName);
+        try {
+            var created = await graph.CreateMessageAsync(
+                prepared.Message,
+                folderIdOrWellKnownName: resolvedFolder,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (prepared.UploadAttachments.Count > 0 && !string.IsNullOrWhiteSpace(created.Id)) {
+                foreach (var attachment in prepared.UploadAttachments) {
+                    await UploadGraphAttachmentAsync(graph, created.Id!, attachment, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            return new NativeSentAppendResult {
+                Appended = true,
+                Folder = resolvedFolder
+            };
+        } finally {
+            foreach (var attachment in prepared.UploadAttachments) {
+                attachment.Dispose();
+            }
+        }
+    }
+
+    public static async Task<NativeSentAppendResult> AppendToGmailSentAsync(
+        GmailMailboxBrowser browser,
+        MimeMessage message,
+        string? requestedSentFolder,
+        string? configuredSentFolder,
+        CancellationToken cancellationToken) {
+        if (browser is null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+        if (message is null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var gmail = GetGmailApiClient(browser);
+        var userId = GetGmailUserId(browser);
+        var folder = ResolveGmailFolder(requestedSentFolder, configuredSentFolder, fallback: "SENT");
+        var labelId = await browser.ResolveLabelIdAsync(folder, cancellationToken).ConfigureAwait(false);
+        var labels = string.IsNullOrWhiteSpace(labelId) ? new[] { "SENT" } : new[] { labelId.Trim() };
+        var raw = EncodeMimeAsBase64Url(message);
+        await gmail.ImportAsync(userId, raw, labelIds: labels, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new NativeSentAppendResult {
+            Appended = true,
+            Folder = folder
+        };
+    }
+
+    public static async Task<NativeSentDuplicateProbeResult> FindGraphSentDuplicateAsync(
+        GraphMailboxBrowser browser,
+        string messageIdToken,
+        string? requestedSentFolder,
+        string? configuredSentFolder,
+        CancellationToken cancellationToken) {
+        if (browser is null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+
+        var normalized = NormalizeMessageIdToken(messageIdToken);
+        if (string.IsNullOrWhiteSpace(normalized)) {
+            return new NativeSentDuplicateProbeResult { IsMatch = false };
+        }
+
+        var folder = ResolveGraphFolder(requestedSentFolder, configuredSentFolder, fallback: "sentitems");
+        var search = await browser.SearchMessagesAsync(new GraphMailboxBrowser.GraphMailboxSearchRequest {
+            Folder = folder,
+            Query = normalized
+        }, max: 25, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var match = search.Messages.FirstOrDefault(m =>
+            string.Equals(NormalizeMessageIdToken(m.MessageId), normalized, StringComparison.OrdinalIgnoreCase));
+        if (match is null) {
+            return new NativeSentDuplicateProbeResult { IsMatch = false };
+        }
+
+        return new NativeSentDuplicateProbeResult {
+            IsMatch = true,
+            Folder = folder,
+            MessageId = NormalizeMessageIdToken(match.MessageId) ?? normalized
+        };
+    }
+
+    public static async Task<NativeSentDuplicateProbeResult> FindGmailSentDuplicateAsync(
+        GmailMailboxBrowser browser,
+        string messageIdToken,
+        string? requestedSentFolder,
+        string? configuredSentFolder,
+        CancellationToken cancellationToken) {
+        if (browser is null) {
+            throw new ArgumentNullException(nameof(browser));
+        }
+
+        var normalized = NormalizeMessageIdToken(messageIdToken);
+        if (string.IsNullOrWhiteSpace(normalized)) {
+            return new NativeSentDuplicateProbeResult { IsMatch = false };
+        }
+
+        var folder = ResolveGmailFolder(requestedSentFolder, configuredSentFolder, fallback: "SENT");
+        var search = await browser.SearchMessagesAsync(new GmailMailboxBrowser.GmailMailboxSearchRequest {
+            Folder = folder,
+            Query = "rfc822msgid:" + normalized
+        }, max: 25, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var match = search.Messages.FirstOrDefault(m =>
+            string.Equals(NormalizeMessageIdToken(m.MessageId), normalized, StringComparison.OrdinalIgnoreCase));
+        if (match is null) {
+            return new NativeSentDuplicateProbeResult { IsMatch = false };
+        }
+
+        return new NativeSentDuplicateProbeResult {
+            IsMatch = true,
+            Folder = search.ResolvedLabelId,
+            MessageId = NormalizeMessageIdToken(match.MessageId) ?? normalized
+        };
+    }
+
+    private static async Task UploadGraphAttachmentAsync(
+        GraphApiClient graph,
+        string messageId,
+        DecodedMimeAttachment attachment,
+        CancellationToken cancellationToken) {
+        var item = new GraphAttachmentItem("file", attachment.Name, attachment.Length) {
+            ContentType = attachment.ContentType,
+            IsInline = attachment.IsInline,
+            ContentId = attachment.ContentId
+        };
+
+        var session = await graph.CreateAttachmentUploadSessionAsync(
+            messageId,
+            item,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        using var stream = attachment.OpenRead();
+        var buffer = new byte[GraphUploadChunkSize];
+        long offset = 0;
+        while (offset < attachment.Length) {
+            var remaining = attachment.Length - offset;
+            var readLength = (int)Math.Min(buffer.Length, remaining);
+#if NET5_0_OR_GREATER
+            var read = await stream.ReadAsync(buffer.AsMemory(0, readLength), cancellationToken).ConfigureAwait(false);
+#else
+            var read = await stream.ReadAsync(buffer, 0, readLength, cancellationToken).ConfigureAwait(false);
+#endif
+            if (read <= 0) {
+                break;
+            }
+
+            var chunk = new byte[read];
+            Buffer.BlockCopy(buffer, 0, chunk, 0, read);
+            var start = offset;
+            var end = offset + read - 1;
+            await graph.UploadAttachmentChunkAsync(
+                session.UploadUrl!,
+                chunk,
+                start,
+                end,
+                attachment.Length,
+                cancellationToken).ConfigureAwait(false);
+            offset += read;
+        }
+    }
+
+    private static GraphApiClient GetGraphApiClient(GraphMailboxBrowser browser) {
+        var field = typeof(GraphMailboxBrowser).GetField("_graph", BindingFlags.Instance | BindingFlags.NonPublic);
+        if (field?.GetValue(browser) is GraphApiClient graph) {
+            return graph;
+        }
+        throw new InvalidOperationException("Unable to resolve Graph API client from mailbox browser.");
+    }
+
+    private static GmailApiClient GetGmailApiClient(GmailMailboxBrowser browser) {
+        var field = typeof(GmailMailboxBrowser).GetField("_gmail", BindingFlags.Instance | BindingFlags.NonPublic);
+        if (field?.GetValue(browser) is GmailApiClient gmail) {
+            return gmail;
+        }
+        throw new InvalidOperationException("Unable to resolve Gmail API client from mailbox browser.");
+    }
+
+    private static string GetGmailUserId(GmailMailboxBrowser browser) {
+        var field = typeof(GmailMailboxBrowser).GetField("_userId", BindingFlags.Instance | BindingFlags.NonPublic);
+        var value = field?.GetValue(browser) as string;
+        return string.IsNullOrWhiteSpace(value) ? "me" : value.Trim();
+    }
+
+    private static string ResolveGraphFolder(string? requestedFolder, string? configuredFolder, string fallback) {
+        var folder = ResolveFolder(requestedFolder, configuredFolder, fallback);
+        if (folder.Equals("sent", StringComparison.OrdinalIgnoreCase) ||
+            folder.Equals("sent items", StringComparison.OrdinalIgnoreCase) ||
+            folder.Equals("sentitems", StringComparison.OrdinalIgnoreCase)) {
+            return "sentitems";
+        }
+        return folder;
+    }
+
+    private static string ResolveGmailFolder(string? requestedFolder, string? configuredFolder, string fallback) {
+        var folder = ResolveFolder(requestedFolder, configuredFolder, fallback);
+        if (folder.Equals("sent", StringComparison.OrdinalIgnoreCase) ||
+            folder.Equals("sent mail", StringComparison.OrdinalIgnoreCase) ||
+            folder.Equals("sent items", StringComparison.OrdinalIgnoreCase)) {
+            return "SENT";
+        }
+        return folder;
+    }
+
+    private static string ResolveFolder(string? requestedFolder, string? configuredFolder, string fallback) {
+        var requested = (requestedFolder ?? string.Empty).Trim();
+        if (requested.Length > 0) {
+            return requested;
+        }
+        var configured = (configuredFolder ?? string.Empty).Trim();
+        if (configured.Length > 0) {
+            return configured;
+        }
+        return fallback;
+    }
+
+    private static string EncodeMimeAsBase64Url(MimeMessage message) {
+        using var ms = new MemoryStream();
+        message.WriteTo(ms);
+        return GraphMimePreparation.Base64UrlEncode(ms.ToArray());
+    }
+
+    private static string? NormalizeMessageIdToken(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+        var trimmed = value.Trim();
+        if (trimmed.StartsWith("<", StringComparison.Ordinal)) {
+            trimmed = trimmed.Substring(1);
+        }
+        if (trimmed.EndsWith(">", StringComparison.Ordinal)) {
+            trimmed = trimmed.Substring(0, trimmed.Length - 1);
+        }
+        trimmed = trimmed.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}


### PR DESCRIPTION
## Summary
- add shared protocol auth primitives (`ProtocolAuth`, `ProtocolAuthMode`)
- add shared IMAP primitives (`ImapMoveOperations`, `ImapDeleteOperations`, `ImapBulkFlagOperations`, `ImapMailboxSearchQueryBuilder`, `ImapSentFolderResolver`, `ImapSentMessageOperations`)
- add shared native sent/threading helpers (`NativeSentMailboxOperations`, `NativeMailboxThreadingMetadataOperations`)
- add focused tests for auth parsing, message-id normalization, and special-folder resolver behavior

## Validation
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~ProtocolAuthTests|FullyQualifiedName~ImapSentMessageOperationsTests|FullyQualifiedName~ImapSentFolderResolverTests"`
