### PR TITLE
Move reusable email session helpers into Mailozaurr

### DIFF
--- a/Sources/Mailozaurr.Tests/ImapMessageReaderTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapMessageReaderTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Net.Imap;
+using MimeKit;
+using Moq;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ImapMessageReaderTests
+{
+    [Fact]
+    public async Task ReadAsync_UsesResolvedFolderAndTruncatesBodies()
+    {
+        var uid = new UniqueId(42);
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+        message.Subject = "subject";
+        message.Date = new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero);
+        var builder = new BodyBuilder {
+            TextBody = "1234567890",
+            HtmlBody = "<p>abcdefghij</p>"
+        };
+        builder.Attachments.Add("report.txt", new byte[] { 1, 2, 3 });
+        message.Body = builder.ToMessageBody();
+
+        var folder = new Mock<IMailFolder>();
+        folder.SetupGet(f => f.FullName).Returns("Inbox/Sub");
+        folder.SetupGet(f => f.IsOpen).Returns(true);
+        folder.SetupGet(f => f.Access).Returns(FolderAccess.ReadOnly);
+        folder.Setup(f => f.GetMessageAsync(uid, It.IsAny<CancellationToken>(), null))
+            .ReturnsAsync(message);
+
+        var personalRoot = new Mock<IMailFolder>();
+        personalRoot.Setup(f => f.GetSubfolder("Sub", It.IsAny<CancellationToken>()))
+            .Returns(folder.Object);
+
+        var client = new Mock<ImapClient> { CallBase = true };
+        client.Setup(c => c.Inbox).Returns(Mock.Of<IMailFolder>(f => f.FullName == "Inbox"));
+        client.Setup(c => c.GetFolder("Sub", It.IsAny<CancellationToken>()))
+            .Throws(new FolderNotFoundException("Sub"));
+        client.Setup(c => c.GetFolder(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((string name, CancellationToken _) => name.Length == 0 ? personalRoot.Object : throw new FolderNotFoundException(name));
+
+        var personalNamespaces = new FolderNamespaceCollection();
+        personalNamespaces.Add(new FolderNamespace('.', ""));
+        client.Setup(c => c.GetFolder(It.IsAny<FolderNamespace>()))
+            .Returns(personalRoot.Object);
+        client.Setup(c => c.PersonalNamespaces)
+            .Returns(personalNamespaces);
+
+        var result = await ImapMessageReader.ReadAsync(
+            client.Object,
+            new ImapMessageReadRequest(uid, "Sub", 8),
+            CancellationToken.None);
+
+        Assert.Equal(42L, result.Uid);
+        Assert.Equal("Inbox/Sub", result.Folder);
+        Assert.Equal("subject", result.Subject);
+        Assert.True(result.TextTruncated);
+        Assert.True(result.HtmlTruncated);
+        Assert.True(result.HasAttachments);
+        var attachment = Assert.Single(result.Attachments);
+        Assert.Equal("report.txt", attachment.FileName);
+    }
+
+    [Fact]
+    public async Task ReadAsync_UsesInboxWhenFolderOmitted()
+    {
+        var uid = new UniqueId(7);
+        var message = new MimeMessage();
+        message.Body = new TextPart("plain") { Text = "body" };
+
+        var inbox = new Mock<IMailFolder>();
+        inbox.SetupGet(f => f.FullName).Returns("Inbox");
+        inbox.SetupGet(f => f.IsOpen).Returns(true);
+        inbox.SetupGet(f => f.Access).Returns(FolderAccess.ReadOnly);
+        inbox.Setup(f => f.GetMessageAsync(uid, It.IsAny<CancellationToken>(), null))
+            .ReturnsAsync(message);
+
+        var client = new Mock<ImapClient> { CallBase = true };
+        client.Setup(c => c.Inbox).Returns(inbox.Object);
+        client.Setup(c => c.PersonalNamespaces).Returns(new FolderNamespaceCollection());
+
+        var result = await ImapMessageReader.ReadAsync(
+            client.Object,
+            new ImapMessageReadRequest(uid, null, 128),
+            CancellationToken.None);
+
+        Assert.Equal("Inbox", result.Folder);
+        Assert.False(result.TextTruncated);
+        Assert.False(result.HasAttachments);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ImapSessionServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapSessionServiceTests.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using MailKit.Net.Imap;
+using MailKit.Security;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ImapSessionServiceTests {
+    private sealed class FakeImapClient : ImapClient {
+        public bool AuthenticateCalled { get; set; }
+        public new bool Authenticated { get; set; }
+        private int _timeout;
+
+        public override bool IsAuthenticated => Authenticated;
+
+        public override int Timeout {
+            get => _timeout;
+            set => _timeout = value;
+        }
+
+        public override Task ConnectAsync(string host, int port, SecureSocketOptions options, System.Threading.CancellationToken cancellationToken = default) {
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ConnectAsync_UsesConnectionAndAuthenticationSettings() {
+        var fakeClient = new FakeImapClient();
+        var previousFactory = ImapConnector.ClientFactory;
+        try {
+            ImapConnector.ClientFactory = () => fakeClient;
+            var request = new ImapSessionRequest {
+                Connection = new ImapConnectionRequest(
+                    "imap.example.test",
+                    1993,
+                    SecureSocketOptions.SslOnConnect,
+                    timeout: 4321,
+                    retryCount: 0),
+                UserName = "user@example.test",
+                Secret = "secret",
+                AuthenticateAsync = (client, _) => {
+                    ((FakeImapClient)client).AuthenticateCalled = true;
+                    ((FakeImapClient)client).Authenticated = true;
+                    return Task.CompletedTask;
+                }
+            };
+
+            var client = await ImapSessionService.ConnectAsync(request);
+
+            Assert.Same(fakeClient, client);
+            Assert.True(fakeClient.AuthenticateCalled);
+            Assert.Equal(4321, fakeClient.Timeout);
+        } finally {
+            ImapConnector.ClientFactory = previousFactory;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/SmtpSessionServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSessionServiceTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading.Tasks;
+using MailKit.Security;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpSessionServiceTests {
+    [Fact]
+    public async Task ConnectAndAuthenticateAsync_ReturnsSuccess() {
+        var request = new SmtpSessionRequest {
+            Server = "smtp.test",
+            Port = 587,
+            SecureSocketOptions = SecureSocketOptions.Auto,
+            UserName = "user",
+            Password = "pass",
+            ConnectAsync = _ => Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero)),
+            AuthenticateAsync = _ => Task.FromResult(new SmtpResult(true, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero))
+        };
+
+        var smtp = new Smtp();
+        var result = await SmtpSessionService.ConnectAndAuthenticateAsync(smtp, request);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(SecureSocketOptions.Auto, result.SecureSocketOptions);
+        Assert.Null(result.ErrorCode);
+    }
+
+    [Fact]
+    public async Task ConnectAndAuthenticateAsync_FlagsConnectFailures() {
+        var request = new SmtpSessionRequest {
+            Server = "smtp.test",
+            Port = 587,
+            SecureSocketOptions = SecureSocketOptions.Auto,
+            UserName = "user",
+            Password = "pass",
+            ConnectAsync = _ => Task.FromResult(new SmtpResult(false, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero, error: "nope"))
+        };
+
+        var smtp = new Smtp();
+        var result = await SmtpSessionService.ConnectAndAuthenticateAsync(smtp, request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("connect_failed", result.ErrorCode);
+        Assert.Equal("nope", result.Error);
+        Assert.True(result.IsTransient);
+    }
+
+    [Fact]
+    public async Task ConnectAndAuthenticateAsync_FlagsAuthFailures() {
+        var request = new SmtpSessionRequest {
+            Server = "smtp.test",
+            Port = 587,
+            SecureSocketOptions = SecureSocketOptions.Auto,
+            UserName = "user",
+            Password = "pass",
+            ConnectAsync = _ => Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero)),
+            AuthenticateAsync = _ => Task.FromResult(new SmtpResult(false, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero, error: "bad auth"))
+        };
+
+        var smtp = new Smtp();
+        var result = await SmtpSessionService.ConnectAndAuthenticateAsync(smtp, request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("auth_failed", result.ErrorCode);
+        Assert.Equal("bad auth", result.Error);
+        Assert.False(result.IsTransient);
+    }
+}

--- a/Sources/Mailozaurr/Connections/ImapSessionService.cs
+++ b/Sources/Mailozaurr/Connections/ImapSessionService.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Imap;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Describes the parameters required for an authenticated IMAP session.
+/// </summary>
+public sealed class ImapSessionRequest {
+    /// <summary>
+    /// Gets or sets the underlying connection request.
+    /// </summary>
+    public ImapConnectionRequest Connection { get; init; } = new("localhost", 993);
+
+    /// <summary>
+    /// Gets or sets the auth username.
+    /// </summary>
+    public string UserName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the auth secret or token.
+    /// </summary>
+    public string Secret { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the protocol auth mode.
+    /// </summary>
+    public ProtocolAuthMode AuthMode { get; init; } = ProtocolAuthMode.Basic;
+
+    /// <summary>
+    /// Gets or sets an optional authenticate delegate used for testing/custom flows.
+    /// </summary>
+    public Func<ImapClient, CancellationToken, Task>? AuthenticateAsync { get; init; }
+}
+
+/// <summary>
+/// Helpers for establishing authenticated IMAP sessions.
+/// </summary>
+public static class ImapSessionService {
+    /// <summary>
+    /// Connects and authenticates an IMAP client from a reusable session request.
+    /// </summary>
+    public static Task<ImapClient> ConnectAsync(ImapSessionRequest request, CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        return ImapConnector.ConnectAsync(
+            request.Connection,
+            request.AuthenticateAsync ?? ((client, ct) => ProtocolAuth.AuthenticateImapAsync(
+                client,
+                request.UserName,
+                request.Secret,
+                request.AuthMode,
+                ct)),
+            cancellationToken);
+    }
+}

--- a/Sources/Mailozaurr/Connections/SmtpSessionService.cs
+++ b/Sources/Mailozaurr/Connections/SmtpSessionService.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Security;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents the result of an SMTP connect/auth flow.
+/// </summary>
+public sealed class SmtpConnectResult {
+    /// <summary>
+    /// Gets a value indicating whether the connection and authentication succeeded.
+    /// </summary>
+    public bool IsSuccess { get; }
+
+    /// <summary>
+    /// Gets the secure socket options used during the connection.
+    /// </summary>
+    public SecureSocketOptions SecureSocketOptions { get; }
+
+    /// <summary>
+    /// Gets the error code when the flow failed.
+    /// </summary>
+    public string? ErrorCode { get; }
+
+    /// <summary>
+    /// Gets the error message when the flow failed.
+    /// </summary>
+    public string? Error { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the failure is transient.
+    /// </summary>
+    public bool IsTransient { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmtpConnectResult"/> class.
+    /// </summary>
+    public SmtpConnectResult(bool isSuccess, SecureSocketOptions secureSocketOptions, string? errorCode, string? error, bool isTransient) {
+        IsSuccess = isSuccess;
+        SecureSocketOptions = secureSocketOptions;
+        ErrorCode = errorCode;
+        Error = error;
+        IsTransient = isTransient;
+    }
+}
+
+/// <summary>
+/// Describes the parameters required for an SMTP session.
+/// </summary>
+public sealed class SmtpSessionRequest {
+    /// <summary>SMTP server address.</summary>
+    public string Server { get; init; } = string.Empty;
+    /// <summary>SMTP port.</summary>
+    public int Port { get; init; } = 587;
+    /// <summary>Secure socket options.</summary>
+    public SecureSocketOptions SecureSocketOptions { get; init; } = SecureSocketOptions.Auto;
+    /// <summary>Force SSL flag.</summary>
+    public bool UseSsl { get; init; }
+    /// <summary>Connection timeout in milliseconds.</summary>
+    public int TimeoutMs { get; init; } = 30_000;
+    /// <summary>Retries for connection/auth flows.</summary>
+    public int RetryCount { get; init; }
+    /// <summary>Base delay for retries.</summary>
+    public int RetryDelayMilliseconds { get; init; }
+    /// <summary>Backoff multiplier.</summary>
+    public double RetryDelayBackoff { get; init; } = 1.0;
+    /// <summary>Skip certificate validation.</summary>
+    public bool SkipCertificateValidation { get; init; }
+    /// <summary>Skip certificate revocation checks.</summary>
+    public bool SkipCertificateRevocation { get; init; }
+    /// <summary>Implements DryRun (no network).</summary>
+    public bool DryRun { get; init; }
+    /// <summary>Auth username.</summary>
+    public string UserName { get; init; } = string.Empty;
+    /// <summary>Auth password.</summary>
+    public string Password { get; init; } = string.Empty;
+    /// <summary>Protocol auth mode.</summary>
+    public ProtocolAuthMode AuthMode { get; init; } = ProtocolAuthMode.Basic;
+    /// <summary>Optional connect delegate used for testing.</summary>
+    public Func<Smtp, Task<SmtpResult>>? ConnectAsync { get; init; }
+    /// <summary>Optional authenticate delegate used for testing.</summary>
+    public Func<Smtp, Task<SmtpResult>>? AuthenticateAsync { get; init; }
+}
+
+/// <summary>
+/// Helpers for establishing SMTP sessions.
+/// </summary>
+public static class SmtpSessionService {
+    /// <summary>
+    /// Attempts to connect and authenticate using the provided SMTP client/configuration.
+    /// </summary>
+    public static async Task<SmtpConnectResult> ConnectAndAuthenticateAsync(Smtp smtp, SmtpSessionRequest request, CancellationToken cancellationToken = default) {
+        if (smtp is null) {
+            throw new ArgumentNullException(nameof(smtp));
+        }
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        smtp.Timeout = request.TimeoutMs;
+        smtp.RetryCount = request.RetryCount;
+        smtp.RetryDelayMilliseconds = request.RetryDelayMilliseconds;
+        smtp.RetryDelayBackoff = request.RetryDelayBackoff;
+        smtp.SkipCertificateValidation = request.SkipCertificateValidation;
+        smtp.CheckCertificateRevocation = !request.SkipCertificateRevocation;
+        smtp.DryRun = request.DryRun;
+
+        var secureOptions = request.SecureSocketOptions;
+        var connectFunc = request.ConnectAsync ?? (_ => smtp.ConnectAsync(request.Server, request.Port, secureOptions, request.UseSsl));
+        var connectResult = await connectFunc(smtp).ConfigureAwait(false);
+        if (!connectResult.Status) {
+            return new SmtpConnectResult(false, secureOptions, "connect_failed", connectResult.Error ?? "Connect failed.", true);
+        }
+
+        var authenticateFunc = request.AuthenticateAsync ?? (_ => smtp.AuthenticateAsync(
+            new NetworkCredential(request.UserName, request.Password),
+            request.AuthMode == ProtocolAuthMode.OAuth2));
+
+        var authResult = await authenticateFunc(smtp).ConfigureAwait(false);
+        if (!authResult.Status) {
+            return new SmtpConnectResult(false, secureOptions, "auth_failed", authResult.Error ?? "Authentication failed.", false);
+        }
+
+        return new SmtpConnectResult(true, secureOptions, null, null, false);
+    }
+
+    /// <summary>
+    /// Best-effort SMTP disconnect/dispose helper.
+    /// </summary>
+    public static void DisposeQuietly(Smtp? smtp) {
+        if (smtp is null) {
+            return;
+        }
+
+        try {
+            smtp.Disconnect();
+        } catch {
+            // best-effort
+        }
+
+        try {
+            smtp.Dispose();
+        } catch {
+            // best-effort
+        }
+    }
+}

--- a/Sources/Mailozaurr/Receive/ImapMessageReader.cs
+++ b/Sources/Mailozaurr/Receive/ImapMessageReader.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Net.Imap;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Request model for reading a single IMAP message by UID.
+/// </summary>
+public sealed record ImapMessageReadRequest(
+    UniqueId Uid,
+    string? Folder,
+    long MaxBodyBytes);
+
+/// <summary>
+/// Attachment projection returned from <see cref="ImapMessageReader"/>.
+/// </summary>
+public sealed record ImapMessageAttachmentInfo(
+    string FileName,
+    string ContentType);
+
+/// <summary>
+/// Flattened IMAP message projection returned from <see cref="ImapMessageReader"/>.
+/// </summary>
+public sealed record ImapMessageReadResult(
+    long Uid,
+    string Folder,
+    string Subject,
+    string From,
+    string To,
+    DateTimeOffset DateUtc,
+    string TextBody,
+    bool TextTruncated,
+    string HtmlBody,
+    bool HtmlTruncated,
+    bool HasAttachments,
+    IReadOnlyList<ImapMessageAttachmentInfo> Attachments);
+
+/// <summary>
+/// Reads a single IMAP message with reusable folder resolution and truncation semantics.
+/// </summary>
+public static class ImapMessageReader
+{
+    /// <summary>
+    /// Reads and projects a single IMAP message by UID.
+    /// </summary>
+    public static async Task<ImapMessageReadResult> ReadAsync(
+        ImapClient client,
+        ImapMessageReadRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (client == null)
+        {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (request == null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var mailFolder = client.GetCachedFolder(request.Folder, FolderAccess.ReadOnly);
+        var message = await mailFolder.GetMessageAsync(request.Uid, cancellationToken).ConfigureAwait(false);
+
+        var attachments = message.Attachments.Select(static attachment => attachment is MimePart part
+            ? new ImapMessageAttachmentInfo(
+                FileName: part.FileName ?? string.Empty,
+                ContentType: part.ContentType?.MimeType ?? string.Empty)
+            : new ImapMessageAttachmentInfo(
+                FileName: string.Empty,
+                ContentType: attachment.ContentType?.MimeType ?? string.Empty)).ToArray();
+
+        var text = TruncateUtf8(message.TextBody, request.MaxBodyBytes, out var textTruncated);
+        var html = TruncateUtf8(message.HtmlBody, request.MaxBodyBytes, out var htmlTruncated);
+
+        return new ImapMessageReadResult(
+            Uid: request.Uid.Id,
+            Folder: mailFolder.FullName,
+            Subject: message.Subject ?? string.Empty,
+            From: string.Join(", ", message.From.Mailboxes.Select(static mailbox => mailbox.ToString())),
+            To: string.Join(", ", message.To.Mailboxes.Select(static mailbox => mailbox.ToString())),
+            DateUtc: message.Date.ToUniversalTime(),
+            TextBody: text ?? string.Empty,
+            TextTruncated: textTruncated,
+            HtmlBody: html ?? string.Empty,
+            HtmlTruncated: htmlTruncated,
+            HasAttachments: attachments.Length > 0,
+            Attachments: attachments);
+    }
+
+    private static string? TruncateUtf8(string? value, long maxBytes, out bool truncated)
+    {
+        truncated = false;
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(value);
+        if (bytes.LongLength <= maxBytes)
+        {
+            return value;
+        }
+
+        truncated = true;
+        var truncatedBytes = new byte[(int)Math.Min(maxBytes, int.MaxValue)];
+        Array.Copy(bytes, truncatedBytes, truncatedBytes.Length);
+        return Encoding.UTF8.GetString(truncatedBytes);
+    }
+}


### PR DESCRIPTION
## Summary
- move reusable SMTP and IMAP session-establishment helpers into Mailozaurr
- add reusable IMAP message reader/fetch projection logic upstream
- add focused Mailozaurr tests for the new helpers

## Validation
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Release --filter FullyQualifiedName~SmtpSessionServiceTests|FullyQualifiedName~ImapSessionServiceTests|FullyQualifiedName~ImapMessageReaderTests