### PR TITLE
fix: harden pending message leasing and module bootstrap

### DIFF
--- a/Mailozaurr.Tests.ps1
+++ b/Mailozaurr.Tests.ps1
@@ -41,8 +41,16 @@ foreach ($Module in $PSDInformation.RequiredModules) {
     }
 }
 Write-Color
-
-Import-Module $PSScriptRoot\*.psd1 -Force
+$ImportedModule = Import-Module $PSScriptRoot\*.psd1 -Force -PassThru -ErrorAction Stop
+if (-not $ImportedModule) {
+    throw "Failed to import module from $PSScriptRoot."
+}
+foreach ($CommandName in 'Get-SmtpConnectionPool', 'Send-EmailMessage') {
+    $Command = Get-Command -Name $CommandName -ErrorAction Stop
+    if ($Command.ModuleName -ne $ImportedModule.Name) {
+        throw "Expected command '$CommandName' to be exported by module '$($ImportedModule.Name)', but got '$($Command.ModuleName)'."
+    }
+}
 $result = Invoke-Pester -Script $PSScriptRoot\Tests -Verbose -PassThru
 
 if ($result.FailedCount -gt 0) {

--- a/Mailozaurr.psm1
+++ b/Mailozaurr.psm1
@@ -146,7 +146,10 @@ $FoundErrors = @(
             $true
         } catch {
             Write-Warning "Processing $($Import.Name) Exception: $($_.Exception.Message)"
-            $LoaderExceptions = $($_.Exception.LoaderExceptions) | Sort-Object -Unique
+            $LoaderExceptions = @()
+            if ($_.Exception -is [System.Reflection.ReflectionTypeLoadException]) {
+                $LoaderExceptions = @($_.Exception.LoaderExceptions) | Sort-Object -Unique
+            }
             foreach ($E in $LoaderExceptions) {
                 Write-Warning "Processing $($Import.Name) LoaderExceptions: $($E.Message)"
             }

--- a/Mailozaurr.psm1
+++ b/Mailozaurr.psm1
@@ -1,19 +1,37 @@
-﻿# to speed up development adding direct path to binaries, instead of the the Lib folder
-$Development = $true
+# to speed up development you can opt into direct build output instead of the Lib folder
+$Development = @('1', 'true', 'yes') -contains "$env:MAILOZAURR_DEVELOPMENT".ToLowerInvariant()
 $DevelopmentPath = "$PSScriptRoot\Sources\Mailozaurr.PowerShell\bin\Debug"
-$DevelopmentFolderCore = "net8.0"
-$DevelopmentFolderDefault = "net472"
+$DevelopmentFolderCore = 'net8.0'
+$DevelopmentFolderDefault = 'net472'
 $BinaryModules = @(
-    "Mailozaurr.PowerShell.dll"
+    'Mailozaurr.PowerShell.dll'
+)
+$SkipAssemblyNames = @(
+    'System.Management.Automation.dll'
+    'System.Management.dll'
 )
 
+if ($PSEdition -eq 'Core') {
+    $SkipAssemblyNames += @(
+        'System.Formats.Asn1.dll'
+        'System.Security.Cryptography.Pkcs.dll'
+        'System.Security.Cryptography.ProtectedData.dll'
+    )
+}
+
 # Get public and private function definition files.
-$Public = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue -Recurse -File)
-$Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue -Recurse -File)
-$Classes = @( Get-ChildItem -Path $PSScriptRoot\Classes\*.ps1 -ErrorAction SilentlyContinue -Recurse -File)
-$Enums = @( Get-ChildItem -Path $PSScriptRoot\Enums\*.ps1 -ErrorAction SilentlyContinue -Recurse -File)
-# Get all assemblies
-$AssemblyFolders = Get-ChildItem -Path $PSScriptRoot\Lib -Directory -ErrorAction SilentlyContinue -File
+$Public = @(Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue -Recurse -File)
+$Private = @(Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue -Recurse -File)
+$Classes = @(Get-ChildItem -Path $PSScriptRoot\Classes\*.ps1 -ErrorAction SilentlyContinue -Recurse -File)
+$Enums = @(Get-ChildItem -Path $PSScriptRoot\Enums\*.ps1 -ErrorAction SilentlyContinue -Recurse -File)
+
+# Get all packaged assembly folders.
+$AssemblyFolders = @(Get-ChildItem -Path $PSScriptRoot\Lib -Directory -ErrorAction SilentlyContinue)
+
+if ($Development -and -not (Test-Path $DevelopmentPath)) {
+    Write-Warning "Development mode requested, but debug binaries were not found in $DevelopmentPath. Falling back to packaged libraries."
+    $Development = $false
+}
 
 # Lets find which libraries we need to load
 if ($Development) {
@@ -56,30 +74,37 @@ if ($Development) {
     }
 }
 
-
 $BinaryDev = @(
-    foreach ($BinaryModule in $BinaryModules) {
-        if ($PSEdition -eq 'Core') {
-            $Variable = Resolve-Path "$DevelopmentPath\$DevelopmentFolderCore\$BinaryModule"
-            $DevelopmentAssemblyFolder = Resolve-Path "$DevelopmentPath\$DevelopmentFolderCore"
-        } else {
-            $Variable = Resolve-Path "$DevelopmentPath\$DevelopmentFolderDefault\$BinaryModule"
-            $DevelopmentAssemblyFolder = Resolve-Path "$DevelopmentPath\$DevelopmentFolderDefault"
+    if ($Development) {
+        foreach ($BinaryModule in $BinaryModules) {
+            if ($PSEdition -eq 'Core') {
+                $Variable = Resolve-Path "$DevelopmentPath\$DevelopmentFolderCore\$BinaryModule"
+                $DevelopmentAssemblyFolder = Resolve-Path "$DevelopmentPath\$DevelopmentFolderCore"
+            } else {
+                $Variable = Resolve-Path "$DevelopmentPath\$DevelopmentFolderDefault\$BinaryModule"
+                $DevelopmentAssemblyFolder = Resolve-Path "$DevelopmentPath\$DevelopmentFolderDefault"
+            }
+            $Variable
+            Write-Warning "Development mode: Using binaries from $Variable"
         }
-        $Variable
-        Write-Warning "Development mode: Using binaries from $Variable"
     }
 )
 
 if ($Development) {
-    $Assembly = Get-ChildItem -Path "$($DevelopmentAssemblyFolder.Path)\*.dll" -ErrorAction SilentlyContinue -File
+    $Assembly = @(Get-ChildItem -Path "$($DevelopmentAssemblyFolder.Path)\*.dll" -ErrorAction SilentlyContinue -File | Where-Object {
+            $_.Name -notin $BinaryModules -and $_.Name -notin $SkipAssemblyNames
+        })
 } else {
     $Assembly = @(
         if ($Framework -and $PSEdition -eq 'Core') {
-            Get-ChildItem -Path $PSScriptRoot\Lib\$Framework\*.dll -ErrorAction SilentlyContinue #-Recurse
+            Get-ChildItem -Path $PSScriptRoot\Lib\$Framework\*.dll -ErrorAction SilentlyContinue | Where-Object {
+                $_.Name -notin $BinaryModules -and $_.Name -notin $SkipAssemblyNames
+            }
         }
         if ($FrameworkNet -and $PSEdition -ne 'Core') {
-            Get-ChildItem -Path $PSScriptRoot\Lib\$FrameworkNet\*.dll -ErrorAction SilentlyContinue #-Recurse
+            Get-ChildItem -Path $PSScriptRoot\Lib\$FrameworkNet\*.dll -ErrorAction SilentlyContinue | Where-Object {
+                $_.Name -notin $BinaryModules -and $_.Name -notin $SkipAssemblyNames
+            }
         }
     )
 }
@@ -111,8 +136,7 @@ $FoundErrors = @(
     }
     foreach ($Import in @($Assembly)) {
         try {
-            # Write-Warning -Message $Import.FullName
-            Add-Type -Path $Import.Fullname -ErrorAction Stop
+            Add-Type -Path $Import.FullName -ErrorAction Stop
         } catch [System.Reflection.ReflectionTypeLoadException] {
             Write-Warning "Processing $($Import.Name) Exception: $($_.Exception.Message)"
             $LoaderExceptions = $($_.Exception.LoaderExceptions) | Sort-Object -Unique
@@ -120,7 +144,6 @@ $FoundErrors = @(
                 Write-Warning "Processing $($Import.Name) LoaderExceptions: $($E.Message)"
             }
             $true
-            #Write-Error -Message "StackTrace: $($_.Exception.StackTrace)"
         } catch {
             Write-Warning "Processing $($Import.Name) Exception: $($_.Exception.Message)"
             $LoaderExceptions = $($_.Exception.LoaderExceptions) | Sort-Object -Unique
@@ -128,15 +151,14 @@ $FoundErrors = @(
                 Write-Warning "Processing $($Import.Name) LoaderExceptions: $($E.Message)"
             }
             $true
-            #Write-Error -Message "StackTrace: $($_.Exception.StackTrace)"
         }
     }
-    #Dot source the files
+    # Dot source the files
     foreach ($Import in @($Classes + $Enums + $Private + $Public)) {
         try {
-            . $Import.Fullname
+            . $Import.FullName
         } catch {
-            Write-Error -Message "Failed to import functions from $($import.Fullname): $_"
+            Write-Error -Message "Failed to import functions from $($Import.FullName): $_"
             $true
         }
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailPendingMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailPendingMessage.cs
@@ -106,7 +106,11 @@ public sealed class CmdletSendEmailPendingMessage : AsyncPSCmdlet {
         }
 
         public void MessageSkipped(PendingMessageRecord record, PendingMessageSkipReason reason) {
-            _cmdlet.WriteVerbose($"Skipping message '{record.MessageId}' ({reason}).");
+            var message = reason switch {
+                PendingMessageSkipReason.LeaseNotAcquired => $"Skipping message '{record.MessageId}' because another processor already claimed it.",
+                _ => $"Skipping message '{record.MessageId}' ({reason})."
+            };
+            _cmdlet.WriteVerbose(message);
         }
 
         public void MessageAttemptStarted(PendingMessageRecord record, int attempt) {
@@ -170,6 +174,28 @@ public sealed class CmdletSendEmailPendingMessage : AsyncPSCmdlet {
         public Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) =>
             _inner.SaveAsync(record, cancellationToken);
 
+        public async Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+            string messageId,
+            DateTimeOffset dueBeforeOrAt,
+            DateTimeOffset leaseUntil,
+            CancellationToken cancellationToken = default) {
+            var record = await _inner.GetByMessageIdAsync(messageId, cancellationToken).ConfigureAwait(false);
+            if (record == null) {
+                return null;
+            }
+
+            if (_messageIds != null && !ContainsMessageId(record.MessageId)) {
+                return null;
+            }
+
+            if (_provider.HasValue && record.Provider != _provider.Value) {
+                return null;
+            }
+
+            var effectiveDueTime = _forceProcessing ? DateTimeOffset.MaxValue : dueBeforeOrAt;
+            return await _inner.TryAcquireLeaseAsync(messageId, effectiveDueTime, leaseUntil, cancellationToken).ConfigureAwait(false);
+        }
+
         public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) =>
             _inner.GetByMessageIdAsync(messageId, cancellationToken);
 
@@ -191,7 +217,10 @@ public sealed class CmdletSendEmailPendingMessage : AsyncPSCmdlet {
                 }
 
                 if (_forceProcessing && record.NextAttemptAt > now) {
-                    record.NextAttemptAt = now;
+                    var forcedRecord = record.Clone();
+                    forcedRecord.NextAttemptAt = now;
+                    yield return forcedRecord;
+                    continue;
                 }
 
                 yield return record;

--- a/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailApiClientTests.cs
@@ -73,6 +73,20 @@ public class GmailApiClientTests {
             return Task.CompletedTask;
         }
 
+        public Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+            string messageId,
+            DateTimeOffset dueBeforeOrAt,
+            DateTimeOffset leaseUntil,
+            CancellationToken cancellationToken = default) {
+            var record = Saved.FirstOrDefault(r => string.Equals(r.MessageId, messageId, StringComparison.OrdinalIgnoreCase));
+            if (record == null || record.NextAttemptAt > dueBeforeOrAt) {
+                return Task.FromResult<PendingMessageRecord?>(null);
+            }
+
+            record.NextAttemptAt = leaseUntil;
+            return Task.FromResult<PendingMessageRecord?>(record);
+        }
+
         public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) =>
             Task.FromResult<PendingMessageRecord?>(Saved.FirstOrDefault(r => string.Equals(r.MessageId, messageId, StringComparison.OrdinalIgnoreCase)));
 

--- a/Sources/Mailozaurr.Tests/SentMessages/GmailPendingMessageSenderTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/GmailPendingMessageSenderTests.cs
@@ -275,6 +275,20 @@ public sealed class GmailPendingMessageSenderTests {
             return Task.CompletedTask;
         }
 
+        public Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+            string messageId,
+            DateTimeOffset dueBeforeOrAt,
+            DateTimeOffset leaseUntil,
+            CancellationToken cancellationToken = default) {
+            var current = record;
+            if (current == null || !string.Equals(current.MessageId, messageId, StringComparison.Ordinal) || current.NextAttemptAt > dueBeforeOrAt) {
+                return Task.FromResult<PendingMessageRecord?>(null);
+            }
+
+            current.NextAttemptAt = leaseUntil;
+            return Task.FromResult<PendingMessageRecord?>(current);
+        }
+
         public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) =>
             Task.FromResult(record);
 

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
@@ -11,6 +11,7 @@ namespace Mailozaurr.Tests;
 public sealed class PendingMessageProcessorTests {
     private sealed class InMemoryPendingMessageRepository : IPendingMessageRepository {
         private readonly ConcurrentDictionary<string, PendingMessageRecord> records = new(StringComparer.OrdinalIgnoreCase);
+        private readonly object syncRoot = new();
 
         public void Add(PendingMessageRecord record) {
             records[record.MessageId] = record;
@@ -19,6 +20,21 @@ public sealed class PendingMessageProcessorTests {
         public Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
             records[record.MessageId] = record;
             return Task.CompletedTask;
+        }
+
+        public Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+            string messageId,
+            DateTimeOffset dueBeforeOrAt,
+            DateTimeOffset leaseUntil,
+            CancellationToken cancellationToken = default) {
+            lock (syncRoot) {
+                if (!records.TryGetValue(messageId, out var record) || record.NextAttemptAt > dueBeforeOrAt) {
+                    return Task.FromResult<PendingMessageRecord?>(null);
+                }
+
+                record.NextAttemptAt = leaseUntil;
+                return Task.FromResult<PendingMessageRecord?>(record);
+            }
         }
 
         public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
@@ -591,5 +607,114 @@ public sealed class PendingMessageProcessorTests {
         Assert.Equal(3, lastRecord.AttemptCount);
         Assert.Equal(EmailProvider.Mailgun, lastRecord.Provider);
         Assert.Equal(new[] { 1, 2 }, attempts);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_DoesNotDoubleSendWhenTwoProcessorsRace() {
+        var currentTime = DateTimeOffset.Parse("2024-06-13T09:00:00Z");
+        var repository = new CoordinatedPendingMessageRepository(currentTime.AddMinutes(-1));
+        var sender = new BlockingPendingMessageSender();
+        var observer = new RecordingObserver();
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var first = new PendingMessageProcessor(repository, factory, clock: () => currentTime, observer: observer);
+        var second = new PendingMessageProcessor(repository, factory, clock: () => currentTime, observer: observer);
+
+        var firstTask = first.ProcessAsync();
+        var secondTask = second.ProcessAsync();
+
+        repository.ReleaseEnumerations();
+        await sender.WaitForFirstSendAsync();
+        sender.Release();
+        await Task.WhenAll(firstTask, secondTask);
+
+        Assert.Equal(1, sender.SendCount);
+        Assert.Contains(observer.Skipped, skipped => skipped.Reason == PendingMessageSkipReason.LeaseNotAcquired);
+    }
+
+    private sealed class CoordinatedPendingMessageRepository : IPendingMessageRepository {
+        private readonly object syncRoot = new();
+        private readonly PendingMessageRecord record;
+        private readonly TaskCompletionSource<bool> firstEnumeratorReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> secondEnumeratorReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> releaseEnumerators = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal CoordinatedPendingMessageRepository(DateTimeOffset nextAttemptAt) {
+            record = CreateRecord(nextAttemptAt, "coordinated-message");
+        }
+
+        public Task SaveAsync(PendingMessageRecord updatedRecord, CancellationToken cancellationToken = default) {
+            lock (syncRoot) {
+                record.AttemptCount = updatedRecord.AttemptCount;
+                record.NextAttemptAt = updatedRecord.NextAttemptAt;
+                record.Timestamp = updatedRecord.Timestamp;
+                record.MimeMessage = updatedRecord.MimeMessage;
+                record.Server = updatedRecord.Server;
+                record.Port = updatedRecord.Port;
+                record.UserName = updatedRecord.UserName;
+                record.Password = updatedRecord.Password;
+                record.Provider = updatedRecord.Provider;
+                record.ProviderData = new Dictionary<string, string>(updatedRecord.ProviderData);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+            string messageId,
+            DateTimeOffset dueBeforeOrAt,
+            DateTimeOffset leaseUntil,
+            CancellationToken cancellationToken = default) {
+            lock (syncRoot) {
+                if (!string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase) || record.NextAttemptAt > dueBeforeOrAt) {
+                    return Task.FromResult<PendingMessageRecord?>(null);
+                }
+
+                record.NextAttemptAt = leaseUntil;
+                return Task.FromResult<PendingMessageRecord?>(record.Clone());
+            }
+        }
+
+        public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+            lock (syncRoot) {
+                return Task.FromResult<PendingMessageRecord?>(
+                    string.Equals(record.MessageId, messageId, StringComparison.OrdinalIgnoreCase) ? record.Clone() : null);
+            }
+        }
+
+        public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            if (!firstEnumeratorReached.Task.IsCompleted) {
+                firstEnumeratorReached.TrySetResult(true);
+            } else {
+                secondEnumeratorReached.TrySetResult(true);
+            }
+
+            await Task.WhenAll(firstEnumeratorReached.Task, secondEnumeratorReached.Task, releaseEnumerators.Task).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return record.Clone();
+        }
+
+        public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        internal void ReleaseEnumerations() => releaseEnumerators.TrySetResult(true);
+    }
+
+    private sealed class BlockingPendingMessageSender : IPendingMessageSender {
+        private readonly TaskCompletionSource<bool> sendStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int SendCount { get; private set; }
+
+        public async Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+            SendCount++;
+            sendStarted.TrySetResult(true);
+            await release.Task.ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+        }
+
+        internal Task WaitForFirstSendAsync() => sendStarted.Task;
+
+        internal void Release() => release.TrySetResult(true);
     }
 }

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
@@ -638,6 +638,8 @@ public sealed class PendingMessageProcessorTests {
         private readonly PendingMessageRecord record;
         private readonly TaskCompletionSource<bool> firstEnumeratorReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource<bool> secondEnumeratorReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> firstSnapshotCaptured = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> secondSnapshotCaptured = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource<bool> releaseEnumerators = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         internal CoordinatedPendingMessageRepository(DateTimeOffset nextAttemptAt) {
@@ -684,7 +686,8 @@ public sealed class PendingMessageProcessorTests {
         }
 
         public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default) {
-            if (!firstEnumeratorReached.Task.IsCompleted) {
+            var isFirstEnumerator = !firstEnumeratorReached.Task.IsCompleted;
+            if (isFirstEnumerator) {
                 firstEnumeratorReached.TrySetResult(true);
             } else {
                 secondEnumeratorReached.TrySetResult(true);
@@ -692,7 +695,15 @@ public sealed class PendingMessageProcessorTests {
 
             await Task.WhenAll(firstEnumeratorReached.Task, secondEnumeratorReached.Task, releaseEnumerators.Task).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
-            yield return record.Clone();
+            var snapshot = record.Clone();
+            if (isFirstEnumerator) {
+                firstSnapshotCaptured.TrySetResult(true);
+            } else {
+                secondSnapshotCaptured.TrySetResult(true);
+            }
+
+            await Task.WhenAll(firstSnapshotCaptured.Task, secondSnapshotCaptured.Task).ConfigureAwait(false);
+            yield return snapshot;
         }
 
         public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -30,6 +30,23 @@ public sealed class ProviderPendingMessageTests {
             return Task.CompletedTask;
         }
 
+        public Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+            string messageId,
+            DateTimeOffset dueBeforeOrAt,
+            DateTimeOffset leaseUntil,
+            CancellationToken cancellationToken = default) {
+            if (messageId == null) {
+                throw new ArgumentNullException(nameof(messageId));
+            }
+
+            if (!records.TryGetValue(messageId, out var record) || record.NextAttemptAt > dueBeforeOrAt) {
+                return Task.FromResult<PendingMessageRecord?>(null);
+            }
+
+            record.NextAttemptAt = leaseUntil;
+            return Task.FromResult<PendingMessageRecord?>(record);
+        }
+
         public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
             if (messageId == null) {
                 throw new ArgumentNullException(nameof(messageId));
@@ -93,6 +110,13 @@ public sealed class ProviderPendingMessageTests {
             saveStarted.TrySetResult(true);
             await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
         }
+
+        public Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+            string messageId,
+            DateTimeOffset dueBeforeOrAt,
+            DateTimeOffset leaseUntil,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<PendingMessageRecord?>(null);
 
         public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) =>
             Task.FromResult<PendingMessageRecord?>(null);

--- a/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageEncryptionTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageEncryptionTests.cs
@@ -108,6 +108,20 @@ public sealed class SmtpPendingMessageEncryptionTests {
             return Task.CompletedTask;
         }
 
+        public Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+            string messageId,
+            DateTimeOffset dueBeforeOrAt,
+            DateTimeOffset leaseUntil,
+            CancellationToken cancellationToken = default) {
+            var record = records.FirstOrDefault(r => string.Equals(r.MessageId, messageId, StringComparison.Ordinal));
+            if (record == null || record.NextAttemptAt > dueBeforeOrAt) {
+                return Task.FromResult<PendingMessageRecord?>(null);
+            }
+
+            record.NextAttemptAt = leaseUntil;
+            return Task.FromResult<PendingMessageRecord?>(record);
+        }
+
         public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
             var record = records.FirstOrDefault(r => string.Equals(r.MessageId, messageId, StringComparison.Ordinal));
             return Task.FromResult<PendingMessageRecord?>(record);

--- a/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageProcessorIntegrationTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageProcessorIntegrationTests.cs
@@ -123,6 +123,20 @@ public sealed class SmtpPendingMessageProcessorIntegrationTests {
             return Task.CompletedTask;
         }
 
+        public Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+            string messageId,
+            DateTimeOffset dueBeforeOrAt,
+            DateTimeOffset leaseUntil,
+            CancellationToken cancellationToken = default) {
+            var record = records.FirstOrDefault(r => string.Equals(r.MessageId, messageId, StringComparison.Ordinal));
+            if (record == null || record.NextAttemptAt > dueBeforeOrAt) {
+                return Task.FromResult<PendingMessageRecord?>(null);
+            }
+
+            record.NextAttemptAt = leaseUntil;
+            return Task.FromResult<PendingMessageRecord?>(record);
+        }
+
         public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
             var record = records.FirstOrDefault(r => string.Equals(r.MessageId, messageId, StringComparison.Ordinal));
             return Task.FromResult<PendingMessageRecord?>(record);

--- a/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
@@ -40,6 +40,20 @@ public sealed class SmtpPendingMessageTests {
             return Task.CompletedTask;
         }
 
+        public Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+            string messageId,
+            DateTimeOffset dueBeforeOrAt,
+            DateTimeOffset leaseUntil,
+            CancellationToken cancellationToken = default) {
+            var record = Saved.FirstOrDefault(r => r.MessageId == messageId);
+            if (record == null || record.NextAttemptAt > dueBeforeOrAt) {
+                return Task.FromResult<PendingMessageRecord?>(null);
+            }
+
+            record.NextAttemptAt = leaseUntil;
+            return Task.FromResult<PendingMessageRecord?>(record);
+        }
+
         public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) =>
             Task.FromResult<PendingMessageRecord?>(Saved.FirstOrDefault(r => r.MessageId == messageId));
 

--- a/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/FilePendingMessageRepository.cs
@@ -333,30 +333,27 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
         }
     }
 
-    /// <summary>Retrieves a pending message by its ID.</summary>
-    public async Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
-        if (!File.Exists(filePath)) {
-            return null;
-        }
+    /// <summary>Attempts to lease a due pending message for processing.</summary>
+    public async Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+        string messageId,
+        DateTimeOffset dueBeforeOrAt,
+        DateTimeOffset leaseUntil,
+        CancellationToken cancellationToken = default) {
         await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
-            if (!index.TryGetValue(messageId, out var offset)) {
+            var current = await GetByMessageIdCoreAsync(messageId, cancellationToken).ConfigureAwait(false);
+            if (current == null || current.NextAttemptAt > dueBeforeOrAt) {
                 return null;
             }
-            using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            read.Seek(offset, SeekOrigin.Begin);
-            using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
-            string? line = await reader.ReadLineAsync().ConfigureAwait(false);
-            if (line == null) {
-                return null;
-            }
-            if (!TryParseLogEntry(line, out var entry) || entry.Kind != LogEntryKind.Upsert || entry.Record == null) {
-                return null;
-            }
-            if (string.Equals(entry.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
-                return entry.Record;
-            }
-            return null;
+
+            _ = current.ProviderData;
+            current.NextAttemptAt = leaseUntil;
+            var offset = await AppendEnvelopeAsync(CreateUpsertEnvelope(current), cancellationToken).ConfigureAwait(false);
+            dirtyEntryCount++;
+            index[current.MessageId] = offset;
+
+            await CompactIfNeededAsync(cancellationToken).ConfigureAwait(false);
+            return current;
         } catch (FileNotFoundException) {
             return null;
         } catch (DirectoryNotFoundException) {
@@ -364,6 +361,48 @@ public sealed class FilePendingMessageRepository : IPendingMessageRepository {
         } finally {
             gate.Release();
         }
+    }
+
+    /// <summary>Retrieves a pending message by its ID.</summary>
+    public async Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+        if (!File.Exists(filePath)) {
+            return null;
+        }
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            return await GetByMessageIdCoreAsync(messageId, cancellationToken).ConfigureAwait(false);
+        } catch (FileNotFoundException) {
+            return null;
+        } catch (DirectoryNotFoundException) {
+            return null;
+        } finally {
+            gate.Release();
+        }
+    }
+
+    private async Task<PendingMessageRecord?> GetByMessageIdCoreAsync(string messageId, CancellationToken cancellationToken) {
+        if (!index.TryGetValue(messageId, out var offset)) {
+            return null;
+        }
+
+        using var read = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        read.Seek(offset, SeekOrigin.Begin);
+        using var reader = new StreamReader(read, Encoding.UTF8, false, 1024, leaveOpen: true);
+        cancellationToken.ThrowIfCancellationRequested();
+        string? line = await reader.ReadLineAsync().ConfigureAwait(false);
+        if (line == null) {
+            return null;
+        }
+
+        if (!TryParseLogEntry(line, out var entry) || entry.Kind != LogEntryKind.Upsert || entry.Record == null) {
+            return null;
+        }
+
+        if (!string.Equals(entry.MessageId, messageId, StringComparison.OrdinalIgnoreCase)) {
+            return null;
+        }
+
+        return entry.Record;
     }
 
     /// <summary>Enumerates all pending messages.</summary>

--- a/Sources/Mailozaurr/SentMessages/IPendingMessageProcessorObserver.cs
+++ b/Sources/Mailozaurr/SentMessages/IPendingMessageProcessorObserver.cs
@@ -48,7 +48,10 @@ public enum PendingMessageSkipReason {
     MissingMessageId,
 
     /// <summary>The record is scheduled for a future attempt.</summary>
-    NotDue
+    NotDue,
+
+    /// <summary>The record was already leased by another processor.</summary>
+    LeaseNotAcquired
 }
 
 /// <summary>

--- a/Sources/Mailozaurr/SentMessages/IPendingMessageRepository.cs
+++ b/Sources/Mailozaurr/SentMessages/IPendingMessageRepository.cs
@@ -9,6 +9,22 @@ public interface IPendingMessageRepository {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Atomically acquires a processing lease for a due message.
+    /// </summary>
+    /// <param name="messageId">The message id to lease.</param>
+    /// <param name="dueBeforeOrAt">Latest due time that still qualifies the message for processing.</param>
+    /// <param name="leaseUntil">Timestamp written to <see cref="PendingMessageRecord.NextAttemptAt"/> when the lease is acquired.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>
+    /// The current leased record when acquisition succeeds; otherwise <c>null</c>.
+    /// </returns>
+    Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+        string messageId,
+        DateTimeOffset dueBeforeOrAt,
+        DateTimeOffset leaseUntil,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Gets a pending message by its unique message id.</summary>
     /// <param name="messageId">The message id to search for.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>

--- a/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
@@ -9,6 +9,7 @@ namespace Mailozaurr;
 /// Processes pending messages by dispatching them through provider specific senders.
 /// </summary>
 public sealed class PendingMessageProcessor {
+    private static readonly TimeSpan MinimumLeaseDuration = TimeSpan.FromTicks(1);
     private readonly IPendingMessageRepository repository;
     private readonly PendingMessageSenderFactory senderFactory;
     private readonly Func<int, TimeSpan> retryDelaySelector;
@@ -92,28 +93,33 @@ public sealed class PendingMessageProcessor {
                 continue;
             }
 
-            await AcquireProcessingLeaseAsync(record, now, cancellationToken).ConfigureAwait(false);
+            var leasedRecord = await AcquireProcessingLeaseAsync(record, now, cancellationToken).ConfigureAwait(false);
+            if (leasedRecord == null) {
+                logger?.WriteVerbose($"Skipping message {record.MessageId} because another processor already acquired the processing lease.");
+                observer.MessageSkipped(record, PendingMessageSkipReason.LeaseNotAcquired);
+                continue;
+            }
 
-            var originalAttemptCount = record.AttemptCount;
-            var attempt = record.IncrementAttemptCount();
-            observer.MessageAttemptStarted(record, attempt);
+            var originalAttemptCount = leasedRecord.AttemptCount;
+            var attempt = leasedRecord.IncrementAttemptCount();
+            observer.MessageAttemptStarted(leasedRecord, attempt);
             var stopwatch = Stopwatch.StartNew();
 
             try {
-                var sender = senderFactory.GetSender(record);
-                await sender.SendAsync(record, cancellationToken).ConfigureAwait(false);
+                var sender = senderFactory.GetSender(leasedRecord);
+                await sender.SendAsync(leasedRecord, cancellationToken).ConfigureAwait(false);
                 stopwatch.Stop();
-                observer.MessageSent(record, attempt, stopwatch.Elapsed);
-                await repository.RemoveAsync(record.MessageId, cancellationToken).ConfigureAwait(false);
+                observer.MessageSent(leasedRecord, attempt, stopwatch.Elapsed);
+                await repository.RemoveAsync(leasedRecord.MessageId, cancellationToken).ConfigureAwait(false);
             } catch (OperationCanceledException ex) {
                 stopwatch.Stop();
-                record.ExchangeAttemptCount(originalAttemptCount);
-                record.NextAttemptAt = ApplyDelay(clock(), TimeSpan.Zero);
-                observer.MessageFailed(record, attempt, ex, stopwatch.Elapsed, willRetry: false, retryDelay: null);
+                leasedRecord.ExchangeAttemptCount(originalAttemptCount);
+                leasedRecord.NextAttemptAt = ApplyDelay(clock(), TimeSpan.Zero);
+                observer.MessageFailed(leasedRecord, attempt, ex, stopwatch.Elapsed, willRetry: false, retryDelay: null);
                 try {
-                    await repository.SaveAsync(record, CancellationToken.None).ConfigureAwait(false);
+                    await repository.SaveAsync(leasedRecord, CancellationToken.None).ConfigureAwait(false);
                 } catch (Exception saveEx) {
-                    logger?.WriteWarning($"Failed to release processing lease for message {record.MessageId} after cancellation: {saveEx.Message}");
+                    logger?.WriteWarning($"Failed to release processing lease for message {leasedRecord.MessageId} after cancellation: {saveEx.Message}");
                 }
                 throw;
             } catch (Exception ex) {
@@ -124,31 +130,31 @@ public sealed class PendingMessageProcessor {
                 if (willRetry) {
                     delay = NormalizeDelay(retryDelaySelector(attempt));
                     var failureTime = clock();
-                    record.NextAttemptAt = ApplyDelay(failureTime, delay.Value);
+                    leasedRecord.NextAttemptAt = ApplyDelay(failureTime, delay.Value);
                 }
 
-                observer.MessageFailed(record, attempt, ex, stopwatch.Elapsed, willRetry, delay);
+                observer.MessageFailed(leasedRecord, attempt, ex, stopwatch.Elapsed, willRetry, delay);
 
                 if (!willRetry) {
-                    logger?.WriteWarning($"Dropping message {record.MessageId} due to {(permanentFailure ? "permanent failure" : "exceeding retry attempts")}: {ex.Message}");
-                    observer.MessageDropped(record, attempt, permanentFailure ? PendingMessageDropReason.PermanentFailure : PendingMessageDropReason.RetryLimitReached, ex);
-                    await repository.RemoveAsync(record.MessageId, cancellationToken).ConfigureAwait(false);
+                    logger?.WriteWarning($"Dropping message {leasedRecord.MessageId} due to {(permanentFailure ? "permanent failure" : "exceeding retry attempts")}: {ex.Message}");
+                    observer.MessageDropped(leasedRecord, attempt, permanentFailure ? PendingMessageDropReason.PermanentFailure : PendingMessageDropReason.RetryLimitReached, ex);
+                    await repository.RemoveAsync(leasedRecord.MessageId, cancellationToken).ConfigureAwait(false);
                     continue;
                 }
 
-                logger?.WriteWarning($"Failed to send message {record.MessageId}. Scheduling retry #{attempt + 1} at {record.NextAttemptAt:O}. Error: {ex.Message}");
-                await repository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+                logger?.WriteWarning($"Failed to send message {leasedRecord.MessageId}. Scheduling retry #{attempt + 1} at {leasedRecord.NextAttemptAt:O}. Error: {ex.Message}");
+                await repository.SaveAsync(leasedRecord, cancellationToken).ConfigureAwait(false);
             }
         }
     }
 
-    private async Task AcquireProcessingLeaseAsync(PendingMessageRecord record, DateTimeOffset now, CancellationToken cancellationToken) {
-        if (processingLeaseDuration == TimeSpan.Zero) {
-            return;
-        }
-
-        record.NextAttemptAt = ApplyDelay(now, processingLeaseDuration);
-        await repository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+    private async Task<PendingMessageRecord?> AcquireProcessingLeaseAsync(
+        PendingMessageRecord record,
+        DateTimeOffset now,
+        CancellationToken cancellationToken) {
+        var leaseDuration = processingLeaseDuration > TimeSpan.Zero ? processingLeaseDuration : MinimumLeaseDuration;
+        var leaseUntil = ApplyDelay(now, leaseDuration);
+        return await repository.TryAcquireLeaseAsync(record.MessageId, now, leaseUntil, cancellationToken).ConfigureAwait(false);
     }
 
     private static TimeSpan DefaultRetryDelaySelector(int attempt) {

--- a/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageRecord.cs
@@ -67,4 +67,21 @@ public sealed class PendingMessageRecord {
     /// <param name="value">Value assigned to the attempt counter.</param>
     /// <returns>The previous value stored in the attempt counter.</returns>
     public int ExchangeAttemptCount(int value) => Interlocked.Exchange(ref attemptCount, value);
+
+    /// <summary>
+    /// Creates a detached copy of this record.
+    /// </summary>
+    public PendingMessageRecord Clone() => new() {
+        MessageId = MessageId,
+        Timestamp = Timestamp,
+        NextAttemptAt = NextAttemptAt,
+        AttemptCount = AttemptCount,
+        MimeMessage = MimeMessage,
+        Server = Server,
+        Port = Port,
+        UserName = UserName,
+        Password = Password,
+        Provider = Provider,
+        ProviderData = new Dictionary<string, string>(ProviderData)
+    };
 }

--- a/Tests/Import-Module.Tests.ps1
+++ b/Tests/Import-Module.Tests.ps1
@@ -1,0 +1,17 @@
+Describe 'Import-Module' {
+    BeforeAll {
+        $modulePath = Resolve-Path "$PSScriptRoot/../Mailozaurr.psd1"
+        Remove-Module Mailozaurr -Force -ErrorAction SilentlyContinue
+        $script:module = Import-Module $modulePath -Force -PassThru -ErrorAction Stop
+    }
+
+    It 'imports the manifest successfully' {
+        $module | Should -Not -BeNullOrEmpty
+        $module.Name | Should -Be 'Mailozaurr'
+    }
+
+    It 'exports representative commands after import' {
+        (Get-Command Get-SmtpConnectionPool -ErrorAction Stop).ModuleName | Should -Be 'Mailozaurr'
+        (Get-Command Send-EmailMessage -ErrorAction Stop).ModuleName | Should -Be 'Mailozaurr'
+    }
+}


### PR DESCRIPTION
## Summary
- make pending message leasing atomic through the repository and surface lease contention as an explicit skip reason
- fix the root module bootstrap to default to packaged binaries, with an opt-in dev path and safer assembly loading
- add import smoke coverage in both Pester and the PowerShell test runner so bootstrap regressions fail fast

## Validation
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --nologo
- Invoke-Pester -Path .\Tests\Import-Module.Tests.ps1 -PassThru
- Import-Module .\Mailozaurr.psd1 -Force -ErrorAction Stop

## Notes
- `IPendingMessageRepository` now includes `TryAcquireLeaseAsync`; custom external implementations will need to add it when compiling against this version.
- Running `.\Mailozaurr.Tests.ps1` still reports existing unrelated PowerShell failures in this branch (for example `Clear-SmtpConnectionPool`, `Connect-POP3`, several `Send-EmailMessage*` tests, and `Test-SmtpConnection`). The new import preflight itself passes and the dedicated import smoke test is green.