### PR TITLE
Forward cancellation to Graph batch send

### DIFF
--- a/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
@@ -76,6 +76,32 @@ public class GraphBatchAndRetryTests {
         }
     }
 
+    [Fact]
+    public async Task SendMessageBatchAsync_Canceled_ThrowsOperationCanceledException() {
+        var handler = new BatchHandler();
+        var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)field.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        try {
+            using var graph = new Graph {
+                From = "sender@example.com",
+                To = new object[] { "recipient@example.com" },
+                Subject = "sub",
+                HTML = "body",
+                ContentType = "HTML"
+            };
+            graph.Authenticate(new System.Net.NetworkCredential("id@tenant", "secret"));
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => graph.SendMessageBatchAsync(cts.Token));
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+
     private class RetryHandler : HttpMessageHandler {
         public int CallCount;
 

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -808,7 +808,7 @@ namespace Mailozaurr;
             Headers = new Dictionary<string, string> { ["Content-Type"] = "application/json" },
             Body = bodyObj
         };
-        var results = await MicrosoftGraphUtils.SendBatchAsync(credential, new[] { request });
+        var results = await MicrosoftGraphUtils.SendBatchAsync(credential, new[] { request }, cancellationToken);
         var response = results.FirstOrDefault();
         var success = response != null && response.Status >= 200 && response.Status < 300;
         return new SmtpResult(


### PR DESCRIPTION
Summary: forward the caller cancellation token through Graph batch send so canceled batch sends stop before auth/batch work instead of succeeding unexpectedly, and add a regression test for the pre-canceled path. Testing: dotnet test Sources/Mailozaurr.sln --no-restore --filter "FullyQualifiedName~GraphBatchAndRetryTests" -v minimal; dotnet test Sources/Mailozaurr.sln --no-restore -v minimal.