### PR TITLE
fix: harden log repositories and html cancellation

### DIFF
--- a/Sources/Mailozaurr.Tests/FilePendingMessageRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/FilePendingMessageRepositoryTests.cs
@@ -1,9 +1,10 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using MimeKit;
-using System.Text.Json;
 
 namespace Mailozaurr.Tests;
 
@@ -212,6 +213,108 @@ public sealed class FilePendingMessageRepositoryTests {
 
             var loaded = await repo.GetByMessageIdAsync(record.MessageId);
             Assert.Null(loaded);
+        } finally {
+            if (File.Exists(filePath)) {
+                File.Delete(filePath);
+            }
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Constructor_RebuildsLfIndexedLogWithoutOffsetDrift() {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var filePath = Path.Combine(dir, "pending.log");
+        Directory.CreateDirectory(dir);
+
+        try {
+            var first = new PendingMessageRecord {
+                MessageId = "msg-1",
+                Timestamp = DateTimeOffset.UtcNow,
+                Provider = EmailProvider.SendGrid
+            };
+            var second = new PendingMessageRecord {
+                MessageId = "msg-2",
+                Timestamp = DateTimeOffset.UtcNow.AddMinutes(1),
+                Provider = EmailProvider.Mailgun
+            };
+
+            var payload = string.Join("\n", new[] {
+                JsonSerializer.Serialize(new PendingMessageLogEnvelope { EntryType = "upsert", MessageId = first.MessageId, Record = first }, MailozaurrJsonContext.Default.PendingMessageLogEnvelope),
+                JsonSerializer.Serialize(new PendingMessageLogEnvelope { EntryType = "upsert", MessageId = second.MessageId, Record = second }, MailozaurrJsonContext.Default.PendingMessageLogEnvelope)
+            }) + "\n";
+            File.WriteAllText(filePath, payload, Encoding.UTF8);
+
+            var repository = new FilePendingMessageRepository(filePath);
+            var loaded = await repository.GetByMessageIdAsync(second.MessageId);
+
+            Assert.NotNull(loaded);
+            Assert.Equal(second.MessageId, loaded!.MessageId);
+            Assert.Equal(second.Provider, loaded.Provider);
+        } finally {
+            if (File.Exists(filePath)) {
+                File.Delete(filePath);
+            }
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GetByMessageIdAsync_ReturnsNullWhenFileIsDeletedAfterIndexing() {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var options = new PendingMessageRepositoryOptions { DirectoryPath = dir, FileNamingScheme = () => "pending.log" };
+        var filePath = Path.Combine(dir, "pending.log");
+        Directory.CreateDirectory(dir);
+
+        try {
+            var repository = new FilePendingMessageRepository(options);
+            var record = new PendingMessageRecord {
+                MessageId = Guid.NewGuid().ToString("N"),
+                Timestamp = DateTimeOffset.UtcNow,
+                Provider = EmailProvider.SendGrid
+            };
+
+            await repository.SaveAsync(record);
+            File.Delete(filePath);
+
+            var loaded = await repository.GetByMessageIdAsync(record.MessageId);
+
+            Assert.Null(loaded);
+        } finally {
+            if (File.Exists(filePath)) {
+                File.Delete(filePath);
+            }
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsEmptyWhenFileIsDeletedAfterIndexing() {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var options = new PendingMessageRepositoryOptions { DirectoryPath = dir, FileNamingScheme = () => "pending.log" };
+        var filePath = Path.Combine(dir, "pending.log");
+        Directory.CreateDirectory(dir);
+
+        try {
+            var repository = new FilePendingMessageRepository(options);
+            var record = new PendingMessageRecord {
+                MessageId = Guid.NewGuid().ToString("N"),
+                Timestamp = DateTimeOffset.UtcNow,
+                Provider = EmailProvider.SendGrid
+            };
+
+            await repository.SaveAsync(record);
+            File.Delete(filePath);
+
+            var records = await ReadAllAsync(repository);
+
+            Assert.Empty(records);
         } finally {
             if (File.Exists(filePath)) {
                 File.Delete(filePath);

--- a/Sources/Mailozaurr.Tests/HtmlUtilsTests.cs
+++ b/Sources/Mailozaurr.Tests/HtmlUtilsTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -171,5 +172,13 @@ public class HtmlUtilsTests
             handlerField.SetValue(client, original);
         }
     }
-}
 
+    [Fact]
+    public async Task DownloadRemoteImagesAsync_PropagatesCancellationAsync() {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await HtmlUtils.DownloadRemoteImagesAsync("<img src=\"https://example.com/img.png\">", cts.Token));
+    }
+}

--- a/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessageRepositoryTests.cs
@@ -133,6 +133,37 @@ public class SentMessageRepositoryTests {
         }
     }
 
+    [Fact]
+    public async Task Constructor_RebuildsLfIndexedLogWithoutOffsetDrift() {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+        try {
+            var payload = string.Join("\n", new[] {
+                JsonSerializer.Serialize(new SentMessageRecord {
+                    MessageId = "1",
+                    Recipients = "first@example.com",
+                    Subject = "first",
+                    Timestamp = DateTimeOffset.UtcNow
+                }, MailozaurrJsonContext.Default.SentMessageRecord),
+                JsonSerializer.Serialize(new SentMessageRecord {
+                    MessageId = "2",
+                    Recipients = "second@example.com",
+                    Subject = "second",
+                    Timestamp = DateTimeOffset.UtcNow.AddMinutes(1)
+                }, MailozaurrJsonContext.Default.SentMessageRecord)
+            }) + "\n";
+            File.WriteAllText(path, payload, Encoding.UTF8);
+
+            var repo = new FileSentMessageRepository(path);
+            var record = await repo.GetByMessageIdAsync("2");
+
+            Assert.NotNull(record);
+            Assert.Equal("second", record!.Subject);
+            Assert.Equal("second@example.com", record.Recipients);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
     private static async Task<SentMessageRecord?> SequentialSearchAsync(string path, string messageId) {
         using var read = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var reader = new StreamReader(read);

--- a/Sources/Mailozaurr/Helpers/HtmlUtils.cs
+++ b/Sources/Mailozaurr/Helpers/HtmlUtils.cs
@@ -91,6 +91,8 @@ public static class HtmlUtils {
                 if (string.IsNullOrEmpty(fileName)) fileName = Guid.NewGuid().ToString("N");
                 replacements[url] = $"cid:{fileName}";
                 images.Add(new RemoteImage { ContentId = fileName, Data = data, MediaType = mediaType });
+            } catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested) {
+                throw new OperationCanceledException(ex.Message, ex, cancellationToken);
             } catch (Exception ex) {
                 LoggingMessages.Logger.WriteWarning($"Failed to download image '{url}': {ex.Message}");
             }

--- a/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
@@ -14,7 +14,7 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
     private readonly string filePath;
     private readonly SemaphoreSlim gate = new(1, 1);
     private readonly Dictionary<string, long> index = new(StringComparer.OrdinalIgnoreCase);
-    private readonly byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+    private static readonly byte[] NewlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
     private int dirtyEntryCount;
 
     /// <summary>Creates a new repository using the specified options.</summary>
@@ -53,33 +53,31 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
             return;
         }
 
-        using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
+        try {
+            foreach (var line in LogFileLineReader.ReadLinesWithOffsets(filePath)) {
+                if (!TryParseLogEntry(line.Line, out var entry)) {
+                    continue;
+                }
 
-        long position = 0;
-        string? line;
-
-        while ((line = reader.ReadLine()) != null) {
-            var offset = position;
-            var byteLength = Encoding.UTF8.GetByteCount(line);
-            position += byteLength + newlineBytes.Length;
-
-            if (!TryParseLogEntry(line, out var entry)) {
-                continue;
-            }
-
-            switch (entry.Kind) {
-                case LogEntryKind.Upsert:
-                    if (index.ContainsKey(entry.MessageId)) {
+                switch (entry.Kind) {
+                    case LogEntryKind.Upsert:
+                        if (index.ContainsKey(entry.MessageId)) {
+                            dirtyEntryCount++;
+                        }
+                        index[entry.MessageId] = line.Offset;
+                        break;
+                    case LogEntryKind.Tombstone:
+                        index.Remove(entry.MessageId);
                         dirtyEntryCount++;
-                    }
-                    index[entry.MessageId] = offset;
-                    break;
-                case LogEntryKind.Tombstone:
-                    index.Remove(entry.MessageId);
-                    dirtyEntryCount++;
-                    break;
+                        break;
+                }
             }
+        } catch (FileNotFoundException) {
+            index.Clear();
+            dirtyEntryCount = 0;
+        } catch (DirectoryNotFoundException) {
+            index.Clear();
+            dirtyEntryCount = 0;
         }
     }
 
@@ -122,7 +120,7 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
         var offset = write.Position;
 
         await write.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
-        await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken).ConfigureAwait(false);
+        await write.WriteAsync(NewlineBytes, 0, NewlineBytes.Length, cancellationToken).ConfigureAwait(false);
         await write.FlushAsync(cancellationToken).ConfigureAwait(false);
 
         return offset;
@@ -190,10 +188,10 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
                     var payload = SerializeEnvelope(envelope);
 
                     await write.WriteAsync(payload, 0, payload.Length, cancellationToken).ConfigureAwait(false);
-                    await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken).ConfigureAwait(false);
+                    await write.WriteAsync(NewlineBytes, 0, NewlineBytes.Length, cancellationToken).ConfigureAwait(false);
 
                     newIndex[id] = position;
-                    position += payload.Length + newlineBytes.Length;
+                    position += payload.Length + NewlineBytes.Length;
                 }
 
                 await write.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -359,6 +357,10 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
                 return entry.Record;
             }
             return null;
+        } catch (FileNotFoundException) {
+            return null;
+        } catch (DirectoryNotFoundException) {
+            return null;
         } finally {
             gate.Release();
         }
@@ -404,6 +406,10 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
                     snapshot.Add(record);
                 }
             }
+        } catch (FileNotFoundException) {
+            snapshot.Clear();
+        } catch (DirectoryNotFoundException) {
+            snapshot.Clear();
         } finally {
             gate.Release();
         }

--- a/Sources/Mailozaurr/SentMessages/FileSentMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FileSentMessageRepository.cs
@@ -7,7 +7,7 @@ public sealed class FileSentMessageRepository : ISentMessageRepository {
     private readonly string filePath;
     private readonly SemaphoreSlim gate = new(1, 1);
     private readonly Dictionary<string, long> index = new(StringComparer.OrdinalIgnoreCase);
-    private readonly byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+    private static readonly byte[] NewlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
 
     /// <summary>
     /// Creates a new repository using the specified file path.
@@ -22,19 +22,16 @@ public sealed class FileSentMessageRepository : ISentMessageRepository {
 
     private void BuildIndex() {
         index.Clear();
-        long position = 0;
         try {
-            foreach (var line in File.ReadLines(filePath)) {
+            foreach (var entry in LogFileLineReader.ReadLinesWithOffsets(filePath)) {
+                var line = entry.Line;
                 if (string.IsNullOrWhiteSpace(line)) {
-                    position += newlineBytes.Length;
                     continue;
                 }
 
                 if (TryDeserializeRecord(line, out var record) && !string.IsNullOrEmpty(record!.MessageId)) {
-                    index[record.MessageId] = position;
+                    index[record.MessageId] = entry.Offset;
                 }
-
-                position += Encoding.UTF8.GetByteCount(line) + newlineBytes.Length;
             }
         } catch (FileNotFoundException) {
             index.Clear();
@@ -68,7 +65,7 @@ public sealed class FileSentMessageRepository : ISentMessageRepository {
             using var write = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
             var offset = write.Position;
             await JsonSerializer.SerializeAsync(write, record, MailozaurrJsonContext.Default.SentMessageRecord, cancellationToken);
-            await write.WriteAsync(newlineBytes, 0, newlineBytes.Length, cancellationToken);
+            await write.WriteAsync(NewlineBytes, 0, NewlineBytes.Length, cancellationToken);
             index[record.MessageId] = offset;
         } finally {
             gate.Release();

--- a/Sources/Mailozaurr/SentMessages/LogFileLineReader.cs
+++ b/Sources/Mailozaurr/SentMessages/LogFileLineReader.cs
@@ -1,0 +1,61 @@
+using System.Text;
+
+namespace Mailozaurr;
+
+internal static class LogFileLineReader {
+    internal readonly struct LineRecord {
+        public LineRecord(long offset, string line) {
+            Offset = offset;
+            Line = line;
+        }
+
+        public long Offset { get; }
+
+        public string Line { get; }
+    }
+
+    public static IEnumerable<LineRecord> ReadLinesWithOffsets(string filePath) {
+        using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        foreach (var line in ReadLinesWithOffsets(stream)) {
+            yield return line;
+        }
+    }
+
+    private static IEnumerable<LineRecord> ReadLinesWithOffsets(FileStream stream) {
+        var buffer = new List<byte>();
+
+        while (true) {
+            var offset = stream.Position;
+            var endOfFile = false;
+
+            while (true) {
+                var value = stream.ReadByte();
+                if (value < 0) {
+                    endOfFile = true;
+                    break;
+                }
+
+                if (value == '\n') {
+                    if (buffer.Count > 0 && buffer[buffer.Count - 1] == '\r') {
+                        buffer.RemoveAt(buffer.Count - 1);
+                    }
+
+                    break;
+                }
+
+                buffer.Add((byte) value);
+            }
+
+            if (endOfFile && buffer.Count == 0) {
+                yield break;
+            }
+
+            yield return new LineRecord(offset, buffer.Count == 0 ? string.Empty : Encoding.UTF8.GetString(buffer.ToArray()));
+            buffer.Clear();
+
+            if (endOfFile) {
+                yield break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- rebuild sent and pending log indexes from actual newline-delimited byte offsets so LF-only files remain readable on Windows
- tolerate missing pending-log files during indexed reads and enumeration instead of throwing
- preserve caller cancellation when remote HTML image embedding is canceled and cover the behavior with regression tests

## Testing
- dotnet test Sources/Mailozaurr.sln --no-restore -v minimal