### PR TITLE
fix: harden sent logs and OAuth session handling

### DIFF
--- a/Sources/Mailozaurr.Tests/NativeMailboxBrowserSessionsTests.cs
+++ b/Sources/Mailozaurr.Tests/NativeMailboxBrowserSessionsTests.cs
@@ -77,6 +77,22 @@ public sealed class NativeMailboxBrowserSessionsTests {
     }
 
     [Fact]
+    public async Task GraphMailboxBrowserSession_Dispose_DoesNotDisposeProvidedHttpClient() {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") });
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://graph.microsoft.com/v1.0/") };
+        var credential = new OAuthCredential { UserName = "me", AccessToken = "graph-token", ExpiresOn = DateTimeOffset.MaxValue };
+        var session = new GraphMailboxBrowserSession(client, credential);
+
+        await session.Browser.ListFoldersAsync();
+        session.Dispose();
+
+        using var response = await client.GetAsync("me");
+        Assert.True(response.IsSuccessStatusCode);
+    }
+
+    [Fact]
     public async Task GmailMailboxBrowserSession_Dispose_IsIdempotent_AndPreventsFurtherUse() {
         var handler = new RecordingHandler();
         var client = new HttpClient(handler) { BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/") };
@@ -87,5 +103,21 @@ public sealed class NativeMailboxBrowserSessionsTests {
         session.Dispose();
 
         await Assert.ThrowsAsync<ObjectDisposedException>(() => session.Browser.ListFoldersAsync());
+    }
+
+    [Fact]
+    public async Task GmailMailboxBrowserSession_Dispose_DoesNotDisposeProvidedHttpClient() {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"labels\":[]}") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") });
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/") };
+        var credential = new OAuthCredential { UserName = "me", AccessToken = "gmail-token", ExpiresOn = DateTimeOffset.MaxValue };
+        var session = new GmailMailboxBrowserSession(client, credential);
+
+        await session.Browser.ListFoldersAsync();
+        session.Dispose();
+
+        using var response = await client.GetAsync("users/me/profile");
+        Assert.True(response.IsSuccessStatusCode);
     }
 }

--- a/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
@@ -15,11 +15,17 @@ public class OAuthHelpersCachedTokenTests {
 
     [Fact]
     public async Task AcquireO365TokenCachedAsync_ReturnsCachedToken() {
-        var cacheKey = "o365:test@example.com";
+        var cacheKey = BuildO365CacheKey(
+            "test@example.com",
+            "client-id",
+            "tenant-id",
+            "https://login.microsoftonline.com/common/oauth2/nativeclient",
+            Array.Empty<string>());
         var credential = new OAuthCredential {
             UserName = "test@example.com",
             AccessToken = "token",
-            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1),
+            ClientId = "client-id"
         };
         await OAuthTokenCache.SetAsync(cacheKey, credential);
 
@@ -32,6 +38,37 @@ public class OAuthHelpersCachedTokenTests {
 
         Assert.Equal(credential.AccessToken, result.AccessToken);
         Assert.Equal(credential.UserName, result.UserName);
+    }
+
+    [Fact]
+    public async Task AcquireO365TokenCachedAsync_SeparatesEntriesPerClientAndScope() {
+        var login = "test@example.com";
+        var redirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+        var cacheKeyA = BuildO365CacheKey(login, "client-a", "tenant-id", redirectUri, new[] { "Mail.Read" });
+        var cacheKeyB = BuildO365CacheKey(login, "client-b", "tenant-id", redirectUri, new[] { "Mail.Read", "offline_access" });
+
+        await OAuthTokenCache.SetAsync(cacheKeyA, new OAuthCredential {
+            UserName = login,
+            AccessToken = "token-a",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1),
+            ClientId = "client-a"
+        });
+        await OAuthTokenCache.SetAsync(cacheKeyB, new OAuthCredential {
+            UserName = login,
+            AccessToken = "token-b",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1),
+            ClientId = "client-b"
+        });
+
+        var result = await OAuthHelpers.AcquireO365TokenCachedAsync(
+            login,
+            "client-b",
+            "tenant-id",
+            redirectUri,
+            new[] { "offline_access", "Mail.Read" });
+
+        Assert.Equal("token-b", result.AccessToken);
+        Assert.Equal("client-b", result.ClientId);
     }
 
     [Fact]
@@ -70,6 +107,16 @@ public class OAuthHelpersCachedTokenTests {
         field?.SetValue(null, null);
     }
 
+    private static string BuildO365CacheKey(
+        string login,
+        string clientId,
+        string tenantId,
+        string redirectUri,
+        string[] scopes) {
+        var method = typeof(OAuthHelpers).GetMethod("BuildO365CacheKey", BindingFlags.Static | BindingFlags.NonPublic);
+        return (string)method!.Invoke(null, new object[] { login, clientId, tenantId, redirectUri, scopes })!;
+    }
+
     private static void DeleteCacheFile() {
         var pathField = typeof(OAuthTokenCache).GetField("CacheFilePath", BindingFlags.Static | BindingFlags.NonPublic);
         var path = pathField?.GetValue(null) as string;
@@ -78,4 +125,3 @@ public class OAuthHelpersCachedTokenTests {
         }
     }
 }
-

--- a/Sources/Mailozaurr.Tests/SendLogResolverTests.cs
+++ b/Sources/Mailozaurr.Tests/SendLogResolverTests.cs
@@ -48,4 +48,22 @@ public class SendLogResolverTests {
         var result = await resolver.ResolveAsync(report);
         Assert.Equal(record, result);
     }
+
+    [Fact]
+    public async Task ResolveAsync_MatchesLegacyFormattedRecipientsWithDisplayNameComma() {
+        var record = new SentMessageRecord {
+            MessageId = "id1",
+            Recipients = "\"Doe, Jane\" <jane@example.com>, John Smith <john@example.com>"
+        };
+        var repo = new InMemoryRepository(record);
+        var resolver = new SendLogResolver(repo);
+        var report = new NonDeliveryReport {
+            OriginalMessageId = "id1",
+            FinalRecipientAddress = "jane@example.com"
+        };
+
+        var result = await resolver.ResolveAsync(report);
+
+        Assert.Equal(record, result);
+    }
 }

--- a/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
@@ -200,6 +200,35 @@ public sealed class SmtpPendingMessageTests {
     }
 
     [Fact]
+    public async Task ProcessPendingMessages_StoresNormalizedRecipientAddressesInSentLog() {
+        var pending = new InMemoryPendingRepository();
+        var sent = new InMemorySentRepository();
+        var smtp = new Smtp { PendingMessageRepository = pending, SentMessageRepository = sent };
+        SetClient(smtp, new SuccessClient());
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(new MailboxAddress("Doe, Jane", "jane@example.com"));
+        message.To.Add(new MailboxAddress("John Smith", "john@example.com"));
+        message.Subject = "queued";
+        message.Body = new TextPart("plain") { Text = "body" };
+        message.MessageId = "msg-normalized";
+        using (var ms = new MemoryStream()) {
+            await message.WriteToAsync(ms);
+            await pending.SaveAsync(new PendingMessageRecord {
+                MessageId = "msg-normalized",
+                MimeMessage = Convert.ToBase64String(ms.ToArray()),
+                Timestamp = DateTimeOffset.UtcNow
+            });
+        }
+
+        await smtp.ProcessPendingMessagesAsync();
+
+        var record = Assert.Single(sent.Saved);
+        Assert.Equal("jane@example.com,john@example.com", record.Recipients);
+    }
+
+    [Fact]
     public async Task ProcessPendingMessages_FailedSendRetainsMessage() {
         var pending = new InMemoryPendingRepository();
         var sent = new InMemorySentRepository();
@@ -383,4 +412,3 @@ public sealed class SmtpPendingMessageTests {
         }
     }
 }
-

--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -14,6 +14,30 @@ namespace Mailozaurr;
 /// Helper methods for acquiring OAuth tokens for various services.
 /// </summary>
 public static class OAuthHelpers {
+    private static string[] NormalizeScopes(IEnumerable<string> scopes) =>
+        scopes?
+            .Where(scope => !string.IsNullOrWhiteSpace(scope))
+            .Select(scope => scope.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(scope => scope, StringComparer.OrdinalIgnoreCase)
+            .ToArray()
+        ?? Array.Empty<string>();
+
+    private static string? BuildO365CacheKey(
+        string? login,
+        string clientId,
+        string tenantId,
+        string redirectUri,
+        IEnumerable<string> scopes) {
+        if (string.IsNullOrWhiteSpace(login)) {
+            return null;
+        }
+
+        var normalizedScopes = NormalizeScopes(scopes);
+        var scopeKey = normalizedScopes.Length == 0 ? "default" : string.Join(" ", normalizedScopes);
+        return $"o365:{login!.Trim()}|{clientId.Trim()}|{tenantId.Trim()}|{redirectUri.Trim()}|{scopeKey}";
+    }
+
     /// <summary>
     /// Acquires an OAuth token for Office 365 using an interactive browser flow.
     /// </summary>
@@ -60,7 +84,8 @@ public static class OAuthHelpers {
         var cred = new OAuthCredential {
             UserName = result.Account.Username,
             AccessToken = result.AccessToken,
-            ExpiresOn = result.ExpiresOn
+            ExpiresOn = result.ExpiresOn,
+            ClientId = clientId
         };
         await OAuthTokenCache.SetAsync($"o365:{cred.UserName}", cred);
         return cred;
@@ -97,7 +122,8 @@ public static class OAuthHelpers {
             return new OAuthCredential {
                 UserName = result.Account.Username,
                 AccessToken = result.AccessToken,
-                ExpiresOn = result.ExpiresOn
+                ExpiresOn = result.ExpiresOn,
+                ClientId = clientId
             };
         } catch (MsalUiRequiredException) {
             return null;
@@ -154,14 +180,15 @@ public static class OAuthHelpers {
         string tenantId,
         string redirectUri,
         IEnumerable<string> scopes) {
-        var cacheKey = string.IsNullOrWhiteSpace(login) ? null : $"o365:{login}";
+        var normalizedScopes = NormalizeScopes(scopes);
+        var cacheKey = BuildO365CacheKey(login, clientId, tenantId, redirectUri, normalizedScopes);
         if (cacheKey != null) {
             var cached = await OAuthTokenCache.GetAsync(cacheKey);
             if (cached != null && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
                 return cached;
             }
             if (cached != null) {
-                var refreshed = await AcquireO365TokenSilentAsync(login, clientId, tenantId, redirectUri, scopes);
+                var refreshed = await AcquireO365TokenSilentAsync(login, clientId, tenantId, redirectUri, normalizedScopes);
                 if (refreshed != null) {
                     await OAuthTokenCache.SetAsync(cacheKey, refreshed);
                     return refreshed;
@@ -169,7 +196,7 @@ public static class OAuthHelpers {
             }
         }
 
-        var cred = await AcquireO365TokenInteractiveAsync(login, clientId, tenantId, redirectUri, scopes);
+        var cred = await AcquireO365TokenInteractiveAsync(login, clientId, tenantId, redirectUri, normalizedScopes);
         if (cacheKey != null) {
             await OAuthTokenCache.SetAsync(cacheKey, cred);
         }

--- a/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
@@ -28,12 +28,18 @@ internal static class OAuthTokenCache {
 
         Dictionary<string, OAuthCredential> cache;
         if (File.Exists(CacheFilePath)) {
+            try {
 #if NETFRAMEWORK || NETSTANDARD2_0
-            var json = await ReadCacheFileAsync(cancellationToken).ConfigureAwait(false);
+                var json = await ReadCacheFileAsync(cancellationToken).ConfigureAwait(false);
 #else
-            var json = await File.ReadAllTextAsync(CacheFilePath, cancellationToken).ConfigureAwait(false);
+                var json = await File.ReadAllTextAsync(CacheFilePath, cancellationToken).ConfigureAwait(false);
 #endif
-            cache = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.DictionaryStringOAuthCredential) ?? new();
+                cache = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.DictionaryStringOAuthCredential) ?? new();
+            } catch (FileNotFoundException) {
+                cache = new Dictionary<string, OAuthCredential>();
+            } catch (DirectoryNotFoundException) {
+                cache = new Dictionary<string, OAuthCredential>();
+            }
         } else {
             cache = new Dictionary<string, OAuthCredential>();
         }

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -21,6 +21,7 @@ public sealed class GmailApiClient : IDisposable {
     private readonly HttpClient _client;
     private readonly Func<CancellationToken, Task<string>>? _refreshToken;
     private readonly OAuthCredential? _credential;
+    private readonly bool _disposeClient;
     private bool _disposed;
 
     private void ThrowIfDisposed() {
@@ -38,6 +39,7 @@ public sealed class GmailApiClient : IDisposable {
         }
 
         _credential = credential;
+        _disposeClient = true;
         _client = new HttpClient {
             BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/")
         };
@@ -56,14 +58,17 @@ public sealed class GmailApiClient : IDisposable {
     /// <param name="refreshToken">Optional delegate used to refresh an access token when a request returns 401/403.</param>
     /// <param name="credential">Optional OAuth credential holding an access token.</param>
     /// <param name="baseAddress">Optional Gmail base address used when <paramref name="client"/> has no base address configured.</param>
+    /// <param name="ownsHttpClient">When <c>true</c>, disposing this API client also disposes <paramref name="client"/>.</param>
     public GmailApiClient(
         HttpClient client,
         Func<CancellationToken, Task<string>>? refreshToken = null,
         OAuthCredential? credential = null,
-        Uri? baseAddress = null) {
+        Uri? baseAddress = null,
+        bool ownsHttpClient = false) {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _refreshToken = refreshToken;
         _credential = credential;
+        _disposeClient = ownsHttpClient;
         if (_client.BaseAddress == null) {
             _client.BaseAddress = baseAddress ?? new Uri("https://gmail.googleapis.com/gmail/v1/");
         }
@@ -88,7 +93,10 @@ public sealed class GmailApiClient : IDisposable {
             return;
         }
 
-        _client.Dispose();
+        if (_disposeClient) {
+            _client.Dispose();
+        }
+
         _disposed = true;
         GC.SuppressFinalize(this);
     }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphApiClient.cs
@@ -23,6 +23,7 @@ public sealed class GraphApiClient : IDisposable {
     private readonly HttpClient _client;
     private readonly Func<CancellationToken, Task<string>>? _refreshToken;
     private readonly OAuthCredential? _credential;
+    private readonly bool _disposeClient;
     private bool _disposed;
 
     private void ThrowIfDisposed() {
@@ -54,6 +55,7 @@ public sealed class GraphApiClient : IDisposable {
         Uri? baseAddress = null) {
         _credential = credential ?? throw new ArgumentNullException(nameof(credential));
         _refreshToken = refreshToken;
+        _disposeClient = true;
         _client = new HttpClient {
             BaseAddress = baseAddress ?? new Uri("https://graph.microsoft.com/v1.0/")
         };
@@ -70,14 +72,17 @@ public sealed class GraphApiClient : IDisposable {
     /// <param name="refreshToken">Optional delegate used to refresh an access token when a request returns 401/403.</param>
     /// <param name="credential">Optional OAuth credential holding an access token.</param>
     /// <param name="baseAddress">Optional Graph base address used when <paramref name="client"/> has no base address configured.</param>
+    /// <param name="ownsHttpClient">When <c>true</c>, disposing this API client also disposes <paramref name="client"/>.</param>
     public GraphApiClient(
         HttpClient client,
         Func<CancellationToken, Task<string>>? refreshToken = null,
         OAuthCredential? credential = null,
-        Uri? baseAddress = null) {
+        Uri? baseAddress = null,
+        bool ownsHttpClient = false) {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _refreshToken = refreshToken;
         _credential = credential;
+        _disposeClient = ownsHttpClient;
         if (_client.BaseAddress == null) {
             _client.BaseAddress = baseAddress ?? new Uri("https://graph.microsoft.com/v1.0/");
         }
@@ -88,7 +93,11 @@ public sealed class GraphApiClient : IDisposable {
         if (_disposed) {
             return;
         }
-        _client.Dispose();
+
+        if (_disposeClient) {
+            _client.Dispose();
+        }
+
         _disposed = true;
         GC.SuppressFinalize(this);
     }

--- a/Sources/Mailozaurr/NativeMailboxBrowserSessions.cs
+++ b/Sources/Mailozaurr/NativeMailboxBrowserSessions.cs
@@ -120,7 +120,7 @@ public sealed class GmailMailboxBrowserSession : IDisposable {
 
         _gmail = baseAddress == null
             ? new GmailApiClient(credential, refreshToken)
-            : new GmailApiClient(new HttpClient(), refreshToken, credential, baseAddress);
+            : new GmailApiClient(new HttpClient(), refreshToken, credential, baseAddress, ownsHttpClient: true);
         Browser = new GmailMailboxBrowser(_gmail, userId);
     }
 

--- a/Sources/Mailozaurr/SentMessages/SendLogResolver.cs
+++ b/Sources/Mailozaurr/SentMessages/SendLogResolver.cs
@@ -28,9 +28,9 @@ public sealed class SendLogResolver {
         var messageId = report.OriginalMessageId!;
         var record = await repository.GetByMessageIdAsync(messageId, cancellationToken);
         if (record != null) {
-            var recipient = report.FinalRecipientAddress ?? report.OriginalRecipientAddress;
+            var recipient = SentMessageRecipients.NormalizeAddress(report.FinalRecipientAddress ?? report.OriginalRecipientAddress);
             if (!string.IsNullOrWhiteSpace(recipient)) {
-                var recipients = record.Recipients.Split(',').Select(r => r.Trim());
+                var recipients = SentMessageRecipients.Parse(record.Recipients);
                 if (!recipients.Any(r => string.Equals(r, recipient, StringComparison.OrdinalIgnoreCase))) {
                     return null;
                 }

--- a/Sources/Mailozaurr/SentMessages/SentMessageRecipients.cs
+++ b/Sources/Mailozaurr/SentMessages/SentMessageRecipients.cs
@@ -1,0 +1,66 @@
+using MimeKit;
+
+namespace Mailozaurr;
+
+internal static class SentMessageRecipients {
+    public static string Serialize(InternetAddressList? recipients) {
+        if (recipients == null || recipients.Count == 0) {
+            return string.Empty;
+        }
+
+        return string.Join(",",
+            recipients.Mailboxes
+                .Select(mailbox => NormalizeAddress(mailbox.Address))
+                .Where(address => !string.IsNullOrWhiteSpace(address))
+                .Distinct(StringComparer.OrdinalIgnoreCase)!);
+    }
+
+    public static IReadOnlyList<string> Parse(string? recipients) {
+        if (string.IsNullOrWhiteSpace(recipients)) {
+            return Array.Empty<string>();
+        }
+
+        var output = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var candidate in recipients!.Split(',')) {
+            var normalized = NormalizeAddress(candidate);
+            if (string.IsNullOrWhiteSpace(normalized)) {
+                continue;
+            }
+
+            var address = normalized!;
+            if (!seen.Add(address)) {
+                continue;
+            }
+
+            output.Add(address);
+        }
+
+        return output;
+    }
+
+    public static string? NormalizeAddress(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        var normalized = value!.Trim();
+        var semicolonIndex = normalized.IndexOf(';');
+        if (semicolonIndex >= 0 && semicolonIndex + 1 < normalized.Length) {
+            normalized = normalized.Substring(semicolonIndex + 1).Trim();
+        }
+
+        var start = normalized.LastIndexOf('<');
+        var end = normalized.LastIndexOf('>');
+        if (start >= 0 && end > start) {
+            normalized = normalized.Substring(start + 1, end - start - 1).Trim();
+        }
+
+        if (normalized.StartsWith("\"", StringComparison.Ordinal) && normalized.EndsWith("\"", StringComparison.Ordinal) && normalized.Length > 1) {
+            normalized = normalized.Substring(1, normalized.Length - 2).Trim();
+        }
+
+        return normalized.Length == 0 ? null : normalized;
+    }
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -907,7 +907,7 @@ public class Smtp {
                 if (SentMessageRepository != null) {
                     var sentRecord = new SentMessageRecord {
                         MessageId = message.MessageId ?? record.MessageId,
-                        Recipients = message.To.ToString(),
+                        Recipients = SentMessageRecipients.Serialize(message.To),
                         Subject = message.Subject ?? string.Empty,
                         Timestamp = DateTimeOffset.UtcNow
                     };
@@ -1013,7 +1013,7 @@ public class Smtp {
 
         var record = new SentMessageRecord {
             MessageId = messageId,
-            Recipients = SentTo,
+            Recipients = SentMessageRecipients.Serialize(Message?.To),
             Subject = Subject,
             Timestamp = DateTimeOffset.UtcNow
         };


### PR DESCRIPTION
## Summary
- normalize SMTP sent-log recipients and keep NDR matching compatible with legacy formatted entries
- isolate cached O365 tokens by app/tenant/redirect URI/scope set and keep external HttpClient instances alive after mailbox session disposal
- harden OAuth token cache loading against file deletion races uncovered by the full-suite run

## Testing
- dotnet test Sources\\Mailozaurr.Tests\\Mailozaurr.Tests.csproj --no-restore --filter "FullyQualifiedName~OAuthHelpersCachedTokenTests|FullyQualifiedName~NativeMailboxBrowserSessionsTests|FullyQualifiedName~SendLogResolverTests|FullyQualifiedName~SmtpPendingMessageTests" -v minimal
- dotnet test Sources\\Mailozaurr.sln --no-restore -v minimal
