### PR TITLE
fix(build): prevent artifacts/ reference pollution for net472

### DIFF
--- a/Sources/Mailozaurr/Mailozaurr.csproj
+++ b/Sources/Mailozaurr/Mailozaurr.csproj
@@ -14,6 +14,8 @@
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <!-- Keep local build artifacts from being treated as SDK default items/references. -->
+        <DefaultItemExcludes>$(DefaultItemExcludes);**/artifacts/**;**/Artifacts/**</DefaultItemExcludes>
         <!-- Required for pointer operations in Helpers/SecureStringHelper.cs -->
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <RepositoryUrl>https://github.com/EvotecIT/Mailozaurr</RepositoryUrl>


### PR DESCRIPTION
## Summary
- exclude `artifacts/**` from SDK default item globs in `Mailozaurr.csproj`
- prevent local test-isolated output from being pulled into reference resolution

## Why
`net472` builds were emitting `MSB3277` conflicts (notably `System.Memory`) because `artifacts/test-isolated/...` assemblies were included as default SDK items.

## Validation
- `dotnet.exe build Sources/Mailozaurr/Mailozaurr.csproj -c Debug -f net472` ✅
- result after fix: `0 Warning(s), 0 Error(s)`