### PR TITLE
Add combined protocol auth helpers for tooling

### DIFF
--- a/Sources/Mailozaurr.Tests/ConnectorTests.cs
+++ b/Sources/Mailozaurr.Tests/ConnectorTests.cs
@@ -23,6 +23,7 @@ public class ConnectorTests
         public override bool IsAuthenticated => Authenticated;
         private bool _connected;
         private int _timeout;
+        public string? AuthMechanism { get; private set; }
         public override bool IsConnected => _connected;
         public override int Timeout { get => _timeout; set => _timeout = value; }
         public bool Disposed { get; private set; }
@@ -42,6 +43,11 @@ public class ConnectorTests
         public override Task DisconnectAsync(bool quit, CancellationToken cancellationToken = default)
         {
             _connected = false;
+            return Task.CompletedTask;
+        }
+        public override Task AuthenticateAsync(SaslMechanism mechanism, CancellationToken cancellationToken = default) {
+            AuthMechanism = mechanism.GetType().Name;
+            Authenticated = true;
             return Task.CompletedTask;
         }
         protected override void Dispose(bool disposing)
@@ -158,6 +164,25 @@ public class ConnectorTests
         Assert.Equal(1993, fake.LastPort);
         Assert.Equal(SecureSocketOptions.SslOnConnect, fake.LastSecureSocketOptions);
         Assert.Equal(4321, fake.Timeout);
+    }
+
+    [Fact]
+    public async Task ImapConnector_ConnectAuthenticatedAsync_UsesOAuthAuthentication() {
+        var fake = new FakeImapClient();
+        ImapConnector.ClientFactory = () => fake;
+        var request = new ImapConnectionRequest("imap.example.test", 993);
+
+        var client = await ImapConnector.ConnectAuthenticatedAsync(
+            request,
+            userName: "user@example.com",
+            secret: "oauth-token",
+            mode: ProtocolAuthMode.OAuth2);
+
+        ImapConnector.ClientFactory = () => new ImapClient();
+
+        Assert.Same(fake, client);
+        Assert.True(fake.IsAuthenticated);
+        Assert.Equal(nameof(SaslMechanismOAuth2), fake.AuthMechanism);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
@@ -117,6 +117,49 @@ public class SmtpAsyncWrappersTests
     }
 
     [Fact]
+    public async Task ConnectAndAuthenticateAsync_DryRunSkipsAuthentication()
+    {
+        var smtp = new Smtp {
+            DryRun = true
+        };
+        var fake = new FakeConnectClient();
+        SetClient(smtp, fake);
+
+        var result = await smtp.ConnectAndAuthenticateAsync(
+            "host",
+            587,
+            "user@example.com",
+            "secret",
+            authMode: ProtocolAuthMode.OAuth2);
+
+        Assert.True(result.IsSuccess);
+        Assert.True(string.IsNullOrWhiteSpace(result.ErrorCode));
+        Assert.Null(fake.AuthMechanism);
+    }
+
+    [Fact]
+    public async Task ConnectAndAuthenticateAsync_ThrowsWhenAlreadyCanceled()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeConnectClient();
+        SetClient(smtp, fake);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => smtp.ConnectAndAuthenticateAsync(
+            "host",
+            587,
+            "user@example.com",
+            "secret",
+            authMode: ProtocolAuthMode.OAuth2,
+            cancellationToken: cts.Token));
+
+        Assert.False(fake.ConnectCalled);
+        Assert.Null(fake.AuthMechanism);
+    }
+
+    [Fact]
     public async Task CreateMessageAsync_AutoEmbedImagesAddsInlineAttachment()
     {
         var tempFile = Path.GetTempFileName();

--- a/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
@@ -16,9 +16,24 @@ public class SmtpAsyncWrappersTests
     private class FakeConnectClient : ClientSmtp
     {
         public bool ConnectCalled;
+        public bool ThrowOnConnect;
+        public bool ThrowOnAuthenticate;
+        public SecureSocketOptions? LastSecureSocketOptions;
+        public string? AuthMechanism;
         public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
         {
+            if (ThrowOnConnect) {
+                throw new InvalidOperationException("connect failed");
+            }
             ConnectCalled = true;
+            LastSecureSocketOptions = options;
+            return Task.CompletedTask;
+        }
+        public override Task AuthenticateAsync(SaslMechanism mechanism, CancellationToken cancellationToken = default) {
+            if (ThrowOnAuthenticate) {
+                throw new InvalidOperationException("auth failed");
+            }
+            AuthMechanism = mechanism.GetType().Name;
             return Task.CompletedTask;
         }
     }
@@ -40,6 +55,65 @@ public class SmtpAsyncWrappersTests
 
         Assert.True(fake.ConnectCalled);
         Assert.True(result.Status);
+    }
+
+    [Fact]
+    public async Task ConnectAndAuthenticateAsync_ReturnsSuccessForOAuthAuthentication()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeConnectClient();
+        SetClient(smtp, fake);
+
+        var result = await smtp.ConnectAndAuthenticateAsync(
+            "host",
+            587,
+            "user@example.com",
+            "oauth-token",
+            SecureSocketOptions.StartTls,
+            useSsl: false,
+            authMode: ProtocolAuthMode.OAuth2);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(SecureSocketOptions.StartTls, result.SecureSocketOptions);
+        Assert.Equal(nameof(SaslMechanismOAuth2), fake.AuthMechanism);
+    }
+
+    [Fact]
+    public async Task ConnectAndAuthenticateAsync_MapsConnectFailure()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeConnectClient { ThrowOnConnect = true };
+        SetClient(smtp, fake);
+
+        var result = await smtp.ConnectAndAuthenticateAsync(
+            "host",
+            587,
+            "user@example.com",
+            "secret",
+            authMode: ProtocolAuthMode.OAuth2);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("connect_failed", result.ErrorCode);
+        Assert.True(result.IsTransient);
+    }
+
+    [Fact]
+    public async Task ConnectAndAuthenticateAsync_MapsAuthenticationFailure()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeConnectClient { ThrowOnAuthenticate = true };
+        SetClient(smtp, fake);
+
+        var result = await smtp.ConnectAndAuthenticateAsync(
+            "host",
+            587,
+            "user@example.com",
+            "secret",
+            authMode: ProtocolAuthMode.OAuth2);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("auth_failed", result.ErrorCode);
+        Assert.False(result.IsTransient);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
@@ -82,6 +82,17 @@ public class SmtpAsyncWrappersTests
     }
 
     [Fact]
+    public void ConnectAsync_PreservesLegacyFourArgumentOverload()
+    {
+        var method = typeof(Smtp).GetMethod(
+            nameof(Smtp.ConnectAsync),
+            new[] { typeof(string), typeof(int), typeof(SecureSocketOptions), typeof(bool) });
+
+        Assert.NotNull(method);
+        Assert.Equal(typeof(Task<SmtpResult>), method!.ReturnType);
+    }
+
+    [Fact]
     public async Task ConnectAndAuthenticateAsync_ReturnsSuccessForOAuthAuthentication()
     {
         var smtp = new Smtp();

--- a/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,6 +54,18 @@ public class SmtpAsyncWrappersTests
     {
         var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
         field.SetValue(smtp, client);
+    }
+
+    private static void SetCredential(Smtp smtp, NetworkCredential credential)
+    {
+        var field = typeof(Smtp).GetField("<Credential>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(smtp, credential);
+    }
+
+    private static string? GetPoolIdentity(Smtp smtp)
+    {
+        var field = typeof(Smtp).GetField("_poolIdentity", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return field.GetValue(smtp) as string;
     }
 
     [Fact]
@@ -148,6 +161,23 @@ public class SmtpAsyncWrappersTests
     }
 
     [Fact]
+    public async Task ConnectAndAuthenticateAsync_ReThrowsAuthFailureWhenErrorActionStop()
+    {
+        var smtp = new Smtp {
+            ErrorAction = ActionPreference.Stop
+        };
+        var fake = new FakeConnectClient { ThrowOnAuthenticate = true };
+        SetClient(smtp, fake);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => smtp.ConnectAndAuthenticateAsync(
+            "host",
+            587,
+            "user@example.com",
+            "secret",
+            authMode: ProtocolAuthMode.OAuth2));
+    }
+
+    [Fact]
     public async Task ConnectAndAuthenticateAsync_DryRunSkipsAuthentication()
     {
         var smtp = new Smtp {
@@ -215,6 +245,29 @@ public class SmtpAsyncWrappersTests
         Assert.True(fake.ConnectCanceled);
         Assert.True(fake.LastConnectCancellationToken.CanBeCanceled);
         Assert.Null(fake.AuthMechanism);
+    }
+
+    [Fact]
+    public async Task ConnectAndAuthenticateAsync_UsesRequestedUsernameForPoolIdentityWhenCredentialWasStale()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeConnectClient();
+        SetClient(smtp, fake);
+        SetCredential(smtp, new NetworkCredential("old.user@example.com", "old-secret"));
+
+        var result = await smtp.ConnectAndAuthenticateAsync(
+            "host",
+            587,
+            "new.user@example.com",
+            "secret",
+            authMode: ProtocolAuthMode.OAuth2);
+
+        var poolIdentity = GetPoolIdentity(smtp);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(poolIdentity);
+        Assert.StartsWith("new.user@example.com|", poolIdentity!, StringComparison.Ordinal);
+        Assert.Null(smtp.ConnectionPoolIdentity);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAsyncWrappersTests.cs
@@ -18,16 +18,27 @@ public class SmtpAsyncWrappersTests
         public bool ConnectCalled;
         public bool ThrowOnConnect;
         public bool ThrowOnAuthenticate;
+        public bool BlockConnectUntilCanceled;
+        public bool ConnectCanceled;
         public SecureSocketOptions? LastSecureSocketOptions;
+        public CancellationToken LastConnectCancellationToken;
         public string? AuthMechanism;
-        public override Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
+        public override async Task ConnectAsync(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default)
         {
+            LastConnectCancellationToken = cancellationToken;
             if (ThrowOnConnect) {
                 throw new InvalidOperationException("connect failed");
             }
+            if (BlockConnectUntilCanceled) {
+                try {
+                    await Task.Delay(global::System.Threading.Timeout.InfiniteTimeSpan, cancellationToken);
+                } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                    ConnectCanceled = true;
+                    throw;
+                }
+            }
             ConnectCalled = true;
             LastSecureSocketOptions = options;
-            return Task.CompletedTask;
         }
         public override Task AuthenticateAsync(SaslMechanism mechanism, CancellationToken cancellationToken = default) {
             if (ThrowOnAuthenticate) {
@@ -98,6 +109,26 @@ public class SmtpAsyncWrappersTests
     }
 
     [Fact]
+    public async Task ConnectAndAuthenticateAsync_MapsValidationFailureAsNonTransient()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeConnectClient();
+        SetClient(smtp, fake);
+
+        var result = await smtp.ConnectAndAuthenticateAsync(
+            string.Empty,
+            0,
+            "user@example.com",
+            "secret",
+            authMode: ProtocolAuthMode.OAuth2);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("connect_failed", result.ErrorCode);
+        Assert.False(result.IsTransient);
+        Assert.False(fake.ConnectCalled);
+    }
+
+    [Fact]
     public async Task ConnectAndAuthenticateAsync_MapsAuthenticationFailure()
     {
         var smtp = new Smtp();
@@ -156,6 +187,33 @@ public class SmtpAsyncWrappersTests
             cancellationToken: cts.Token));
 
         Assert.False(fake.ConnectCalled);
+        Assert.Null(fake.AuthMechanism);
+    }
+
+    [Fact]
+    public async Task ConnectAndAuthenticateAsync_PropagatesCancellationIntoConnect()
+    {
+        var smtp = new Smtp();
+        var fake = new FakeConnectClient {
+            BlockConnectUntilCanceled = true
+        };
+        SetClient(smtp, fake);
+
+        using var cts = new CancellationTokenSource();
+        var operation = smtp.ConnectAndAuthenticateAsync(
+            "host",
+            587,
+            "user@example.com",
+            "secret",
+            authMode: ProtocolAuthMode.OAuth2,
+            cancellationToken: cts.Token);
+
+        cts.CancelAfter(TimeSpan.FromMilliseconds(25));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
+
+        Assert.True(fake.ConnectCanceled);
+        Assert.True(fake.LastConnectCancellationToken.CanBeCanceled);
         Assert.Null(fake.AuthMechanism);
     }
 

--- a/Sources/Mailozaurr/Connections/ImapConnector.cs
+++ b/Sources/Mailozaurr/Connections/ImapConnector.cs
@@ -94,4 +94,29 @@ public static class ImapConnector {
             retryDelayBackoff,
             DelayAsync,
             cancellationToken);
+
+    /// <summary>
+    /// Connects and authenticates to an IMAP server using protocol auth settings in one step.
+    /// </summary>
+    /// <param name="request">Connection request settings.</param>
+    /// <param name="userName">IMAP user name.</param>
+    /// <param name="secret">IMAP password or OAuth token.</param>
+    /// <param name="mode">Authentication mode.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>Authenticated <see cref="ImapClient"/> instance.</returns>
+    public static Task<ImapClient> ConnectAuthenticatedAsync(
+        ImapConnectionRequest request,
+        string userName,
+        string secret,
+        ProtocolAuthMode mode = ProtocolAuthMode.Basic,
+        CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        return ConnectAsync(
+            request,
+            (client, ct) => ProtocolAuth.AuthenticateImapAsync(client, userName, secret, mode, ct),
+            cancellationToken);
+    }
 }

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -77,6 +77,11 @@ public class Smtp {
     public NetworkCredential? Credential { get; private set; }
 
     /// <summary>
+    /// Effective secure socket options used by the active or most recent connection attempt.
+    /// </summary>
+    public SecureSocketOptions ActiveSecureSocketOptions => _activeSecureSocketOptions;
+
+    /// <summary>
     /// Optional identity hint used to isolate SMTP connection pooling by credentials.
     /// </summary>
     public string? ConnectionPoolIdentity { get; set; }
@@ -587,6 +592,58 @@ public class Smtp {
                 throw;
             }
             return new SmtpResult(false, EmailAction.Connect, SentTo, SentFrom, server, port, Stopwatch.Elapsed, "", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Connects and authenticates using the provided user name/secret in one step.
+    /// </summary>
+    /// <param name="server">SMTP server hostname.</param>
+    /// <param name="port">SMTP server port.</param>
+    /// <param name="userName">SMTP user name.</param>
+    /// <param name="secret">SMTP password or OAuth token.</param>
+    /// <param name="secureSocketOptions">TLS/SSL options.</param>
+    /// <param name="useSsl">Compatibility SSL switch.</param>
+    /// <param name="authMode">Authentication mode.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Combined connect/auth outcome.</returns>
+    public async Task<SmtpConnectAuthenticateResult> ConnectAndAuthenticateAsync(
+        string server,
+        int port,
+        string userName,
+        string secret,
+        SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto,
+        bool useSsl = false,
+        ProtocolAuthMode authMode = ProtocolAuthMode.Basic,
+        CancellationToken cancellationToken = default) {
+        var connectResult = await ConnectAsync(server, port, secureSocketOptions, useSsl).ConfigureAwait(false);
+        if (!connectResult.Status) {
+            return new SmtpConnectAuthenticateResult {
+                IsSuccess = false,
+                SecureSocketOptions = ActiveSecureSocketOptions,
+                ErrorCode = "connect_failed",
+                Error = connectResult.Error ?? "Connect failed.",
+                IsTransient = true
+            };
+        }
+
+        try {
+            await ProtocolAuth.AuthenticateSmtpAsync(Client, userName, secret, authMode, cancellationToken).ConfigureAwait(false);
+            Credential = new NetworkCredential(userName?.Trim() ?? string.Empty, secret ?? string.Empty);
+            return new SmtpConnectAuthenticateResult {
+                IsSuccess = true,
+                SecureSocketOptions = ActiveSecureSocketOptions
+            };
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception ex) {
+            return new SmtpConnectAuthenticateResult {
+                IsSuccess = false,
+                SecureSocketOptions = ActiveSecureSocketOptions,
+                ErrorCode = "auth_failed",
+                Error = ex.Message,
+                IsTransient = false
+            };
         }
     }
 

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -616,6 +616,8 @@ public class Smtp {
         bool useSsl = false,
         ProtocolAuthMode authMode = ProtocolAuthMode.Basic,
         CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var connectResult = await ConnectAsync(server, port, secureSocketOptions, useSsl).ConfigureAwait(false);
         if (!connectResult.Status) {
             return new SmtpConnectAuthenticateResult {
@@ -624,6 +626,15 @@ public class Smtp {
                 ErrorCode = "connect_failed",
                 Error = connectResult.Error ?? "Connect failed.",
                 IsTransient = true
+            };
+        }
+
+        if (DryRun) {
+            LogVerbose("Send-EmailMessage - DryRun enabled, skipping authentication.");
+            Credential = new NetworkCredential(userName?.Trim() ?? string.Empty, secret ?? string.Empty);
+            return new SmtpConnectAuthenticateResult {
+                IsSuccess = true,
+                SecureSocketOptions = ActiveSecureSocketOptions
             };
         }
 

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -627,7 +627,25 @@ public class Smtp {
         CancellationToken cancellationToken = default) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var connectResult = await ConnectAsync(server, port, secureSocketOptions, useSsl, cancellationToken).ConfigureAwait(false);
+        var normalizedUserName = userName?.Trim() ?? string.Empty;
+        var previousConnectionPoolIdentity = ConnectionPoolIdentity;
+        var shouldOverrideConnectionPoolIdentity =
+            string.IsNullOrWhiteSpace(previousConnectionPoolIdentity) &&
+            !string.IsNullOrWhiteSpace(normalizedUserName);
+
+        if (shouldOverrideConnectionPoolIdentity) {
+            ConnectionPoolIdentity = normalizedUserName;
+        }
+
+        SmtpResult connectResult;
+        try {
+            connectResult = await ConnectAsync(server, port, secureSocketOptions, useSsl, cancellationToken).ConfigureAwait(false);
+        } finally {
+            if (shouldOverrideConnectionPoolIdentity) {
+                ConnectionPoolIdentity = previousConnectionPoolIdentity;
+            }
+        }
+
         if (!connectResult.Status) {
             return new SmtpConnectAuthenticateResult {
                 IsSuccess = false,
@@ -640,7 +658,7 @@ public class Smtp {
 
         if (DryRun) {
             LogVerbose("Send-EmailMessage - DryRun enabled, skipping authentication.");
-            Credential = new NetworkCredential(userName?.Trim() ?? string.Empty, secret ?? string.Empty);
+            Credential = new NetworkCredential(normalizedUserName, secret ?? string.Empty);
             return new SmtpConnectAuthenticateResult {
                 IsSuccess = true,
                 SecureSocketOptions = ActiveSecureSocketOptions
@@ -648,8 +666,8 @@ public class Smtp {
         }
 
         try {
-            await ProtocolAuth.AuthenticateSmtpAsync(Client, userName, secret, authMode, cancellationToken).ConfigureAwait(false);
-            Credential = new NetworkCredential(userName?.Trim() ?? string.Empty, secret ?? string.Empty);
+            await ProtocolAuth.AuthenticateSmtpAsync(Client, normalizedUserName, secret, authMode, cancellationToken).ConfigureAwait(false);
+            Credential = new NetworkCredential(normalizedUserName, secret ?? string.Empty);
             return new SmtpConnectAuthenticateResult {
                 IsSuccess = true,
                 SecureSocketOptions = ActiveSecureSocketOptions
@@ -657,6 +675,9 @@ public class Smtp {
         } catch (OperationCanceledException) {
             throw;
         } catch (Exception ex) {
+            if (ErrorAction == ActionPreference.Stop) {
+                throw;
+            }
             return new SmtpConnectAuthenticateResult {
                 IsSuccess = false,
                 SecureSocketOptions = ActiveSecureSocketOptions,

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -529,8 +529,15 @@ public class Smtp {
     /// <param name="useSsl">Compatibility switch. Overrides
     /// <paramref name="secureSocketOptions"/> only when set to <c>true</c> and the
     /// option is left as <see cref="SecureSocketOptions.Auto"/>.</param>
+    /// <param name="cancellationToken">Cancellation token for the connect operation.</param>
     /// <returns></returns>
-    public async Task<SmtpResult> ConnectAsync(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false) {
+    public async Task<SmtpResult> ConnectAsync(
+        string server,
+        int port,
+        SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto,
+        bool useSsl = false,
+        CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         var oldServer = Server;
         var oldPort = Port;
         var oldPoolIdentity = _poolIdentity ?? GetConnectionPoolIdentity();
@@ -580,11 +587,13 @@ public class Smtp {
         try {
             if (!Client.IsConnected)
             {
-                await Client.ConnectAsync(server, port, effectiveOptions);
+                await Client.ConnectAsync(server, port, effectiveOptions, cancellationToken).ConfigureAwait(false);
             }
             _poolIdentity = poolIdentity;
             LogVerbose($"Connected to {server} on {port} port using SSL: {effectiveOptions}");
             return new SmtpResult(true, EmailAction.Connect, SentTo, SentFrom, server, port, Stopwatch.Elapsed, "");
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            throw;
         } catch (Exception ex) {
             LogWarning($"Send-EmailMessage - Error during connect: {ex.Message}");
             LogWarning($"Send-EmailMessage - Possible issue: Port? ({port} was used), Using SSL? ({effectiveOptions}, was used). You can also try 'SkipCertificateValidation' or 'SkipCertificateRevocation'.");
@@ -618,14 +627,14 @@ public class Smtp {
         CancellationToken cancellationToken = default) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var connectResult = await ConnectAsync(server, port, secureSocketOptions, useSsl).ConfigureAwait(false);
+        var connectResult = await ConnectAsync(server, port, secureSocketOptions, useSsl, cancellationToken).ConfigureAwait(false);
         if (!connectResult.Status) {
             return new SmtpConnectAuthenticateResult {
                 IsSuccess = false,
                 SecureSocketOptions = ActiveSecureSocketOptions,
                 ErrorCode = "connect_failed",
                 Error = connectResult.Error ?? "Connect failed.",
-                IsTransient = true
+                IsTransient = SmtpValidation.TryValidateServer(server, port, out _)
             };
         }
 

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -529,14 +529,34 @@ public class Smtp {
     /// <param name="useSsl">Compatibility switch. Overrides
     /// <paramref name="secureSocketOptions"/> only when set to <c>true</c> and the
     /// option is left as <see cref="SecureSocketOptions.Auto"/>.</param>
+    /// <returns></returns>
+    public Task<SmtpResult> ConnectAsync(
+        string server,
+        int port,
+        SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto,
+        bool useSsl = false) {
+        return ConnectAsync(server, port, secureSocketOptions, useSsl, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Asynchronously connect to the SMTP server using the provided server and port.
+    /// </summary>
+    /// <param name="server"></param>
+    /// <param name="port"></param>
+    /// <param name="secureSocketOptions">Options controlling SSL/TLS usage. If left
+    /// as <see cref="SecureSocketOptions.Auto"/> and <paramref name="useSsl"/> is
+    /// <c>true</c>, <see cref="SecureSocketOptions.StartTls"/> will be used.</param>
+    /// <param name="useSsl">Compatibility switch. Overrides
+    /// <paramref name="secureSocketOptions"/> only when set to <c>true</c> and the
+    /// option is left as <see cref="SecureSocketOptions.Auto"/>.</param>
     /// <param name="cancellationToken">Cancellation token for the connect operation.</param>
     /// <returns></returns>
     public async Task<SmtpResult> ConnectAsync(
         string server,
         int port,
-        SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto,
-        bool useSsl = false,
-        CancellationToken cancellationToken = default) {
+        SecureSocketOptions secureSocketOptions,
+        bool useSsl,
+        CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
         var oldServer = Server;
         var oldPort = Port;

--- a/Sources/Mailozaurr/Smtp/SmtpConnectAuthenticateResult.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectAuthenticateResult.cs
@@ -1,0 +1,33 @@
+using MailKit.Security;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Result of connecting and authenticating an SMTP session.
+/// </summary>
+public sealed class SmtpConnectAuthenticateResult {
+    /// <summary>
+    /// True when both connect and authenticate succeeded.
+    /// </summary>
+    public bool IsSuccess { get; init; }
+
+    /// <summary>
+    /// Effective secure socket options used for the connection.
+    /// </summary>
+    public SecureSocketOptions SecureSocketOptions { get; init; } = SecureSocketOptions.Auto;
+
+    /// <summary>
+    /// Stable error code for connect/auth failures.
+    /// </summary>
+    public string ErrorCode { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable error text.
+    /// </summary>
+    public string Error { get; init; } = string.Empty;
+
+    /// <summary>
+    /// True when the failure is likely transient.
+    /// </summary>
+    public bool IsTransient { get; init; }
+}


### PR DESCRIPTION
## Summary
- add an authenticated IMAP connector helper for tooling wrappers
- add a combined SMTP connect/auth result plus helper so wrappers stop reimplementing protocol auth flow handling
- cover the new helpers with focused Mailozaurr tests

## Verification
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release --filter "FullyQualifiedName~ConnectorTests.ImapConnector_ConnectAuthenticatedAsync|FullyQualifiedName~SmtpAsyncWrappersTests.ConnectAndAuthenticateAsync|FullyQualifiedName~ProtocolAuthTests"`
