### PR TITLE
Align mailbox session ctor behavior and add dispose tests

### DIFF
--- a/Sources/Mailozaurr.Tests/NativeMailboxBrowserSessionsTests.cs
+++ b/Sources/Mailozaurr.Tests/NativeMailboxBrowserSessionsTests.cs
@@ -62,4 +62,30 @@ public sealed class NativeMailboxBrowserSessionsTests {
         Assert.Single(handler.Requests);
         Assert.Equal("https://gmail.googleapis.com/gmail/v1/users/me/labels?fields=labels(id,name,type)", handler.Requests[0].RequestUri!.ToString());
     }
+
+    [Fact]
+    public async Task GraphMailboxBrowserSession_Dispose_IsIdempotent_AndPreventsFurtherUse() {
+        var handler = new RecordingHandler();
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://graph.microsoft.com/v1.0/") };
+        var credential = new OAuthCredential { UserName = "me", AccessToken = "graph-token", ExpiresOn = DateTimeOffset.MaxValue };
+        var session = new GraphMailboxBrowserSession(client, credential);
+
+        session.Dispose();
+        session.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => session.Browser.ListFoldersAsync());
+    }
+
+    [Fact]
+    public async Task GmailMailboxBrowserSession_Dispose_IsIdempotent_AndPreventsFurtherUse() {
+        var handler = new RecordingHandler();
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/") };
+        var credential = new OAuthCredential { UserName = "me", AccessToken = "gmail-token", ExpiresOn = DateTimeOffset.MaxValue };
+        var session = new GmailMailboxBrowserSession(client, credential);
+
+        session.Dispose();
+        session.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => session.Browser.ListFoldersAsync());
+    }
 }

--- a/Sources/Mailozaurr/NativeMailboxBrowserSessions.cs
+++ b/Sources/Mailozaurr/NativeMailboxBrowserSessions.cs
@@ -118,7 +118,9 @@ public sealed class GmailMailboxBrowserSession : IDisposable {
             throw new ArgumentNullException(nameof(credential));
         }
 
-        _gmail = new GmailApiClient(new HttpClient(), refreshToken, credential, baseAddress);
+        _gmail = baseAddress == null
+            ? new GmailApiClient(credential, refreshToken)
+            : new GmailApiClient(new HttpClient(), refreshToken, credential, baseAddress);
         Browser = new GmailMailboxBrowser(_gmail, userId);
     }
 


### PR DESCRIPTION
## Summary
- align `GmailMailboxBrowserSession` internal-client constructor behavior with `GraphMailboxBrowserSession`
- when no custom base address is provided, use `new GmailApiClient(credential, refreshToken)`
- keep custom base-address support via the HttpClient overload path
- add disposal-focused tests to verify both session types are idempotently disposable and reject usage after disposal

## Why
Addresses prior review feedback on constructor consistency and adds explicit lifecycle tests around session disposal semantics.

## Validation
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~NativeMailboxBrowserSessionsTests|FullyQualifiedName~GraphMailboxBrowserTests|FullyQualifiedName~GmailMailboxBrowserTests"`
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release`
