### PR TITLE
Harden listener startup cleanup and oauth test stability

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
@@ -147,11 +147,8 @@ public class GraphBatchAndRetryTests {
         var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
         cache.Clear();
-        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
-        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
-        oauthField?.SetValue(null, null);
-        string cachePath = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
-        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
         try {
             var credential = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
             string token = await MicrosoftGraphUtils.ConnectO365GraphWithRetryAsync(credential, "tenant", 2, 0, 1);
@@ -173,11 +170,8 @@ public class GraphBatchAndRetryTests {
         var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
         cache.Clear();
-        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
-        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
-        oauthField?.SetValue(null, null);
-        string cachePath = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
-        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
         try {
             var credential = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
             await Assert.ThrowsAsync<GraphApiException>(() => MicrosoftGraphUtils.ConnectO365GraphWithRetryAsync(credential, "tenant", 0, 0, 1));
@@ -198,11 +192,8 @@ public class GraphBatchAndRetryTests {
         var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
         cache.Clear();
-        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
-        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
-        oauthField?.SetValue(null, null);
-        string cachePath = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
-        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
         try {
             var credential = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
             string token = await MicrosoftGraphUtils.ConnectO365GraphAsync(credential, "tenant", "https://graph.microsoft.com");
@@ -224,11 +215,8 @@ public class GraphBatchAndRetryTests {
         var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
         cache.Clear();
-        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
-        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
-        oauthField?.SetValue(null, null);
-        string cachePath = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
-        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
         var cts = new CancellationTokenSource(100);
         try {
             var credential = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
@@ -249,11 +237,8 @@ public class GraphBatchAndRetryTests {
         var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
         cache.Clear();
-        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
-        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
-        oauthField?.SetValue(null, null);
-        string cachePath = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
-        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
         var cts = new CancellationTokenSource(100);
         try {
             var credential = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };

--- a/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMessageListenerTests.cs
@@ -59,11 +59,8 @@ public class GraphMessageListenerTests {
         var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var cache = (ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
         cache.Clear();
-        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
-        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
-        oauthField?.SetValue(null, null);
-        string cachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
-        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
         try {
             var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
             var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));
@@ -108,11 +105,8 @@ public class GraphMessageListenerTests {
         var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var cache = (ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
         cache.Clear();
-        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
-        var oauthField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
-        oauthField?.SetValue(null, null);
-        string cachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mailozaurr", "oauth_cache.json");
-        if (System.IO.File.Exists(cachePath)) System.IO.File.Delete(cachePath);
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
         try {
             var cred = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
             var listener = new GraphMessageListener(cred, "user", TimeSpan.FromSeconds(1));

--- a/Sources/Mailozaurr.Tests/ImapIdleListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapIdleListenerTests.cs
@@ -46,6 +46,19 @@ public class ImapIdleListenerTests {
     }
 
     [Fact]
+    public async Task StartAsync_FailureDuringInitialSetup_CleansUpState() {
+        var listener = new ImapIdleListener(new ImapClient());
+
+        await Assert.ThrowsAnyAsync<Exception>(() => listener.StartAsync());
+
+        Assert.Null(GetPrivateField<CancellationTokenSource?>(listener, "_cancel"));
+        Assert.Null(GetPrivateField<Task?>(listener, "_idleTask"));
+        Assert.Null(GetPrivateField<IMailFolder?>(listener, "_folder"));
+
+        await Assert.ThrowsAnyAsync<Exception>(() => listener.StartAsync());
+    }
+
+    [Fact]
     public async Task StopAsync_PropagatesExceptionsFromIdleLoop() {
         var listener = new ImapIdleListener(new ImapClient());
         var cancellation = new CancellationTokenSource();

--- a/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsCertificateTokenCachingTests.cs
+++ b/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsCertificateTokenCachingTests.cs
@@ -83,14 +83,8 @@ public class MicrosoftGraphUtilsCertificateTokenCachingTests : IDisposable {
             cache.Clear();
         }
 
-        var oauthType = typeof(MicrosoftGraphUtils).Assembly.GetType("Mailozaurr.OAuthTokenCache");
-        var internalCacheField = oauthType?.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
-        internalCacheField?.SetValue(null, null);
-        var cachePathField = oauthType?.GetField("CacheFilePath", BindingFlags.NonPublic | BindingFlags.Static);
-        var cachePath = cachePathField?.GetValue(null) as string;
-        if (!string.IsNullOrEmpty(cachePath) && File.Exists(cachePath)) {
-            File.Delete(cachePath);
-        }
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
     }
 
     public void Dispose() {

--- a/Sources/Mailozaurr.Tests/OAuthCacheTestHelper.cs
+++ b/Sources/Mailozaurr.Tests/OAuthCacheTestHelper.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+
+namespace Mailozaurr.Tests;
+
+internal static class OAuthCacheTestHelper {
+    internal static void ResetOAuthTokenCache() {
+        var field = typeof(OAuthTokenCache).GetField("_cache", BindingFlags.Static | BindingFlags.NonPublic);
+        field?.SetValue(null, null);
+    }
+
+    internal static string GetOAuthCacheFilePath() {
+        var pathField = typeof(OAuthTokenCache).GetField("CacheFilePath", BindingFlags.Static | BindingFlags.NonPublic);
+        return (string)pathField!.GetValue(null)!;
+    }
+
+    internal static void DeleteOAuthCacheFile() {
+        var path = GetOAuthCacheFilePath();
+        for (var attempt = 0; ; attempt++) {
+            try {
+                if (File.Exists(path)) {
+                    File.Delete(path);
+                }
+
+                return;
+            } catch (IOException) when (attempt < 4) {
+                Thread.Sleep(25 * (attempt + 1));
+            } catch (UnauthorizedAccessException) when (attempt < 4) {
+                Thread.Sleep(25 * (attempt + 1));
+            }
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -9,8 +8,8 @@ namespace Mailozaurr.Tests;
 
 public class OAuthHelpersCachedTokenTests {
     public OAuthHelpersCachedTokenTests() {
-        ResetCache();
-        DeleteCacheFile();
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
     }
 
     [Fact]
@@ -129,11 +128,6 @@ public class OAuthHelpersCachedTokenTests {
         await Assert.ThrowsAsync<OperationCanceledException>(() => OAuthTokenCache.SetAsync(cacheKey, credential, cts.Token));
     }
 
-    private static void ResetCache() {
-        var field = typeof(OAuthTokenCache).GetField("_cache", BindingFlags.Static | BindingFlags.NonPublic);
-        field?.SetValue(null, null);
-    }
-
     private static string BuildO365CacheKey(
         string login,
         string clientId,
@@ -155,11 +149,4 @@ public class OAuthHelpersCachedTokenTests {
         await task.ConfigureAwait(false);
     }
 
-    private static void DeleteCacheFile() {
-        var pathField = typeof(OAuthTokenCache).GetField("CacheFilePath", BindingFlags.Static | BindingFlags.NonPublic);
-        var path = pathField?.GetValue(null) as string;
-        if (!string.IsNullOrEmpty(path) && File.Exists(path)) {
-            File.Delete(path);
-        }
-    }
 }

--- a/Sources/Mailozaurr.Tests/OAuthHelpersGoogleCachedTokenTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthHelpersGoogleCachedTokenTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
@@ -8,8 +7,8 @@ namespace Mailozaurr.Tests;
 
 public class OAuthHelpersGoogleCachedTokenTests {
     public OAuthHelpersGoogleCachedTokenTests() {
-        ResetCache();
-        DeleteCacheFile();
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
     }
 
     [Fact]
@@ -91,11 +90,6 @@ public class OAuthHelpersGoogleCachedTokenTests {
         Assert.Equal(clientId, legacy.ClientId);
     }
 
-    private static void ResetCache() {
-        var field = typeof(OAuthTokenCache).GetField("_cache", BindingFlags.Static | BindingFlags.NonPublic);
-        field?.SetValue(null, null);
-    }
-
     private static async Task PersistGoogleCredentialAsync(
         OAuthCredential credential,
         string gmailAccount,
@@ -105,11 +99,4 @@ public class OAuthHelpersGoogleCachedTokenTests {
         await task.ConfigureAwait(false);
     }
 
-    private static void DeleteCacheFile() {
-        var pathField = typeof(OAuthTokenCache).GetField("CacheFilePath", BindingFlags.Static | BindingFlags.NonPublic);
-        var path = pathField?.GetValue(null) as string;
-        if (!string.IsNullOrEmpty(path) && File.Exists(path)) {
-            File.Delete(path);
-        }
-    }
 }

--- a/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -9,8 +8,8 @@ namespace Mailozaurr.Tests;
 
 public sealed class OAuthTokenCacheProtectionTests {
     public OAuthTokenCacheProtectionTests() {
-        ResetCache();
-        DeleteCacheFile();
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
     }
 
     [Fact]
@@ -29,7 +28,7 @@ public sealed class OAuthTokenCacheProtectionTests {
 
         await OAuthTokenCache.SetAsync(cacheKey, credential);
 
-        var path = GetCacheFilePath();
+        var path = OAuthCacheTestHelper.GetOAuthCacheFilePath();
         Assert.True(File.Exists(path));
 
         var json = File.ReadAllText(path);
@@ -45,7 +44,7 @@ public sealed class OAuthTokenCacheProtectionTests {
         Assert.True(entry.TryGetProperty("ClientSecretProtected", out _));
         Assert.True(entry.TryGetProperty("ServiceAccountJsonProtected", out _));
 
-        ResetCache();
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
         var reloaded = await OAuthTokenCache.GetAsync(cacheKey);
 
         Assert.NotNull(reloaded);
@@ -70,7 +69,7 @@ public sealed class OAuthTokenCacheProtectionTests {
             ServiceAccountSubject = "legacy-subject@example.com"
         };
 
-        var path = GetCacheFilePath();
+        var path = OAuthCacheTestHelper.GetOAuthCacheFilePath();
         var directory = Path.GetDirectoryName(path);
         if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
             Directory.CreateDirectory(directory);
@@ -97,7 +96,7 @@ public sealed class OAuthTokenCacheProtectionTests {
     [Fact]
     public async Task GetAsync_MalformedCacheFileReturnsNull() {
         var cacheKey = "oauth:malformed@example.com";
-        var path = GetCacheFilePath();
+        var path = OAuthCacheTestHelper.GetOAuthCacheFilePath();
         var directory = Path.GetDirectoryName(path);
         if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
             Directory.CreateDirectory(directory);
@@ -113,7 +112,7 @@ public sealed class OAuthTokenCacheProtectionTests {
     [Fact]
     public async Task SetAsync_MalformedCacheFileIsRecovered() {
         var cacheKey = "oauth:recover@example.com";
-        var path = GetCacheFilePath();
+        var path = OAuthCacheTestHelper.GetOAuthCacheFilePath();
         var directory = Path.GetDirectoryName(path);
         if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
             Directory.CreateDirectory(directory);
@@ -129,7 +128,7 @@ public sealed class OAuthTokenCacheProtectionTests {
 
         await OAuthTokenCache.SetAsync(cacheKey, credential);
 
-        ResetCache();
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
         var loaded = await OAuthTokenCache.GetAsync(cacheKey);
 
         Assert.NotNull(loaded);
@@ -149,7 +148,7 @@ public sealed class OAuthTokenCacheProtectionTests {
             ExpiresOn = DateTimeOffset.UtcNow.AddMinutes(30)
         };
 
-        var path = GetCacheFilePath();
+        var path = OAuthCacheTestHelper.GetOAuthCacheFilePath();
         var directory = Path.GetDirectoryName(path);
         if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
             Directory.CreateDirectory(directory);
@@ -160,8 +159,6 @@ public sealed class OAuthTokenCacheProtectionTests {
         };
         var json = JsonSerializer.Serialize(cacheEntries, MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry);
         File.WriteAllText(path, json);
-        ResetCache();
-
         var lockStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
         try {
             var releaseTask = Task.Run(async () => {
@@ -179,20 +176,4 @@ public sealed class OAuthTokenCacheProtectionTests {
         }
     }
 
-    private static void ResetCache() {
-        var field = typeof(OAuthTokenCache).GetField("_cache", BindingFlags.Static | BindingFlags.NonPublic);
-        field?.SetValue(null, null);
-    }
-
-    private static string GetCacheFilePath() {
-        var pathField = typeof(OAuthTokenCache).GetField("CacheFilePath", BindingFlags.Static | BindingFlags.NonPublic);
-        return (string)pathField!.GetValue(null)!;
-    }
-
-    private static void DeleteCacheFile() {
-        var path = GetCacheFilePath();
-        if (File.Exists(path)) {
-            File.Delete(path);
-        }
-    }
 }

--- a/Sources/Mailozaurr.Tests/Pop3PollListenerTests.cs
+++ b/Sources/Mailozaurr.Tests/Pop3PollListenerTests.cs
@@ -43,6 +43,20 @@ public class Pop3PollListenerTests {
     }
 
     [Fact]
+    public async Task StartAsync_FailureDuringInitialSnapshot_CleansUpState() {
+        var listener = new Pop3PollListener(new Pop3Client());
+        var cancelField = typeof(Pop3PollListener).GetField("_cancel", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var pollingTaskField = typeof(Pop3PollListener).GetField("_pollingTask", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        await Assert.ThrowsAnyAsync<Exception>(() => listener.StartAsync());
+
+        Assert.Null(cancelField.GetValue(listener));
+        Assert.Null(pollingTaskField.GetValue(listener));
+
+        await Assert.ThrowsAnyAsync<Exception>(() => listener.StartAsync());
+    }
+
+    [Fact]
     public async Task StartAsync_RaisesEventsForNewUidsOnly() {
         var listener = new TestPop3PollListener();
         listener.SetMessages(

--- a/Sources/Mailozaurr/Receive/ImapIdleListener.cs
+++ b/Sources/Mailozaurr/Receive/ImapIdleListener.cs
@@ -65,22 +65,36 @@ public class ImapIdleListener : IDisposable, IAsyncDisposable {
         }
 
         _cancel = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        try {
+            _folder = _client.GetCachedFolder(_folderName, FolderAccess.ReadOnly);
+            await _folder.OpenAsync(FolderAccess.ReadOnly, _cancel.Token).ConfigureAwait(false);
 
-        _folder = _client.GetCachedFolder(_folderName, FolderAccess.ReadOnly);
-        await _folder.OpenAsync(FolderAccess.ReadOnly, _cancel.Token).ConfigureAwait(false);
+            var search = _searchQuery ?? SearchQuery.All;
+            var initialUids = await _folder.SearchAsync(search, _cancel.Token).ConfigureAwait(false);
+            var initial = await _folder.FetchAsync(initialUids, _fetchRequest, _cancel.Token).ConfigureAwait(false);
+            foreach (var summary in initial) {
+                _summaries.Add(summary);
+                _known.Add(summary.UniqueId);
+            }
 
-        var search = _searchQuery ?? SearchQuery.All;
-        var initialUids = await _folder.SearchAsync(search, _cancel.Token).ConfigureAwait(false);
-        var initial = await _folder.FetchAsync(initialUids, _fetchRequest, _cancel.Token).ConfigureAwait(false);
-        foreach (var summary in initial) {
-            _summaries.Add(summary);
-            _known.Add(summary.UniqueId);
+            _folder.CountChanged += OnCountChanged;
+            _folder.MessageExpunged += OnMessageExpunged;
+
+            _idleTask = IdleLoopAsync();
+        } catch {
+            if (_folder?.IsOpen == true) {
+                try {
+                    await _folder.CloseAsync(expunge: false, CancellationToken.None).ConfigureAwait(false);
+                } catch {
+                }
+            }
+
+            _summaries.Clear();
+            _known.Clear();
+            Cleanup();
+            _idleTask = null;
+            throw;
         }
-
-        _folder.CountChanged += OnCountChanged;
-        _folder.MessageExpunged += OnMessageExpunged;
-
-        _idleTask = IdleLoopAsync();
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/Receive/Pop3PollListener.cs
+++ b/Sources/Mailozaurr/Receive/Pop3PollListener.cs
@@ -50,15 +50,24 @@ public class Pop3PollListener : IDisposable, IAsyncDisposable {
         }
 
         _cancel = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _knownUids.Clear();
-        var count = GetMessageCount();
-        for (var i = 0; i < count; i++) {
-            var uid = await GetMessageUidAsync(i, _cancel.Token).ConfigureAwait(false);
-            if (!string.IsNullOrEmpty(uid)) {
-                _knownUids.Add(uid);
+        try {
+            _knownUids.Clear();
+            var count = GetMessageCount();
+            for (var i = 0; i < count; i++) {
+                var uid = await GetMessageUidAsync(i, _cancel.Token).ConfigureAwait(false);
+                if (!string.IsNullOrEmpty(uid)) {
+                    _knownUids.Add(uid);
+                }
             }
+
+            _pollingTask = PollLoopAsync();
+        } catch {
+            _knownUids.Clear();
+            _cancel.Dispose();
+            _cancel = null;
+            _pollingTask = null;
+            throw;
         }
-        _pollingTask = PollLoopAsync();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- clean up IMAP and POP3 listener state when startup fails during initial setup or snapshotting
- add retrying shared OAuth cache test cleanup to avoid cross-target file contention
- expand regressions around listener startup recovery and OAuth cache stability

## Testing
- dotnet test Sources/Mailozaurr.sln --no-restore --filter "FullyQualifiedName~OAuthHelpersCachedTokenTests|FullyQualifiedName~OAuthHelpersGoogleCachedTokenTests|FullyQualifiedName~OAuthTokenCacheProtectionTests|FullyQualifiedName~GraphBatchAndRetryTests|FullyQualifiedName~GraphMessageListenerTests|FullyQualifiedName~MicrosoftGraphUtilsCertificateTokenCachingTests|FullyQualifiedName~Pop3PollListenerTests|FullyQualifiedName~ImapIdleListenerTests" -v minimal
- dotnet test Sources/Mailozaurr.sln --no-restore -v minimal