### PR TITLE
fix: keep canceled gmail sends out of pending queue

### DIFF
--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -64,6 +64,43 @@ public class GmailApiClientTests {
             base.Dispose(disposing);
         }
     }
+
+    private sealed class PendingRepositoryStub : IPendingMessageRepository {
+        public List<PendingMessageRecord> Saved { get; } = new();
+
+        public Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
+            Saved.Add(record);
+            return Task.CompletedTask;
+        }
+
+        public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<PendingMessageRecord?>(Saved.FirstOrDefault(r => string.Equals(r.MessageId, messageId, StringComparison.OrdinalIgnoreCase)));
+
+        public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            foreach (var record in Saved) {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return record;
+                await Task.Yield();
+            }
+        }
+
+        public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+            Saved.RemoveAll(r => string.Equals(r.MessageId, messageId, StringComparison.OrdinalIgnoreCase));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class DelayedCancellationHandler : HttpMessageHandler {
+        private readonly TaskCompletionSource<bool> _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task WaitForStartAsync() => _started.Task;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            _started.TrySetResult(true);
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("Unreachable");
+        }
+    }
     [Fact]
     public void Constructor_SetsAuthorizationHeader() {
         var cred = new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue };
@@ -570,6 +607,30 @@ public class GmailApiClientTests {
         cts.Cancel();
         var message = new MimeKit.MimeMessage();
         await Assert.ThrowsAnyAsync<System.OperationCanceledException>(() => client.SendAsync("me", message, cts.Token));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SendAsync_CallerCancellation_DoesNotQueuePendingMessage() {
+        var handler = new DelayedCancellationHandler();
+        var repository = new PendingRepositoryStub();
+        var client = new GmailApiClient(new OAuthCredential { UserName = "u", AccessToken = "t", ExpiresOn = System.DateTimeOffset.MaxValue }) {
+            PendingMessageRepository = repository
+        };
+        var field = typeof(GmailApiClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(client, new System.Net.Http.HttpClient(handler) { BaseAddress = new System.Uri("https://gmail.googleapis.com/gmail/v1/") });
+
+        var message = new MimeKit.MimeMessage();
+        message.From.Add(MimeKit.MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MimeKit.MailboxAddress.Parse("recipient@example.com"));
+        message.Body = new MimeKit.TextPart("plain") { Text = "body" };
+
+        using var cts = new System.Threading.CancellationTokenSource();
+        var task = client.SendAsync("me", message, cts.Token);
+        await handler.WaitForStartAsync();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<System.OperationCanceledException>(async () => await task);
+        Assert.Empty(repository.Saved);
     }
 
     [Fact]

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -250,6 +250,8 @@ public sealed class GmailApiClient : IDisposable {
                 queued = true;
             }
             throw;
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            throw;
         } catch (TaskCanceledException) {
             if (!queued) {
                 await QueuePendingMessageAsync(userId, message, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- preserve caller cancellation in GmailApiClient.SendAsync instead of treating it as a retryable send failure
- avoid creating pending-message retry records when a Gmail send is explicitly canceled by the caller
- add regression coverage for canceled in-flight sends with a pending repository configured

## Testing
- dotnet test Sources/Mailozaurr.sln --no-restore -v minimal