### PR TITLE
Harden Graph junk mail skip filters

### DIFF
--- a/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsJunkMailTests.cs
+++ b/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsJunkMailTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+[Collection("GraphCollection")]
+public sealed class MicrosoftGraphUtilsJunkMailTests {
+    [Fact]
+    public void FilterJunkMessages_SingleUseSkipEnumerables_AppliesFiltersAcrossMultipleMessages() {
+        var skipFrom = new SingleUseEnumerable<string>("skip-from@example.com");
+        var skipTo = new SingleUseEnumerable<string>("skip-to@example.com");
+        var skipSubjectContains = new SingleUseEnumerable<string>("urgent");
+
+        var first = new Dictionary<string, object> {
+            ["id"] = "1",
+            ["from"] = new Dictionary<string, object> {
+                ["emailAddress"] = new Dictionary<string, object> { ["address"] = "keep@example.com" }
+            },
+            ["toRecipients"] = new object[] {
+                new Dictionary<string, object> {
+                    ["emailAddress"] = new Dictionary<string, object> { ["address"] = "keep-recipient@example.com" }
+                }
+            },
+            ["subject"] = "normal"
+        };
+        var second = new Dictionary<string, object> {
+            ["id"] = "2",
+            ["from"] = new Dictionary<string, object> {
+                ["emailAddress"] = new Dictionary<string, object> { ["address"] = "skip-from@example.com" }
+            },
+            ["toRecipients"] = new object[] {
+                new Dictionary<string, object> {
+                    ["emailAddress"] = new Dictionary<string, object> { ["address"] = "skip-to@example.com" }
+                }
+            },
+            ["subject"] = "urgent message"
+        };
+
+        var filtered = MicrosoftGraphUtils.FilterJunkMessages(
+            new[] { first, second },
+            skipFrom: skipFrom,
+            skipTo: skipTo,
+            skipSubjectContains: skipSubjectContains);
+
+        var remaining = Assert.Single(filtered);
+        Assert.Same(first, remaining);
+        Assert.Equal(1, skipFrom.EnumerationCount);
+        Assert.Equal(1, skipTo.EnumerationCount);
+        Assert.Equal(1, skipSubjectContains.EnumerationCount);
+    }
+
+    [Fact]
+    public async Task GetJunkMailMessagesAsync_SingleUseSkipAttachmentExtensions_AppliesFilter() {
+        var handler = new JunkMailHandler();
+        var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)field.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
+        cache.Clear();
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
+        try {
+            var credential = new GraphCredential { ClientId = "id", ClientSecret = "secret", DirectoryId = "tenant" };
+            var skipExtensions = new SingleUseEnumerable<string>(".pdf");
+
+            var results = await MicrosoftGraphUtils.GetJunkMailMessagesAsync(
+                credential,
+                "user@example.com",
+                skipAttachmentExtension: skipExtensions);
+
+            var remaining = Assert.Single(results);
+            Assert.Equal("message-keep", remaining["id"]);
+            Assert.Equal(1, skipExtensions.EnumerationCount);
+            Assert.Equal(1, handler.AttachmentRequestCount);
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+
+    private static FieldInfo GetHandlerField()
+        => typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? typeof(HttpMessageInvoker).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("HttpClient handler field not found");
+
+    private sealed class JunkMailHandler : HttpMessageHandler {
+        public int AttachmentRequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            var uri = request.RequestUri!;
+            if (uri.AbsoluteUri.Contains("oauth2", StringComparison.Ordinal)) {
+                var json = "{\"access_token\":\"token\",\"token_type\":\"Bearer\"}";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent(json)
+                });
+            }
+
+            if (uri.AbsolutePath.EndsWith("/mailFolders/junkemail/messages", StringComparison.Ordinal)) {
+                const string json = "{\"value\":[{\"id\":\"message-drop\",\"hasAttachments\":true},{\"id\":\"message-keep\",\"hasAttachments\":false}]}";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent(json)
+                });
+            }
+
+            if (uri.AbsolutePath.EndsWith("/messages/message-drop/attachments", StringComparison.Ordinal)) {
+                AttachmentRequestCount++;
+                const string json = "{\"value\":[{\"name\":\"invoice.pdf\"}]}";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent(json)
+                });
+            }
+
+            if (uri.AbsolutePath.EndsWith("/messages/message-keep/attachments", StringComparison.Ordinal)) {
+                AttachmentRequestCount++;
+                const string json = "{\"value\":[{\"name\":\"note.txt\"}]}";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent(json)
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
+    private sealed class SingleUseEnumerable<T> : IEnumerable<T> {
+        private readonly IReadOnlyList<T> items;
+
+        public SingleUseEnumerable(params T[] items) {
+            this.items = items;
+        }
+
+        public int EnumerationCount { get; private set; }
+
+        public IEnumerator<T> GetEnumerator() {
+            EnumerationCount++;
+            if (EnumerationCount > 1) {
+                throw new InvalidOperationException("Sequence was enumerated more than once.");
+            }
+
+            return items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -892,24 +892,29 @@ namespace Mailozaurr {
             bool skipHasAttachment = false) {
             var result = new List<Dictionary<string, object>>();
             var skipIdsSet = skipIds != null ? new HashSet<string>(skipIds, StringComparer.OrdinalIgnoreCase) : null;
+            var skipFromSet = skipFrom != null ? new HashSet<string>(skipFrom, StringComparer.OrdinalIgnoreCase) : null;
+            var skipToSet = skipTo != null ? new HashSet<string>(skipTo, StringComparer.OrdinalIgnoreCase) : null;
+            var skipSubjectTokens = skipSubjectContains?
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .ToArray();
             foreach (var msg in messages) {
                 var id = msg.TryGetValue("id", out var idObj) ? idObj as string : null;
                 if (!string.IsNullOrWhiteSpace(id) && skipIdsSet != null && skipIdsSet.Contains(id!)) {
                     continue;
                 }
 
-                if (skipFrom != null &&
+                if (skipFromSet != null &&
                     msg.TryGetValue("from", out var fromObj) &&
                     fromObj is Dictionary<string, object> fDict &&
                     fDict.TryGetValue("emailAddress", out var addrObj) &&
                     addrObj is Dictionary<string, object> addr &&
                     addr.TryGetValue("address", out var fromAddrObj) &&
                     fromAddrObj is string fromAddr &&
-                    skipFrom.Contains(fromAddr, StringComparer.OrdinalIgnoreCase)) {
+                    skipFromSet.Contains(fromAddr)) {
                     continue;
                 }
 
-                if (skipTo != null &&
+                if (skipToSet != null &&
                     msg.TryGetValue("toRecipients", out var toObj) &&
                     toObj is object[] arr &&
                     arr.OfType<Dictionary<string, object>>().Any(rec =>
@@ -917,14 +922,14 @@ namespace Mailozaurr {
                         tAddrObj is Dictionary<string, object> tAddr &&
                         tAddr.TryGetValue("address", out var addrVal) &&
                         addrVal is string addrStr &&
-                        skipTo.Contains(addrStr, StringComparer.OrdinalIgnoreCase))) {
+                        skipToSet.Contains(addrStr))) {
                     continue;
                 }
 
-                if (skipSubjectContains != null &&
+                if (skipSubjectTokens != null &&
                     msg.TryGetValue("subject", out var subjObj) &&
                     subjObj is string subj &&
-                    skipSubjectContains.Any(s => subj.IndexOf(s, StringComparison.OrdinalIgnoreCase) >= 0)) {
+                    skipSubjectTokens.Any(s => subj.IndexOf(s, StringComparison.OrdinalIgnoreCase) >= 0)) {
                     continue;
                 }
 
@@ -956,7 +961,21 @@ namespace Mailozaurr {
             var token = await ConnectO365GraphAsync(credential, credential.DirectoryId, "https://graph.microsoft.com").ConfigureAwait(false);
             headers["Authorization"] = token;
             var props = properties != null ? new List<string>(properties) : new List<string>();
-            if (skipHasAttachment || skipAttachmentExtension != null) {
+            HashSet<string>? skipAttachmentExtensions = null;
+            if (skipAttachmentExtension != null) {
+                skipAttachmentExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var ext in skipAttachmentExtension) {
+                    if (string.IsNullOrWhiteSpace(ext)) {
+                        continue;
+                    }
+
+                    var normalized = ext.Trim().TrimStart('.');
+                    if (normalized.Length > 0) {
+                        skipAttachmentExtensions.Add(normalized);
+                    }
+                }
+            }
+            if (skipHasAttachment || (skipAttachmentExtensions?.Count > 0)) {
                 if (!props.Contains("hasAttachments")) props.Add("hasAttachments");
             }
             var query = new Dictionary<string, object>();
@@ -980,7 +999,7 @@ namespace Mailozaurr {
                 messages = FilterJunkMessages(messages, skipIds, skipFrom, skipTo, skipSubjectContains, skipHasAttachment);
             }
 
-            if (skipAttachmentExtension != null && skipAttachmentExtension.Any()) {
+            if (skipAttachmentExtensions?.Count > 0) {
                 var result = new List<Dictionary<string, object>>();
                 foreach (var msg in messages) {
                     if (!msg.TryGetValue("id", out var idObj) || idObj is not string id) continue;
@@ -991,9 +1010,8 @@ namespace Mailozaurr {
                             id,
                             new[] { "name" }).ConfigureAwait(false);
                         if (atts.Any(att =>
-                                skipAttachmentExtension.Contains(
-                                    System.IO.Path.GetExtension(att.Name ?? string.Empty).TrimStart('.'),
-                                    StringComparer.OrdinalIgnoreCase))) {
+                                skipAttachmentExtensions.Contains(
+                                    System.IO.Path.GetExtension(att.Name ?? string.Empty).TrimStart('.')))) {
                             continue;
                         }
                     }


### PR DESCRIPTION
## Summary
- materialize Graph junk-mail skip filters once so single-use enumerables do not break filtering
- normalize attachment extension skips before comparing attachment names
- add regression coverage for repeated skip-list use and attachment extension filtering

## Testing
- dotnet test Sources/Mailozaurr.sln --no-restore --filter "FullyQualifiedName~MicrosoftGraphUtilsJunkMailTests|FullyQualifiedName~MicrosoftGraphUtilsTests" -v minimal
- dotnet test Sources/Mailozaurr.sln --no-restore -v minimal