### PR TITLE
fix: keep canceled sendgrid sends out of pending queue

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -72,6 +72,18 @@ public sealed class ProviderPendingMessageTests {
         }
     }
 
+    private sealed class DelayedCancellationHandler : HttpMessageHandler {
+        private readonly TaskCompletionSource<bool> started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task WaitForStartAsync() => started.Task;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            started.TrySetResult(true);
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException("Unreachable");
+        }
+    }
+
     [Fact]
     public async Task SendGridClientQueuesAndProcessesPendingMessage() {
         using var client = new SendGridClient {
@@ -121,6 +133,33 @@ public sealed class ProviderPendingMessageTests {
 
         Assert.Equal(1, successHandler.CallCount);
         Assert.Null(await repository.GetByMessageIdAsync(record!.MessageId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SendGridClient_CallerCancellation_DoesNotQueuePendingMessage() {
+        using var client = new SendGridClient {
+            Credentials = new NetworkCredential("apikey", "SG.API"),
+            From = "sender@example.com",
+            To = new List<object> { "recipient@example.com" },
+            Subject = "canceled",
+            Text = "hello"
+        };
+        client.CreateMessage();
+
+        var repository = new InMemoryPendingMessageRepository();
+        client.PendingMessageRepository = repository;
+
+        var delayedHandler = new DelayedCancellationHandler();
+        var httpClientField = typeof(SendGridClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        httpClientField.SetValue(client, new HttpClient(delayedHandler));
+
+        using var cts = new CancellationTokenSource();
+        var sendTask = client.SendEmailAsync(cts.Token);
+        await delayedHandler.WaitForStartAsync();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
+        Assert.Null(repository.LastSaved);
     }
 
     [Fact]

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -411,6 +411,8 @@ public sealed class SendGridClient : IDisposable {
                 if (delayMilliseconds > 0) {
                     await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken).ConfigureAwait(false);
                 }
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                throw;
             } catch (TaskCanceledException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Request canceled: {ex.Message}");


### PR DESCRIPTION
## Summary
- preserve caller cancellation in SendGridClient.SendEmailAsync instead of treating it as a retryable failure
- avoid creating pending-message retry records when a SendGrid send is explicitly canceled by the caller
- add provider-level regression coverage for canceled in-flight sends with a pending repository configured

## Testing
- dotnet test Sources/Mailozaurr.sln --no-restore -v minimal