### PR TITLE
fix: persist interactive OAuth tokens under composite keys

### DIFF
--- a/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
@@ -72,6 +72,33 @@ public class OAuthHelpersCachedTokenTests {
     }
 
     [Fact]
+    public async Task PersistO365CredentialAsync_WritesLegacyAndCompositeEntries() {
+        var login = "persist@example.com";
+        var redirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+        var credential = new OAuthCredential {
+            UserName = login,
+            AccessToken = "persist-token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        await PersistO365CredentialAsync(
+            credential,
+            "client-id",
+            "tenant-id",
+            redirectUri,
+            new[] { "offline_access", "Mail.Read" });
+
+        var composite = await OAuthTokenCache.GetAsync(BuildO365CacheKey(login, "client-id", "tenant-id", redirectUri, new[] { "Mail.Read", "offline_access" }));
+        var legacy = await OAuthTokenCache.GetAsync("o365:persist@example.com");
+
+        Assert.NotNull(composite);
+        Assert.NotNull(legacy);
+        Assert.Equal("persist-token", composite!.AccessToken);
+        Assert.Equal("persist-token", legacy!.AccessToken);
+        Assert.Equal("client-id", legacy.ClientId);
+    }
+
+    [Fact]
     public async Task GetAsync_ThrowsWhenCancellationRequested() {
         var cacheKey = "o365:cancel@example.com";
         var credential = new OAuthCredential {
@@ -115,6 +142,17 @@ public class OAuthHelpersCachedTokenTests {
         string[] scopes) {
         var method = typeof(OAuthHelpers).GetMethod("BuildO365CacheKey", BindingFlags.Static | BindingFlags.NonPublic);
         return (string)method!.Invoke(null, new object[] { login, clientId, tenantId, redirectUri, scopes })!;
+    }
+
+    private static async Task PersistO365CredentialAsync(
+        OAuthCredential credential,
+        string clientId,
+        string tenantId,
+        string redirectUri,
+        string[] scopes) {
+        var method = typeof(OAuthHelpers).GetMethod("PersistO365CredentialAsync", BindingFlags.Static | BindingFlags.NonPublic);
+        var task = (Task)method!.Invoke(null, new object[] { credential, clientId, tenantId, redirectUri, scopes })!;
+        await task.ConfigureAwait(false);
     }
 
     private static void DeleteCacheFile() {

--- a/Sources/Mailozaurr.Tests/OAuthHelpersGoogleCachedTokenTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthHelpersGoogleCachedTokenTests.cs
@@ -67,9 +67,42 @@ public class OAuthHelpersGoogleCachedTokenTests {
         Assert.Equal("legacy-token", migrated!.AccessToken);
     }
 
+    [Fact]
+    public async Task PersistGoogleCredentialAsync_WritesLegacyAndCompositeEntries() {
+        var account = "user3@example.com";
+        var clientId = "client-123";
+        var compositeKey = $"google:{clientId}:{account}";
+        var legacyKey = $"google:{account}";
+        var credential = new OAuthCredential {
+            UserName = account,
+            AccessToken = "persisted-token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        await PersistGoogleCredentialAsync(credential, account, clientId);
+
+        var composite = await OAuthTokenCache.GetAsync(compositeKey);
+        var legacy = await OAuthTokenCache.GetAsync(legacyKey);
+
+        Assert.NotNull(composite);
+        Assert.NotNull(legacy);
+        Assert.Equal("persisted-token", composite!.AccessToken);
+        Assert.Equal("persisted-token", legacy!.AccessToken);
+        Assert.Equal(clientId, legacy.ClientId);
+    }
+
     private static void ResetCache() {
         var field = typeof(OAuthTokenCache).GetField("_cache", BindingFlags.Static | BindingFlags.NonPublic);
         field?.SetValue(null, null);
+    }
+
+    private static async Task PersistGoogleCredentialAsync(
+        OAuthCredential credential,
+        string gmailAccount,
+        string clientId) {
+        var method = typeof(OAuthHelpers).GetMethod("PersistGoogleCredentialAsync", BindingFlags.Static | BindingFlags.NonPublic);
+        var task = (Task)method!.Invoke(null, new object[] { credential, gmailAccount, clientId })!;
+        await task.ConfigureAwait(false);
     }
 
     private static void DeleteCacheFile() {
@@ -80,4 +113,3 @@ public class OAuthHelpersGoogleCachedTokenTests {
         }
     }
 }
-

--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -23,6 +23,8 @@ public static class OAuthHelpers {
             .ToArray()
         ?? Array.Empty<string>();
 
+    private static string BuildO365LegacyCacheKey(string userName) => $"o365:{userName}";
+
     private static string? BuildO365CacheKey(
         string? login,
         string clientId,
@@ -36,6 +38,49 @@ public static class OAuthHelpers {
         var normalizedScopes = NormalizeScopes(scopes);
         var scopeKey = normalizedScopes.Length == 0 ? "default" : string.Join(" ", normalizedScopes);
         return $"o365:{login!.Trim()}|{clientId.Trim()}|{tenantId.Trim()}|{redirectUri.Trim()}|{scopeKey}";
+    }
+
+    private static string BuildGoogleLegacyCacheKey(string gmailAccount) => $"google:{gmailAccount}";
+
+    private static string BuildGoogleCacheKey(string gmailAccount, string clientId) => $"google:{clientId}:{gmailAccount}";
+
+    private static async Task PersistO365CredentialAsync(
+        OAuthCredential credential,
+        string clientId,
+        string tenantId,
+        string redirectUri,
+        IEnumerable<string> scopes) {
+        if (credential == null) {
+            throw new ArgumentNullException(nameof(credential));
+        }
+        if (string.IsNullOrWhiteSpace(credential.UserName)) {
+            return;
+        }
+
+        credential.ClientId = clientId;
+        await OAuthTokenCache.SetAsync(BuildO365LegacyCacheKey(credential.UserName), credential).ConfigureAwait(false);
+
+        var compositeKey = BuildO365CacheKey(credential.UserName, clientId, tenantId, redirectUri, scopes);
+        if (compositeKey != null) {
+            await OAuthTokenCache.SetAsync(compositeKey, credential).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task PersistGoogleCredentialAsync(
+        OAuthCredential credential,
+        string gmailAccount,
+        string clientId) {
+        if (credential == null) {
+            throw new ArgumentNullException(nameof(credential));
+        }
+        if (string.IsNullOrWhiteSpace(gmailAccount) && string.IsNullOrWhiteSpace(credential.UserName)) {
+            return;
+        }
+
+        var account = string.IsNullOrWhiteSpace(gmailAccount) ? credential.UserName : gmailAccount.Trim();
+        credential.ClientId = clientId;
+        await OAuthTokenCache.SetAsync(BuildGoogleLegacyCacheKey(account), credential).ConfigureAwait(false);
+        await OAuthTokenCache.SetAsync(BuildGoogleCacheKey(account, clientId), credential).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -87,7 +132,7 @@ public static class OAuthHelpers {
             ExpiresOn = result.ExpiresOn,
             ClientId = clientId
         };
-        await OAuthTokenCache.SetAsync($"o365:{cred.UserName}", cred);
+        await PersistO365CredentialAsync(cred, clientId, tenantId, redirectUri, scopes).ConfigureAwait(false);
         return cred;
     }
 
@@ -167,7 +212,7 @@ public static class OAuthHelpers {
             ClientId = clientId,
             ClientSecret = clientSecret
         };
-        await OAuthTokenCache.SetAsync($"google:{cred.UserName}", cred);
+        await PersistGoogleCredentialAsync(cred, gmailAccount, clientId).ConfigureAwait(false);
         return cred;
     }
 
@@ -190,16 +235,13 @@ public static class OAuthHelpers {
             if (cached != null) {
                 var refreshed = await AcquireO365TokenSilentAsync(login, clientId, tenantId, redirectUri, normalizedScopes);
                 if (refreshed != null) {
-                    await OAuthTokenCache.SetAsync(cacheKey, refreshed);
+                    await PersistO365CredentialAsync(refreshed, clientId, tenantId, redirectUri, normalizedScopes).ConfigureAwait(false);
                     return refreshed;
                 }
             }
         }
 
         var cred = await AcquireO365TokenInteractiveAsync(login, clientId, tenantId, redirectUri, normalizedScopes);
-        if (cacheKey != null) {
-            await OAuthTokenCache.SetAsync(cacheKey, cred);
-        }
         return cred;
     }
 
@@ -212,8 +254,8 @@ public static class OAuthHelpers {
         string clientSecret,
         IEnumerable<string> scopes) {
         // Prefer a cache key that includes client id to avoid token confusion across apps.
-        var compositeKey = $"google:{clientId}:{gmailAccount}";
-        var legacyKey = $"google:{gmailAccount}";
+        var compositeKey = BuildGoogleCacheKey(gmailAccount, clientId);
+        var legacyKey = BuildGoogleLegacyCacheKey(gmailAccount);
 
         bool loadedFromLegacy = false;
         var cached = await OAuthTokenCache.GetAsync(compositeKey).ConfigureAwait(false);
@@ -241,7 +283,7 @@ public static class OAuthHelpers {
         if (cached != null && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
             // Migrate legacy entries to composite key to prevent cross-app confusion.
             if (loadedFromLegacy) {
-                await OAuthTokenCache.SetAsync(compositeKey, cached).ConfigureAwait(false);
+                await PersistGoogleCredentialAsync(cached, gmailAccount, clientId).ConfigureAwait(false);
             }
             return cached;
         }
@@ -266,13 +308,12 @@ public static class OAuthHelpers {
                     ClientId = clientId,
                     ClientSecret = clientSecret
                 };
-                await OAuthTokenCache.SetAsync(compositeKey, newCred).ConfigureAwait(false);
+                await PersistGoogleCredentialAsync(newCred, gmailAccount, clientId).ConfigureAwait(false);
                 return newCred;
             }
         }
 
         var cred = await AcquireGoogleTokenInteractiveAsync(gmailAccount, clientId, clientSecret, scopes).ConfigureAwait(false);
-        await OAuthTokenCache.SetAsync(compositeKey, cred).ConfigureAwait(false);
         return cred;
     }
 
@@ -303,9 +344,10 @@ public static class OAuthHelpers {
         var cred = new OAuthCredential {
             UserName = result.Account.Username,
             AccessToken = result.AccessToken,
-            ExpiresOn = result.ExpiresOn
+            ExpiresOn = result.ExpiresOn,
+            ClientId = clientId
         };
-        await OAuthTokenCache.SetAsync($"o365:{cred.UserName}", cred);
+        await OAuthTokenCache.SetAsync(BuildO365LegacyCacheKey(cred.UserName), cred).ConfigureAwait(false);
         return cred;
     }
 


### PR DESCRIPTION
## Summary
- persist O365 interactive tokens under both legacy and composite cache keys so cached lookups can reuse them without a second prompt
- persist Google interactive tokens under both legacy and composite cache keys for the same reason
- add focused regression tests around the private persistence helpers to verify cache interoperability without live auth

## Testing
- dotnet test Sources\\Mailozaurr.Tests\\Mailozaurr.Tests.csproj --no-restore --filter "FullyQualifiedName~OAuthHelpersCachedTokenTests|FullyQualifiedName~OAuthHelpersGoogleCachedTokenTests" -v minimal
- dotnet test Sources\\Mailozaurr.sln --no-restore -v minimal
