### PR TITLE
Preserve cancellation during pending save

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -84,6 +84,27 @@ public sealed class ProviderPendingMessageTests {
         }
     }
 
+    private sealed class CancellationOnSavePendingMessageRepository : IPendingMessageRepository {
+        private readonly TaskCompletionSource<bool> saveStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task WaitForSaveStartAsync() => saveStarted.Task;
+
+        public async Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
+            saveStarted.TrySetResult(true);
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<PendingMessageRecord?>(null);
+
+        public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
     [Fact]
     public async Task SendGridClientQueuesAndProcessesPendingMessage() {
         using var client = new SendGridClient {
@@ -163,6 +184,34 @@ public sealed class ProviderPendingMessageTests {
     }
 
     [Fact]
+    public async Task SendGridClient_CancellationDuringPendingSave_PropagatesCancellation() {
+        using var client = new SendGridClient {
+            Credentials = new NetworkCredential("apikey", "SG.API"),
+            From = "sender@example.com",
+            To = new List<object> { "recipient@example.com" },
+            Subject = "pending-save-cancel",
+            Text = "hello"
+        };
+        client.CreateMessage();
+
+        var repository = new CancellationOnSavePendingMessageRepository();
+        client.PendingMessageRepository = repository;
+
+        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError) {
+            Content = new StringContent("failure", Encoding.UTF8, "text/plain")
+        }));
+        var httpClientField = typeof(SendGridClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        httpClientField.SetValue(client, new HttpClient(failureHandler));
+
+        using var cts = new CancellationTokenSource();
+        var sendTask = client.SendEmailAsync(cts.Token);
+        await repository.WaitForSaveStartAsync();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
+    }
+
+    [Fact]
     public async Task MailgunClientQueuesAndProcessesPendingMessage() {
         var repository = new InMemoryPendingMessageRepository();
         using var client = new MailgunClient {
@@ -210,6 +259,32 @@ public sealed class ProviderPendingMessageTests {
 
         Assert.Equal(1, successHandler.CallCount);
         Assert.Null(await repository.GetByMessageIdAsync(record!.MessageId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task MailgunClient_CancellationDuringPendingSave_PropagatesCancellation() {
+        var repository = new CancellationOnSavePendingMessageRepository();
+        using var client = new MailgunClient {
+            PendingMessageRepository = repository,
+            Credentials = new NetworkCredential("user", "mailgun-api-key"),
+            From = "sender@example.com",
+            To = new List<object> { "recipient@example.com" },
+            Subject = "mailgun-cancel",
+            Text = "body"
+        };
+
+        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway) {
+            Content = new StringContent("error", Encoding.UTF8, "text/plain")
+        }));
+        var httpClientField = typeof(MailgunClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        httpClientField.SetValue(client, new HttpClient(failureHandler));
+
+        using var cts = new CancellationTokenSource();
+        var sendTask = client.SendEmailAsync(cts.Token);
+        await repository.WaitForSaveStartAsync();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
     }
 
     [Fact]
@@ -280,6 +355,41 @@ public sealed class ProviderPendingMessageTests {
     }
 
     [Fact]
+    public async Task GmailClient_CancellationDuringPendingSave_PropagatesCancellation() {
+        var credential = new OAuthCredential {
+            UserName = "user@example.com",
+            AccessToken = "access-token",
+            RefreshToken = "refresh-token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1),
+            ClientId = "client-123",
+            ClientSecret = "client-secret"
+        };
+        var repository = new CancellationOnSavePendingMessageRepository();
+        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError) {
+            Content = new StringContent("{\"error\":\"failed\"}", Encoding.UTF8, "application/json")
+        }));
+        using var failureClient = new HttpClient(failureHandler) {
+            BaseAddress = new Uri("https://gmail.googleapis.com/gmail/v1/")
+        };
+        using var client = new GmailApiClient(failureClient, credential: credential) {
+            PendingMessageRepository = repository
+        };
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+        message.Subject = "gmail-cancel";
+        message.Body = new TextPart("plain") { Text = "body" };
+
+        using var cts = new CancellationTokenSource();
+        var sendTask = client.SendAsync("me", message, cts.Token);
+        await repository.WaitForSaveStartAsync();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
+    }
+
+    [Fact]
     public async Task SesClientQueuesAndProcessesPendingMessage() {
         var repository = new InMemoryPendingMessageRepository();
         using var client = new SesClient {
@@ -328,5 +438,32 @@ public sealed class ProviderPendingMessageTests {
 
         Assert.Equal(1, successHandler.CallCount);
         Assert.Null(await repository.GetByMessageIdAsync(record!.MessageId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SesClient_CancellationDuringPendingSave_PropagatesCancellation() {
+        var repository = new CancellationOnSavePendingMessageRepository();
+        using var client = new SesClient {
+            PendingMessageRepository = repository,
+            Credentials = new NetworkCredential("AKIA123", "secret-key"),
+            Region = "us-east-1",
+            From = "sender@example.com",
+            To = new List<object> { "recipient@example.com" },
+            Subject = "ses-cancel",
+            Text = "body"
+        };
+
+        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) {
+            Content = new StringContent("failure", Encoding.UTF8, "text/plain")
+        }));
+        var httpClientField = typeof(SesClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        httpClientField.SetValue(client, new HttpClient(failureHandler));
+
+        using var cts = new CancellationTokenSource();
+        var sendTask = client.SendEmailAsync(cts.Token);
+        await repository.WaitForSaveStartAsync();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
     }
 }

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -254,6 +254,10 @@ public class SesClient : IDisposable {
         {
             await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             LogCollector.LogWarning($"Send-EmailMessage - Failed to persist SES pending message: {ex.Message}");

--- a/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
@@ -12,6 +12,7 @@ namespace Mailozaurr;
 /// </summary>
 internal static class OAuthTokenCache {
     private static readonly object LockObj = new();
+    private const int IoRetryCount = 5;
     private static readonly string CacheFilePath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "Mailozaurr",
@@ -77,6 +78,8 @@ internal static class OAuthTokenCache {
                 cache = new Dictionary<string, OAuthCredential>();
             } catch (JsonException) {
                 cache = new Dictionary<string, OAuthCredential>();
+            } catch (IOException) {
+                cache = new Dictionary<string, OAuthCredential>();
             }
         } else {
             cache = new Dictionary<string, OAuthCredential>();
@@ -124,45 +127,95 @@ internal static class OAuthTokenCache {
             json = JsonSerializer.Serialize(cacheEntries, MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry);
         }
         cancellationToken.ThrowIfCancellationRequested();
-#if NETFRAMEWORK || NETSTANDARD2_0
         await WriteCacheFileAsync(json, cancellationToken).ConfigureAwait(false);
-#else
-        await File.WriteAllTextAsync(CacheFilePath, json, cancellationToken).ConfigureAwait(false);
-#endif
     }
 
-#if NETFRAMEWORK || NETSTANDARD2_0
     private static async Task<string> ReadCacheFileAsync(CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-        using (var stream = new FileStream(CacheFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true))
-        using (cancellationToken.Register(() => stream.Dispose()))
-        using (var reader = new StreamReader(stream))
-        using (cancellationToken.Register(() => reader.Dispose())) {
+        for (var attempt = 0; ; attempt++) {
+            cancellationToken.ThrowIfCancellationRequested();
             try {
-                var json = await reader.ReadToEndAsync().ConfigureAwait(false);
-                cancellationToken.ThrowIfCancellationRequested();
-                return json;
-            } catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested) {
-                throw new OperationCanceledException(cancellationToken);
+                using (var stream = new FileStream(CacheFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete, 4096, true))
+                using (cancellationToken.Register(() => stream.Dispose()))
+                using (var reader = new StreamReader(stream))
+                using (cancellationToken.Register(() => reader.Dispose())) {
+                    try {
+                        var json = await reader.ReadToEndAsync().ConfigureAwait(false);
+                        cancellationToken.ThrowIfCancellationRequested();
+                        return json;
+                    } catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested) {
+                        throw new OperationCanceledException(cancellationToken);
+                    }
+                }
+            } catch (IOException) when (attempt < IoRetryCount - 1) {
+                await Task.Delay(GetRetryDelay(attempt), cancellationToken).ConfigureAwait(false);
             }
         }
     }
 
     private static async Task WriteCacheFileAsync(string json, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-        using (var stream = new FileStream(CacheFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true))
-        using (cancellationToken.Register(() => stream.Dispose()))
-        using (var writer = new StreamWriter(stream))
-        using (cancellationToken.Register(() => writer.Dispose())) {
+        var directory = Path.GetDirectoryName(CacheFilePath);
+        if (string.IsNullOrWhiteSpace(directory)) {
+            throw new InvalidOperationException("OAuth cache path is invalid.");
+        }
+
+        for (var attempt = 0; ; attempt++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            var tempPath = Path.Combine(directory, Path.GetRandomFileName());
             try {
-                await writer.WriteAsync(json).ConfigureAwait(false);
-                await writer.FlushAsync().ConfigureAwait(false);
-                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
-                cancellationToken.ThrowIfCancellationRequested();
-            } catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested) {
-                throw new OperationCanceledException(cancellationToken);
+                using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete, 4096, true))
+                using (cancellationToken.Register(() => stream.Dispose()))
+                using (var writer = new StreamWriter(stream))
+                using (cancellationToken.Register(() => writer.Dispose())) {
+                    try {
+                        await writer.WriteAsync(json).ConfigureAwait(false);
+                        await writer.FlushAsync().ConfigureAwait(false);
+                        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                        cancellationToken.ThrowIfCancellationRequested();
+                    } catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested) {
+                        throw new OperationCanceledException(cancellationToken);
+                    }
+                }
+
+                ReplaceCacheFile(tempPath);
+                tempPath = string.Empty;
+                return;
+            } catch (IOException) when (attempt < IoRetryCount - 1) {
+                await Task.Delay(GetRetryDelay(attempt), cancellationToken).ConfigureAwait(false);
+            } finally {
+                if (!string.IsNullOrEmpty(tempPath) && File.Exists(tempPath)) {
+                    try {
+                        File.Delete(tempPath);
+                    } catch (IOException) {
+                    }
+                }
             }
         }
     }
-#endif
+
+    private static void ReplaceCacheFile(string tempPath) {
+        if (File.Exists(CacheFilePath)) {
+            try {
+                File.Replace(tempPath, CacheFilePath, null, ignoreMetadataErrors: true);
+                return;
+            } catch (FileNotFoundException) {
+            } catch (PlatformNotSupportedException) {
+            }
+        }
+
+        if (File.Exists(CacheFilePath)) {
+            File.Copy(tempPath, CacheFilePath, overwrite: true);
+            File.Delete(tempPath);
+            return;
+        }
+
+        try {
+            File.Move(tempPath, CacheFilePath);
+        } catch (IOException) when (File.Exists(CacheFilePath)) {
+            File.Copy(tempPath, CacheFilePath, overwrite: true);
+            File.Delete(tempPath);
+        }
+    }
+
+    private static TimeSpan GetRetryDelay(int attempt) =>
+        TimeSpan.FromMilliseconds(25 * (attempt + 1));
 }

--- a/Sources/Mailozaurr/Gmail/GmailApiClient.cs
+++ b/Sources/Mailozaurr/Gmail/GmailApiClient.cs
@@ -200,6 +200,8 @@ public sealed class GmailApiClient : IDisposable {
 
         try {
             await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            throw;
         } catch (Exception ex) {
             LoggingMessages.Logger.WriteWarning($"Failed to persist Gmail pending message: {ex.Message}");
         }

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -266,6 +266,8 @@ public class MailgunClient : IDisposable {
 
         try {
             await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            throw;
         } catch (Exception ex) {
             LogCollector.LogWarning($"Send-EmailMessage - Failed to persist Mailgun pending message: {ex.Message}");
         }

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -473,6 +473,8 @@ public sealed class SendGridClient : IDisposable {
 
         try {
             await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            throw;
         } catch (Exception ex) {
             LogCollector.LogWarning($"Send-EmailMessage - Failed to persist SendGrid pending message: {ex.Message}");
         }


### PR DESCRIPTION
## Summary
- preserve caller cancellation when Gmail, SendGrid, Mailgun, and SES try to persist a pending message after a failed send
- harden OAuth token cache file I/O for concurrent readers and writers with shared reads, retries, and atomic replacement
- add provider regressions covering cancellation during pending-message persistence

## Testing
- dotnet test Sources/Mailozaurr.sln --no-restore --filter 'FullyQualifiedName~ProviderPendingMessageTests' -v minimal
- dotnet test Sources/Mailozaurr.sln --no-restore --filter 'FullyQualifiedName~OAuthHelpersGoogleCachedTokenTests|FullyQualifiedName~GraphBatchAndRetryTests|FullyQualifiedName~GraphMessageListenerTests|FullyQualifiedName~OAuthTokenCacheProtectionTests' -v minimal
- dotnet test Sources/Mailozaurr.sln --no-restore -v minimal