### PR TITLE
Harden junk cleaner skip filters

### DIFF
--- a/Sources/Mailozaurr.Tests/JunkCleanerTests.cs
+++ b/Sources/Mailozaurr.Tests/JunkCleanerTests.cs
@@ -1,0 +1,142 @@
+using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Search;
+using MimeKit;
+using Moq;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class JunkCleanerTests {
+    [Fact]
+    public async Task GetImapJunkAsync_SingleUseSkipEnumerables_AreEnumeratedOnce() {
+        var keepUid = new UniqueId(1);
+        var skipUid = new UniqueId(2);
+        var keepMessage = CreateMessage("keep@example.com", "keep-recipient@example.com", "normal", "keep-id");
+        var filteredMessage = CreateMessage("skip-from@example.com", "skip-to@example.com", "urgent subject", "skip-id");
+
+        var folder = new Mock<IMailFolder>();
+        folder.SetupGet(f => f.FullName).Returns("Junk");
+        folder.SetupGet(f => f.IsOpen).Returns(true);
+        folder.SetupGet(f => f.Access).Returns(FolderAccess.ReadOnly);
+        folder.Setup(f => f.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UniqueId> { keepUid, skipUid });
+        folder.Setup(f => f.GetMessageAsync(keepUid, It.IsAny<CancellationToken>(), null))
+            .ReturnsAsync(keepMessage);
+        folder.Setup(f => f.GetMessageAsync(skipUid, It.IsAny<CancellationToken>(), null))
+            .ReturnsAsync(filteredMessage);
+
+        var client = new Mock<ImapClient> { CallBase = true };
+        client.Setup(c => c.Inbox).Returns(Mock.Of<IMailFolder>(f => f.FullName == "Inbox"));
+        client.Setup(c => c.GetFolder("Junk", It.IsAny<CancellationToken>())).Returns(folder.Object);
+        client.Setup(c => c.PersonalNamespaces).Returns(new FolderNamespaceCollection());
+
+        var skipFrom = new SingleUseEnumerable<string>("skip-from@example.com");
+        var skipTo = new SingleUseEnumerable<string>("skip-to@example.com");
+        var skipSubject = new SingleUseEnumerable<string>("urgent");
+        var skipMessageId = new SingleUseEnumerable<string>("skip-id");
+
+        var results = new List<ImapEmailMessage>();
+        await foreach (var message in JunkCleaner.GetImapJunkAsync(
+            client.Object,
+            folder: "Junk",
+            skipFrom: skipFrom,
+            skipTo: skipTo,
+            skipSubjectContains: skipSubject,
+            skipMessageId: skipMessageId)) {
+            results.Add(message);
+        }
+
+        var remaining = Assert.Single(results);
+        Assert.Equal(keepUid, remaining.Uid);
+        Assert.Equal(1, skipFrom.EnumerationCount);
+        Assert.Equal(1, skipTo.EnumerationCount);
+        Assert.Equal(1, skipSubject.EnumerationCount);
+        Assert.Equal(1, skipMessageId.EnumerationCount);
+    }
+
+    [Fact]
+    public async Task GetImapJunkAsync_NormalizesAttachmentExtensionsBeforeFiltering() {
+        var keepUid = new UniqueId(1);
+        var skipUid = new UniqueId(2);
+        var keepMessage = CreateMessage("keep@example.com", "keep-recipient@example.com", "normal", "keep-id");
+        var filteredMessage = CreateMessage("sender@example.com", "recipient@example.com", "subject", "skip-id", "invoice.pdf");
+
+        var folder = new Mock<IMailFolder>();
+        folder.SetupGet(f => f.FullName).Returns("Junk");
+        folder.SetupGet(f => f.IsOpen).Returns(true);
+        folder.SetupGet(f => f.Access).Returns(FolderAccess.ReadOnly);
+        folder.Setup(f => f.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UniqueId> { keepUid, skipUid });
+        folder.Setup(f => f.GetMessageAsync(keepUid, It.IsAny<CancellationToken>(), null))
+            .ReturnsAsync(keepMessage);
+        folder.Setup(f => f.GetMessageAsync(skipUid, It.IsAny<CancellationToken>(), null))
+            .ReturnsAsync(filteredMessage);
+
+        var client = new Mock<ImapClient> { CallBase = true };
+        client.Setup(c => c.Inbox).Returns(Mock.Of<IMailFolder>(f => f.FullName == "Inbox"));
+        client.Setup(c => c.GetFolder("Junk", It.IsAny<CancellationToken>())).Returns(folder.Object);
+        client.Setup(c => c.PersonalNamespaces).Returns(new FolderNamespaceCollection());
+
+        var results = new List<ImapEmailMessage>();
+        await foreach (var message in JunkCleaner.GetImapJunkAsync(
+            client.Object,
+            folder: "Junk",
+            skipAttachmentExtension: new[] { ".pdf" })) {
+            results.Add(message);
+        }
+
+        var remaining = Assert.Single(results);
+        Assert.Equal(keepUid, remaining.Uid);
+    }
+
+    private static MimeMessage CreateMessage(
+        string from,
+        string to,
+        string subject,
+        string messageId,
+        string? attachmentName = null) {
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse(from));
+        message.To.Add(MailboxAddress.Parse(to));
+        message.Subject = subject;
+        message.MessageId = messageId;
+
+        if (attachmentName == null) {
+            message.Body = new TextPart("plain") { Text = "body" };
+            return message;
+        }
+
+        var builder = new BodyBuilder { TextBody = "body" };
+        builder.Attachments.Add(attachmentName, new byte[] { 1, 2, 3 });
+        message.Body = builder.ToMessageBody();
+        return message;
+    }
+
+    private sealed class SingleUseEnumerable<T> : IEnumerable<T> {
+        private readonly IReadOnlyList<T> items;
+
+        public SingleUseEnumerable(params T[] items) {
+            this.items = items;
+        }
+
+        public int EnumerationCount { get; private set; }
+
+        public IEnumerator<T> GetEnumerator() {
+            EnumerationCount++;
+            if (EnumerationCount > 1) {
+                throw new InvalidOperationException("Sequence was enumerated more than once.");
+            }
+
+            return items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/Sources/Mailozaurr/Receive/JunkCleaner.cs
+++ b/Sources/Mailozaurr/Receive/JunkCleaner.cs
@@ -1,7 +1,10 @@
 using MailKit;
 using MailKit.Net.Imap;
 using MailKit.Search;
+using MimeKit;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +15,15 @@ namespace Mailozaurr;
 /// Helper methods for clearing junk mail folders.
 /// </summary>
 public static class JunkCleaner {
+    private sealed class JunkSkipCriteria {
+        public HashSet<string>? MessageIds { get; init; }
+        public HashSet<uint>? Uids { get; init; }
+        public HashSet<string>? From { get; init; }
+        public HashSet<string>? To { get; init; }
+        public string[]? SubjectTokens { get; init; }
+        public HashSet<string>? AttachmentExtensions { get; init; }
+    }
+
     /// <summary>
     /// Deletes all messages from the specified junk folder.
     /// </summary>
@@ -74,20 +86,12 @@ public static class JunkCleaner {
             return;
         }
 
-        var skipUidSet = skipUid != null ? new HashSet<uint>(skipUid) : null;
+        var criteria = CreateSkipCriteria(skipFrom, skipTo, skipSubjectContains, skipMessageId, skipUid, skipAttachmentExtension);
         var toDelete = new List<UniqueId>(uids.Count);
         foreach (var uid in uids) {
-            if (skipUidSet != null && skipUidSet.Contains(uid.Id)) continue;
+            if (criteria.Uids != null && criteria.Uids.Contains(uid.Id)) continue;
             var message = await junk.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-            if (skipMessageId != null && message.MessageId != null && skipMessageId.Contains(message.MessageId)) continue;
-            if (skipFrom != null && message.From.Mailboxes.Any(m => skipFrom.Contains(m.Address, StringComparer.OrdinalIgnoreCase))) continue;
-            if (skipTo != null && message.To.Mailboxes.Any(m => skipTo.Contains(m.Address, StringComparer.OrdinalIgnoreCase))) continue;
-            if (skipSubjectContains != null && message.Subject != null && skipSubjectContains.Any(s => message.Subject.IndexOf(s, StringComparison.OrdinalIgnoreCase) >= 0)) continue;
-            if (skipHasAttachment && message.Attachments.Any()) continue;
-            if (skipAttachmentExtension != null && message.Attachments.OfType<MimeKit.MimePart>().Any(att =>
-                    skipAttachmentExtension.Contains(
-                        System.IO.Path.GetExtension(att.FileName ?? string.Empty).TrimStart('.'),
-                        StringComparer.OrdinalIgnoreCase))) {
+            if (ShouldSkipMessage(message, skipHasAttachment, criteria)) {
                 continue;
             }
             toDelete.Add(uid);
@@ -125,22 +129,82 @@ public static class JunkCleaner {
         [EnumeratorCancellation] CancellationToken cancellationToken = default) {
         var junk = client.GetCachedFolder(folder ?? "Junk", FolderAccess.ReadOnly);
         var uids = await junk.SearchAsync(SearchQuery.All, cancellationToken).ConfigureAwait(false);
-        var skipUidSet = skipUid != null ? new HashSet<uint>(skipUid) : null;
+        var criteria = CreateSkipCriteria(skipFrom, skipTo, skipSubjectContains, skipMessageId, skipUid, skipAttachmentExtension);
         foreach (var uid in uids) {
-            if (skipUidSet != null && skipUidSet.Contains(uid.Id)) continue;
+            if (criteria.Uids != null && criteria.Uids.Contains(uid.Id)) continue;
             var message = await junk.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
-            if (skipMessageId != null && message.MessageId != null && skipMessageId.Contains(message.MessageId)) continue;
-            if (skipFrom != null && message.From.Mailboxes.Any(m => skipFrom.Contains(m.Address, StringComparer.OrdinalIgnoreCase))) continue;
-            if (skipTo != null && message.To.Mailboxes.Any(m => skipTo.Contains(m.Address, StringComparer.OrdinalIgnoreCase))) continue;
-            if (skipSubjectContains != null && message.Subject != null && skipSubjectContains.Any(s => message.Subject.IndexOf(s, StringComparison.OrdinalIgnoreCase) >= 0)) continue;
-            if (skipHasAttachment && message.Attachments.Any()) continue;
-            if (skipAttachmentExtension != null && message.Attachments.OfType<MimeKit.MimePart>().Any(att =>
-                    skipAttachmentExtension.Contains(
-                        System.IO.Path.GetExtension(att.FileName ?? string.Empty).TrimStart('.'),
-                        StringComparer.OrdinalIgnoreCase))) {
+            if (ShouldSkipMessage(message, skipHasAttachment, criteria)) {
                 continue;
             }
             yield return new ImapEmailMessage(uid, message);
         }
+    }
+
+    private static JunkSkipCriteria CreateSkipCriteria(
+        IEnumerable<string>? skipFrom,
+        IEnumerable<string>? skipTo,
+        IEnumerable<string>? skipSubjectContains,
+        IEnumerable<string>? skipMessageId,
+        IEnumerable<uint>? skipUid,
+        IEnumerable<string>? skipAttachmentExtension) =>
+        new() {
+            MessageIds = skipMessageId != null ? new HashSet<string>(skipMessageId, StringComparer.OrdinalIgnoreCase) : null,
+            Uids = skipUid != null ? new HashSet<uint>(skipUid) : null,
+            From = skipFrom != null ? new HashSet<string>(skipFrom, StringComparer.OrdinalIgnoreCase) : null,
+            To = skipTo != null ? new HashSet<string>(skipTo, StringComparer.OrdinalIgnoreCase) : null,
+            SubjectTokens = skipSubjectContains?
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .ToArray(),
+            AttachmentExtensions = NormalizeAttachmentExtensions(skipAttachmentExtension)
+        };
+
+    private static HashSet<string>? NormalizeAttachmentExtensions(IEnumerable<string>? skipAttachmentExtension) {
+        if (skipAttachmentExtension == null) {
+            return null;
+        }
+
+        var normalized = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var extension in skipAttachmentExtension) {
+            if (string.IsNullOrWhiteSpace(extension)) {
+                continue;
+            }
+
+            var value = extension.Trim().TrimStart('.');
+            if (value.Length > 0) {
+                normalized.Add(value);
+            }
+        }
+
+        return normalized;
+    }
+
+    private static bool ShouldSkipMessage(MimeMessage message, bool skipHasAttachment, JunkSkipCriteria criteria) {
+        if (criteria.MessageIds != null && message.MessageId != null && criteria.MessageIds.Contains(message.MessageId)) {
+            return true;
+        }
+
+        if (criteria.From != null && message.From.Mailboxes.Any(mailbox => criteria.From.Contains(mailbox.Address))) {
+            return true;
+        }
+
+        if (criteria.To != null && message.To.Mailboxes.Any(mailbox => criteria.To.Contains(mailbox.Address))) {
+            return true;
+        }
+
+        if (criteria.SubjectTokens != null && message.Subject != null &&
+            criteria.SubjectTokens.Any(token => message.Subject.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0)) {
+            return true;
+        }
+
+        if (skipHasAttachment && message.Attachments.Any()) {
+            return true;
+        }
+
+        if (criteria.AttachmentExtensions != null && message.Attachments.OfType<MimePart>().Any(att =>
+                criteria.AttachmentExtensions.Contains(System.IO.Path.GetExtension(att.FileName ?? string.Empty).TrimStart('.')))) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- materialize IMAP junk-cleaner skip filters once so single-use enumerables do not break filtering
- normalize attachment extension skips before comparing attachment names
- share the skip logic between clear and list paths and add focused IMAP regressions

## Testing
- dotnet test Sources/Mailozaurr.sln --no-restore --filter "FullyQualifiedName~JunkCleanerTests" -v minimal
- dotnet test Sources/Mailozaurr.sln --no-restore -v minimal