### PR TITLE
Add disposable native mailbox browser sessions

### DIFF
--- a/Sources/Mailozaurr.Tests/NativeMailboxBrowserSessionsTests.cs
+++ b/Sources/Mailozaurr.Tests/NativeMailboxBrowserSessionsTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class NativeMailboxBrowserSessionsTests {
+    [Fact]
+    public async Task GraphMailboxBrowserSession_UsesProvidedHttpClientAndCredential() {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") });
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://graph.microsoft.com/v1.0/") };
+        var credential = new OAuthCredential { UserName = "me", AccessToken = "graph-token", ExpiresOn = DateTimeOffset.MaxValue };
+
+        using var session = new GraphMailboxBrowserSession(client, credential);
+        var folders = await session.Browser.ListFoldersAsync();
+
+        Assert.Empty(folders);
+        Assert.Single(handler.Requests);
+        Assert.Equal("https://graph.microsoft.com/v1.0/me/mailFolders", handler.Requests[0].RequestUri!.GetLeftPart(UriPartial.Path));
+        Assert.Contains("$top=200", handler.Requests[0].RequestUri!.Query, StringComparison.Ordinal);
+        Assert.Contains("displayName", handler.Requests[0].RequestUri!.Query, StringComparison.Ordinal);
+        Assert.Equal("Bearer", handler.Requests[0].Headers.Authorization?.Scheme);
+        Assert.Equal("graph-token", handler.Requests[0].Headers.Authorization?.Parameter);
+    }
+
+    [Fact]
+    public void GraphMailboxBrowserSession_CreateWithAccessToken_RejectsEmptyToken() {
+        var ex = Assert.Throws<ArgumentException>(() => GraphMailboxBrowserSession.CreateWithAccessToken(" "));
+        Assert.Equal("accessToken", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task GmailMailboxBrowserSession_UsesProvidedUserIdAndCredential() {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"labels\":[]}") });
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/") };
+        var credential = new OAuthCredential { UserName = "mailbox-user", AccessToken = "gmail-token", ExpiresOn = DateTimeOffset.MaxValue };
+
+        using var session = new GmailMailboxBrowserSession(client, credential, userId: "custom-user");
+        var labels = await session.Browser.ListFoldersAsync();
+
+        Assert.Empty(labels);
+        Assert.Single(handler.Requests);
+        Assert.Equal("https://gmail.googleapis.com/gmail/v1/users/custom-user/labels?fields=labels(id,name,type)", handler.Requests[0].RequestUri!.ToString());
+        Assert.Equal("Bearer", handler.Requests[0].Headers.Authorization?.Scheme);
+        Assert.Equal("gmail-token", handler.Requests[0].Headers.Authorization?.Parameter);
+    }
+
+    [Fact]
+    public async Task GmailMailboxBrowserSession_CreateWithAccessToken_DefaultsToMeUserId() {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"labels\":[]}") });
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/") };
+
+        using var session = GmailMailboxBrowserSession.CreateWithAccessToken("token-1", client: client);
+        var labels = await session.Browser.ListFoldersAsync();
+
+        Assert.Empty(labels);
+        Assert.Single(handler.Requests);
+        Assert.Equal("https://gmail.googleapis.com/gmail/v1/users/me/labels?fields=labels(id,name,type)", handler.Requests[0].RequestUri!.ToString());
+    }
+}

--- a/Sources/Mailozaurr/NativeMailboxBrowserSessions.cs
+++ b/Sources/Mailozaurr/NativeMailboxBrowserSessions.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Owns a <see cref="GraphApiClient"/> instance and exposes a <see cref="GraphMailboxBrowser"/> built on top of it.
+/// </summary>
+public sealed class GraphMailboxBrowserSession : IDisposable {
+    private readonly GraphApiClient _graph;
+
+    /// <summary>
+    /// Initializes a new session with an internally managed <see cref="HttpClient"/>.
+    /// </summary>
+    /// <param name="credential">OAuth credential used for Graph requests.</param>
+    /// <param name="refreshToken">Optional token refresh delegate.</param>
+    /// <param name="baseAddress">Optional Graph API base address.</param>
+    public GraphMailboxBrowserSession(
+        OAuthCredential credential,
+        Func<CancellationToken, Task<string>>? refreshToken = null,
+        Uri? baseAddress = null) {
+        if (credential == null) {
+            throw new ArgumentNullException(nameof(credential));
+        }
+
+        _graph = new GraphApiClient(credential, refreshToken, baseAddress);
+        Browser = new GraphMailboxBrowser(_graph);
+    }
+
+    /// <summary>
+    /// Initializes a new session with an externally provided <see cref="HttpClient"/>.
+    /// </summary>
+    /// <param name="client">HTTP client to use for Graph requests.</param>
+    /// <param name="credential">OAuth credential used for Graph requests.</param>
+    /// <param name="refreshToken">Optional token refresh delegate.</param>
+    /// <param name="baseAddress">Optional Graph API base address used when <paramref name="client"/> has no base address configured.</param>
+    public GraphMailboxBrowserSession(
+        HttpClient client,
+        OAuthCredential credential,
+        Func<CancellationToken, Task<string>>? refreshToken = null,
+        Uri? baseAddress = null) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (credential == null) {
+            throw new ArgumentNullException(nameof(credential));
+        }
+
+        _graph = new GraphApiClient(client, refreshToken, credential, baseAddress);
+        Browser = new GraphMailboxBrowser(_graph);
+    }
+
+    /// <summary>
+    /// Gets the high-level mailbox browser.
+    /// </summary>
+    public GraphMailboxBrowser Browser { get; }
+
+    /// <summary>
+    /// Creates a session from a raw OAuth access token.
+    /// </summary>
+    /// <param name="accessToken">OAuth access token.</param>
+    /// <param name="client">Optional HTTP client instance.</param>
+    /// <param name="userName">Credential user name (defaults to <c>me</c>).</param>
+    /// <param name="expiresOn">Credential expiration time (defaults to <see cref="DateTimeOffset.MaxValue"/>).</param>
+    /// <param name="refreshToken">Optional token refresh delegate.</param>
+    /// <param name="baseAddress">Optional Graph API base address.</param>
+    /// <returns>A new <see cref="GraphMailboxBrowserSession"/>.</returns>
+    public static GraphMailboxBrowserSession CreateWithAccessToken(
+        string accessToken,
+        HttpClient? client = null,
+        string userName = "me",
+        DateTimeOffset? expiresOn = null,
+        Func<CancellationToken, Task<string>>? refreshToken = null,
+        Uri? baseAddress = null) {
+        if (string.IsNullOrWhiteSpace(accessToken)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(accessToken));
+        }
+
+        var credential = new OAuthCredential {
+            UserName = string.IsNullOrWhiteSpace(userName) ? "me" : userName.Trim(),
+            AccessToken = accessToken.Trim(),
+            ExpiresOn = expiresOn ?? DateTimeOffset.MaxValue
+        };
+
+        return client == null
+            ? new GraphMailboxBrowserSession(credential, refreshToken, baseAddress)
+            : new GraphMailboxBrowserSession(client, credential, refreshToken, baseAddress);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        _graph.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}
+
+/// <summary>
+/// Owns a <see cref="GmailApiClient"/> instance and exposes a <see cref="GmailMailboxBrowser"/> built on top of it.
+/// </summary>
+public sealed class GmailMailboxBrowserSession : IDisposable {
+    private readonly GmailApiClient _gmail;
+
+    /// <summary>
+    /// Initializes a new session with an internally managed <see cref="HttpClient"/>.
+    /// </summary>
+    /// <param name="credential">OAuth credential used for Gmail requests.</param>
+    /// <param name="userId">Mailbox user id (defaults to <c>me</c>).</param>
+    /// <param name="refreshToken">Optional token refresh delegate.</param>
+    /// <param name="baseAddress">Optional Gmail API base address.</param>
+    public GmailMailboxBrowserSession(
+        OAuthCredential credential,
+        string userId = "me",
+        Func<CancellationToken, Task<string>>? refreshToken = null,
+        Uri? baseAddress = null) {
+        if (credential == null) {
+            throw new ArgumentNullException(nameof(credential));
+        }
+
+        _gmail = new GmailApiClient(new HttpClient(), refreshToken, credential, baseAddress);
+        Browser = new GmailMailboxBrowser(_gmail, userId);
+    }
+
+    /// <summary>
+    /// Initializes a new session with an externally provided <see cref="HttpClient"/>.
+    /// </summary>
+    /// <param name="client">HTTP client to use for Gmail requests.</param>
+    /// <param name="credential">OAuth credential used for Gmail requests.</param>
+    /// <param name="userId">Mailbox user id (defaults to <c>me</c>).</param>
+    /// <param name="refreshToken">Optional token refresh delegate.</param>
+    /// <param name="baseAddress">Optional Gmail API base address used when <paramref name="client"/> has no base address configured.</param>
+    public GmailMailboxBrowserSession(
+        HttpClient client,
+        OAuthCredential credential,
+        string userId = "me",
+        Func<CancellationToken, Task<string>>? refreshToken = null,
+        Uri? baseAddress = null) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (credential == null) {
+            throw new ArgumentNullException(nameof(credential));
+        }
+
+        _gmail = new GmailApiClient(client, refreshToken, credential, baseAddress);
+        Browser = new GmailMailboxBrowser(_gmail, userId);
+    }
+
+    /// <summary>
+    /// Gets the high-level mailbox browser.
+    /// </summary>
+    public GmailMailboxBrowser Browser { get; }
+
+    /// <summary>
+    /// Creates a session from a raw OAuth access token.
+    /// </summary>
+    /// <param name="accessToken">OAuth access token.</param>
+    /// <param name="client">Optional HTTP client instance.</param>
+    /// <param name="userId">Mailbox user id (defaults to <c>me</c>).</param>
+    /// <param name="expiresOn">Credential expiration time (defaults to <see cref="DateTimeOffset.MaxValue"/>).</param>
+    /// <param name="refreshToken">Optional token refresh delegate.</param>
+    /// <param name="baseAddress">Optional Gmail API base address.</param>
+    /// <returns>A new <see cref="GmailMailboxBrowserSession"/>.</returns>
+    public static GmailMailboxBrowserSession CreateWithAccessToken(
+        string accessToken,
+        HttpClient? client = null,
+        string userId = "me",
+        DateTimeOffset? expiresOn = null,
+        Func<CancellationToken, Task<string>>? refreshToken = null,
+        Uri? baseAddress = null) {
+        if (string.IsNullOrWhiteSpace(accessToken)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(accessToken));
+        }
+
+        var normalizedUserId = string.IsNullOrWhiteSpace(userId) ? "me" : userId.Trim();
+        var credential = new OAuthCredential {
+            UserName = normalizedUserId,
+            AccessToken = accessToken.Trim(),
+            ExpiresOn = expiresOn ?? DateTimeOffset.MaxValue
+        };
+
+        return client == null
+            ? new GmailMailboxBrowserSession(credential, normalizedUserId, refreshToken, baseAddress)
+            : new GmailMailboxBrowserSession(client, credential, normalizedUserId, refreshToken, baseAddress);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        _gmail.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## Summary
- add `GraphMailboxBrowserSession` and `GmailMailboxBrowserSession` wrappers that own API client lifetime and expose mailbox browser APIs
- add convenience `CreateWithAccessToken(...)` constructors for both providers
- add focused tests for token guards, request auth propagation, and user-id routing

## Validation
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~NativeMailboxBrowserSessionsTests|FullyQualifiedName~GraphMailboxBrowserTests|FullyQualifiedName~GmailMailboxBrowserTests"`

## Notes
- net472 test execution is not run on this mac because `mono` is unavailable in the current environment.
