### PR TITLE
Fix remaining listener shutdown cancellation

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -12,20 +12,28 @@ namespace Mailozaurr.Tests;
 
 [Collection("GraphCollection")]
 public class GraphMessageListenerTests {
-    private class QueueHandler : HttpMessageHandler {
-        private readonly Queue<HttpResponseMessage> _responses;
+    private sealed class QueueHandler : HttpMessageHandler {
+        private readonly Queue<HttpResponseMessage> responses;
 
         public QueueHandler(IEnumerable<HttpResponseMessage> responses) {
-            _responses = new Queue<HttpResponseMessage>(responses);
+            this.responses = new Queue<HttpResponseMessage>(responses);
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
-            if (_responses.Count > 0) {
-                return Task.FromResult(_responses.Dequeue());
+            if (responses.Count > 0) {
+                return Task.FromResult(responses.Dequeue());
             }
+
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
                 Content = new StringContent("{\"value\":[]}")
             });
+        }
+    }
+
+    private sealed class HangingHandler : HttpMessageHandler {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("Unreachable");
         }
     }
 
@@ -87,4 +95,37 @@ public class GraphMessageListenerTests {
         } finally {
             handlerField.SetValue(client, original);
         }
-    }}
+    }
+
+    [Fact]
+    public async Task StartAsync_CancellationDuringInitialFetch_CleansUpState() {
+        var handler = new HangingHandler();
+        var clientField = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)clientField.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cache = (ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
+        cache.Clear();
+        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
+        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+        oauthField?.SetValue(null, null);
+        string cachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
+        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        try {
+            var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
+            var cancelField = typeof(GraphMessageListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var pollField = typeof(GraphMessageListener).GetField("_pollTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            using var cts = new CancellationTokenSource(100);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => listener.StartAsync(cts.Token));
+
+            Assert.Null(cancelField.GetValue(listener));
+            Assert.Null(pollField.GetValue(listener));
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/Pop3PollListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/Pop3PollListenerTests.cs
@@ -155,6 +155,31 @@ public class Pop3PollListenerTests {
         Assert.Equal("New", receivedSubjects[0]);
     }
 
+    [Fact]
+    public async Task StopAsync_DuringErrorBackoff_CompletesPollingTaskSuccessfully() {
+        var listener = new TestPop3PollListener();
+        listener.SetMessages(new TestPop3PollListener.TestMessage("uid1", CreateMessage("Initial")));
+
+        await listener.StartAsync();
+        await listener.WaitForDelayAsync();
+
+        listener.SetMessages(
+            new TestPop3PollListener.TestMessage("uid1", CreateMessage("Initial")),
+            new TestPop3PollListener.TestMessage("uid2", CreateMessage("New")));
+        listener.ThrowOnNextFetch(new InvalidOperationException("Boom"));
+        listener.ReleaseNextDelay();
+
+        await listener.WaitForDelayAsync();
+
+        var pollingTaskField = typeof(Pop3PollListener).GetField("_pollingTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var pollingTask = (Task)pollingTaskField.GetValue(listener)!;
+
+        await listener.StopAsync();
+
+        Assert.Equal(TaskStatus.RanToCompletion, pollingTask.Status);
+        Assert.Null(pollingTaskField.GetValue(listener));
+    }
+
     private static MimeMessage CreateMessage(string subject) {
         var message = new MimeMessage();
         message.Subject = subject;

--- a/Sources/Mailozaurr/Receive/GraphMessageListener.cs
+++ b/Sources/Mailozaurr/Receive/GraphMessageListener.cs
@@ -51,15 +51,21 @@ public class GraphMessageListener : IDisposable {
         }
 
         _cancel = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-        var initial = await MicrosoftGraphUtils.GetMailMessagesAsync(_credential, _userPrincipalName).ConfigureAwait(false);
-        foreach (var msg in initial) {
-            if (msg.TryGetValue("id", out var idObj) && idObj is string id) {
-                _seenIds.Add(id);
+        try {
+            var initial = await MicrosoftGraphUtils.GetMailMessagesAsync(_credential, _userPrincipalName, cancellationToken: _cancel.Token).ConfigureAwait(false);
+            foreach (var msg in initial) {
+                if (msg.TryGetValue("id", out var idObj) && idObj is string id) {
+                    _seenIds.Add(id);
+                }
             }
-        }
 
-        _pollTask = PollLoopAsync();
+            _pollTask = PollLoopAsync();
+        } catch {
+            _cancel.Dispose();
+            _cancel = null;
+            _pollTask = null;
+            throw;
+        }
     }
 
     /// <summary>
@@ -86,7 +92,7 @@ public class GraphMessageListener : IDisposable {
         while (!_cancel!.IsCancellationRequested) {
             try {
                 await Task.Delay(_interval, _cancel.Token).ConfigureAwait(false);
-                var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(_credential, _userPrincipalName).ConfigureAwait(false);
+                var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(_credential, _userPrincipalName, cancellationToken: _cancel.Token).ConfigureAwait(false);
                 foreach (var msg in messages) {
                     if (msg.TryGetValue("id", out var idObj) && idObj is string id && !_seenIds.Contains(id)) {
                         _seenIds.Add(id);
@@ -97,7 +103,11 @@ public class GraphMessageListener : IDisposable {
                 break;
             } catch (Exception ex) {
                 PollError?.Invoke(this, ex);
-                await Task.Delay(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+                try {
+                    await Task.Delay(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+                } catch (OperationCanceledException) when (_cancel.IsCancellationRequested) {
+                    break;
+                }
             }
         }
     }

--- a/Sources/Mailozaurr/Receive/Pop3PollListener.cs
+++ b/Sources/Mailozaurr/Receive/Pop3PollListener.cs
@@ -129,7 +129,11 @@ public class Pop3PollListener : IDisposable, IAsyncDisposable {
                 break;
             } catch (Exception ex) {
                 PollError?.Invoke(this, ex);
-                await DelayAsync(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+                try {
+                    await DelayAsync(TimeSpan.FromSeconds(5), _cancel.Token).ConfigureAwait(false);
+                } catch (OperationCanceledException) when (_cancel.IsCancellationRequested) {
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- keep Graph listener startup and polling requests cancellable by forwarding the linked listener token
- clean up Graph listener state when initial startup fetch is canceled or fails so the listener is not left half-started
- keep POP3 and Graph listener error-backoff cancellation from faulting the loop during shutdown

## Testing
- dotnet test Sources/Mailozaurr.sln --no-restore --filter 'FullyQualifiedName~GraphMessageListenerTests|FullyQualifiedName~Pop3PollListenerTests' -v minimal
- dotnet test Sources/Mailozaurr.sln --no-restore -v minimal