### PR TITLE
fix: make Send-EmailMessage sent log opt-in

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
@@ -451,7 +451,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
     public string? LogPath { get; set; }
 
     /// <summary>
-    /// <para>Specifies the path used to persist sent message metadata.</para>
+    /// <para>Specifies the path used to persist sent message metadata (opt-in).</para>
     /// </summary>
     [Parameter(Mandatory = false)]
     public string? SentLogPath { get; set; }

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -435,11 +435,9 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         // Attach the LogCollector to the SMTP client's logger
         smtpClient.LogCollector = logCollector;
         
-        var providedSentLogPath = SentLogPath;
-        var sentLogPath = string.IsNullOrWhiteSpace(providedSentLogPath)
-            ? Path.Combine(Path.GetTempPath(), "Mailozaurr", "sentlog.json")
-            : providedSentLogPath!;
-        smtpClient.SentMessageRepository = new FileSentMessageRepository(sentLogPath);
+        if (!string.IsNullOrWhiteSpace(SentLogPath)) {
+            smtpClient.SentMessageRepository = new FileSentMessageRepository(SentLogPath!);
+        }
         smtpClient.From = Helpers.GetFromObject(fromEmail, fromName);
         smtpClient.ReplyTo = ReplyTo;
         smtpClient.Cc = Cc;

--- a/Tests/Send-EmailMessage.SentLogPath.Tests.ps1
+++ b/Tests/Send-EmailMessage.SentLogPath.Tests.ps1
@@ -1,0 +1,99 @@
+Describe 'Send-EmailMessage - SentLogPath OptIn' {
+    BeforeAll {
+        if (-not ('FakeClientSentLogPs' -as [type])) {
+            $refs = @(
+                [Mailozaurr.ClientSmtp].Assembly.Location,
+                [MailKit.Security.SecureSocketOptions].Assembly.Location,
+                [MimeKit.MimeMessage].Assembly.Location
+            )
+            Add-Type -ReferencedAssemblies $refs -TypeDefinition @"
+using Mailozaurr;
+using MailKit;
+using MailKit.Security;
+using MimeKit;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class FakeClientSentLogPs : ClientSmtp {
+    private bool _connected;
+
+    public override bool IsConnected {
+        get { return _connected; }
+    }
+
+    public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken) {
+        _connected = true;
+    }
+
+    public override void Disconnect(bool quit, CancellationToken cancellationToken) {
+        _connected = false;
+    }
+
+    public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken, ITransferProgress progress) {
+        if (string.IsNullOrWhiteSpace(message.MessageId)) {
+            message.MessageId = "fake-" + Guid.NewGuid().ToString("N") + "@mailozaurr.test";
+        }
+
+        return Task.FromResult(message.MessageId);
+    }
+}
+"@
+        }
+    }
+
+    It 'Does not create default temp sent log when SentLogPath is not provided' {
+        $oldTemp = $env:TEMP
+        $oldTmp = $env:TMP
+
+        try {
+            $tempDir = Join-Path $TestDrive 'tmp-default'
+            New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+            $env:TEMP = $tempDir
+            $env:TMP = $tempDir
+
+            [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
+            [Mailozaurr.Smtp]::ClientFactory = { [FakeClientSentLogPs]::new() }
+
+            $result = Send-EmailMessage -From 'from@example.com' -To 'to@example.com' -Server 'smtp.example.com' -Port 25 -Subject 'Subject' -Text 'Body'
+
+            $result.Status | Should -BeTrue
+            $defaultSentLogPath = Join-Path $tempDir 'Mailozaurr\sentlog.json'
+            (Test-Path $defaultSentLogPath) | Should -BeFalse
+        } finally {
+            [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
+            [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
+            $env:TEMP = $oldTemp
+            $env:TMP = $oldTmp
+        }
+    }
+
+    It 'Creates sent log when SentLogPath is provided' {
+        $oldTemp = $env:TEMP
+        $oldTmp = $env:TMP
+
+        try {
+            $tempDir = Join-Path $TestDrive 'tmp-optin'
+            New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+            $env:TEMP = $tempDir
+            $env:TMP = $tempDir
+
+            [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
+            [Mailozaurr.Smtp]::ClientFactory = { [FakeClientSentLogPs]::new() }
+
+            $sentLogPath = Join-Path $TestDrive 'sent\sentlog.json'
+            $result = Send-EmailMessage -From 'from@example.com' -To 'to@example.com' -Server 'smtp.example.com' -Port 25 -Subject 'Subject' -Text 'Body' -SentLogPath $sentLogPath
+
+            $result.Status | Should -BeTrue
+            (Test-Path $sentLogPath) | Should -BeTrue
+
+            $records = Get-Content -Path $sentLogPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+            $records.Count | Should -BeGreaterThan 0
+        } finally {
+            [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
+            [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
+            $env:TEMP = $oldTemp
+            $env:TMP = $oldTmp
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR makes SMTP sent-log persistence opt-in for `Send-EmailMessage`.

Previously, SMTP sending always created a `FileSentMessageRepository` and defaulted to `%TEMP%\Mailozaurr\sentlog.json` when `-SentLogPath` was not provided. That could trigger warnings on locked-down systems even for simple sending.

Now, sent metadata is persisted only when `-SentLogPath` is explicitly provided.

Fixes #570

## Changes
- Update SMTP path in `CmdletSendEmailMessage.Process.cs` to initialize `SentMessageRepository` only when `SentLogPath` has a value.
- Update `SentLogPath` parameter help text to mark it as opt-in.
- Add Pester regression tests:
  - does not create default `%TEMP%\Mailozaurr\sentlog.json` when `-SentLogPath` is omitted
  - creates sent log when `-SentLogPath` is provided

## Validation
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Debug --no-build --framework net8.0`
- `Invoke-Pester -Path ./Tests/Send-EmailMessage.SentLogPath.Tests.ps1`