### PR TITLE
Propagate Graph send cancellation

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphDraftTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphDraftTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -59,6 +60,25 @@ public class GraphDraftTests
 
         var warnings = graph.LogCollector.Logs.ToArray();
         Assert.Contains(warnings, entry => entry.Type == LogType.Warning && entry.Message.IndexOf(missing, StringComparison.OrdinalIgnoreCase) >= 0);
+    }
+
+    [Fact]
+    public async Task CreateGraphAttachment_Canceled_ThrowsOperationCanceledException()
+    {
+        string tmp = Path.GetTempFileName();
+        File.WriteAllBytes(tmp, new byte[1024]);
+        using var graph = new Graph();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        try
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => graph.CreateGraphAttachment(tmp, cts.Token));
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
+++ b/Sources/Mailozaurr.Tests/SendEmailBasicTests.cs
@@ -4,6 +4,7 @@ using Mailozaurr;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using System.IO;
 using System.Management.Automation;
@@ -225,6 +226,50 @@ namespace Mailozaurr.Tests {
 
             Assert.True(result.Status, $"Graph send failed: {result.Error}");
             Assert.Single(handler.Requests);
+        }
+
+        [Fact]
+        public async Task ConnectO365GraphAsync_GraphCanceled_ThrowsOperationCanceledException() {
+            using var graph = new Graph();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            graph.Authenticate(new NetworkCredential("client@tenant", "secret"));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => graph.ConnectO365GraphAsync(cts.Token));
+        }
+
+        [Fact]
+        public async Task SendEmail_GraphCanceled_ThrowsOperationCanceledException() {
+            using var graph = new Graph {
+                From = "sender@example.com",
+                To = new object[] { "recipient@example.com" },
+                Subject = "Test Email (Graph Cancel)",
+                HTML = "<b>Hello from Mailozaurr Graph!</b>",
+                ContentType = "HTML",
+                AccessToken = "token",
+                TokenType = "Bearer"
+            };
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => graph.SendMessageAsync(cts.Token));
+        }
+
+        [Fact]
+        public async Task SendDraftEmail_GraphCanceled_ThrowsOperationCanceledException() {
+            using var graph = new Graph {
+                From = "sender@example.com",
+                To = new object[] { "recipient@example.com" },
+                Subject = "Test Draft Email (Graph Cancel)",
+                HTML = "<b>Hello from Mailozaurr Graph Draft!</b>",
+                ContentType = "HTML",
+                AccessToken = "token",
+                TokenType = "Bearer"
+            };
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => graph.SendMessageDraftAsync(cts.Token));
         }
 
         [Fact]

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -564,6 +564,8 @@ namespace Mailozaurr;
             } finally {
                 MicrosoftGraphUtils.ConcurrencySemaphore.Release();
             }
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            throw;
         } catch (TaskCanceledException ex) {
             LogCollector.LogWarning($"Send-EmailMessage - Connection to Graph API cancelled: {ex.Message}");
             return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, "GraphAPI", 0, operationStopwatch.Elapsed, string.Empty, ex.Message);
@@ -631,6 +633,8 @@ namespace Mailozaurr;
                 } finally {
                     MicrosoftGraphUtils.ConcurrencySemaphore.Release();
                 }
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                throw;
             } catch (TaskCanceledException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Sending via Graph API cancelled: {ex.Message}");
@@ -693,6 +697,8 @@ namespace Mailozaurr;
         do {
             try {
                 return await SendDraftMessage(draftMessage, cancellationToken);
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                throw;
             } catch (TaskCanceledException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Sending draft via Graph API cancelled: {ex.Message}");
@@ -1010,10 +1016,9 @@ namespace Mailozaurr;
         int bytesRead;
         long offset = 0;
         try {
+            cancellationToken.ThrowIfCancellationRequested();
             while ((bytesRead = fileStream.Read(buffer, 0, chunkSize)) > 0) {
-                if (cancellationToken.IsCancellationRequested) {
-                    return fileContents;
-                }
+                cancellationToken.ThrowIfCancellationRequested();
 
                 var chunk = new byte[bytesRead];
                 Array.Copy(buffer, chunk, bytesRead);
@@ -1125,6 +1130,8 @@ namespace Mailozaurr;
             try {
                 await SendAttachmentChunkOnceAsync(uploadUrl, chunk, offset, fileSize, cancellationToken);
                 return;
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                throw;
             } catch (Exception ex) {
                 lastException = ex;
                 var shouldRetry = (policy?.RetryOnTransient ?? true) ? GraphRetryHelper.IsTransient(ex) : RetryAlways;
@@ -1153,6 +1160,8 @@ namespace Mailozaurr;
                 var uploadUrl = await CreateUploadSession(draftMessage, attachmentItemJson.Json, cancellationToken);
                 await SendFileChunks(uploadUrl, attachmentItemJson.FilePath, attachmentItemJson.FileSize, cancellationToken);
                 return;
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                throw;
             } catch (FileNotFoundException) {
                 throw;
             } catch (Exception ex) {


### PR DESCRIPTION
Summary: propagate explicit caller cancellation through Graph connect/send flows instead of converting it into normal failures or retries, and make canceled attachment preparation throw instead of returning partial chunks. Testing: dotnet test Sources/Mailozaurr.sln --no-restore --filter "FullyQualifiedName~SendEmailBasicTests|FullyQualifiedName~GraphDraftTests" -v minimal; dotnet test Sources/Mailozaurr.sln --no-restore -v minimal.