### PR TITLE
fix: protect oauth token cache secrets

### DIFF
--- a/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.Tests;
+
+public sealed class OAuthTokenCacheProtectionTests {
+    public OAuthTokenCacheProtectionTests() {
+        ResetCache();
+        DeleteCacheFile();
+    }
+
+    [Fact]
+    public async Task SetAsync_WritesProtectedSecretsToDisk() {
+        var cacheKey = "oauth:protected@example.com";
+        var credential = new OAuthCredential {
+            UserName = "protected@example.com",
+            AccessToken = "access-token-value",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1),
+            RefreshToken = "refresh-token-value",
+            ClientId = "client-id",
+            ClientSecret = "client-secret-value",
+            ServiceAccountJson = "{\"type\":\"service_account\"}",
+            ServiceAccountSubject = "subject@example.com"
+        };
+
+        await OAuthTokenCache.SetAsync(cacheKey, credential);
+
+        var path = GetCacheFilePath();
+        Assert.True(File.Exists(path));
+
+        var json = File.ReadAllText(path);
+        Assert.DoesNotContain("access-token-value", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("refresh-token-value", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("client-secret-value", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"type\":\"service_account\"", json, StringComparison.Ordinal);
+
+        using var document = JsonDocument.Parse(json);
+        var entry = document.RootElement.GetProperty(cacheKey);
+        Assert.True(entry.TryGetProperty("AccessTokenProtected", out _));
+        Assert.True(entry.TryGetProperty("RefreshTokenProtected", out _));
+        Assert.True(entry.TryGetProperty("ClientSecretProtected", out _));
+        Assert.True(entry.TryGetProperty("ServiceAccountJsonProtected", out _));
+
+        ResetCache();
+        var reloaded = await OAuthTokenCache.GetAsync(cacheKey);
+
+        Assert.NotNull(reloaded);
+        Assert.Equal(credential.AccessToken, reloaded!.AccessToken);
+        Assert.Equal(credential.RefreshToken, reloaded.RefreshToken);
+        Assert.Equal(credential.ClientSecret, reloaded.ClientSecret);
+        Assert.Equal(credential.ServiceAccountJson, reloaded.ServiceAccountJson);
+        Assert.Equal(credential.ServiceAccountSubject, reloaded.ServiceAccountSubject);
+    }
+
+    [Fact]
+    public async Task GetAsync_LoadsLegacyPlaintextCacheFile() {
+        var cacheKey = "oauth:legacy@example.com";
+        var credential = new OAuthCredential {
+            UserName = "legacy@example.com",
+            AccessToken = "legacy-access-token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddMinutes(30),
+            RefreshToken = "legacy-refresh-token",
+            ClientId = "legacy-client",
+            ClientSecret = "legacy-secret",
+            ServiceAccountJson = "{\"legacy\":true}",
+            ServiceAccountSubject = "legacy-subject@example.com"
+        };
+
+        var path = GetCacheFilePath();
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        var legacyCache = new Dictionary<string, OAuthCredential>(StringComparer.Ordinal) {
+            [cacheKey] = credential
+        };
+        var json = JsonSerializer.Serialize(legacyCache, MailozaurrJsonContext.Default.DictionaryStringOAuthCredential);
+        File.WriteAllText(path, json);
+
+        var loaded = await OAuthTokenCache.GetAsync(cacheKey);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(credential.UserName, loaded!.UserName);
+        Assert.Equal(credential.AccessToken, loaded.AccessToken);
+        Assert.Equal(credential.RefreshToken, loaded.RefreshToken);
+        Assert.Equal(credential.ClientId, loaded.ClientId);
+        Assert.Equal(credential.ClientSecret, loaded.ClientSecret);
+        Assert.Equal(credential.ServiceAccountJson, loaded.ServiceAccountJson);
+        Assert.Equal(credential.ServiceAccountSubject, loaded.ServiceAccountSubject);
+    }
+
+    private static void ResetCache() {
+        var field = typeof(OAuthTokenCache).GetField("_cache", BindingFlags.Static | BindingFlags.NonPublic);
+        field?.SetValue(null, null);
+    }
+
+    private static string GetCacheFilePath() {
+        var pathField = typeof(OAuthTokenCache).GetField("CacheFilePath", BindingFlags.Static | BindingFlags.NonPublic);
+        return (string)pathField!.GetValue(null)!;
+    }
+
+    private static void DeleteCacheFile() {
+        var path = GetCacheFilePath();
+        if (File.Exists(path)) {
+            File.Delete(path);
+        }
+    }
+}

--- a/Sources/Mailozaurr/Authentication/OAuthCredentialCacheEntry.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthCredentialCacheEntry.cs
@@ -1,0 +1,101 @@
+using System;
+
+namespace Mailozaurr;
+
+#pragma warning disable CS1591
+public sealed class OAuthCredentialCacheEntry {
+    public string UserName { get; set; } = string.Empty;
+
+    public string? AccessTokenProtected { get; set; }
+
+    public string? AccessToken { get; set; }
+
+    public DateTimeOffset ExpiresOn { get; set; }
+
+    public string? RefreshTokenProtected { get; set; }
+
+    public string? RefreshToken { get; set; }
+
+    public string? ClientId { get; set; }
+
+    public string? ClientSecretProtected { get; set; }
+
+    public string? ClientSecret { get; set; }
+
+    public string? ServiceAccountJsonProtected { get; set; }
+
+    public string? ServiceAccountJson { get; set; }
+
+    public string? ServiceAccountSubject { get; set; }
+
+    public static OAuthCredentialCacheEntry FromCredential(OAuthCredential credential, ICredentialProtector protector) {
+        if (credential == null) {
+            throw new ArgumentNullException(nameof(credential));
+        }
+
+        if (protector == null) {
+            throw new ArgumentNullException(nameof(protector));
+        }
+
+        return new OAuthCredentialCacheEntry {
+            UserName = credential.UserName,
+            AccessTokenProtected = ProtectRequired(protector, credential.AccessToken),
+            ExpiresOn = credential.ExpiresOn,
+            RefreshTokenProtected = ProtectOptional(protector, credential.RefreshToken),
+            ClientId = credential.ClientId,
+            ClientSecretProtected = ProtectOptional(protector, credential.ClientSecret),
+            ServiceAccountJsonProtected = ProtectOptional(protector, credential.ServiceAccountJson),
+            ServiceAccountSubject = credential.ServiceAccountSubject
+        };
+    }
+
+    public OAuthCredential ToCredential(ICredentialProtector protector) {
+        if (protector == null) {
+            throw new ArgumentNullException(nameof(protector));
+        }
+
+        return new OAuthCredential {
+            UserName = UserName,
+            AccessToken = ReadRequiredSecret(protector, AccessTokenProtected, AccessToken),
+            ExpiresOn = ExpiresOn,
+            RefreshToken = ReadOptionalSecret(protector, RefreshTokenProtected, RefreshToken),
+            ClientId = ClientId,
+            ClientSecret = ReadOptionalSecret(protector, ClientSecretProtected, ClientSecret),
+            ServiceAccountJson = ReadOptionalSecret(protector, ServiceAccountJsonProtected, ServiceAccountJson),
+            ServiceAccountSubject = ServiceAccountSubject
+        };
+    }
+
+    private static string ProtectRequired(ICredentialProtector protector, string value) {
+        if (string.IsNullOrEmpty(value)) {
+            return string.Empty;
+        }
+
+        return protector.Protect(value);
+    }
+
+    private static string? ProtectOptional(ICredentialProtector protector, string? value) {
+        if (string.IsNullOrEmpty(value)) {
+            return null;
+        }
+
+        return protector.Protect(value!);
+    }
+
+    private static string ReadRequiredSecret(ICredentialProtector protector, string? protectedValue, string? legacyValue) {
+        var value = ReadOptionalSecret(protector, protectedValue, legacyValue);
+        return value ?? string.Empty;
+    }
+
+    private static string? ReadOptionalSecret(ICredentialProtector protector, string? protectedValue, string? legacyValue) {
+        if (!string.IsNullOrEmpty(protectedValue)) {
+            var unprotected = CredentialProtection.UnprotectWithFallback(protector, protectedValue);
+            if (!string.IsNullOrEmpty(unprotected) || string.IsNullOrEmpty(legacyValue)) {
+                return unprotected;
+            }
+        }
+
+        return legacyValue;
+    }
+}
+#pragma warning restore CS1591

--- a/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
@@ -19,6 +19,40 @@ internal static class OAuthTokenCache {
 
     private static Dictionary<string, OAuthCredential>? _cache;
 
+    private static Dictionary<string, OAuthCredential> ConvertCacheEntries(
+        Dictionary<string, OAuthCredentialCacheEntry>? cacheEntries,
+        ICredentialProtector protector) {
+        var cache = new Dictionary<string, OAuthCredential>(StringComparer.Ordinal);
+        if (cacheEntries == null) {
+            return cache;
+        }
+
+        foreach (var pair in cacheEntries) {
+            if (pair.Value == null) {
+                continue;
+            }
+
+            cache[pair.Key] = pair.Value.ToCredential(protector);
+        }
+
+        return cache;
+    }
+
+    private static Dictionary<string, OAuthCredentialCacheEntry> CreateCacheEntries(
+        Dictionary<string, OAuthCredential> cache,
+        ICredentialProtector protector) {
+        var entries = new Dictionary<string, OAuthCredentialCacheEntry>(StringComparer.Ordinal);
+        foreach (var pair in cache) {
+            if (pair.Value == null) {
+                continue;
+            }
+
+            entries[pair.Key] = OAuthCredentialCacheEntry.FromCredential(pair.Value, protector);
+        }
+
+        return entries;
+    }
+
     private static async Task<Dictionary<string, OAuthCredential>> LoadCacheAsync(CancellationToken cancellationToken = default) {
         cancellationToken.ThrowIfCancellationRequested();
         if (_cache != null) {
@@ -34,7 +68,9 @@ internal static class OAuthTokenCache {
 #else
                 var json = await File.ReadAllTextAsync(CacheFilePath, cancellationToken).ConfigureAwait(false);
 #endif
-                cache = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.DictionaryStringOAuthCredential) ?? new();
+                var protector = CredentialProtection.Default;
+                var cacheEntries = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry);
+                cache = ConvertCacheEntries(cacheEntries, protector);
             } catch (FileNotFoundException) {
                 cache = new Dictionary<string, OAuthCredential>();
             } catch (DirectoryNotFoundException) {
@@ -82,7 +118,8 @@ internal static class OAuthTokenCache {
             if (!Directory.Exists(dir)) {
                 Directory.CreateDirectory(dir!);
             }
-            json = JsonSerializer.Serialize(cache, MailozaurrJsonContext.Default.DictionaryStringOAuthCredential);
+            var cacheEntries = CreateCacheEntries(cache, CredentialProtection.Default);
+            json = JsonSerializer.Serialize(cacheEntries, MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry);
         }
         cancellationToken.ThrowIfCancellationRequested();
 #if NETFRAMEWORK || NETSTANDARD2_0

--- a/Sources/Mailozaurr/Serialization/MailozaurrJsonContext.cs
+++ b/Sources/Mailozaurr/Serialization/MailozaurrJsonContext.cs
@@ -12,6 +12,8 @@ namespace Mailozaurr;
 [JsonSerializable(typeof(SentMessageRecord))]
 [JsonSerializable(typeof(OAuthCredential))]
 [JsonSerializable(typeof(Dictionary<string, OAuthCredential>))]
+[JsonSerializable(typeof(OAuthCredentialCacheEntry), TypeInfoPropertyName = "OAuthCredentialCacheEntry")]
+[JsonSerializable(typeof(Dictionary<string, OAuthCredentialCacheEntry>), TypeInfoPropertyName = "DictionaryStringOAuthCredentialCacheEntry")]
 [JsonSerializable(typeof(Dictionary<string, string>))]
 [JsonSerializable(typeof(Dictionary<string, bool>), TypeInfoPropertyName = "DictionaryStringBool")]
 [JsonSerializable(typeof(Dictionary<string, int>), TypeInfoPropertyName = "DictionaryStringInt")]


### PR DESCRIPTION
## Summary
- persist oauth cache entries using protected fields for access tokens, refresh tokens, client secrets, and service-account JSON
- keep cache reads backward compatible with legacy plaintext oauth_cache.json files
- add regression tests covering protected disk writes and legacy cache migration

## Testing
- dotnet test Sources/Mailozaurr.sln --no-restore -v minimal