### PR TITLE
Short-circuit empty Graph bulk move operations

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
@@ -542,6 +542,18 @@ public class GraphMailboxBrowserTests {
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task MoveMessagesAsync_WithNoMessageIds_SkipsFolderResolution() {
+        var handler = new RecordingHandler();
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var results = await browser.MoveMessagesAsync(Array.Empty<string>(), "Archive");
+
+        Assert.Empty(results);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task ArchiveConversationsAsync_UsesArchiveDestinationAlias() {
         var folderJson = "{\"id\":\"archive-id\"}";
         var listJson = "{\"value\":[{\"id\":\"m1\"}]}";
@@ -565,6 +577,18 @@ public class GraphMailboxBrowserTests {
         var body = await handler.Requests[2].Content!.ReadAsStringAsync();
         Assert.Contains("me/messages/m1/move", body, StringComparison.Ordinal);
         Assert.Contains("\"destinationId\":\"archive-id\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MoveConversationsAsync_WithNoConversationIds_SkipsFolderResolution() {
+        var handler = new RecordingHandler();
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var results = await browser.MoveConversationsAsync(Array.Empty<string>(), "Archive");
+
+        Assert.Empty(results);
+        Assert.Empty(handler.Requests);
     }
 
     [Fact]

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
@@ -730,9 +730,14 @@ public sealed class GraphMailboxBrowser {
             throw new ArgumentNullException(nameof(messageIds));
         }
 
+        var ids = NormalizeBulkIds(messageIds);
+        if (ids.Count == 0) {
+            return Array.Empty<GraphBulkOperationResult>();
+        }
+
         var destinationId = await ResolveFolderIdAsync(targetFolder, cancellationToken).ConfigureAwait(false);
         return await _graph.BatchMoveMessagesAsync(
-            messageIds,
+            ids,
             destinationId,
             batchSize: batchSize,
             cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -825,9 +830,14 @@ public sealed class GraphMailboxBrowser {
             throw new ArgumentNullException(nameof(conversationIds));
         }
 
+        var ids = NormalizeBulkIds(conversationIds);
+        if (ids.Count == 0) {
+            return Array.Empty<GraphBulkOperationResult>();
+        }
+
         var destinationId = await ResolveFolderIdAsync(targetFolder, cancellationToken).ConfigureAwait(false);
         return await _graph.BatchMoveConversationsAsync(
-            conversationIds,
+            ids,
             destinationId,
             batchSize: batchSize,
             cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -1040,6 +1050,17 @@ public sealed class GraphMailboxBrowser {
     private static string? NormalizeOptional(string? raw) {
         var trimmed = (raw ?? string.Empty).Trim();
         return trimmed.Length == 0 ? null : trimmed;
+    }
+
+    private static List<string> NormalizeBulkIds(IEnumerable<string> values) {
+        var normalized = new List<string>();
+        foreach (var value in values) {
+            var trimmed = NormalizeOptional(value);
+            if (trimmed != null) {
+                normalized.Add(trimmed);
+            }
+        }
+        return normalized;
     }
 
     private static string EscapeGraphLiteral(string value) =>


### PR DESCRIPTION
Summary: return early for empty Graph message and conversation bulk move inputs, avoid unnecessary folder resolution for no-op bulk operations, and add regression tests proving empty inputs make no Graph requests. Testing: dotnet test Sources/Mailozaurr.sln --no-restore --filter "FullyQualifiedName~GraphMailboxBrowserTests" -v minimal; dotnet test Sources/Mailozaurr.sln --no-restore -v minimal.