### PR TITLE
fix: harden sent message repository reads

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
@@ -77,6 +77,62 @@ public class SentMessageRepositoryTests {
         }
     }
 
+    [Fact]
+    public async Task Constructor_IgnoresMalformedLinesAndIndexesValidRecords() {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+        try {
+            var newline = Encoding.UTF8.GetBytes(Environment.NewLine);
+            using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read)) {
+                await JsonSerializer.SerializeAsync(stream, new SentMessageRecord {
+                    MessageId = "1",
+                    Recipients = "a@b.com",
+                    Subject = "ok-1",
+                    Timestamp = DateTimeOffset.UtcNow
+                });
+                await stream.WriteAsync(newline, 0, newline.Length);
+                await stream.WriteAsync(Encoding.UTF8.GetBytes("{not-json"), 0, Encoding.UTF8.GetByteCount("{not-json"));
+                await stream.WriteAsync(newline, 0, newline.Length);
+                await JsonSerializer.SerializeAsync(stream, new SentMessageRecord {
+                    MessageId = "2",
+                    Recipients = "c@d.com",
+                    Subject = "ok-2",
+                    Timestamp = DateTimeOffset.UtcNow
+                });
+                await stream.WriteAsync(newline, 0, newline.Length);
+            }
+
+            var repo = new FileSentMessageRepository(path);
+            var record = await repo.GetByMessageIdAsync("2");
+
+            Assert.NotNull(record);
+            Assert.Equal("ok-2", record!.Subject);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task GetByMessageIdAsync_ReturnsNullWhenIndexedLineBecomesMalformed() {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+        try {
+            var repo = new FileSentMessageRepository(path);
+            await repo.SaveAsync(new SentMessageRecord {
+                MessageId = "1",
+                Recipients = "a@b.com",
+                Subject = "subject",
+                Timestamp = DateTimeOffset.UtcNow
+            });
+
+            File.WriteAllText(path, "{broken");
+
+            var record = await repo.GetByMessageIdAsync("1");
+
+            Assert.Null(record);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
     private static async Task<SentMessageRecord?> SequentialSearchAsync(string path, string messageId) {
         using var read = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var reader = new StreamReader(read);

--- a/Sources/Mailozaurr/Authentication/TokenCacheHelper.cs
+++ b/Sources/Mailozaurr/Authentication/TokenCacheHelper.cs
@@ -26,8 +26,14 @@ internal static class TokenCacheHelper {
     private static void BeforeAccessNotification(TokenCacheNotificationArgs args) {
         lock (FileLock) {
             if (File.Exists(CacheFilePath)) {
-                var data = File.ReadAllBytes(CacheFilePath);
-                args.TokenCache.DeserializeMsalV3(data, shouldClearExistingCache: true);
+                try {
+                    var data = File.ReadAllBytes(CacheFilePath);
+                    args.TokenCache.DeserializeMsalV3(data, shouldClearExistingCache: true);
+                } catch (FileNotFoundException) {
+                    // another thread/process deleted the cache between the existence check and read
+                } catch (DirectoryNotFoundException) {
+                    // treat a missing cache directory as an empty cache
+                }
             }
         }
     }

--- a/Sources/Mailozaurr/SentMessages/FileSentMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FileSentMessageRepository.cs
@@ -21,17 +21,39 @@ public sealed class FileSentMessageRepository : ISentMessageRepository {
     }
 
     private void BuildIndex() {
+        index.Clear();
         long position = 0;
-        foreach (var line in File.ReadLines(filePath)) {
-            if (string.IsNullOrWhiteSpace(line)) {
-                position += newlineBytes.Length;
-                continue;
+        try {
+            foreach (var line in File.ReadLines(filePath)) {
+                if (string.IsNullOrWhiteSpace(line)) {
+                    position += newlineBytes.Length;
+                    continue;
+                }
+
+                if (TryDeserializeRecord(line, out var record) && !string.IsNullOrEmpty(record!.MessageId)) {
+                    index[record.MessageId] = position;
+                }
+
+                position += Encoding.UTF8.GetByteCount(line) + newlineBytes.Length;
             }
-            var record = JsonSerializer.Deserialize(line, MailozaurrJsonContext.Default.SentMessageRecord);
-            if (record != null && !string.IsNullOrEmpty(record.MessageId)) {
-                index[record.MessageId] = position;
-            }
-            position += Encoding.UTF8.GetByteCount(line) + newlineBytes.Length;
+        } catch (FileNotFoundException) {
+            index.Clear();
+        } catch (DirectoryNotFoundException) {
+            index.Clear();
+        }
+    }
+
+    private static bool TryDeserializeRecord(string json, out SentMessageRecord? record) {
+        record = null;
+        if (string.IsNullOrWhiteSpace(json)) {
+            return false;
+        }
+
+        try {
+            record = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.SentMessageRecord);
+            return record != null;
+        } catch (JsonException) {
+            return false;
         }
     }
 
@@ -70,10 +92,13 @@ public sealed class FileSentMessageRepository : ISentMessageRepository {
             if (string.IsNullOrWhiteSpace(line)) {
                 return null;
             }
-            var record = JsonSerializer.Deserialize(line, MailozaurrJsonContext.Default.SentMessageRecord);
-            if (record != null && string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
+            if (TryDeserializeRecord(line, out var record) && string.Equals(record!.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
                 return record;
             }
+            return null;
+        } catch (FileNotFoundException) {
+            return null;
+        } catch (DirectoryNotFoundException) {
             return null;
         } finally {
             gate.Release();


### PR DESCRIPTION
## Summary
- make FileSentMessageRepository skip malformed sent-log lines instead of failing repository construction or lookups
- return null instead of throwing when the sent-log file disappears between existence checks and reads
- harden MSAL token cache reads against file deletion races

## Testing
- dotnet test Sources\\Mailozaurr.Tests\\Mailozaurr.Tests.csproj --no-restore --filter "FullyQualifiedName~SentMessageRepositoryTests" -v minimal
- dotnet test Sources\\Mailozaurr.sln --no-restore -v minimal
