### PR TITLE
Propagate Graph search cancellation and stabilize OAuth cache tests

### DIFF
--- a/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthHelpersCachedTokenTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Mailozaurr.Tests;
 
+[Collection("GraphCollection")]
 public class OAuthHelpersCachedTokenTests {
     public OAuthHelpersCachedTokenTests() {
         OAuthCacheTestHelper.ResetOAuthTokenCache();

--- a/Sources/Mailozaurr.Tests/OAuthHelpersGoogleCachedTokenTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthHelpersGoogleCachedTokenTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Mailozaurr.Tests;
 
+[Collection("GraphCollection")]
 public class OAuthHelpersGoogleCachedTokenTests {
     public OAuthHelpersGoogleCachedTokenTests() {
         OAuthCacheTestHelper.ResetOAuthTokenCache();

--- a/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace Mailozaurr.Tests;
 
+[Collection("GraphCollection")]
 public sealed class OAuthTokenCacheProtectionTests {
     public OAuthTokenCacheProtectionTests() {
         OAuthCacheTestHelper.ResetOAuthTokenCache();

--- a/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchDmarcReportsTests.cs
@@ -6,6 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -257,6 +260,36 @@ public class SearchDmarcReportsTests {
     }
 
     [Fact]
+    public async Task SearchDmarcReportsAsync_Graph_PropagatesCancellationToMimeDownload() {
+        var handler = new CancelDuringGraphMimeHandler();
+        var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)field.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        try {
+            var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
+            using var cts = new CancellationTokenSource();
+            var searchTask = MailboxSearcher.SearchDmarcReportsAsync(
+                cred,
+                "user@example.com",
+                cancellationToken: cts.Token);
+
+            var startedTask = handler.MimeStarted.Task;
+            var completed = await Task.WhenAny(startedTask, Task.Delay(TimeSpan.FromSeconds(1)));
+            Assert.Same(startedTask, completed);
+
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await searchTask);
+
+            Assert.True(handler.MimeRequestCanceled);
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+
+    [Fact]
     public void FilterDmarcReports_IgnoresMalformedArchive() {
         var now = DateTimeOffset.UtcNow;
         var message = new MimeMessage();
@@ -315,6 +348,44 @@ public class SearchDmarcReportsTests {
             Assert.True(logged);
         } finally {
             LoggingMessages.Logger.OnErrorMessage -= Handler;
+        }
+    }
+
+    private static FieldInfo GetHandlerField() =>
+        typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? typeof(HttpMessageInvoker).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("HttpClient handler field not found");
+
+    private sealed class CancelDuringGraphMimeHandler : HttpMessageHandler {
+        public TaskCompletionSource<object?> MimeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool MimeRequestCanceled { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            var uri = request.RequestUri!;
+            if (uri.AbsoluteUri.Contains("oauth2")) {
+                var json = "{\"access_token\":\"token\",\"token_type\":\"Bearer\"}";
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) };
+            }
+
+            if (uri.AbsolutePath.EndsWith("/messages", StringComparison.Ordinal)) {
+                var json = "{\"value\":[{\"id\":\"1\"}]}";
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) };
+            }
+
+            if (uri.AbsolutePath.Contains("/messages/", StringComparison.Ordinal) && uri.AbsolutePath.EndsWith("/$value", StringComparison.Ordinal)) {
+                MimeStarted.TrySetResult(null);
+                try {
+                    await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken).ConfigureAwait(false);
+                } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                    MimeRequestCanceled = true;
+                    throw;
+                }
+
+                const string raw = "Date: Mon, 1 Jan 2024 00:00:00 +0000\r\nSubject: report domain: example.com\r\n\r\nbody";
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(raw) };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
     }
 }

--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -355,6 +355,30 @@ public class SearchNonDeliveryReportsTests {
         }
     }
 
+    [Fact]
+    public async Task SearchNonDeliveryReportsAsync_Graph_PropagatesCancellationToMessageListing() {
+        var handler = new CancelDuringGraphListHandler();
+        var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)field.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        try {
+            var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                MailboxSearcher.SearchNonDeliveryReportsAsync(
+                    cred,
+                    "user@example.com",
+                    cancellationToken: cts.Token));
+
+            Assert.True(handler.ListRequestCanceled);
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+
     [Theory]
     [InlineData(1)]
     [InlineData(2)]
@@ -471,6 +495,31 @@ public class SearchNonDeliveryReportsTests {
             }
 
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
+    private sealed class CancelDuringGraphListHandler : HttpMessageHandler {
+        public bool ListRequestCanceled { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            var uri = request.RequestUri!;
+            if (uri.AbsoluteUri.Contains("oauth2")) {
+                var json = "{\"access_token\":\"token\",\"token_type\":\"Bearer\"}";
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) };
+            }
+
+            if (uri.AbsolutePath.EndsWith("/messages", StringComparison.Ordinal)) {
+                try {
+                    await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken).ConfigureAwait(false);
+                } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                    ListRequestCanceled = true;
+                    throw;
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[]}") };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
     }
 }

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -791,16 +791,20 @@ namespace Mailozaurr {
         /// <summary>
         /// Retrieves the raw MIME content of a mail message.
         /// </summary>
-        public static async Task<MimeMessage> GetMailMessageMimeAsync(GraphCredential credential, string userPrincipalName, string messageId) {
-            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
+        public static async Task<MimeMessage> GetMailMessageMimeAsync(
+            GraphCredential credential,
+            string userPrincipalName,
+            string messageId,
+            CancellationToken cancellationToken = default) {
+            var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com", cancellationToken).ConfigureAwait(false);
             var request = new HttpRequestMessage(HttpMethod.Get, $"https://graph.microsoft.com/v1.0/users/{userPrincipalName}/messages/{messageId}/$value");
             request.Headers.TryAddWithoutValidation("Authorization", token);
-            await ConcurrencySemaphore.WaitAsync().ConfigureAwait(false);
+            await ConcurrencySemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try {
-                using var response = await HttpClient.SendAsync(request).ConfigureAwait(false);
+                using var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
                 using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                return await MimeMessage.LoadAsync(stream).ConfigureAwait(false);
+                return await MimeMessage.LoadAsync(stream, cancellationToken).ConfigureAwait(false);
             } finally {
                 ConcurrencySemaphore.Release();
             }

--- a/Sources/Mailozaurr/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr/Receive/MailboxSearcher.cs
@@ -374,14 +374,15 @@ public static class MailboxSearcher {
             userPrincipalName,
             new[] { "id" },
             filter,
-            maxResults > 0 ? maxResults : (int?)null).ConfigureAwait(false);
+            maxResults > 0 ? maxResults : (int?)null,
+            cancellationToken).ConfigureAwait(false);
         var results = new List<NonDeliveryReport>();
         if (parallelDownloadLimit <= 1) {
             foreach (var m in msgs) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (maxResults > 0 && results.Count >= maxResults) break;
                 if (m.TryGetValue("id", out var idObj) && idObj is string id) {
-                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id, cancellationToken).ConfigureAwait(false);
                     var reports = FilterNonDeliveryReports(new[] { mime }, since, before, recipientContains, messageId);
                     if (reports.Count > 0) {
                         foreach (var r in reports) {
@@ -411,7 +412,7 @@ public static class MailboxSearcher {
                         MimeMessage mime;
                         try {
                             cts.Token.ThrowIfCancellationRequested();
-                            mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                            mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id, cts.Token).ConfigureAwait(false);
                         } catch (OperationCanceledException) {
                             return;
                         }
@@ -740,13 +741,14 @@ public static class MailboxSearcher {
             userPrincipalName,
             new[] { "id" },
             filter,
-            maxResults > 0 ? maxResults : (int?)null).ConfigureAwait(false);
+            maxResults > 0 ? maxResults : (int?)null,
+            cancellationToken).ConfigureAwait(false);
         var mimeMessages = new List<MimeMessage>(msgs.Count);
         if (parallelDownloadLimit <= 1) {
             foreach (var m in msgs) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (m.TryGetValue("id", out var idObj) && idObj is string id) {
-                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id, cancellationToken).ConfigureAwait(false);
                     mimeMessages.Add(mime);
                 }
             }
@@ -758,7 +760,7 @@ public static class MailboxSearcher {
                 await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id).ConfigureAwait(false);
+                    var mime = await MicrosoftGraphUtils.GetMailMessageMimeAsync(credential, userPrincipalName, id, cancellationToken).ConfigureAwait(false);
                     lock (mimeMessages) mimeMessages.Add(mime);
                 } finally {
                     semaphore.Release();


### PR DESCRIPTION
## Summary
- propagate caller cancellation through Graph mailbox search list and MIME download paths
- add Graph mailbox search regressions for cancellation during listing and MIME retrieval
- serialize OAuth cache file tests with the existing Graph collection to avoid shared-file races in full runs

## Testing
- dotnet test Sources/Mailozaurr.sln --no-restore --filter "FullyQualifiedName~SearchNonDeliveryReportsTests|FullyQualifiedName~SearchDmarcReportsTests" -v minimal
- dotnet test Sources/Mailozaurr.sln --no-restore -v minimal