### PR TITLE
Bump mail dependencies to 2.0.7

### DIFF
--- a/Sources/Mailozaurr.Msg/Mailozaurr.Msg.csproj
+++ b/Sources/Mailozaurr.Msg/Mailozaurr.Msg.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
-        <VersionPrefix>2.0.5</VersionPrefix>
+        <VersionPrefix>2.0.7</VersionPrefix>
         <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
         <AssemblyName>Mailozaurr.Msg</AssemblyName>
         <Copyright>(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
@@ -25,8 +25,8 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Mailozaurr\Mailozaurr.csproj" />
-        <PackageReference Include="MsgKit" Version="3.0.2" />
-        <PackageReference Include="MsgReader" Version="6.0.6" />
+        <PackageReference Include="MsgKit" Version="3.0.3" />
+        <PackageReference Include="MsgReader" Version="6.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/Mailozaurr.Tests/SmtpAttachmentTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAttachmentTests.cs
@@ -58,7 +58,8 @@ public class SmtpAttachmentTests
         Assert.Equal("Stream", part.Headers["X-Test"]);
 
         using var extracted = new MemoryStream();
-        part.Content.DecodeTo(extracted);
+        var content = Assert.IsAssignableFrom<IMimeContent>(part.Content);
+        content.DecodeTo(extracted);
         Assert.Equal(data, extracted.ToArray());
 
         Assert.True(source.CanRead);
@@ -91,7 +92,8 @@ public class SmtpAttachmentTests
         Assert.Equal("application/octet-stream", part.ContentType.MimeType);
 
         using var extracted = new MemoryStream();
-        part.Content.DecodeTo(extracted);
+        var content = Assert.IsAssignableFrom<IMimeContent>(part.Content);
+        content.DecodeTo(extracted);
         Assert.Equal(data, extracted.ToArray());
     }
 }

--- a/Sources/Mailozaurr.Tests/SmtpInlineAttachmentTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpInlineAttachmentTests.cs
@@ -24,7 +24,7 @@ public class SmtpInlineAttachmentTests
         smtp.HtmlBody = "<img src=\"cid:test\">";
         smtp.InlineAttachments = new List<AttachmentDescriptor> { new FileAttachmentDescriptor(tmp) };
         smtp.CreateMessage();
-        var body = (MultipartRelated)smtp.Message.Body;
+        var body = Assert.IsType<MultipartRelated>(smtp.Message.Body);
         var inlineCount = body.OfType<MimePart>().Count(p => p.ContentDisposition?.Disposition == ContentDisposition.Inline);
         File.Delete(tmp);
         Assert.Equal(1, inlineCount);

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -215,7 +215,7 @@ public class SesClient : IDisposable {
                 base64 = Convert.ToBase64String(stream.ToArray());
             }
 
-            messageId = message.MessageId;
+            messageId = message.MessageId!;
         }
         else
         {

--- a/Sources/Mailozaurr/Cryptography/TemporaryPgpKeyPair.cs
+++ b/Sources/Mailozaurr/Cryptography/TemporaryPgpKeyPair.cs
@@ -161,8 +161,7 @@ public sealed class TemporaryPgpKeyPair : IDisposable
             var decrypted = encrypted.Decrypt(ctx);
             if (decrypted is TextPart text)
             {
-                using var reader = new StreamReader(text.Content.Open());
-                return reader.ReadToEnd();
+                return text.Text ?? string.Empty;
             }
         }
 

--- a/Sources/Mailozaurr/Definitions/AttachmentDescriptor.cs
+++ b/Sources/Mailozaurr/Definitions/AttachmentDescriptor.cs
@@ -59,10 +59,10 @@ public abstract class AttachmentDescriptor
         var mediaType = !string.IsNullOrWhiteSpace(ContentType)
             ? ContentType
             : !string.IsNullOrWhiteSpace(FileName)
-                ? MimeTypes.GetMimeType(FileName)
+                ? MimeTypes.GetMimeType(FileName!)
                 : "application/octet-stream";
 
-        var part = new MimePart(mediaType)
+        var part = new MimePart(mediaType!)
         {
             Content = new MimeContent(stream),
             FileName = FileName,

--- a/Sources/Mailozaurr/Definitions/AttachmentDescriptor.cs
+++ b/Sources/Mailozaurr/Definitions/AttachmentDescriptor.cs
@@ -62,7 +62,7 @@ public abstract class AttachmentDescriptor
                 ? MimeTypes.GetMimeType(FileName!)
                 : "application/octet-stream";
 
-        var part = new MimePart(mediaType!)
+        var part = new MimePart(mediaType ?? "application/octet-stream")
         {
             Content = new MimeContent(stream),
             FileName = FileName,

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -145,7 +145,7 @@ public sealed class GmailApiClient : IDisposable {
 
         var now = DateTimeOffset.UtcNow;
         var record = new PendingMessageRecord {
-            MessageId = message.MessageId,
+            MessageId = message.MessageId!,
             MimeMessage = Convert.ToBase64String(stream.ToArray()),
             Timestamp = now,
             NextAttemptAt = now,

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -245,7 +245,7 @@ public class MailgunClient : IDisposable {
 
         var messageId = string.IsNullOrEmpty(message.MessageId)
             ? MimeKit.Utils.MimeUtils.GenerateMessageId(domain)
-            : message.MessageId;
+            : message.MessageId!;
 
         using var stream = new MemoryStream();
         await message.WriteToAsync(stream, cancellationToken).ConfigureAwait(false);

--- a/Sources/Mailozaurr/Mailozaurr.csproj
+++ b/Sources/Mailozaurr/Mailozaurr.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
-        <VersionPrefix>2.0.5</VersionPrefix>
+        <VersionPrefix>2.0.7</VersionPrefix>
         <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
         <AssemblyName>Mailozaurr</AssemblyName>
         <Copyright>(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
@@ -32,22 +32,22 @@
 
         <PackageReference Include="EmailValidation" Version="1.3.0" />
         <PackageReference Include="Google.Apis.Auth" Version="1.73.0" />
-        <PackageReference Include="MailKit" Version="4.14.1" />
-        <PackageReference Include="MimeKit" Version="4.14.0" />
-        <PackageReference Include="Microsoft.Identity.Client" Version="4.79.2" />
+        <PackageReference Include="MailKit" Version="4.15.1" />
+        <PackageReference Include="MimeKit" Version="4.15.1" />
+        <PackageReference Include="Microsoft.Identity.Client" Version="4.82.1" />
         <PackageReference Include="NSspi" Version="0.3.1" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-        <PackageReference Include="System.Text.Json" Version="10.0.0" />
+        <PackageReference Include="System.Text.Json" Version="10.0.3" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="System.Text.Json" Version="10.0.0" />
+        <PackageReference Include="System.Text.Json" Version="10.0.3" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net8.0' ">
-        <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
+        <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.3" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMimePreparation.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMimePreparation.cs
@@ -215,6 +215,8 @@ public sealed class DecodedMimeAttachment : IDisposable {
             using var fs = new FileStream(tempPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
             if (part.Content != null) {
                 part.Content.DecodeTo(fs);
+            } else {
+                part.WriteTo(fs);
             }
             fs.Flush(true);
             return new DecodedMimeAttachment(tempPath, fileName, contentType, isInline, contentId, fs.Length);

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMimePreparation.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMimePreparation.cs
@@ -133,7 +133,7 @@ public static class GraphMimePreparation {
             recipients.Add(new GraphEmailAddress {
                 Email = new GraphEmail {
                     Address = address,
-                    Name = string.IsNullOrWhiteSpace(mailbox.Name) ? null : mailbox.Name.Trim()
+                    Name = string.IsNullOrWhiteSpace(mailbox.Name) ? null : mailbox.Name!.Trim()
                 }
             });
         }
@@ -213,7 +213,9 @@ public sealed class DecodedMimeAttachment : IDisposable {
 
         try {
             using var fs = new FileStream(tempPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
-            part.Content.DecodeTo(fs);
+            if (part.Content != null) {
+                part.Content.DecodeTo(fs);
+            }
             fs.Flush(true);
             return new DecodedMimeAttachment(tempPath, fileName, contentType, isInline, contentId, fs.Length);
         } catch {

--- a/Sources/Mailozaurr/MimeKitUtils.cs
+++ b/Sources/Mailozaurr/MimeKitUtils.cs
@@ -21,11 +21,15 @@ public static class MimeKitUtils {
             if (attachment is MimePart mp) {
                 var file = Path.Combine(resolved, mp.FileName ?? Path.GetRandomFileName());
                 using var fs = File.Create(file);
-                mp.Content.DecodeTo(fs);
+                if (mp.Content != null) {
+                    mp.Content.DecodeTo(fs);
+                }
             } else if (attachment is MessagePart msgPart) {
                 var name = msgPart.ContentDisposition?.FileName ?? msgPart.ContentType.Name ?? Path.GetRandomFileName();
                 var file = Path.Combine(resolved, name);
-                msgPart.Message.WriteTo(file);
+                if (msgPart.Message != null) {
+                    msgPart.Message.WriteTo(file);
+                }
             }
         }
     }
@@ -70,7 +74,11 @@ public static class MimeKitUtils {
         return reports.Count > 0 ? reports[0] : null;
     }
 
-    private static MessageDeliveryStatus? FindDeliveryStatus(MimeEntity entity) {
+    private static MessageDeliveryStatus? FindDeliveryStatus(MimeEntity? entity) {
+        if (entity == null) {
+            return null;
+        }
+
         if (entity is MessageDeliveryStatus mds) {
             return mds;
         }
@@ -101,7 +109,7 @@ public static class MimeKitUtils {
     public static EmailEncryption GetEncryption(MimeMessage message) {
         if (message.Body is MultipartEncrypted encrypted) {
             var protocol = encrypted.ContentType.Parameters["protocol"];
-            if (!string.IsNullOrEmpty(protocol) && protocol.Equals("application/pgp-encrypted", System.StringComparison.OrdinalIgnoreCase)) {
+            if (!string.IsNullOrEmpty(protocol) && protocol!.Equals("application/pgp-encrypted", System.StringComparison.OrdinalIgnoreCase)) {
                 return EmailEncryption.PgpEncrypted;
             }
         }
@@ -111,12 +119,12 @@ public static class MimeKitUtils {
         }
 
         if (message.Body is MultipartSigned signed) {
-            var mimeType = signed[1].ContentType.MimeType;
-            if (mimeType.Equals("application/pgp-signature", System.StringComparison.OrdinalIgnoreCase)) {
+            var mimeType = signed.Count > 1 ? signed[1].ContentType?.MimeType : null;
+            if (string.Equals(mimeType, "application/pgp-signature", System.StringComparison.OrdinalIgnoreCase)) {
                 return EmailEncryption.PgpSigned;
             }
-            if (mimeType.Equals("application/pkcs7-signature", System.StringComparison.OrdinalIgnoreCase) ||
-                mimeType.Equals("application/x-pkcs7-signature", System.StringComparison.OrdinalIgnoreCase)) {
+            if (string.Equals(mimeType, "application/pkcs7-signature", System.StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(mimeType, "application/x-pkcs7-signature", System.StringComparison.OrdinalIgnoreCase)) {
                 return EmailEncryption.SmimeSigned;
             }
         }
@@ -130,7 +138,10 @@ public static class MimeKitUtils {
         using var ctx = new EphemeralOpenPgpContext(password);
         using (var sec = File.OpenRead(privateKeyPath))
             ctx.Import(new Org.BouncyCastle.Bcpg.OpenPgp.PgpSecretKeyRingBundle(new Org.BouncyCastle.Bcpg.ArmoredInputStream(sec)));
-        var encrypted = (MultipartEncrypted)message.Body;
+        if (message.Body is not MultipartEncrypted encrypted) {
+            return message;
+        }
+
         var decrypted = encrypted.Decrypt(ctx);
         var result = new MimeMessage(message.Headers);
         result.Body = decrypted;
@@ -142,7 +153,10 @@ public static class MimeKitUtils {
         if (GetEncryption(message) != EmailEncryption.SmimeEncrypted) return message;
         using var ctx = new MimeKit.Cryptography.TemporarySecureMimeContext();
         ctx.Import(certificate);
-        var pkcs7 = (ApplicationPkcs7Mime)message.Body;
+        if (message.Body is not ApplicationPkcs7Mime pkcs7) {
+            return message;
+        }
+
         var decrypted = pkcs7.Decrypt(ctx);
         var result = new MimeMessage(message.Headers);
         result.Body = decrypted;
@@ -155,7 +169,10 @@ public static class MimeKitUtils {
         using var ctx = new EphemeralOpenPgpContext();
         using (var pub = File.OpenRead(publicKeyPath))
             ctx.Import(pub);
-        var signed = (MultipartSigned)message.Body;
+        if (message.Body is not MultipartSigned signed) {
+            return false;
+        }
+
         var signatures = signed.Verify(ctx);
         foreach (var sig in signatures) sig.Verify();
         return true;
@@ -166,7 +183,10 @@ public static class MimeKitUtils {
         if (GetEncryption(message) != EmailEncryption.SmimeSigned) return false;
         using var ctx = new MimeKit.Cryptography.TemporarySecureMimeContext();
         foreach (var cert in certificates) ctx.Import(cert);
-        var signed = (MultipartSigned)message.Body;
+        if (message.Body is not MultipartSigned signed) {
+            return false;
+        }
+
         var signatures = signed.Verify(ctx);
         foreach (var sig in signatures) sig.Verify();
         return true;

--- a/Sources/Mailozaurr/MimeKitUtils.cs
+++ b/Sources/Mailozaurr/MimeKitUtils.cs
@@ -23,12 +23,16 @@ public static class MimeKitUtils {
                 using var fs = File.Create(file);
                 if (mp.Content != null) {
                     mp.Content.DecodeTo(fs);
+                } else {
+                    mp.WriteTo(fs);
                 }
             } else if (attachment is MessagePart msgPart) {
                 var name = msgPart.ContentDisposition?.FileName ?? msgPart.ContentType.Name ?? Path.GetRandomFileName();
                 var file = Path.Combine(resolved, name);
                 if (msgPart.Message != null) {
                     msgPart.Message.WriteTo(file);
+                } else {
+                    msgPart.WriteTo(file);
                 }
             }
         }

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -871,6 +871,10 @@ public static class MailboxSearcher {
             foreach (var att in message.Attachments) {
                 if (IsDmarcAttachment(att) && att is MimePart part) {
                     if (!string.IsNullOrWhiteSpace(domain) && !AttachmentMatchesDomain(part, domain!, maxUncompressedSize)) continue;
+                    if (part.Content == null) {
+                        continue;
+                    }
+
                     var stream = part.Content.Open();
                     report.Attachments.Add(new DmarcReportAttachment(part.FileName ?? "report.zip", stream));
                     if (!domainMatched) domainMatched = true;
@@ -883,6 +887,10 @@ public static class MailboxSearcher {
 
     private static bool AttachmentMatchesDomain(MimePart part, string domain, long maxUncompressedSize) {
         if (part.FileName?.IndexOf(domain, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        if (part.Content == null) {
+            return false;
+        }
+
         try {
             using var stream = part.Content.Open();
             var name = part.FileName ?? string.Empty;
@@ -954,7 +962,7 @@ public static class MailboxSearcher {
     private static bool IsDmarcAttachment(MimeEntity entity) {
         if (entity is MimePart part) {
             var name = part.FileName;
-            if (!string.IsNullOrEmpty(name) && (name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) || name.EndsWith(".gz", StringComparison.OrdinalIgnoreCase) || name.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))) return true;
+            if (!string.IsNullOrEmpty(name) && (name!.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) || name.EndsWith(".gz", StringComparison.OrdinalIgnoreCase) || name.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))) return true;
             var ct = part.ContentType;
             if (ct != null) {
                 if (ct.MediaType.Equals("application", StringComparison.OrdinalIgnoreCase)) {
@@ -1037,8 +1045,10 @@ public static class MailboxSearcher {
 
     private static bool AddressMatches(InternetAddressList list, string filter) {
         foreach (var addr in list.Mailboxes) {
-            if (addr.Address.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
-            if (!string.IsNullOrWhiteSpace(addr.Name) && addr.Name.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            if (!string.IsNullOrWhiteSpace(addr.Address) &&
+                addr.Address.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            var displayName = addr.Name;
+            if (!string.IsNullOrWhiteSpace(displayName) && displayName!.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) return true;
         }
         return false;
     }

--- a/Sources/Mailozaurr/Receive/MessageFetcher.cs
+++ b/Sources/Mailozaurr/Receive/MessageFetcher.cs
@@ -252,10 +252,13 @@ public static class MessageFetcher {
 
     private static bool AddressMatches(InternetAddressList list, string filter) {
         foreach (var addr in list.Mailboxes) {
-            if (addr.Address.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) {
+            if (!string.IsNullOrWhiteSpace(addr.Address) &&
+                addr.Address.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) {
                 return true;
             }
-            if (!string.IsNullOrWhiteSpace(addr.Name) && addr.Name.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) {
+            var displayName = addr.Name;
+            if (!string.IsNullOrWhiteSpace(displayName) &&
+                displayName!.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) {
                 return true;
             }
         }

--- a/Sources/Mailozaurr/Receive/Pop3AttachmentPayloadBuilder.cs
+++ b/Sources/Mailozaurr/Receive/Pop3AttachmentPayloadBuilder.cs
@@ -81,9 +81,17 @@ public static class Pop3AttachmentPayloadBuilder {
         try {
             using var limited = new SizeLimitedWriteStream(ms, maxBytes);
             if (entity is MimePart mimePart) {
-                mimePart.Content.DecodeTo(limited);
+                if (mimePart.Content != null) {
+                    mimePart.Content.DecodeTo(limited);
+                } else {
+                    mimePart.WriteTo(limited);
+                }
             } else if (entity is MessagePart nestedMessagePart) {
-                nestedMessagePart.Message.WriteTo(limited);
+                if (nestedMessagePart.Message != null) {
+                    nestedMessagePart.Message.WriteTo(limited);
+                } else {
+                    nestedMessagePart.WriteTo(limited);
+                }
             } else {
                 entity.WriteTo(limited);
             }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -241,8 +241,8 @@ public partial class ClientSmtp : SmtpClient {
                 }
             }
         }
-        if (AutoEmbedRemoteImages && !string.IsNullOrWhiteSpace(bodyBuilder.HtmlBody)) {
-            var (html, images) = await HtmlUtils.DownloadRemoteImagesAsync(bodyBuilder.HtmlBody, cancellationToken).ConfigureAwait(false);
+        if (AutoEmbedRemoteImages && bodyBuilder.HtmlBody is { Length: > 0 } htmlBody) {
+            var (html, images) = await HtmlUtils.DownloadRemoteImagesAsync(htmlBody, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             bodyBuilder.HtmlBody = html;
             HtmlBody = html;

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -241,7 +241,7 @@ public partial class ClientSmtp : SmtpClient {
                 }
             }
         }
-        if (AutoEmbedRemoteImages && bodyBuilder.HtmlBody is { Length: > 0 } htmlBody) {
+        if (AutoEmbedRemoteImages && bodyBuilder.HtmlBody is { } htmlBody && !string.IsNullOrWhiteSpace(htmlBody)) {
             var (html, images) = await HtmlUtils.DownloadRemoteImagesAsync(htmlBody, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             bodyBuilder.HtmlBody = html;

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -1003,7 +1003,7 @@ public class Smtp {
         if (string.IsNullOrEmpty(id)) {
             Message.MessageId = id = MimeKit.Utils.MimeUtils.GenerateMessageId();
         }
-        return id;
+        return id!;
     }
 
     private async Task SaveSentMessageAsync(string messageId, CancellationToken cancellationToken) {
@@ -1397,6 +1397,14 @@ public class Smtp {
     /// <returns></returns>
     public SmtpResult Encrypt(X509Certificate2 certificate) {
         MimeMessage message = Message;
+        var body = message.Body;
+        if (body is null) {
+            const string messageText = "Message body is empty.";
+            if (ErrorAction == ActionPreference.Stop) {
+                throw new InvalidOperationException(messageText);
+            }
+            return new SmtpResult(false, EmailAction.SMimeEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
+        }
         // encrypt our message body using a temporary S/MIME context to avoid SQLite dependency
         using (var ctx = new TemporarySecureMimeContext()) {
             try {
@@ -1405,7 +1413,7 @@ public class Smtp {
                 recipients.Add(new CmsRecipient(certificate));
 
                 // Encrypt the message body with the certificate
-                message.Body = ApplicationPkcs7Mime.Encrypt(ctx, recipients, message.Body);
+                message.Body = ApplicationPkcs7Mime.Encrypt(ctx, recipients, body!);
             } catch (Exception ex) {
                 LogWarning($"Send-EmailMessage - Error during encryption: {ex.Message}");
                 LogWarning($"Send-EmailMessage - Possible issue: Certificate? ({certificate.Thumbprint} was used).");
@@ -1427,6 +1435,14 @@ public class Smtp {
     /// <returns></returns>
     public SmtpResult Sign(X509Certificate2 certificate) {
         MimeMessage message = Message;
+        var body = message.Body;
+        if (body is null) {
+            const string messageText = "Message body is empty.";
+            if (ErrorAction == ActionPreference.Stop) {
+                throw new InvalidOperationException(messageText);
+            }
+            return new SmtpResult(false, EmailAction.SMimeSignature, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
+        }
         // digitally sign our message body using a temporary S/MIME context
         // TemporarySecureMimeContext avoids the SQLite dependency of DefaultSecureMimeContext
         using (var ctx = new TemporarySecureMimeContext()) {
@@ -1434,7 +1450,7 @@ public class Smtp {
                 var signer = new CmsSigner(certificate) {
                     DigestAlgorithm = DigestAlgorithm.Sha1
                 };
-                message.Body = MultipartSigned.Create(ctx, signer, message.Body);
+                message.Body = MultipartSigned.Create(ctx, signer, body!);
             } catch (Exception ex) {
                 LogWarning($"Send-EmailMessage - Error during signing: {ex.Message}");
                 LogWarning($"Send-EmailMessage - Possible issue: Certificate? ({certificate.Thumbprint} was used).");
@@ -1551,6 +1567,14 @@ public class Smtp {
     public SmtpResult Pkcs7Sign(X509Certificate2 certificate) {
         try {
             MimeMessage message = Message;
+            var body = message.Body;
+            if (body is null) {
+                const string messageText = "Message body is empty.";
+                if (ErrorAction == ActionPreference.Stop) {
+                    throw new InvalidOperationException(messageText);
+                }
+                return new SmtpResult(false, EmailAction.SMimeSignaturePKCS7, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
+            }
             // digitally sign our message body using a temporary S/MIME context to avoid SQLite dependency
             using (var ctx = new TemporarySecureMimeContext()) {
                 // Create a signer with the certificate
@@ -1559,7 +1583,7 @@ public class Smtp {
                 };
 
                 // Sign the message body with the signer
-                message.Body = ApplicationPkcs7Mime.Sign(ctx, signer, message.Body);
+                message.Body = ApplicationPkcs7Mime.Sign(ctx, signer, body!);
             }
 
             Message = message;
@@ -1665,13 +1689,21 @@ public class Smtp {
         }
 
         MimeMessage message = Message;
+        var body = message.Body;
+        if (body is null) {
+            const string messageText = "Message body is empty.";
+            if (ErrorAction == ActionPreference.Stop) {
+                throw new InvalidOperationException(messageText);
+            }
+            return new SmtpResult(false, EmailAction.PgpEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
+        }
         using (var ctx = new EphemeralOpenPgpContext()) {
             using (var pub = File.OpenRead(publicKeyPath))
                 ctx.Import(pub);
             var recipients = message.To.Mailboxes.Concat(message.Cc.Mailboxes).Concat(message.Bcc.Mailboxes).ToList();
             try {
                 var keys = ctx.GetPublicKeys(recipients);
-                message.Body = MultipartEncrypted.Encrypt(ctx, keys, message.Body);
+                message.Body = MultipartEncrypted.Encrypt(ctx, keys, body!);
             } catch (Exception ex) {
                 if (ErrorAction == ActionPreference.Stop) throw;
                 return new SmtpResult(false, EmailAction.PgpEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message);
@@ -1693,6 +1725,14 @@ public class Smtp {
         password = ConvertSecureStringToPlainString(password, isSecureString);
         try {
             MimeMessage message = Message;
+            var body = message.Body;
+            if (body is null) {
+                const string messageText = "Message body is empty.";
+                if (ErrorAction == ActionPreference.Stop) {
+                    throw new InvalidOperationException(messageText);
+                }
+                return new SmtpResult(false, EmailAction.PgpSign, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
+            }
             using (var ctx = new EphemeralOpenPgpContext(password)) {
                 if (!File.Exists(publicKeyPath)) {
                     string messageText = $"Public key file not found: {publicKeyPath}";
@@ -1714,7 +1754,7 @@ public class Smtp {
                 try {
                     var signer = message.From.Mailboxes.First();
                     var signingKey = ctx.GetSigningKey(signer);
-                    message.Body = MultipartSigned.Create(ctx, signingKey, DigestAlgorithm.Sha256, message.Body);
+                    message.Body = MultipartSigned.Create(ctx, signingKey, DigestAlgorithm.Sha256, body!);
                     var signed = (MultipartSigned)message.Body;
                     var sigs = signed.Verify(ctx);
                     foreach (var sig in sigs)
@@ -1748,6 +1788,14 @@ public class Smtp {
         password = ConvertSecureStringToPlainString(password, isSecureString);
         try {
             MimeMessage message = Message;
+            var body = message.Body;
+            if (body is null) {
+                const string messageText = "Message body is empty.";
+                if (ErrorAction == ActionPreference.Stop) {
+                    throw new InvalidOperationException(messageText);
+                }
+                return new SmtpResult(false, EmailAction.PgpSignAndEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", messageText);
+            }
             using (var ctx = new EphemeralOpenPgpContext(password)) {
                 if (!File.Exists(publicKeyPath)) {
                     string messageText = $"Public key file not found: {publicKeyPath}";
@@ -1770,7 +1818,7 @@ public class Smtp {
                 try {
                     var signingKey = ctx.GetSigningKey(message.From.Mailboxes.First());
                     var encKeys = ctx.GetPublicKeys(recipients);
-                    message.Body = MultipartEncrypted.SignAndEncrypt(ctx, signingKey, DigestAlgorithm.Sha256, EncryptionAlgorithm.Cast5, encKeys, message.Body);
+                    message.Body = MultipartEncrypted.SignAndEncrypt(ctx, signingKey, DigestAlgorithm.Sha256, EncryptionAlgorithm.Cast5, encKeys, body!);
                 } catch (Exception ex) {
                     if (ErrorAction == ActionPreference.Stop) throw;
                     return new SmtpResult(false, EmailAction.PgpSignAndEncrypt, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message);

--- a/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
@@ -110,8 +110,10 @@ public static class SmtpSendPipeline {
             throw new ArgumentNullException(nameof(message));
         }
 
-        if (idempotencyHeaderName is { Length: > 0 } headerName &&
-            idempotencyKey is { Length: > 0 } headerValue) {
+        if (!string.IsNullOrWhiteSpace(idempotencyHeaderName) &&
+            !string.IsNullOrWhiteSpace(idempotencyKey)) {
+            var headerName = idempotencyHeaderName!.Trim();
+            var headerValue = idempotencyKey!.Trim();
             message.Headers.Replace(headerName, headerValue);
         }
 

--- a/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpSendPipeline.cs
@@ -110,18 +110,19 @@ public static class SmtpSendPipeline {
             throw new ArgumentNullException(nameof(message));
         }
 
-        if (!string.IsNullOrWhiteSpace(idempotencyHeaderName) && !string.IsNullOrWhiteSpace(idempotencyKey)) {
-            message.Headers.Replace(idempotencyHeaderName, idempotencyKey);
+        if (idempotencyHeaderName is { Length: > 0 } headerName &&
+            idempotencyKey is { Length: > 0 } headerValue) {
+            message.Headers.Replace(headerName, headerValue);
         }
 
         var normalizedMessageId = NormalizeMessageIdToken(messageId);
-        if (!string.IsNullOrWhiteSpace(normalizedMessageId)) {
-            message.MessageId = normalizedMessageId;
+        if (normalizedMessageId is { Length: > 0 } ensuredMessageId) {
+            message.MessageId = ensuredMessageId;
         }
 
         var inReplyTo = NormalizeMessageIdToken(inReplyToCandidate);
-        if (!string.IsNullOrWhiteSpace(inReplyTo)) {
-            message.InReplyTo = inReplyTo;
+        if (inReplyTo is { Length: > 0 } ensuredInReplyTo) {
+            message.InReplyTo = ensuredInReplyTo;
         }
 
         var refs = new List<string>();


### PR DESCRIPTION
## Summary
- bump Mailozaurr and Mailozaurr.Msg package versions to `2.0.7`
- update mail-related package dependencies, including `MimeKit` and `MailKit`
- fix nullability compile breaks introduced by the newer package annotations

## Dependency updates
- `MailKit` `4.14.1` -> `4.15.1`
- `MimeKit` `4.14.0` -> `4.15.1`
- `Microsoft.Identity.Client` `4.79.2` -> `4.82.1`
- `System.Text.Json` `10.0.0` -> `10.0.3`
- `System.Security.Cryptography.ProtectedData` `10.0.0` -> `10.0.3`
- `MsgKit` `3.0.2` -> `3.0.3`
- `MsgReader` `6.0.6` -> `6.0.9`

## Validation
- `dotnet build Sources/Mailozaurr/Mailozaurr.csproj -c Release`
- `dotnet build Sources/Mailozaurr.Msg/Mailozaurr.Msg.csproj -c Release`
