### PR TITLE
Harden listener shutdown and token cache contention

### DIFF
--- a/Sources/Mailozaurr.Tests/ImapIdleListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapIdleListenerTests.cs
@@ -62,6 +62,35 @@ public class ImapIdleListenerTests {
         Assert.Null(GetPrivateField<CancellationTokenSource?>(listener, "_cancel"));
     }
 
+    [Fact]
+    public async Task StopAsync_IgnoresCancellationFromIdleLoopWhenStopping() {
+        var listener = new ImapIdleListener(new ImapClient());
+        var cancellation = new CancellationTokenSource();
+
+        SetPrivateField(listener, "_cancel", cancellation);
+        SetPrivateField(listener, "_idleTask", Task.FromCanceled(new CancellationToken(canceled: true)));
+
+        await listener.StopAsync();
+
+        Assert.True(cancellation.IsCancellationRequested);
+        Assert.Null(GetPrivateField<Task?>(listener, "_idleTask"));
+        Assert.Null(GetPrivateField<CancellationTokenSource?>(listener, "_cancel"));
+    }
+
+    [Fact]
+    public void Dispose_IgnoresCancellationFromIdleLoopWhenStopping() {
+        var listener = new ImapIdleListener(new ImapClient());
+        var cancellation = new CancellationTokenSource();
+
+        SetPrivateField(listener, "_cancel", cancellation);
+        SetPrivateField(listener, "_idleTask", Task.FromCanceled(new CancellationToken(canceled: true)));
+
+        listener.Dispose();
+
+        Assert.Null(GetPrivateField<Task?>(listener, "_idleTask"));
+        Assert.Null(GetPrivateField<CancellationTokenSource?>(listener, "_cancel"));
+    }
+
     private static void SetPrivateField<T>(ImapIdleListener listener, string name, T value) =>
         typeof(ImapIdleListener).GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(listener, value);
 

--- a/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
@@ -140,6 +140,45 @@ public sealed class OAuthTokenCacheProtectionTests {
         Assert.DoesNotContain("{broken", json, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task GetAsync_RetriesTransientFileLockAndLoadsCredential() {
+        var cacheKey = "oauth:locked@example.com";
+        var credential = new OAuthCredential {
+            UserName = "locked@example.com",
+            AccessToken = "locked-access-token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddMinutes(30)
+        };
+
+        var path = GetCacheFilePath();
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        var cacheEntries = new Dictionary<string, OAuthCredentialCacheEntry>(StringComparer.Ordinal) {
+            [cacheKey] = OAuthCredentialCacheEntry.FromCredential(credential, CredentialProtection.Default)
+        };
+        var json = JsonSerializer.Serialize(cacheEntries, MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry);
+        File.WriteAllText(path, json);
+        ResetCache();
+
+        var lockStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+        try {
+            var releaseTask = Task.Run(async () => {
+                await Task.Delay(75);
+                lockStream.Dispose();
+            });
+
+            var loaded = await OAuthTokenCache.GetAsync(cacheKey);
+            await releaseTask;
+
+            Assert.NotNull(loaded);
+            Assert.Equal(credential.AccessToken, loaded!.AccessToken);
+        } finally {
+            lockStream.Dispose();
+        }
+    }
+
     private static void ResetCache() {
         var field = typeof(OAuthTokenCache).GetField("_cache", BindingFlags.Static | BindingFlags.NonPublic);
         field?.SetValue(null, null);

--- a/Sources/Mailozaurr.Tests/TokenCacheHelperTests.cs
+++ b/Sources/Mailozaurr.Tests/TokenCacheHelperTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mailozaurr.Tests;
+
+public sealed class TokenCacheHelperTests {
+    public TokenCacheHelperTests() {
+        DeleteCacheFile();
+    }
+
+    [Fact]
+    public async Task ReadCacheData_RetriesTransientFileLockAndReturnsBytes() {
+        var path = GetCacheFilePath();
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        var expected = Encoding.UTF8.GetBytes("cached-token-data");
+        File.WriteAllBytes(path, expected);
+
+        var method = typeof(TokenCacheHelper).GetMethod("ReadCacheData", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var lockStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+        try {
+            var releaseTask = Task.Run(async () => {
+                await Task.Delay(75);
+                lockStream.Dispose();
+            });
+
+            var actual = (byte[]?)method!.Invoke(null, null);
+            await releaseTask;
+
+            Assert.NotNull(actual);
+            Assert.Equal(expected, actual);
+        } finally {
+            lockStream.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task WriteCacheData_RetriesTransientFileLockAndPersistsBytes() {
+        var path = GetCacheFilePath();
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllBytes(path, new byte[] { 0x00 });
+
+        var method = typeof(TokenCacheHelper).GetMethod("WriteCacheData", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var expected = Encoding.UTF8.GetBytes("updated-token-data");
+        var lockStream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        try {
+            var releaseTask = Task.Run(async () => {
+                await Task.Delay(75);
+                lockStream.Dispose();
+            });
+
+            method!.Invoke(null, new object[] { expected });
+            await releaseTask;
+
+            Assert.Equal(expected, File.ReadAllBytes(path));
+        } finally {
+            lockStream.Dispose();
+        }
+    }
+
+    private static string GetCacheFilePath() {
+        var pathField = typeof(TokenCacheHelper).GetField("CacheFilePath", BindingFlags.Static | BindingFlags.NonPublic);
+        return (string)pathField!.GetValue(null)!;
+    }
+
+    private static void DeleteCacheFile() {
+        var path = GetCacheFilePath();
+        if (File.Exists(path)) {
+            File.Delete(path);
+        }
+    }
+}

--- a/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
@@ -64,11 +64,7 @@ internal static class OAuthTokenCache {
         Dictionary<string, OAuthCredential> cache;
         if (File.Exists(CacheFilePath)) {
             try {
-#if NETFRAMEWORK || NETSTANDARD2_0
                 var json = await ReadCacheFileAsync(cancellationToken).ConfigureAwait(false);
-#else
-                var json = await File.ReadAllTextAsync(CacheFilePath, cancellationToken).ConfigureAwait(false);
-#endif
                 var protector = CredentialProtection.Default;
                 var cacheEntries = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry);
                 cache = ConvertCacheEntries(cacheEntries, protector);

--- a/Sources/Mailozaurr/Authentication/TokenCacheHelper.cs
+++ b/Sources/Mailozaurr/Authentication/TokenCacheHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using Microsoft.Identity.Client;
 
 namespace Mailozaurr;
@@ -9,6 +10,7 @@ namespace Mailozaurr;
 /// </summary>
 internal static class TokenCacheHelper {
     private static readonly object FileLock = new();
+    private const int IoRetryCount = 5;
     private static readonly string CacheFilePath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "Mailozaurr",
@@ -25,15 +27,9 @@ internal static class TokenCacheHelper {
 
     private static void BeforeAccessNotification(TokenCacheNotificationArgs args) {
         lock (FileLock) {
-            if (File.Exists(CacheFilePath)) {
-                try {
-                    var data = File.ReadAllBytes(CacheFilePath);
-                    args.TokenCache.DeserializeMsalV3(data, shouldClearExistingCache: true);
-                } catch (FileNotFoundException) {
-                    // another thread/process deleted the cache between the existence check and read
-                } catch (DirectoryNotFoundException) {
-                    // treat a missing cache directory as an empty cache
-                }
+            var data = ReadCacheData();
+            if (data != null && data.Length > 0) {
+                args.TokenCache.DeserializeMsalV3(data, shouldClearExistingCache: true);
             }
         }
     }
@@ -41,13 +37,95 @@ internal static class TokenCacheHelper {
     private static void AfterAccessNotification(TokenCacheNotificationArgs args) {
         if (args.HasStateChanged) {
             lock (FileLock) {
-                var directory = Path.GetDirectoryName(CacheFilePath);
-                if (!Directory.Exists(directory)) {
-                    Directory.CreateDirectory(directory!);
-                }
-                var data = args.TokenCache.SerializeMsalV3();
-                File.WriteAllBytes(CacheFilePath, data);
+                WriteCacheData(args.TokenCache.SerializeMsalV3());
             }
         }
     }
+
+    private static byte[]? ReadCacheData() {
+        if (!File.Exists(CacheFilePath)) {
+            return null;
+        }
+
+        for (var attempt = 0; ; attempt++) {
+            try {
+                using var stream = new FileStream(CacheFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                using var buffer = new MemoryStream();
+                stream.CopyTo(buffer);
+                return buffer.ToArray();
+            } catch (FileNotFoundException) {
+                return null;
+            } catch (DirectoryNotFoundException) {
+                return null;
+            } catch (IOException) when (attempt < IoRetryCount - 1) {
+                Thread.Sleep(GetRetryDelay(attempt));
+            } catch (IOException ex) {
+                LoggingMessages.Logger.WriteWarning($"Failed to read MSAL token cache: {ex.Message}");
+                return null;
+            }
+        }
+    }
+
+    private static void WriteCacheData(byte[] data) {
+        var directory = Path.GetDirectoryName(CacheFilePath);
+        if (string.IsNullOrWhiteSpace(directory)) {
+            return;
+        }
+
+        if (!Directory.Exists(directory)) {
+            Directory.CreateDirectory(directory!);
+        }
+
+        for (var attempt = 0; ; attempt++) {
+            var tempPath = Path.Combine(directory, Path.GetRandomFileName());
+            try {
+                using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete)) {
+                    stream.Write(data, 0, data.Length);
+                    stream.Flush(flushToDisk: true);
+                }
+
+                ReplaceCacheFile(tempPath);
+                tempPath = string.Empty;
+                return;
+            } catch (IOException) when (attempt < IoRetryCount - 1) {
+                Thread.Sleep(GetRetryDelay(attempt));
+            } catch (IOException ex) {
+                LoggingMessages.Logger.WriteWarning($"Failed to persist MSAL token cache: {ex.Message}");
+                return;
+            } finally {
+                if (!string.IsNullOrEmpty(tempPath) && File.Exists(tempPath)) {
+                    try {
+                        File.Delete(tempPath);
+                    } catch (IOException) {
+                    }
+                }
+            }
+        }
+    }
+
+    private static void ReplaceCacheFile(string tempPath) {
+        if (File.Exists(CacheFilePath)) {
+            try {
+                File.Replace(tempPath, CacheFilePath, null, ignoreMetadataErrors: true);
+                return;
+            } catch (FileNotFoundException) {
+            } catch (PlatformNotSupportedException) {
+            }
+        }
+
+        if (File.Exists(CacheFilePath)) {
+            File.Copy(tempPath, CacheFilePath, overwrite: true);
+            File.Delete(tempPath);
+            return;
+        }
+
+        try {
+            File.Move(tempPath, CacheFilePath);
+        } catch (IOException) when (File.Exists(CacheFilePath)) {
+            File.Copy(tempPath, CacheFilePath, overwrite: true);
+            File.Delete(tempPath);
+        }
+    }
+
+    private static int GetRetryDelay(int attempt) => 25 * (attempt + 1);
 }

--- a/Sources/Mailozaurr/Receive/ImapIdleListener.cs
+++ b/Sources/Mailozaurr/Receive/ImapIdleListener.cs
@@ -93,6 +93,7 @@ public class ImapIdleListener : IDisposable, IAsyncDisposable {
     /// </summary>
     public async Task StopAsync() {
         var idleTask = _idleTask;
+        var cancel = _cancel;
 
         Stop();
 
@@ -103,6 +104,8 @@ public class ImapIdleListener : IDisposable, IAsyncDisposable {
 
         try {
             await idleTask.ConfigureAwait(false);
+        } catch (OperationCanceledException) when (cancel?.IsCancellationRequested == true) {
+            // Listener shutdown requested cancellation while the loop was unwinding.
         } finally {
             Cleanup();
             if (ReferenceEquals(_idleTask, idleTask)) {
@@ -125,7 +128,11 @@ public class ImapIdleListener : IDisposable, IAsyncDisposable {
                     break;
                 } catch (Exception ex) {
                     IdleError?.Invoke(this, ex);
-                    await Task.Delay(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+                    try {
+                        await Task.Delay(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+                    } catch (OperationCanceledException) when (_cancel.IsCancellationRequested) {
+                        break;
+                    }
                 }
             }
         } finally {
@@ -197,7 +204,11 @@ public class ImapIdleListener : IDisposable, IAsyncDisposable {
 
             var idleTask = _idleTask;
             if (idleTask != null) {
-                idleTask.GetAwaiter().GetResult();
+                try {
+                    idleTask.GetAwaiter().GetResult();
+                } catch (OperationCanceledException) when (_cancel?.IsCancellationRequested == true) {
+                    // Listener shutdown requested cancellation while the loop was unwinding.
+                }
             }
         } finally {
             Cleanup();


### PR DESCRIPTION
## Summary
- keep IMAP listener stop and dispose paths from surfacing cancellation when shutdown happens during error backoff
- route all OAuth cache reads through the hardened retrying reader and add transient-lock coverage
- harden the MSAL cache helper against transient cross-process file contention with retrying shared reads and atomic writes

## Testing
- dotnet test Sources/Mailozaurr.sln --no-restore --filter 'FullyQualifiedName~ImapIdleListenerTests|FullyQualifiedName~OAuthTokenCacheProtectionTests|FullyQualifiedName~TokenCacheHelperTests|FullyQualifiedName~OAuthHelpersGoogleCachedTokenTests|FullyQualifiedName~GraphBatchAndRetryTests' -v minimal
- dotnet test Sources/Mailozaurr.sln --no-restore -v minimal