### PR TITLE
Add reusable Mailozaurr application, CLI, and MCP platform

### DIFF
--- a/Docs/Platform-Architecture.md
+++ b/Docs/Platform-Architecture.md
@@ -1,0 +1,284 @@
+# Mailozaurr Platform Architecture
+
+This document defines how Mailozaurr should evolve across its library, PowerShell, CLI, MCP, and GUI surfaces.
+
+The main goal is reuse. If a new capability can be shared by more than one surface, it should not be implemented only in a wrapper. It should live in the reusable layer and be consumed by wrappers.
+
+## Goals
+
+- Keep one canonical implementation of reusable mail behavior.
+- Avoid duplicating business logic across PowerShell, CLI, MCP, GUI, and ad hoc examples.
+- Support provider differences without forcing a fake one-size-fits-all abstraction.
+- Make new work easier to place correctly.
+- Keep public surfaces consistent in naming, behavior, and safety rules.
+
+## Product Surfaces
+
+Mailozaurr should be treated as one platform with multiple front doors:
+
+- `Mailozaurr`: reusable .NET library and provider engine
+- `Mailozaurr.PowerShell`: PowerShell adapter
+- `mailozaurr`: cross-platform CLI
+- `mailozaurr mcp serve`: MCP server mode
+- Desktop/GUI apps built on the same core concepts
+
+These are not separate products with separate logic. They are adapters over shared capabilities.
+
+## Target Layering
+
+The preferred long-term structure is:
+
+- `Mailozaurr`
+- `Mailozaurr.Application`
+- `Mailozaurr.PowerShell`
+- `Mailozaurr.Cli`
+- `Mailozaurr.Mcp`
+- Desktop/GUI app projects
+
+### Layer Responsibilities
+
+`Mailozaurr`
+
+- Provider and protocol implementations
+- SMTP, IMAP, POP3, Graph, Gmail, SendGrid, Mailgun, SES support
+- Authentication primitives and provider clients
+- Message parsing, conversion, attachments, transport rules
+- Reusable send, search, fetch, save, move, mark, delete logic
+- Reusable queue and pending-message primitives
+- Provider-specific models and helpers
+
+`Mailozaurr.Application`
+
+- Cross-surface workflows and orchestration
+- Profile store and profile validation
+- Secret and token orchestration
+- Session management
+- Capability discovery
+- Normalized DTOs used by CLI, MCP, GUI, and optionally PowerShell
+- Safe send, queue, draft, delete, and move workflows
+- Audit and operation result models
+
+`Mailozaurr.PowerShell`
+
+- Cmdlet binding and parameter mapping
+- PowerShell pipeline and `ShouldProcess` integration
+- Formatting and help metadata
+- PowerShell-only compatibility behaviors
+
+`Mailozaurr.Cli`
+
+- Command parsing
+- Human-readable output
+- JSON output
+- Exit codes
+
+`Mailozaurr.Mcp`
+
+- MCP transport and tool registration
+- Tool schema definitions
+- Mapping tool calls to application services
+
+GUI projects
+
+- View models, UI state, platform integration
+- Human-first flows for accounts, mailbox browsing, drafts, and queue review
+
+## Reuse Rules
+
+These rules should be used when deciding where new work belongs.
+
+### Rule 1
+
+If logic is reusable by more than one surface, it should not be implemented only in PowerShell, CLI, MCP, or GUI code.
+
+It should be placed in:
+
+- `Mailozaurr` when it is protocol/provider behavior or reusable low-level mail functionality
+- `Mailozaurr.Application` when it is a cross-surface workflow, orchestration rule, normalized DTO, or policy
+
+### Rule 2
+
+Wrappers should adapt, not own business logic.
+
+PowerShell, CLI, MCP, and GUI layers should translate user intent into calls to shared services. They should not each reinvent send/search/profile behavior.
+
+### Rule 3
+
+Provider-neutral concepts should be shared. Provider-specific concepts should remain explicit.
+
+Do not force every provider to look identical. Instead:
+
+- share common operations such as search, get message, save attachment, draft, queue, send, mark, move, delete
+- keep provider-specific operations explicit, such as Graph inbox rules, Graph events, Gmail threads, Gmail labels, IMAP IDLE behavior, and POP3 limitations
+
+### Rule 4
+
+A wrapper-only implementation is acceptable only when the behavior is genuinely wrapper-specific.
+
+Examples:
+
+- PowerShell parameter sets and pipeline binding belong in `Mailozaurr.PowerShell`
+- CLI help text and shell-friendly formatting belong in `Mailozaurr.Cli`
+- MCP tool schemas belong in `Mailozaurr.Mcp`
+- GUI dialogs, views, and local UX behavior belong in the GUI project
+
+## Feature Placement Guide
+
+Use this checklist when adding a new feature.
+
+Place it in `Mailozaurr` if it is:
+
+- a provider client enhancement
+- a reusable transport or mailbox operation
+- message parsing, attachment, MIME, cryptography, or auth logic
+- reusable folder/message/provider helpers
+- reusable pending-message or send pipeline logic
+
+Place it in `Mailozaurr.Application` if it is:
+
+- a profile concept shared by multiple front ends
+- a cross-provider workflow
+- a capability model
+- a normalized DTO for message summaries/details
+- a queue or draft workflow shared by CLI, MCP, GUI, or PowerShell
+- a safety policy for destructive operations or sending
+- an operation result or audit event that more than one surface should use
+
+Place it in `Mailozaurr.PowerShell` if it is:
+
+- cmdlet syntax
+- PowerShell-specific validation and parameter shaping
+- `ShouldProcess`, verbose output, pipeline behavior, and formatting
+
+Place it in `Mailozaurr.Cli` if it is:
+
+- command syntax
+- argument parsing
+- console output formatting
+- shell completion and exit code concerns
+
+Place it in `Mailozaurr.Mcp` if it is:
+
+- MCP server bootstrapping
+- tool declaration and transport behavior
+- mapping between tool requests and application services
+
+Place it in the GUI project if it is:
+
+- view logic
+- window/dialog composition
+- UI state management
+- platform-specific desktop integration
+
+## Canonical Shared Concepts
+
+The following concepts should use consistent naming across all surfaces:
+
+- `Profile`
+- `ProfileCapabilities`
+- `FolderRef`
+- `MailboxRef`
+- `MessageSummary`
+- `MessageDetail`
+- `AttachmentSummary`
+- `DraftMessage`
+- `QueuedMessage`
+- `SendResult`
+- `OperationResult`
+
+The same concept should not have different names in different surfaces unless there is a compelling reason.
+
+## Provider Capability Model
+
+Mailozaurr should be designed around capabilities, not around the assumption that every provider supports the same things.
+
+### Common Capability Areas
+
+- read/search messages
+- list folders or mailbox containers
+- get message details
+- save attachments
+- mark/move/delete messages
+- send messages
+- wait/listen for new messages
+
+### Provider Notes
+
+- IMAP: strong mailbox support, folders, flags, move, search, and wait/idle patterns
+- POP3: limited mailbox model, fetch/search/delete style workflows, no real folder story
+- Graph: rich mailbox and send support, plus rules, events, and permissions
+- Gmail API: mailbox and send support with Gmail-specific thread and label behavior
+- SMTP: send only, not mailbox browsing
+- SendGrid/Mailgun/SES: send only, provider-specific sending features
+
+The shared layers should expose common operations where they exist and explicit provider extensions where they do not.
+
+## Profiles and Sessions
+
+Future work should prefer explicit profiles over implicit global sessions.
+
+Profiles should store:
+
+- provider type
+- display name
+- server or tenant settings
+- auth mode
+- sender defaults where relevant
+- mailbox defaults where relevant
+- non-secret metadata in config
+- secrets in secure OS-backed storage where possible
+
+Wrappers should not rely on hidden global state when a profile or explicit handle can be used instead.
+
+## Safety Rules
+
+Safety behavior should be shared, not reimplemented separately in each surface.
+
+Preferred defaults:
+
+- drafts before send when practical
+- queue-first sending for automation and agents
+- explicit confirmation for destructive actions
+- provider-limit validation before send
+- dry-run support where possible
+- reusable audit and logging models
+
+## CLI and MCP Design Direction
+
+The CLI and MCP server should be thin adapters over shared services.
+
+The recommended shape is:
+
+- CLI for human and automation use
+- MCP as a structured tool surface over the same workflows
+- one executable host eventually able to run both normal CLI commands and `mcp serve`
+
+This avoids duplicating logic and gives one headless contract for the ecosystem.
+
+## Migration Guidance
+
+Not every existing area must be refactored immediately.
+
+When touching an existing feature:
+
+1. Keep behavior working.
+2. Extract reusable logic into `Mailozaurr` or `Mailozaurr.Application` when the change naturally allows it.
+3. Leave only surface-specific adaptation in PowerShell, CLI, MCP, or GUI code.
+
+Incremental improvement is preferred over a disruptive rewrite.
+
+## Decision Rule for New Work
+
+Before adding code, ask:
+
+1. Is this reusable outside the current wrapper?
+2. Is it protocol/provider logic or workflow/orchestration logic?
+3. Will CLI, MCP, GUI, PowerShell, or plain C# users eventually want the same behavior?
+
+If the answer to reuse is yes, the default destination should be a shared layer, not the wrapper.
+
+## Working Principle
+
+Mailozaurr should have one core behavior model with many adapters, not many implementations with similar names.
+
+That principle should guide future CLI, MCP, GUI, PowerShell, and library work.

--- a/README.MD
+++ b/README.MD
@@ -59,6 +59,10 @@ Additional dependency:
 
 - [System.DataSQLite](https://system.data.sqlite.org/)
 
+## Architecture notes
+
+- [Platform Architecture](Docs/Platform-Architecture.md) - layering and reuse rules for future library, PowerShell, CLI, MCP, and GUI work
+
 This started with a single goal to replace `Send-MailMessage` which is deprecated/obsolete with something more modern, but since MailKit and MimeKit have lots of options why not build on that?
 
 ## Support This Project

--- a/Sources/Mailozaurr.Application/AttachmentSummary.cs
+++ b/Sources/Mailozaurr.Application/AttachmentSummary.cs
@@ -1,0 +1,27 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents normalized attachment metadata.
+/// </summary>
+public sealed class AttachmentSummary {
+    /// <summary>Owning message identifier.</summary>
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>Provider-specific attachment identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Attachment file name.</summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>Attachment content type.</summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>Attachment size in bytes when known.</summary>
+    public long? SizeInBytes { get; set; }
+
+    /// <summary>Whether the attachment is inline content.</summary>
+    public bool IsInline { get; set; }
+
+    /// <summary>Inline content id when applicable.</summary>
+    public string? ContentId { get; set; }
+}

--- a/Sources/Mailozaurr.Application/DraftAttachment.cs
+++ b/Sources/Mailozaurr.Application/DraftAttachment.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents an attachment that should be included when composing a draft.
+/// </summary>
+public sealed class DraftAttachment {
+    /// <summary>Absolute or relative source path.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Optional explicit attachment name override.</summary>
+    public string? FileName { get; set; }
+
+    /// <summary>Optional explicit content type.</summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>Whether the attachment should be embedded inline.</summary>
+    public bool IsInline { get; set; }
+
+    /// <summary>Content id used for inline attachments.</summary>
+    public string? ContentId { get; set; }
+}

--- a/Sources/Mailozaurr.Application/DraftMessage.cs
+++ b/Sources/Mailozaurr.Application/DraftMessage.cs
@@ -1,0 +1,39 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents a normalized draft message before it is queued or sent.
+/// </summary>
+public sealed class DraftMessage {
+    /// <summary>Source profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Sender address or display entry.</summary>
+    public MessageRecipient? From { get; set; }
+
+    /// <summary>Primary recipients.</summary>
+    public List<MessageRecipient> To { get; set; } = new();
+
+    /// <summary>Carbon-copy recipients.</summary>
+    public List<MessageRecipient> Cc { get; set; } = new();
+
+    /// <summary>Blind carbon-copy recipients.</summary>
+    public List<MessageRecipient> Bcc { get; set; } = new();
+
+    /// <summary>Reply-to recipients.</summary>
+    public List<MessageRecipient> ReplyTo { get; set; } = new();
+
+    /// <summary>Message subject.</summary>
+    public string? Subject { get; set; }
+
+    /// <summary>Plain text body.</summary>
+    public string? TextBody { get; set; }
+
+    /// <summary>HTML body.</summary>
+    public string? HtmlBody { get; set; }
+
+    /// <summary>Attachments included with the draft.</summary>
+    public List<DraftAttachment> Attachments { get; set; } = new();
+
+    /// <summary>Optional custom headers.</summary>
+    public Dictionary<string, string> Headers { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/Sources/Mailozaurr.Application/DraftMimeMessageFactory.cs
+++ b/Sources/Mailozaurr.Application/DraftMimeMessageFactory.cs
@@ -1,0 +1,164 @@
+using MimeKit;
+using MimeKit.Utils;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Converts normalized draft messages into MIME messages that can be reused across send providers.
+/// </summary>
+public sealed class DraftMimeMessageFactory : IDraftMimeMessageFactory {
+    /// <inheritdoc />
+    public Task<MimeMessage> CreateAsync(MailProfile profile, DraftMessage draft, CancellationToken cancellationToken = default) {
+        if (profile == null) {
+            throw new ArgumentNullException(nameof(profile));
+        }
+        if (draft == null) {
+            throw new ArgumentNullException(nameof(draft));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var message = new MimeMessage {
+            Subject = draft.Subject ?? string.Empty,
+            Date = DateTimeOffset.UtcNow,
+            MessageId = MimeUtils.GenerateMessageId()
+        };
+
+        AddSender(message, profile, draft);
+        AddRecipients(message.To, draft.To);
+        AddRecipients(message.Cc, draft.Cc);
+        AddRecipients(message.Bcc, draft.Bcc);
+        AddRecipients(message.ReplyTo, draft.ReplyTo);
+        if (!message.To.Any() && !message.Cc.Any() && !message.Bcc.Any()) {
+            throw new InvalidOperationException("Draft message requires at least one recipient.");
+        }
+
+        AddHeaders(message, draft.Headers);
+        message.Body = BuildBody(draft, cancellationToken);
+        return Task.FromResult(message);
+    }
+
+    private static void AddSender(MimeMessage message, MailProfile profile, DraftMessage draft) {
+        var sender = draft.From;
+        if (sender != null) {
+            message.From.Add(CreateMailboxAddress(sender));
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(profile.DefaultSender)) {
+            message.From.Add(MailboxAddress.Parse(profile.DefaultSender!.Trim()));
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
+            message.From.Add(MailboxAddress.Parse(profile.DefaultMailbox!.Trim()));
+            return;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' does not define a sender and the draft does not specify one.");
+    }
+
+    private static void AddRecipients(InternetAddressList target, IEnumerable<MessageRecipient> recipients) {
+        if (target == null) {
+            throw new ArgumentNullException(nameof(target));
+        }
+        if (recipients == null) {
+            return;
+        }
+
+        foreach (var recipient in recipients) {
+            if (recipient == null || string.IsNullOrWhiteSpace(recipient.Address)) {
+                continue;
+            }
+
+            target.Add(CreateMailboxAddress(recipient));
+        }
+    }
+
+    private static MailboxAddress CreateMailboxAddress(MessageRecipient recipient) {
+        if (recipient == null) {
+            throw new ArgumentNullException(nameof(recipient));
+        }
+        if (string.IsNullOrWhiteSpace(recipient.Address)) {
+            throw new InvalidOperationException("Recipient address cannot be empty.");
+        }
+
+        return string.IsNullOrWhiteSpace(recipient.Name)
+            ? MailboxAddress.Parse(recipient.Address.Trim())
+            : new MailboxAddress(recipient.Name!.Trim(), recipient.Address.Trim());
+    }
+
+    private static void AddHeaders(MimeMessage message, IReadOnlyDictionary<string, string> headers) {
+        if (headers == null || headers.Count == 0) {
+            return;
+        }
+
+        foreach (var header in headers) {
+            if (string.IsNullOrWhiteSpace(header.Key) || string.IsNullOrWhiteSpace(header.Value)) {
+                continue;
+            }
+
+            message.Headers.Add(header.Key.Trim(), header.Value.Trim());
+        }
+    }
+
+    private static MimeEntity BuildBody(DraftMessage draft, CancellationToken cancellationToken) {
+        var bodyBuilder = new BodyBuilder();
+        if (!string.IsNullOrWhiteSpace(draft.TextBody)) {
+            bodyBuilder.TextBody = draft.TextBody;
+        }
+        if (!string.IsNullOrWhiteSpace(draft.HtmlBody)) {
+            bodyBuilder.HtmlBody = draft.HtmlBody;
+        }
+
+        foreach (var attachment in draft.Attachments) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (attachment == null || string.IsNullOrWhiteSpace(attachment.Path)) {
+                continue;
+            }
+
+            var entity = CreateAttachmentEntity(attachment);
+            if (attachment.IsInline) {
+                bodyBuilder.LinkedResources.Add(entity);
+            } else {
+                bodyBuilder.Attachments.Add(entity);
+            }
+        }
+
+        return bodyBuilder.ToMessageBody();
+    }
+
+    private static MimeEntity CreateAttachmentEntity(DraftAttachment attachment) {
+        var fullPath = Path.GetFullPath(attachment.Path);
+        if (!File.Exists(fullPath)) {
+            throw new FileNotFoundException($"Attachment '{attachment.Path}' was not found.", fullPath);
+        }
+
+        var fileName = string.IsNullOrWhiteSpace(attachment.FileName)
+            ? Path.GetFileName(fullPath)
+            : attachment.FileName!.Trim();
+        var contentType = ResolveContentType(attachment, fileName);
+        var part = new MimePart(contentType) {
+            Content = new MimeContent(new MemoryStream(File.ReadAllBytes(fullPath), writable: false)),
+            FileName = fileName,
+            ContentDisposition = new ContentDisposition(attachment.IsInline ? ContentDisposition.Inline : ContentDisposition.Attachment),
+            ContentTransferEncoding = ContentEncoding.Base64
+        };
+
+        if (attachment.IsInline) {
+            part.ContentId = string.IsNullOrWhiteSpace(attachment.ContentId)
+                ? MimeUtils.GenerateMessageId()
+                : attachment.ContentId!.Trim();
+        }
+
+        return part;
+    }
+
+    private static ContentType ResolveContentType(DraftAttachment attachment, string fileName) {
+        if (!string.IsNullOrWhiteSpace(attachment.ContentType)) {
+            return ContentType.Parse(attachment.ContentType!.Trim());
+        }
+
+        return ContentType.Parse(MimeTypes.GetMimeType(fileName));
+    }
+}

--- a/Sources/Mailozaurr.Application/FileMailDraftStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailDraftStore.cs
@@ -1,0 +1,208 @@
+using System.Text.Json;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Stores reusable drafts in a JSON document on disk.
+/// </summary>
+public sealed class FileMailDraftStore : IMailDraftStore {
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private static readonly JsonSerializerOptions SerializerOptions = new() {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    /// <summary>
+    /// Creates a new store using the provided options.
+    /// </summary>
+    public FileMailDraftStore(MailDraftStoreOptions? options = null)
+        : this((options ?? new MailDraftStoreOptions()).GetFilePath()) {
+    }
+
+    /// <summary>
+    /// Creates a new store using the specified file path.
+    /// </summary>
+    public FileMailDraftStore(string filePath) {
+        _filePath = Path.GetFullPath(filePath ?? throw new ArgumentNullException(nameof(filePath)));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailDraft>> GetAllAsync(CancellationToken cancellationToken = default) {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            return document.Drafts
+                .Select(CloneDraft)
+                .OrderBy(draft => draft.Name, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(draft => draft.Id, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<MailDraft?> GetByIdAsync(string draftId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(draftId)) {
+            throw new ArgumentException("Draft id is required.", nameof(draftId));
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var draft = document.Drafts.FirstOrDefault(existing => string.Equals(existing.Id, draftId, StringComparison.OrdinalIgnoreCase));
+            return draft == null ? null : CloneDraft(draft);
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(MailDraft draft, CancellationToken cancellationToken = default) {
+        ValidateDraft(draft);
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var index = document.Drafts.FindIndex(existing => string.Equals(existing.Id, draft.Id, StringComparison.OrdinalIgnoreCase));
+            var draftToStore = CloneDraft(draft);
+            if (draftToStore.CreatedAt == default) {
+                draftToStore.CreatedAt = DateTimeOffset.UtcNow;
+            }
+            draftToStore.UpdatedAt = DateTimeOffset.UtcNow;
+
+            if (index >= 0) {
+                draftToStore.CreatedAt = document.Drafts[index].CreatedAt == default
+                    ? draftToStore.CreatedAt
+                    : document.Drafts[index].CreatedAt;
+                document.Drafts[index] = draftToStore;
+            } else {
+                document.Drafts.Add(draftToStore);
+            }
+
+            await SaveDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveAsync(string draftId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(draftId)) {
+            throw new ArgumentException("Draft id is required.", nameof(draftId));
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var removed = document.Drafts.RemoveAll(existing => string.Equals(existing.Id, draftId, StringComparison.OrdinalIgnoreCase)) > 0;
+            if (!removed) {
+                return false;
+            }
+
+            await SaveDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+            return true;
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    private async Task<MailDraftStoreDocument> LoadDocumentAsync(CancellationToken cancellationToken) {
+        if (!File.Exists(_filePath)) {
+            return new MailDraftStoreDocument();
+        }
+
+        using (var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+            var document = await JsonSerializer.DeserializeAsync<MailDraftStoreDocument>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            return document ?? new MailDraftStoreDocument();
+        }
+    }
+
+    private async Task SaveDocumentAsync(MailDraftStoreDocument document, CancellationToken cancellationToken) {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (string.IsNullOrWhiteSpace(directory)) {
+            throw new InvalidOperationException("Draft store path is invalid.");
+        }
+
+        Directory.CreateDirectory(directory);
+
+        var tempPath = Path.Combine(directory, Path.GetRandomFileName());
+        try {
+            using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
+                await JsonSerializer.SerializeAsync(stream, document, SerializerOptions, cancellationToken).ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (File.Exists(_filePath)) {
+                File.Delete(_filePath);
+            }
+
+            File.Move(tempPath, _filePath);
+            tempPath = string.Empty;
+        } finally {
+            if (!string.IsNullOrEmpty(tempPath) && File.Exists(tempPath)) {
+                File.Delete(tempPath);
+            }
+        }
+    }
+
+    private static void ValidateDraft(MailDraft? draft) {
+        if (draft == null) {
+            throw new ArgumentNullException(nameof(draft));
+        }
+        if (string.IsNullOrWhiteSpace(draft.Id)) {
+            throw new InvalidOperationException("Draft id is required.");
+        }
+        if (string.IsNullOrWhiteSpace(draft.Name)) {
+            throw new InvalidOperationException("Draft name is required.");
+        }
+        if (draft.Message == null) {
+            throw new InvalidOperationException("Draft message is required.");
+        }
+        if (string.IsNullOrWhiteSpace(draft.Message.ProfileId)) {
+            throw new InvalidOperationException("Draft message profile id is required.");
+        }
+    }
+
+    private static MailDraft CloneDraft(MailDraft draft) => new() {
+        Id = draft.Id,
+        Name = draft.Name,
+        CreatedAt = draft.CreatedAt,
+        UpdatedAt = draft.UpdatedAt,
+        Message = CloneMessage(draft.Message)
+    };
+
+    private static DraftMessage CloneMessage(DraftMessage message) => new() {
+        ProfileId = message.ProfileId,
+        From = message.From == null ? null : CloneRecipient(message.From),
+        To = message.To.Select(CloneRecipient).ToList(),
+        Cc = message.Cc.Select(CloneRecipient).ToList(),
+        Bcc = message.Bcc.Select(CloneRecipient).ToList(),
+        ReplyTo = message.ReplyTo.Select(CloneRecipient).ToList(),
+        Subject = message.Subject,
+        TextBody = message.TextBody,
+        HtmlBody = message.HtmlBody,
+        Headers = new Dictionary<string, string>(message.Headers, StringComparer.OrdinalIgnoreCase),
+        Attachments = message.Attachments.Select(CloneAttachment).ToList()
+    };
+
+    private static MessageRecipient CloneRecipient(MessageRecipient recipient) => new() {
+        Name = recipient.Name,
+        Address = recipient.Address
+    };
+
+    private static DraftAttachment CloneAttachment(DraftAttachment attachment) => new() {
+        Path = attachment.Path,
+        FileName = attachment.FileName,
+        ContentType = attachment.ContentType,
+        IsInline = attachment.IsInline,
+        ContentId = attachment.ContentId
+    };
+
+    private sealed class MailDraftStoreDocument {
+        public int Version { get; set; } = 1;
+
+        public List<MailDraft> Drafts { get; set; } = new();
+    }
+}

--- a/Sources/Mailozaurr.Application/FileMailProfileStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailProfileStore.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Stores profiles in a JSON document on disk.
+/// </summary>
+public sealed class FileMailProfileStore : IMailProfileStore {
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private static readonly JsonSerializerOptions SerializerOptions = new() {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    /// <summary>
+    /// Creates a new store using the provided options.
+    /// </summary>
+    public FileMailProfileStore(MailProfileStoreOptions? options = null)
+        : this((options ?? new MailProfileStoreOptions()).GetFilePath()) {
+    }
+
+    /// <summary>
+    /// Creates a new store using the specified file path.
+    /// </summary>
+    public FileMailProfileStore(string filePath) {
+        _filePath = Path.GetFullPath(filePath ?? throw new ArgumentNullException(nameof(filePath)));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailProfile>> GetAllAsync(CancellationToken cancellationToken = default) {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            return CloneProfiles(document.Profiles);
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<MailProfile?> GetByIdAsync(string profileId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            throw new ArgumentException("Profile id is required.", nameof(profileId));
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var profile = document.Profiles.FirstOrDefault(p => string.Equals(p.Id, profileId, StringComparison.OrdinalIgnoreCase));
+            return profile == null ? null : CloneProfile(profile);
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+        ValidateProfile(profile);
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var existingIndex = document.Profiles.FindIndex(p => string.Equals(p.Id, profile.Id, StringComparison.OrdinalIgnoreCase));
+            var profileToStore = CloneProfile(profile);
+
+            if (profileToStore.IsDefault) {
+                foreach (var existing in document.Profiles) {
+                    existing.IsDefault = false;
+                }
+            }
+
+            if (existingIndex >= 0) {
+                document.Profiles[existingIndex] = profileToStore;
+            } else {
+                document.Profiles.Add(profileToStore);
+            }
+
+            await SaveDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            throw new ArgumentException("Profile id is required.", nameof(profileId));
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var removed = document.Profiles.RemoveAll(p => string.Equals(p.Id, profileId, StringComparison.OrdinalIgnoreCase)) > 0;
+            if (!removed) {
+                return false;
+            }
+
+            await SaveDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+            return true;
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    private async Task<MailProfileStoreDocument> LoadDocumentAsync(CancellationToken cancellationToken) {
+        if (!File.Exists(_filePath)) {
+            return new MailProfileStoreDocument();
+        }
+
+        using (var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+            var document = await JsonSerializer.DeserializeAsync<MailProfileStoreDocument>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            return document ?? new MailProfileStoreDocument();
+        }
+    }
+
+    private async Task SaveDocumentAsync(MailProfileStoreDocument document, CancellationToken cancellationToken) {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (string.IsNullOrWhiteSpace(directory)) {
+            throw new InvalidOperationException("Profile store path is invalid.");
+        }
+
+        Directory.CreateDirectory(directory);
+
+        var tempPath = Path.Combine(directory, Path.GetRandomFileName());
+        try {
+            using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
+                await JsonSerializer.SerializeAsync(stream, document, SerializerOptions, cancellationToken).ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (File.Exists(_filePath)) {
+                File.Delete(_filePath);
+            }
+
+            File.Move(tempPath, _filePath);
+            tempPath = string.Empty;
+        } finally {
+            if (!string.IsNullOrEmpty(tempPath) && File.Exists(tempPath)) {
+                File.Delete(tempPath);
+            }
+        }
+    }
+
+    private static void ValidateProfile(MailProfile? profile) {
+        if (profile == null) {
+            throw new ArgumentNullException(nameof(profile));
+        }
+
+        if (string.IsNullOrWhiteSpace(profile.Id)) {
+            throw new InvalidOperationException("Profile id is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(profile.DisplayName)) {
+            throw new InvalidOperationException("Profile display name is required.");
+        }
+    }
+
+    private static IReadOnlyList<MailProfile> CloneProfiles(IEnumerable<MailProfile> profiles) =>
+        profiles.Select(CloneProfile).ToArray();
+
+    private static MailProfile CloneProfile(MailProfile profile) => new() {
+        Id = profile.Id,
+        DisplayName = profile.DisplayName,
+        Description = profile.Description,
+        Kind = profile.Kind,
+        DefaultSender = profile.DefaultSender,
+        DefaultMailbox = profile.DefaultMailbox,
+        IsDefault = profile.IsDefault,
+        Settings = new Dictionary<string, string>(profile.Settings, StringComparer.OrdinalIgnoreCase),
+        Capabilities = profile.Capabilities == null
+            ? null
+            : new ProfileCapabilities(profile.Capabilities.Kind, profile.Capabilities.Capabilities)
+    };
+
+    private sealed class MailProfileStoreDocument {
+        public int Version { get; set; } = 1;
+
+        public List<MailProfile> Profiles { get; set; } = new();
+    }
+}

--- a/Sources/Mailozaurr.Application/FileMailSecretStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailSecretStore.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Stores protected secrets in a JSON document on disk.
+/// </summary>
+public sealed class FileMailSecretStore : IMailSecretStore {
+    private readonly string _filePath;
+    private readonly ICredentialProtector _protector;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private static readonly JsonSerializerOptions SerializerOptions = new() {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    /// <summary>
+    /// Creates a new store using the default credential protector.
+    /// </summary>
+    public FileMailSecretStore(MailSecretStoreOptions? options = null)
+        : this((options ?? new MailSecretStoreOptions()).GetFilePath(), CredentialProtection.Default) {
+    }
+
+    /// <summary>
+    /// Creates a new store using the specified file path and protector.
+    /// </summary>
+    public FileMailSecretStore(string filePath, ICredentialProtector protector) {
+        _filePath = Path.GetFullPath(filePath ?? throw new ArgumentNullException(nameof(filePath)));
+        _protector = protector ?? throw new ArgumentNullException(nameof(protector));
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+        ValidateKeyPart(profileId, nameof(profileId));
+        ValidateKeyPart(secretName, nameof(secretName));
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            if (!document.Secrets.TryGetValue(CreateKey(profileId, secretName), out var protectedValue)) {
+                return null;
+            }
+
+            return _protector.Unprotect(protectedValue);
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+        ValidateKeyPart(profileId, nameof(profileId));
+        ValidateKeyPart(secretName, nameof(secretName));
+        if (secretValue == null) {
+            throw new ArgumentNullException(nameof(secretValue));
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            document.Secrets[CreateKey(profileId, secretName)] = _protector.Protect(secretValue);
+            await SaveDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+        ValidateKeyPart(profileId, nameof(profileId));
+        ValidateKeyPart(secretName, nameof(secretName));
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var removed = document.Secrets.Remove(CreateKey(profileId, secretName));
+            if (!removed) {
+                return false;
+            }
+
+            await SaveDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+            return true;
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    private async Task<MailSecretStoreDocument> LoadDocumentAsync(CancellationToken cancellationToken) {
+        if (!File.Exists(_filePath)) {
+            return new MailSecretStoreDocument();
+        }
+
+        using (var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+            var document = await JsonSerializer.DeserializeAsync<MailSecretStoreDocument>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            return document ?? new MailSecretStoreDocument();
+        }
+    }
+
+    private async Task SaveDocumentAsync(MailSecretStoreDocument document, CancellationToken cancellationToken) {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (string.IsNullOrWhiteSpace(directory)) {
+            throw new InvalidOperationException("Secret store path is invalid.");
+        }
+
+        Directory.CreateDirectory(directory);
+
+        var tempPath = Path.Combine(directory, Path.GetRandomFileName());
+        try {
+            using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
+                await JsonSerializer.SerializeAsync(stream, document, SerializerOptions, cancellationToken).ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (File.Exists(_filePath)) {
+                File.Delete(_filePath);
+            }
+
+            File.Move(tempPath, _filePath);
+            tempPath = string.Empty;
+        } finally {
+            if (!string.IsNullOrEmpty(tempPath) && File.Exists(tempPath)) {
+                File.Delete(tempPath);
+            }
+        }
+    }
+
+    private static string CreateKey(string profileId, string secretName) => $"{profileId.Trim()}::{secretName.Trim()}";
+
+    private static void ValidateKeyPart(string value, string parameterName) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            throw new ArgumentException("A non-empty value is required.", parameterName);
+        }
+    }
+
+    private sealed class MailSecretStoreDocument {
+        public int Version { get; set; } = 1;
+
+        public Dictionary<string, string> Secrets { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/Sources/Mailozaurr.Application/FolderRef.cs
+++ b/Sources/Mailozaurr.Application/FolderRef.cs
@@ -1,0 +1,30 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Identifies a folder or folder-like mailbox container.
+/// </summary>
+public sealed class FolderRef {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Owning mailbox identifier when relevant.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Provider-specific folder identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>User-facing folder name.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Full path or canonical folder name.</summary>
+    public string? Path { get; set; }
+
+    /// <summary>Provider-specific special use marker such as Inbox or Sent.</summary>
+    public string? SpecialUse { get; set; }
+
+    /// <summary>Total message count when known.</summary>
+    public int? MessageCount { get; set; }
+
+    /// <summary>Unread message count when known.</summary>
+    public int? UnreadCount { get; set; }
+}

--- a/Sources/Mailozaurr.Application/FolderRefCompact.cs
+++ b/Sources/Mailozaurr.Application/FolderRefCompact.cs
@@ -1,0 +1,33 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Lightweight projection of a folder or folder-like mailbox container.
+/// </summary>
+public sealed class FolderRefCompact {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Owning mailbox identifier when relevant.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Provider-specific folder identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>User-facing folder name.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Full path or canonical folder name.</summary>
+    public string? Path { get; set; }
+
+    /// <summary>Provider-specific special use marker such as Inbox or Sent.</summary>
+    public string? SpecialUse { get; set; }
+
+    /// <summary>Total message count when known.</summary>
+    public int? MessageCount { get; set; }
+
+    /// <summary>Unread message count when known.</summary>
+    public int? UnreadCount { get; set; }
+
+    /// <summary>Short human-readable summary line.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/GetMessageRequest.cs
+++ b/Sources/Mailozaurr.Application/GetMessageRequest.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for retrieving a message.
+/// </summary>
+public sealed class GetMessageRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifier.</summary>
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>Whether raw content should be included when available.</summary>
+    public bool IncludeRawContent { get; set; }
+}

--- a/Sources/Mailozaurr.Application/GmailMailReadHandler.cs
+++ b/Sources/Mailozaurr.Application/GmailMailReadHandler.cs
@@ -1,0 +1,323 @@
+using System.Globalization;
+using MimeKit;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Normalized Gmail read handler backed by Mailozaurr Gmail helpers.
+/// </summary>
+public sealed class GmailMailReadHandler : IMailReadHandler {
+    private readonly IGmailSessionFactory _sessionFactory;
+    private readonly Func<GmailSession, MailProfile, MailFolderQuery, CancellationToken, Task<IReadOnlyList<FolderRef>>> _getFoldersAsync;
+    private readonly Func<GmailSession, MailProfile, MailSearchRequest, CancellationToken, Task<IReadOnlyList<MessageSummary>>> _searchAsync;
+    private readonly Func<GmailSession, MailProfile, GetMessageRequest, CancellationToken, Task<MessageDetail?>> _getMessageAsync;
+    private readonly Func<GmailSession, MailProfile, SaveAttachmentRequest, CancellationToken, Task<OperationResult>> _saveAttachmentAsync;
+
+    /// <summary>
+    /// Creates a new Gmail read handler.
+    /// </summary>
+    public GmailMailReadHandler(
+        IGmailSessionFactory sessionFactory,
+        Func<GmailSession, MailProfile, MailFolderQuery, CancellationToken, Task<IReadOnlyList<FolderRef>>>? getFoldersAsync = null,
+        Func<GmailSession, MailProfile, MailSearchRequest, CancellationToken, Task<IReadOnlyList<MessageSummary>>>? searchAsync = null,
+        Func<GmailSession, MailProfile, GetMessageRequest, CancellationToken, Task<MessageDetail?>>? getMessageAsync = null,
+        Func<GmailSession, MailProfile, SaveAttachmentRequest, CancellationToken, Task<OperationResult>>? saveAttachmentAsync = null) {
+        _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
+        _getFoldersAsync = getFoldersAsync ?? DefaultGetFoldersAsync;
+        _searchAsync = searchAsync ?? DefaultSearchAsync;
+        _getMessageAsync = getMessageAsync ?? DefaultGetMessageAsync;
+        _saveAttachmentAsync = saveAttachmentAsync ?? DefaultSaveAttachmentAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Gmail;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailProfile profile, MailFolderQuery query, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _getFoldersAsync(session, profile, query, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MessageSummary>> SearchAsync(MailProfile profile, MailSearchRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _searchAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageDetail?> GetMessageAsync(MailProfile profile, GetMessageRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _getMessageAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SaveAttachmentAsync(MailProfile profile, SaveAttachmentRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _saveAttachmentAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<IReadOnlyList<FolderRef>> DefaultGetFoldersAsync(
+        GmailSession session,
+        MailProfile profile,
+        MailFolderQuery query,
+        CancellationToken cancellationToken) {
+        var userId = ResolveUserId(profile, query.MailboxId);
+        var folders = await session.Browser.ListFoldersAsync(cancellationToken).ConfigureAwait(false);
+
+        bool MatchesFilter(GmailMailboxBrowser.GmailMailboxFolderSummary folder) {
+            if (query.RootOnly) {
+                return !folder.Name.Contains("/", StringComparison.Ordinal);
+            }
+            if (string.IsNullOrWhiteSpace(query.ParentFolderId)) {
+                return true;
+            }
+
+            var parent = GetParentPath(folder.Name);
+            return string.Equals(parent, query.ParentFolderId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return folders
+            .Where(MatchesFilter)
+            .Select(folder => new FolderRef {
+                ProfileId = profile.Id,
+                MailboxId = userId,
+                Id = folder.Id,
+                DisplayName = folder.Name,
+                Path = folder.Name,
+                SpecialUse = folder.Type
+            })
+            .OrderBy(folder => folder.Path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static async Task<IReadOnlyList<MessageSummary>> DefaultSearchAsync(
+        GmailSession session,
+        MailProfile profile,
+        MailSearchRequest request,
+        CancellationToken cancellationToken) {
+        var folder = ResolveFolder(request.FolderId, profile);
+        var result = await session.Browser.SearchMessagesAsync(
+            new GmailMailboxBrowser.GmailMailboxSearchRequest {
+                Folder = folder,
+                Query = request.QueryText,
+                SubjectContains = request.SubjectContains,
+                FromContains = request.FromContains,
+                ToContains = request.ToContains,
+                UnseenOnly = request.IsRead.HasValue ? !request.IsRead.Value : false,
+                HasAttachment = request.HasAttachments,
+                SinceUtc = request.Since?.UtcDateTime,
+                BeforeUtc = request.Before?.UtcDateTime
+            },
+            request.Limit ?? 100,
+            cancellationToken).ConfigureAwait(false);
+
+        return result.Messages
+            .Select(message => MapSummary(profile.Id, folder, message))
+            .ToArray();
+    }
+
+    private static async Task<MessageDetail?> DefaultGetMessageAsync(
+        GmailSession session,
+        MailProfile profile,
+        GetMessageRequest request,
+        CancellationToken cancellationToken) {
+        var folder = ResolveFolder(request.FolderId, profile);
+        var messageId = request.MessageId.Trim();
+        var getResult = await session.Browser.GetMessageContentAsync(
+            messageId,
+            GetMaxMimeBytes(profile),
+            cancellationToken).ConfigureAwait(false);
+        var summary = MapSummary(
+            profile.Id,
+            folder,
+            await session.Browser.GetMessageSummaryAsync(messageId, cancellationToken).ConfigureAwait(false),
+            getResult.Message);
+
+        var detail = new MessageDetail {
+            ProfileId = profile.Id,
+            Id = summary.Id,
+            Summary = summary,
+            TextBody = getResult.Message.TextBody,
+            HtmlBody = getResult.Message.HtmlBody,
+            Attachments = (await session.Client.ListAttachmentsAsync(session.UserId, messageId, cancellationToken).ConfigureAwait(false))
+                .OfType<GmailAttachmentInfo>()
+                .Select((attachment, index) => new AttachmentSummary {
+                    MessageId = summary.Id,
+                    Id = !string.IsNullOrWhiteSpace(attachment.Id)
+                        ? attachment.Id!.Trim()
+                        : index.ToString(CultureInfo.InvariantCulture),
+                    FileName = string.IsNullOrWhiteSpace(attachment.FileName)
+                        ? (!string.IsNullOrWhiteSpace(attachment.Id)
+                            ? attachment.Id!.Trim()
+                            : index.ToString(CultureInfo.InvariantCulture))
+                        : attachment.FileName!.Trim(),
+                    ContentType = attachment.MimeType
+                })
+                .ToList()
+        };
+
+        if (request.IncludeRawContent) {
+            using var stream = new MemoryStream();
+            await getResult.Message.WriteToAsync(stream, cancellationToken).ConfigureAwait(false);
+            stream.Position = 0;
+            using var reader = new StreamReader(stream);
+            detail.RawContent = reader.ReadToEnd();
+        }
+
+        return detail;
+    }
+
+    private static async Task<OperationResult> DefaultSaveAttachmentAsync(
+        GmailSession session,
+        MailProfile profile,
+        SaveAttachmentRequest request,
+        CancellationToken cancellationToken) {
+        var attachments = await session.Client.ListAttachmentsAsync(session.UserId, request.MessageId, cancellationToken).ConfigureAwait(false);
+        if (attachments == null || attachments.Count == 0) {
+            return OperationResult.Failure("attachment_not_found", "Message has no attachments.");
+        }
+
+        var resolved = ResolveAttachment(attachments, request.AttachmentId);
+        if (resolved == null || string.IsNullOrWhiteSpace(resolved.Id)) {
+            return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
+        }
+
+        var fileName = string.IsNullOrWhiteSpace(resolved.FileName) ? resolved.Id!.Trim() : resolved.FileName!.Trim();
+        var destinationPath = ResolveDestinationPath(request.DestinationPath, fileName);
+        if (File.Exists(destinationPath) && !request.Overwrite) {
+            return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
+        }
+
+        var bytes = await session.Client.DownloadAttachmentAsync(
+            session.UserId,
+            request.MessageId,
+            resolved.Id!.Trim(),
+            cancellationToken).ConfigureAwait(false);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        using (var stream = File.Create(destinationPath)) {
+#if NETSTANDARD2_0
+            await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+#else
+            await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+#endif
+        }
+        return OperationResult.Success($"Attachment saved to '{destinationPath}'.");
+    }
+
+    private static MessageSummary MapSummary(
+        string profileId,
+        string folderId,
+        GmailMailboxBrowser.GmailMailboxMessageSummary message,
+        MimeMessage? mimeMessage = null) => new() {
+        ProfileId = profileId,
+        Id = message.NativeId,
+        ThreadId = message.NativeThreadId,
+        FolderId = folderId,
+        Subject = message.Subject ?? mimeMessage?.Subject,
+        Preview = mimeMessage?.TextBody,
+        From = MapRecipients(message.From, mimeMessage?.From.Mailboxes),
+        To = MapRecipients(message.To, mimeMessage?.To.Mailboxes),
+        ReceivedAt = message.DateUtc,
+        SentAt = mimeMessage?.Date,
+        IsRead = message.Seen,
+        HasAttachments = message.HasAttachments
+    };
+
+    private static List<MessageRecipient> MapRecipients(string? raw, IEnumerable<MailboxAddress>? fallback) {
+        if (!string.IsNullOrWhiteSpace(raw)) {
+            var normalizedRaw = raw!.Trim();
+            try {
+                var parsed = InternetAddressList.Parse(normalizedRaw);
+                var recipients = parsed.Mailboxes.Select(mailbox => new MessageRecipient {
+                    Name = mailbox.Name,
+                    Address = mailbox.Address ?? string.Empty
+                }).ToList();
+                if (recipients.Count > 0) {
+                    return recipients;
+                }
+            } catch {
+                return new List<MessageRecipient> {
+                    new() {
+                        Address = normalizedRaw
+                    }
+                };
+            }
+        }
+
+        return fallback?
+            .Select(mailbox => new MessageRecipient {
+                Name = mailbox.Name,
+                Address = mailbox.Address ?? string.Empty
+            })
+            .ToList() ?? new List<MessageRecipient>();
+    }
+
+    private static string ResolveFolder(string? folderId, MailProfile profile) {
+        if (!string.IsNullOrWhiteSpace(folderId)) {
+            return folderId!.Trim();
+        }
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Folder, out var folder) && !string.IsNullOrWhiteSpace(folder)) {
+            return folder!.Trim();
+        }
+
+        return "INBOX";
+    }
+
+    private static string ResolveUserId(MailProfile profile, string? mailboxOverride = null) {
+        if (!string.IsNullOrWhiteSpace(mailboxOverride)) {
+            return mailboxOverride!.Trim();
+        }
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) && !string.IsNullOrWhiteSpace(mailbox)) {
+            return mailbox!.Trim();
+        }
+        if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
+            return profile.DefaultMailbox!.Trim();
+        }
+
+        return "me";
+    }
+
+    private static int GetMaxMimeBytes(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.MaxBodyBytes, out var raw) &&
+            int.TryParse(raw, out var value) &&
+            value > 0) {
+            return value;
+        }
+
+        return GmailMailboxBrowser.DefaultMaxMimeBytes;
+    }
+
+    private static GmailAttachmentInfo? ResolveAttachment(IList<GmailAttachmentInfo> attachments, string attachmentId) {
+        if (int.TryParse(attachmentId, out var index) && index >= 0 && index < attachments.Count) {
+            return attachments[index];
+        }
+
+        return attachments.FirstOrDefault(attachment =>
+            string.Equals(attachment.Id, attachmentId, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(attachment.FileName, attachmentId, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ResolveDestinationPath(string requestedPath, string fileName) {
+        var destinationPath = Path.GetFullPath(requestedPath);
+        if (Directory.Exists(destinationPath)) {
+            return Path.Combine(destinationPath, fileName);
+        }
+
+        var directory = Path.GetDirectoryName(destinationPath);
+        if (!string.IsNullOrWhiteSpace(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        return destinationPath;
+    }
+
+    private static string? GetParentPath(string path) {
+        var separatorIndex = path.LastIndexOf('/');
+        if (separatorIndex <= 0) {
+            return null;
+        }
+
+        return path.Substring(0, separatorIndex);
+    }
+}

--- a/Sources/Mailozaurr.Application/GmailMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/GmailMailSendHandler.cs
@@ -1,0 +1,86 @@
+using MimeKit;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Normalized Gmail send handler backed by Mailozaurr Gmail helpers.
+/// </summary>
+public sealed class GmailMailSendHandler : IMailSendHandler {
+    private readonly IGmailSessionFactory _sessionFactory;
+    private readonly IDraftMimeMessageFactory _draftMimeMessageFactory;
+    private readonly IPendingMessageRepository? _pendingMessageRepository;
+    private readonly Func<GmailSession, MailProfile, SendMessageRequest, MimeMessage, CancellationToken, Task<GmailMessage>> _sendAsync;
+
+    /// <summary>
+    /// Creates a new Gmail send handler.
+    /// </summary>
+    public GmailMailSendHandler(
+        IGmailSessionFactory sessionFactory,
+        IDraftMimeMessageFactory? draftMimeMessageFactory = null,
+        IPendingMessageRepository? pendingMessageRepository = null,
+        Func<GmailSession, MailProfile, SendMessageRequest, MimeMessage, CancellationToken, Task<GmailMessage>>? sendAsync = null) {
+        _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
+        _draftMimeMessageFactory = draftMimeMessageFactory ?? new DraftMimeMessageFactory();
+        _pendingMessageRepository = pendingMessageRepository;
+        _sendAsync = sendAsync ?? DefaultSendAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Gmail;
+
+    /// <inheritdoc />
+    public async Task<SendResult> SendAsync(MailProfile profile, SendMessageRequest request, CancellationToken cancellationToken = default) {
+        if (profile == null) {
+            throw new ArgumentNullException(nameof(profile));
+        }
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+        if (request.NotBefore.HasValue) {
+            throw new NotSupportedException("Scheduled Gmail sends are not yet supported by the application send handler.");
+        }
+
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        var message = await _draftMimeMessageFactory.CreateAsync(profile, request.Message, cancellationToken).ConfigureAwait(false);
+        var queueEnabled = _pendingMessageRepository != null && request.PreferQueue && !request.RequireImmediateSend;
+        session.Client.PendingMessageRepository = queueEnabled ? _pendingMessageRepository : null;
+
+        try {
+            var providerResult = await _sendAsync(session, profile, request, message, cancellationToken).ConfigureAwait(false);
+            return new SendResult {
+                Succeeded = true,
+                ProfileId = profile.Id,
+                ProfileKind = profile.Kind,
+                ProviderMessageId = providerResult.Id,
+                QueueMessageId = message.MessageId,
+                Message = "Message sent successfully."
+            };
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            throw;
+        } catch (Exception ex) when (queueEnabled && !string.IsNullOrWhiteSpace(message.MessageId)) {
+            var queued = await _pendingMessageRepository!.GetByMessageIdAsync(message.MessageId!, cancellationToken).ConfigureAwait(false);
+            if (queued != null) {
+                return new SendResult {
+                    Succeeded = true,
+                    ProfileId = profile.Id,
+                    ProfileKind = profile.Kind,
+                    Queued = true,
+                    QueueMessageId = queued.MessageId,
+                    Message = $"Message queued after send failure: {ex.Message}"
+                };
+            }
+
+            throw;
+        }
+    }
+
+    private static Task<GmailMessage> DefaultSendAsync(
+        GmailSession session,
+        MailProfile profile,
+        SendMessageRequest request,
+        MimeMessage message,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return session.Client.SendAsync(session.UserId, message, cancellationToken);
+    }
+}

--- a/Sources/Mailozaurr.Application/GmailProfileBootstrapRequest.cs
+++ b/Sources/Mailozaurr.Application/GmailProfileBootstrapRequest.cs
@@ -1,0 +1,36 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request used to create or update a reusable Gmail profile.
+/// </summary>
+public sealed class GmailProfileBootstrapRequest {
+    /// <summary>Stable profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Human-readable display name.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Optional operator-focused description.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Mailbox address or Gmail user id. Defaults to <c>me</c> when omitted.</summary>
+    public string? Mailbox { get; set; }
+
+    /// <summary>Optional default sender address. Falls back to the mailbox when omitted.</summary>
+    public string? DefaultSender { get; set; }
+
+    /// <summary>When true, marks the saved profile as the default profile.</summary>
+    public bool IsDefault { get; set; }
+
+    /// <summary>Optional Google OAuth client identifier.</summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>Optional Google OAuth client secret to store securely.</summary>
+    public string? ClientSecret { get; set; }
+
+    /// <summary>Optional refresh token to store securely.</summary>
+    public string? RefreshToken { get; set; }
+
+    /// <summary>Optional explicit access token to store securely.</summary>
+    public string? AccessToken { get; set; }
+}

--- a/Sources/Mailozaurr.Application/GmailProfileLoginRequest.cs
+++ b/Sources/Mailozaurr.Application/GmailProfileLoginRequest.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request used to authenticate an existing Gmail profile.
+/// </summary>
+public sealed class GmailProfileLoginRequest {
+    /// <summary>Stable profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional Gmail account override used for the login flow.</summary>
+    public string? GmailAccount { get; set; }
+
+    /// <summary>Optional OAuth client identifier override.</summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>Optional OAuth client secret override.</summary>
+    public string? ClientSecret { get; set; }
+
+    /// <summary>Optional scopes override. Defaults to the Mailozaurr Gmail mail scope.</summary>
+    public IReadOnlyList<string>? Scopes { get; set; }
+}

--- a/Sources/Mailozaurr.Application/GmailSession.cs
+++ b/Sources/Mailozaurr.Application/GmailSession.cs
@@ -1,0 +1,30 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents an authenticated Gmail API session for a resolved mailbox context.
+/// </summary>
+public sealed class GmailSession : IDisposable {
+    /// <summary>
+    /// Creates a new Gmail session wrapper.
+    /// </summary>
+    public GmailSession(GmailApiClient client, string userId) {
+        Client = client ?? throw new ArgumentNullException(nameof(client));
+        UserId = string.IsNullOrWhiteSpace(userId) ? "me" : userId.Trim();
+        Browser = new GmailMailboxBrowser(Client, UserId);
+    }
+
+    /// <summary>Gmail API client.</summary>
+    public GmailApiClient Client { get; }
+
+    /// <summary>Resolved mailbox user id used for Gmail requests.</summary>
+    public string UserId { get; }
+
+    /// <summary>High-level Gmail mailbox browser.</summary>
+    public GmailMailboxBrowser Browser { get; }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        Client.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Sources/Mailozaurr.Application/GmailSessionFactory.cs
+++ b/Sources/Mailozaurr.Application/GmailSessionFactory.cs
@@ -1,0 +1,219 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Builds Gmail API sessions from reusable profile and secret stores.
+/// </summary>
+public sealed class GmailSessionFactory : IGmailSessionFactory {
+    private static readonly Uri GoogleTokenEndpoint = new("https://oauth2.googleapis.com/token");
+    private readonly IMailSecretStore _secretStore;
+    private readonly Func<GmailRefreshRequest, CancellationToken, Task<OAuthCredential>> _refreshCredentialAsync;
+    private readonly Func<GmailSessionRequest, CancellationToken, Task<GmailSession>> _connectAsync;
+
+    /// <summary>
+    /// Creates a new Gmail session factory.
+    /// </summary>
+    public GmailSessionFactory(
+        IMailSecretStore secretStore,
+        Func<GmailRefreshRequest, CancellationToken, Task<OAuthCredential>>? refreshCredentialAsync = null,
+        Func<GmailSessionRequest, CancellationToken, Task<GmailSession>>? connectAsync = null) {
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+        _refreshCredentialAsync = refreshCredentialAsync ?? DefaultRefreshCredentialAsync;
+        _connectAsync = connectAsync ?? DefaultConnectAsync;
+    }
+
+    /// <inheritdoc />
+    public async Task<GmailSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+        if (profile == null) {
+            throw new ArgumentNullException(nameof(profile));
+        }
+
+        var userId = ResolveUserId(profile);
+        var (credential, refreshRequest) = await ResolveCredentialAsync(profile, userId, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(credential.UserName)) {
+            credential.UserName = userId;
+        }
+        if (credential.ExpiresOn == default) {
+            credential.ExpiresOn = DateTimeOffset.MaxValue;
+        }
+
+        Func<CancellationToken, Task<string>>? refreshDelegate = null;
+        if (refreshRequest != null) {
+            refreshDelegate = async token => {
+                var refreshed = await _refreshCredentialAsync(refreshRequest, token).ConfigureAwait(false);
+                credential.AccessToken = refreshed.AccessToken;
+                credential.ExpiresOn = refreshed.ExpiresOn;
+                credential.RefreshToken = refreshed.RefreshToken ?? credential.RefreshToken;
+                return refreshed.AccessToken;
+            };
+        }
+
+        return await _connectAsync(new GmailSessionRequest {
+            UserId = userId,
+            Credential = credential,
+            RefreshAccessTokenAsync = refreshDelegate
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<(OAuthCredential Credential, GmailRefreshRequest? RefreshRequest)> ResolveCredentialAsync(
+        MailProfile profile,
+        string userId,
+        CancellationToken cancellationToken) {
+        var accessToken = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.AccessToken, cancellationToken).ConfigureAwait(false);
+        var refreshToken = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.RefreshToken, cancellationToken).ConfigureAwait(false);
+        var tokenExpiresOn = TryResolveTokenExpiration(profile);
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientId);
+        var clientSecret = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false);
+
+        GmailRefreshRequest? refreshRequest = null;
+        if (!string.IsNullOrWhiteSpace(refreshToken) &&
+            !string.IsNullOrWhiteSpace(clientId) &&
+            !string.IsNullOrWhiteSpace(clientSecret)) {
+            var normalizedClientId = clientId!.Trim();
+            var normalizedClientSecret = clientSecret!.Trim();
+            var normalizedRefreshToken = refreshToken!.Trim();
+            refreshRequest = new GmailRefreshRequest {
+                UserId = userId,
+                ClientId = normalizedClientId,
+                ClientSecret = normalizedClientSecret,
+                RefreshToken = normalizedRefreshToken
+            };
+        }
+
+        if (!string.IsNullOrWhiteSpace(accessToken) && !ShouldRefreshToken(tokenExpiresOn)) {
+            var normalizedAccessToken = accessToken!.Trim();
+            var normalizedRefreshToken = string.IsNullOrWhiteSpace(refreshToken) ? null : refreshToken!.Trim();
+            var normalizedClientId = string.IsNullOrWhiteSpace(clientId) ? null : clientId!.Trim();
+            var normalizedClientSecret = string.IsNullOrWhiteSpace(clientSecret) ? null : clientSecret!.Trim();
+            return (new OAuthCredential {
+                UserName = userId,
+                AccessToken = normalizedAccessToken,
+                RefreshToken = normalizedRefreshToken,
+                ClientId = normalizedClientId,
+                ClientSecret = normalizedClientSecret,
+                ExpiresOn = tokenExpiresOn ?? DateTimeOffset.MaxValue
+            }, refreshRequest);
+        }
+
+        if (refreshRequest == null) {
+            throw new InvalidOperationException(
+                $"Gmail profile '{profile.Id}' requires secret '{MailSecretNames.AccessToken}' or the combination of secret '{MailSecretNames.RefreshToken}', setting '{MailProfileSettingsKeys.ClientId}', and secret '{MailSecretNames.ClientSecret}'.");
+        }
+
+        var refreshed = await _refreshCredentialAsync(refreshRequest, cancellationToken).ConfigureAwait(false);
+        refreshed.UserName = userId;
+        refreshed.ClientId ??= refreshRequest.ClientId;
+        refreshed.ClientSecret ??= refreshRequest.ClientSecret;
+        refreshed.RefreshToken ??= refreshRequest.RefreshToken;
+        return (refreshed, refreshRequest);
+    }
+
+    private static async Task<OAuthCredential> DefaultRefreshCredentialAsync(
+        GmailRefreshRequest request,
+        CancellationToken cancellationToken) {
+        using var client = new HttpClient();
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string> {
+            ["client_id"] = request.ClientId,
+            ["client_secret"] = request.ClientSecret,
+            ["refresh_token"] = request.RefreshToken,
+            ["grant_type"] = "refresh_token"
+        });
+        using var response = await client.PostAsync(GoogleTokenEndpoint, content, cancellationToken).ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+        if (!response.IsSuccessStatusCode) {
+            throw new InvalidOperationException($"Gmail token refresh failed with status {(int)response.StatusCode}: {body}");
+        }
+
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+        if (!root.TryGetProperty("access_token", out var accessTokenElement) ||
+            accessTokenElement.ValueKind != JsonValueKind.String) {
+            throw new InvalidDataException("Gmail token refresh response did not contain an access_token.");
+        }
+
+        var accessToken = accessTokenElement.GetString();
+        if (string.IsNullOrWhiteSpace(accessToken)) {
+            throw new InvalidDataException("Gmail token refresh response contained an empty access_token.");
+        }
+
+        var expiresOn = DateTimeOffset.MaxValue;
+        if (root.TryGetProperty("expires_in", out var expiresInElement)) {
+            if (expiresInElement.ValueKind == JsonValueKind.Number &&
+                expiresInElement.TryGetInt64(out var expiresInSeconds)) {
+                expiresOn = DateTimeOffset.UtcNow.AddSeconds(expiresInSeconds);
+            } else if (expiresInElement.ValueKind == JsonValueKind.String &&
+                       long.TryParse(expiresInElement.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedExpiresInSeconds)) {
+                expiresOn = DateTimeOffset.UtcNow.AddSeconds(parsedExpiresInSeconds);
+            }
+        }
+
+        string? refreshToken = null;
+        if (root.TryGetProperty("refresh_token", out var refreshTokenElement) &&
+            refreshTokenElement.ValueKind == JsonValueKind.String) {
+            refreshToken = refreshTokenElement.GetString();
+        }
+
+        return new OAuthCredential {
+            UserName = request.UserId,
+            AccessToken = accessToken!.Trim(),
+            RefreshToken = string.IsNullOrWhiteSpace(refreshToken) ? request.RefreshToken : refreshToken!.Trim(),
+            ClientId = request.ClientId,
+            ClientSecret = request.ClientSecret,
+            ExpiresOn = expiresOn
+        };
+    }
+
+    private static Task<GmailSession> DefaultConnectAsync(GmailSessionRequest request, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(new GmailSession(new GmailApiClient(request.Credential, request.RefreshAccessTokenAsync), request.UserId));
+    }
+
+    private static string ResolveUserId(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) &&
+            !string.IsNullOrWhiteSpace(mailbox)) {
+            return mailbox.Trim();
+        }
+        if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
+            return profile.DefaultMailbox!.Trim();
+        }
+
+        return "me";
+    }
+
+    private static DateTimeOffset? TryResolveTokenExpiration(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.TokenExpiresOn, out var expiresOnValue) &&
+            !string.IsNullOrWhiteSpace(expiresOnValue) &&
+            DateTimeOffset.TryParse(expiresOnValue, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var expiresOn)) {
+            return expiresOn;
+        }
+
+        return null;
+    }
+
+    private static bool ShouldRefreshToken(DateTimeOffset? expiresOn) =>
+        expiresOn.HasValue && expiresOn.Value <= DateTimeOffset.UtcNow.Add(MailProfileAuthDefaults.TokenRefreshWindow);
+
+    /// <summary>
+    /// Represents the refresh-token input required to mint a Gmail access token.
+    /// </summary>
+    public sealed class GmailRefreshRequest {
+        /// <summary>Resolved Gmail user id.</summary>
+        public string UserId { get; set; } = "me";
+
+        /// <summary>OAuth client id.</summary>
+        public string ClientId { get; set; } = string.Empty;
+
+        /// <summary>OAuth client secret.</summary>
+        public string ClientSecret { get; set; } = string.Empty;
+
+        /// <summary>OAuth refresh token.</summary>
+        public string RefreshToken { get; set; } = string.Empty;
+    }
+}

--- a/Sources/Mailozaurr.Application/GmailSessionRequest.cs
+++ b/Sources/Mailozaurr.Application/GmailSessionRequest.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents the resolved session input required to connect to Gmail.
+/// </summary>
+public sealed class GmailSessionRequest {
+    /// <summary>Resolved Gmail mailbox user id.</summary>
+    public string UserId { get; set; } = "me";
+
+    /// <summary>OAuth credential used to authenticate Gmail requests.</summary>
+    public OAuthCredential Credential { get; set; } = new();
+
+    /// <summary>Optional access-token refresh delegate.</summary>
+    public Func<CancellationToken, Task<string>>? RefreshAccessTokenAsync { get; set; }
+}

--- a/Sources/Mailozaurr.Application/GraphMailReadHandler.cs
+++ b/Sources/Mailozaurr.Application/GraphMailReadHandler.cs
@@ -1,0 +1,408 @@
+using System.Globalization;
+using MimeKit;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Normalized Graph read handler backed by Mailozaurr Graph helpers.
+/// </summary>
+public sealed class GraphMailReadHandler : IMailReadHandler {
+    private const string SummarySelect = "id,subject,receivedDateTime,from,toRecipients,internetMessageId,hasAttachments,isRead,flag,conversationId";
+    private readonly IGraphSessionFactory _sessionFactory;
+    private readonly Func<GraphSession, MailProfile, MailFolderQuery, CancellationToken, Task<IReadOnlyList<FolderRef>>> _getFoldersAsync;
+    private readonly Func<GraphSession, MailProfile, MailSearchRequest, CancellationToken, Task<IReadOnlyList<MessageSummary>>> _searchAsync;
+    private readonly Func<GraphSession, MailProfile, GetMessageRequest, CancellationToken, Task<MessageDetail?>> _getMessageAsync;
+    private readonly Func<GraphSession, MailProfile, SaveAttachmentRequest, CancellationToken, Task<OperationResult>> _saveAttachmentAsync;
+
+    /// <summary>
+    /// Creates a new Graph read handler.
+    /// </summary>
+    public GraphMailReadHandler(
+        IGraphSessionFactory sessionFactory,
+        Func<GraphSession, MailProfile, MailFolderQuery, CancellationToken, Task<IReadOnlyList<FolderRef>>>? getFoldersAsync = null,
+        Func<GraphSession, MailProfile, MailSearchRequest, CancellationToken, Task<IReadOnlyList<MessageSummary>>>? searchAsync = null,
+        Func<GraphSession, MailProfile, GetMessageRequest, CancellationToken, Task<MessageDetail?>>? getMessageAsync = null,
+        Func<GraphSession, MailProfile, SaveAttachmentRequest, CancellationToken, Task<OperationResult>>? saveAttachmentAsync = null) {
+        _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
+        _getFoldersAsync = getFoldersAsync ?? DefaultGetFoldersAsync;
+        _searchAsync = searchAsync ?? DefaultSearchAsync;
+        _getMessageAsync = getMessageAsync ?? DefaultGetMessageAsync;
+        _saveAttachmentAsync = saveAttachmentAsync ?? DefaultSaveAttachmentAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Graph;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailProfile profile, MailFolderQuery query, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _getFoldersAsync(session, profile, query, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MessageSummary>> SearchAsync(MailProfile profile, MailSearchRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _searchAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageDetail?> GetMessageAsync(MailProfile profile, GetMessageRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _getMessageAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SaveAttachmentAsync(MailProfile profile, SaveAttachmentRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _saveAttachmentAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<IReadOnlyList<FolderRef>> DefaultGetFoldersAsync(
+        GraphSession session,
+        MailProfile profile,
+        MailFolderQuery query,
+        CancellationToken cancellationToken) {
+        var userId = ResolveUserId(profile, query.MailboxId);
+        var folders = await session.Client.ListMailFoldersRecursiveAsync(userId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var nodes = folders.ToDictionary(
+            folder => folder.Id,
+            folder => new GraphFolderNode(
+                folder.Id,
+                folder.DisplayName,
+                folder.ParentFolderId,
+                folder.WellKnownName,
+                folder.TotalItemCount,
+                folder.UnreadItemCount),
+            StringComparer.Ordinal);
+
+        string BuildPath(string id) {
+            if (!nodes.TryGetValue(id, out var node)) {
+                return id;
+            }
+
+            var parts = new List<string>();
+            var current = node;
+            var guard = 0;
+            while (guard++ < 100) {
+                parts.Add(current.DisplayName);
+                if (string.IsNullOrWhiteSpace(current.ParentId) ||
+                    !nodes.TryGetValue(current.ParentId!, out current)) {
+                    break;
+                }
+            }
+            parts.Reverse();
+            return string.Join("/", parts);
+        }
+
+        bool MatchesFilter(GraphFolderNode node) {
+            if (query.RootOnly) {
+                return string.IsNullOrWhiteSpace(node.ParentId);
+            }
+            if (string.IsNullOrWhiteSpace(query.ParentFolderId)) {
+                return true;
+            }
+
+            if (string.Equals(node.Id, query.ParentFolderId, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+
+            var currentParentId = node.ParentId;
+            var guard = 0;
+            while (!string.IsNullOrWhiteSpace(currentParentId) && guard++ < 100) {
+                if (string.Equals(currentParentId, query.ParentFolderId, StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+
+                if (!nodes.TryGetValue(currentParentId!, out var parentNode)) {
+                    break;
+                }
+
+                currentParentId = parentNode.ParentId;
+            }
+
+            return false;
+        }
+
+        return nodes.Values
+            .Where(MatchesFilter)
+            .Select(node => new FolderRef {
+                ProfileId = profile.Id,
+                MailboxId = userId,
+                Id = node.Id,
+                DisplayName = node.DisplayName,
+                Path = BuildPath(node.Id),
+                SpecialUse = node.WellKnownName,
+                MessageCount = node.TotalItemCount,
+                UnreadCount = node.UnreadItemCount
+            })
+            .OrderBy(folder => folder.Path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static async Task<IReadOnlyList<MessageSummary>> DefaultSearchAsync(
+        GraphSession session,
+        MailProfile profile,
+        MailSearchRequest request,
+        CancellationToken cancellationToken) {
+        var userId = ResolveUserId(profile, request.MailboxId);
+        var folder = ResolveFolder(request.FolderId, profile);
+        var filterParts = new List<string>();
+
+        if (request.IsRead.HasValue) {
+            filterParts.Add("isRead eq " + (request.IsRead.Value ? "true" : "false"));
+        }
+        if (request.HasAttachments) {
+            filterParts.Add("hasAttachments eq true");
+        }
+        if (request.Since.HasValue) {
+            filterParts.Add("receivedDateTime ge " + request.Since.Value.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture));
+        }
+        if (request.Before.HasValue) {
+            filterParts.Add("receivedDateTime lt " + request.Before.Value.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture));
+        }
+
+        var searchTerms = new List<string>();
+        AddSearchToken(searchTerms, request.QueryText);
+        AddSearchToken(searchTerms, request.SubjectContains);
+        AddSearchToken(searchTerms, request.FromContains);
+        AddSearchToken(searchTerms, request.ToContains);
+
+        var page = await session.Client.ListMessagesAsync(
+            folder,
+            userId: userId,
+            top: request.Limit ?? 100,
+            skip: null,
+            select: SummarySelect,
+            orderBy: "receivedDateTime desc",
+            filter: filterParts.Count == 0 ? null : string.Join(" and ", filterParts),
+            search: searchTerms.Count == 0 ? null : string.Join(" ", searchTerms),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return page.Items
+            .Select(message => MapSummary(profile.Id, folder, message))
+            .ToArray();
+    }
+
+    private static async Task<MessageDetail?> DefaultGetMessageAsync(
+        GraphSession session,
+        MailProfile profile,
+        GetMessageRequest request,
+        CancellationToken cancellationToken) {
+        var userId = ResolveUserId(profile, request.MailboxId);
+        var folder = ResolveFolder(request.FolderId, profile);
+        var maxMimeBytes = GetMaxMimeBytes(profile);
+        var metadata = await session.Client.GetMessageAsync(
+            request.MessageId,
+            userId: userId,
+            select: SummarySelect,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        var mimeBytes = await session.Client.GetMessageMimeAsync(
+            request.MessageId,
+            userId: userId,
+            maxBytes: maxMimeBytes,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        MimeMessage message;
+        try {
+            message = MimeMessage.Load(new MemoryStream(mimeBytes, writable: false));
+        } catch (Exception ex) {
+            throw new InvalidDataException("Failed to parse Graph MIME message.", ex);
+        }
+
+        var summary = MapSummary(profile.Id, folder, metadata, message);
+        var detail = new MessageDetail {
+            ProfileId = profile.Id,
+            Id = summary.Id,
+            Summary = summary,
+            TextBody = message.TextBody,
+            HtmlBody = message.HtmlBody,
+            Attachments = message.Attachments.Select((attachment, index) => new AttachmentSummary {
+                MessageId = summary.Id,
+                Id = index.ToString(CultureInfo.InvariantCulture),
+                FileName = MimeAttachmentStorage.GetAttachmentFileName(attachment),
+                ContentType = attachment.ContentType?.MimeType
+            }).ToList()
+        };
+
+        if (request.IncludeRawContent) {
+            using var stream = new MemoryStream(mimeBytes, writable: false);
+            using var reader = new StreamReader(stream);
+            detail.RawContent = reader.ReadToEnd();
+        }
+
+        return detail;
+    }
+
+    private static async Task<OperationResult> DefaultSaveAttachmentAsync(
+        GraphSession session,
+        MailProfile profile,
+        SaveAttachmentRequest request,
+        CancellationToken cancellationToken) {
+        var userId = ResolveUserId(profile, request.MailboxId);
+        var maxMimeBytes = GetMaxMimeBytes(profile);
+        var mimeBytes = await session.Client.GetMessageMimeAsync(
+            request.MessageId,
+            userId: userId,
+            maxBytes: maxMimeBytes,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        MimeMessage message;
+        try {
+            message = MimeMessage.Load(new MemoryStream(mimeBytes, writable: false));
+        } catch (Exception ex) {
+            throw new InvalidDataException("Failed to parse Graph MIME message.", ex);
+        }
+
+        var attachments = message.Attachments.ToList();
+        if (attachments.Count == 0) {
+            return OperationResult.Failure("attachment_not_found", "Message has no attachments.");
+        }
+
+        var attachment = MimeAttachmentStorage.ResolveAttachment(attachments, request.AttachmentId);
+        if (attachment == null) {
+            return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
+        }
+
+        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(request.DestinationPath, attachment);
+        if (File.Exists(destinationPath) && !request.Overwrite) {
+            return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
+        }
+
+        MimeAttachmentStorage.SaveAttachment(attachment, destinationPath);
+        return OperationResult.Success($"Attachment saved to '{destinationPath}'.");
+    }
+
+    private static MessageSummary MapSummary(
+        string profileId,
+        string folderId,
+        GraphMailMessage message,
+        MimeMessage? mimeMessage = null) => new() {
+        ProfileId = profileId,
+        Id = message.Id,
+        ThreadId = message.ConversationId,
+        FolderId = folderId,
+        Subject = string.IsNullOrWhiteSpace(message.Subject) ? mimeMessage?.Subject : message.Subject,
+        Preview = mimeMessage?.TextBody,
+        From = MapRecipients(message.From, mimeMessage?.From.Mailboxes),
+        To = MapRecipients(message.ToRecipients, mimeMessage?.To.Mailboxes),
+        ReceivedAt = message.ReceivedDateTime ?? mimeMessage?.Date,
+        SentAt = mimeMessage?.Date,
+        IsRead = message.IsRead,
+        HasAttachments = message.HasAttachments ?? mimeMessage?.Attachments.Any() ?? false
+    };
+
+    private static List<MessageRecipient> MapRecipients(GraphEmailAddress? sender, IEnumerable<MailboxAddress>? fallback) {
+        if (sender?.Email != null && !string.IsNullOrWhiteSpace(sender.Email.Address)) {
+            return new List<MessageRecipient> {
+                new() {
+                    Name = sender.Email.Name,
+                    Address = sender.Email.Address
+                }
+            };
+        }
+
+        return fallback?
+            .Select(mailbox => new MessageRecipient {
+                Name = mailbox.Name,
+                Address = mailbox.Address ?? string.Empty
+            })
+            .ToList() ?? new List<MessageRecipient>();
+    }
+
+    private static List<MessageRecipient> MapRecipients(IEnumerable<GraphEmailAddress>? recipients, IEnumerable<MailboxAddress>? fallback) {
+        var output = recipients?
+            .Where(recipient => recipient.Email != null && !string.IsNullOrWhiteSpace(recipient.Email.Address))
+            .Select(recipient => new MessageRecipient {
+                Name = recipient.Email.Name,
+                Address = recipient.Email.Address
+            })
+            .ToList();
+        if (output != null && output.Count > 0) {
+            return output;
+        }
+
+        return fallback?
+            .Select(mailbox => new MessageRecipient {
+                Name = mailbox.Name,
+                Address = mailbox.Address ?? string.Empty
+            })
+            .ToList() ?? new List<MessageRecipient>();
+    }
+
+    private static string ResolveFolder(string? folderId, MailProfile profile) {
+        if (!string.IsNullOrWhiteSpace(folderId)) {
+            return folderId!.Trim();
+        }
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Folder, out var folder) && !string.IsNullOrWhiteSpace(folder)) {
+            return folder!.Trim();
+        }
+
+        return "inbox";
+    }
+
+    private static string ResolveUserId(MailProfile profile, string? mailboxOverride = null) {
+        if (!string.IsNullOrWhiteSpace(mailboxOverride)) {
+            return mailboxOverride!.Trim();
+        }
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) && !string.IsNullOrWhiteSpace(mailbox)) {
+            return mailbox!.Trim();
+        }
+        if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
+            return profile.DefaultMailbox!.Trim();
+        }
+
+        return "me";
+    }
+
+    private static int GetMaxMimeBytes(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.MaxBodyBytes, out var raw) &&
+            int.TryParse(raw, out var value) &&
+            value > 0) {
+            return value;
+        }
+
+        return GraphMailboxBrowser.DefaultMaxMimeBytes;
+    }
+
+    private static void AddSearchToken(List<string> tokens, string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return;
+        }
+
+        var normalized = value!.Trim();
+        if (normalized.Length == 0) {
+            return;
+        }
+
+        tokens.Add(normalized.Replace("\"", string.Empty));
+    }
+
+    private sealed class GraphFolderNode {
+        public GraphFolderNode(
+            string id,
+            string displayName,
+            string? parentId,
+            string? wellKnownName,
+            int? totalItemCount,
+            int? unreadItemCount) {
+            Id = id;
+            DisplayName = displayName;
+            ParentId = parentId;
+            WellKnownName = wellKnownName;
+            TotalItemCount = totalItemCount;
+            UnreadItemCount = unreadItemCount;
+        }
+
+        public string Id { get; }
+
+        public string DisplayName { get; }
+
+        public string? ParentId { get; }
+
+        public string? WellKnownName { get; }
+
+        public int? TotalItemCount { get; }
+
+        public int? UnreadItemCount { get; }
+    }
+}

--- a/Sources/Mailozaurr.Application/GraphMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/GraphMailSendHandler.cs
@@ -1,0 +1,156 @@
+using System.Globalization;
+using System.IO;
+using MimeKit;
+using MimeKit.Utils;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Normalized Graph send handler backed by Mailozaurr Graph helpers.
+/// </summary>
+public sealed class GraphMailSendHandler : IMailSendHandler {
+    private readonly IGraphSessionFactory _sessionFactory;
+    private readonly IDraftMimeMessageFactory _draftMimeMessageFactory;
+    private readonly IPendingMessageRepository? _pendingMessageRepository;
+    private readonly Func<GraphSession, MailProfile, SendMessageRequest, MimeMessage, CancellationToken, Task<GraphMessage>> _sendAsync;
+
+    /// <summary>
+    /// Creates a new Graph send handler.
+    /// </summary>
+    public GraphMailSendHandler(
+        IGraphSessionFactory sessionFactory,
+        IDraftMimeMessageFactory? draftMimeMessageFactory = null,
+        IPendingMessageRepository? pendingMessageRepository = null,
+        Func<GraphSession, MailProfile, SendMessageRequest, MimeMessage, CancellationToken, Task<GraphMessage>>? sendAsync = null) {
+        _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
+        _draftMimeMessageFactory = draftMimeMessageFactory ?? new DraftMimeMessageFactory();
+        _pendingMessageRepository = pendingMessageRepository;
+        _sendAsync = sendAsync ?? DefaultSendAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Graph;
+
+    /// <inheritdoc />
+    public async Task<SendResult> SendAsync(MailProfile profile, SendMessageRequest request, CancellationToken cancellationToken = default) {
+        if (profile == null) {
+            throw new ArgumentNullException(nameof(profile));
+        }
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        var message = await _draftMimeMessageFactory.CreateAsync(profile, request.Message, cancellationToken).ConfigureAwait(false);
+        var shouldQueue = _pendingMessageRepository != null && request.PreferQueue && !request.RequireImmediateSend;
+        if (request.NotBefore.HasValue || shouldQueue) {
+            if (_pendingMessageRepository == null) {
+                throw new NotSupportedException("Queue-backed Graph sends require a pending-message repository.");
+            }
+
+            var queuedRecord = await QueueMessageAsync(
+                profile,
+                session,
+                message,
+                request.NotBefore,
+                cancellationToken).ConfigureAwait(false);
+            return new SendResult {
+                Succeeded = true,
+                ProfileId = profile.Id,
+                ProfileKind = profile.Kind,
+                Queued = true,
+                QueueMessageId = queuedRecord.MessageId,
+                Message = "Message queued successfully."
+            };
+        }
+
+        var providerResult = await _sendAsync(session, profile, request, message, cancellationToken).ConfigureAwait(false);
+
+        return new SendResult {
+            Succeeded = true,
+            ProfileId = profile.Id,
+            ProfileKind = profile.Kind,
+            ProviderMessageId = providerResult.Id,
+            QueueMessageId = message.MessageId,
+            Message = "Message sent successfully."
+        };
+    }
+
+    private static async Task<GraphMessage> DefaultSendAsync(
+        GraphSession session,
+        MailProfile profile,
+        SendMessageRequest request,
+        MimeMessage message,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await GraphMimeMessageSender.SendAsync(session.Client, session.UserId, message, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<PendingMessageRecord> QueueMessageAsync(
+        MailProfile profile,
+        GraphSession session,
+        MimeMessage message,
+        DateTimeOffset? notBefore,
+        CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(message.MessageId)) {
+            message.MessageId = MimeUtils.GenerateMessageId();
+        }
+
+        using var stream = new MemoryStream();
+        await message.WriteToAsync(stream, cancellationToken).ConfigureAwait(false);
+
+        var now = DateTimeOffset.UtcNow;
+        var record = new PendingMessageRecord {
+            MessageId = message.MessageId!,
+            MimeMessage = Convert.ToBase64String(stream.ToArray()),
+            Timestamp = now,
+            NextAttemptAt = notBefore?.ToUniversalTime() ?? now,
+            Provider = EmailProvider.Graph
+        };
+
+        record.ProviderData[GraphPendingMessageSender.UserIdKey] = session.UserId;
+        var credential = session.Credential;
+        var userName = !string.IsNullOrWhiteSpace(credential?.UserName)
+            ? credential!.UserName
+            : session.UserId;
+        record.ProviderData[GraphPendingMessageSender.UserNameKey] = userName;
+
+        if (!string.IsNullOrWhiteSpace(credential?.AccessToken)) {
+            record.ProviderData[GraphPendingMessageSender.AccessTokenProtectedKey] =
+                CredentialProtection.Default.Protect(credential!.AccessToken);
+        }
+
+        if (credential != null) {
+            record.ProviderData[GraphPendingMessageSender.ExpiresOnKey] =
+                (credential.ExpiresOn == default ? DateTimeOffset.MaxValue : credential.ExpiresOn).ToString("o", CultureInfo.InvariantCulture);
+        }
+
+        var graphCredential = session.GraphCredential;
+        if (!string.IsNullOrWhiteSpace(graphCredential?.ClientId)) {
+            record.ProviderData[GraphPendingMessageSender.ClientIdKey] = graphCredential!.ClientId;
+        }
+        if (!string.IsNullOrWhiteSpace(graphCredential?.DirectoryId)) {
+            record.ProviderData[GraphPendingMessageSender.TenantIdKey] = graphCredential!.DirectoryId;
+        }
+        if (!string.IsNullOrWhiteSpace(graphCredential?.ClientSecret)) {
+            record.ProviderData[GraphPendingMessageSender.ClientSecretProtectedKey] =
+                CredentialProtection.Default.Protect(graphCredential!.ClientSecret!);
+        }
+        if (!string.IsNullOrWhiteSpace(graphCredential?.CertificatePath)) {
+            record.ProviderData[GraphPendingMessageSender.CertificatePathKey] = graphCredential!.CertificatePath!;
+        }
+        if (!string.IsNullOrWhiteSpace(graphCredential?.CertificatePassword)) {
+            record.ProviderData[GraphPendingMessageSender.CertificatePasswordProtectedKey] =
+                CredentialProtection.Default.Protect(graphCredential!.CertificatePassword!);
+        }
+
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.TenantId, out var tenantId);
+        if (!string.IsNullOrWhiteSpace(tenantId) &&
+            !record.ProviderData.ContainsKey(GraphPendingMessageSender.TenantIdKey)) {
+            record.ProviderData[GraphPendingMessageSender.TenantIdKey] = tenantId.Trim();
+        }
+
+        await _pendingMessageRepository!.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+        return record;
+    }
+}

--- a/Sources/Mailozaurr.Application/GraphProfileBootstrapRequest.cs
+++ b/Sources/Mailozaurr.Application/GraphProfileBootstrapRequest.cs
@@ -1,0 +1,42 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request used to create or update a reusable Microsoft Graph profile.
+/// </summary>
+public sealed class GraphProfileBootstrapRequest {
+    /// <summary>Stable profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Human-readable display name.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Optional operator-focused description.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Mailbox address or user principal name.</summary>
+    public string Mailbox { get; set; } = string.Empty;
+
+    /// <summary>Optional default sender address. Falls back to <see cref="Mailbox" /> when omitted.</summary>
+    public string? DefaultSender { get; set; }
+
+    /// <summary>When true, marks the saved profile as the default profile.</summary>
+    public bool IsDefault { get; set; }
+
+    /// <summary>Optional Graph client/application identifier.</summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>Optional Graph tenant/directory identifier.</summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>Optional confidential-client secret to store securely.</summary>
+    public string? ClientSecret { get; set; }
+
+    /// <summary>Optional explicit access token to store securely.</summary>
+    public string? AccessToken { get; set; }
+
+    /// <summary>Optional certificate path for certificate-based authentication.</summary>
+    public string? CertificatePath { get; set; }
+
+    /// <summary>Optional certificate password to store securely.</summary>
+    public string? CertificatePassword { get; set; }
+}

--- a/Sources/Mailozaurr.Application/GraphProfileLoginRequest.cs
+++ b/Sources/Mailozaurr.Application/GraphProfileLoginRequest.cs
@@ -1,0 +1,27 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request used to authenticate an existing Microsoft Graph profile.
+/// </summary>
+public sealed class GraphProfileLoginRequest {
+    /// <summary>Stable profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional login hint override for the interactive flow.</summary>
+    public string? Login { get; set; }
+
+    /// <summary>Optional mailbox override that should be persisted with the profile.</summary>
+    public string? Mailbox { get; set; }
+
+    /// <summary>Optional application/client identifier override.</summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>Optional tenant/directory identifier override.</summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>Optional redirect URI override. Defaults to the Mailozaurr Graph native-client redirect URI.</summary>
+    public string? RedirectUri { get; set; }
+
+    /// <summary>Optional scopes override. Defaults to Mail.ReadWrite, Mail.Send, email, and offline_access.</summary>
+    public IReadOnlyList<string>? Scopes { get; set; }
+}

--- a/Sources/Mailozaurr.Application/GraphSession.cs
+++ b/Sources/Mailozaurr.Application/GraphSession.cs
@@ -1,0 +1,38 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents an authenticated Graph API session for a resolved mailbox context.
+/// </summary>
+public sealed class GraphSession : IDisposable {
+    /// <summary>
+    /// Creates a new Graph session wrapper.
+    /// </summary>
+    public GraphSession(
+        GraphApiClient client,
+        string userId,
+        OAuthCredential? credential = null,
+        GraphCredential? graphCredential = null) {
+        Client = client ?? throw new ArgumentNullException(nameof(client));
+        UserId = string.IsNullOrWhiteSpace(userId) ? "me" : userId.Trim();
+        Credential = credential;
+        GraphCredential = graphCredential;
+    }
+
+    /// <summary>Graph API client.</summary>
+    public GraphApiClient Client { get; }
+
+    /// <summary>Resolved mailbox user id used for Graph requests.</summary>
+    public string UserId { get; }
+
+    /// <summary>Resolved OAuth credential used to authenticate the session.</summary>
+    public OAuthCredential? Credential { get; }
+
+    /// <summary>Optional Graph credential metadata that can mint a fresh access token later.</summary>
+    public GraphCredential? GraphCredential { get; }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        Client.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Sources/Mailozaurr.Application/GraphSessionFactory.cs
+++ b/Sources/Mailozaurr.Application/GraphSessionFactory.cs
@@ -1,0 +1,266 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Builds Graph API sessions from reusable profile and secret stores.
+/// </summary>
+public sealed class GraphSessionFactory : IGraphSessionFactory {
+    private readonly IMailSecretStore _secretStore;
+    private readonly Func<MailProfile, GraphCredential, CancellationToken, Task<OAuthCredential>> _acquireCredentialAsync;
+    private readonly Func<MailProfile, CancellationToken, Task<OAuthCredential?>> _acquireSilentCredentialAsync;
+    private readonly Func<GraphSessionRequest, CancellationToken, Task<GraphSession>> _connectAsync;
+
+    /// <summary>
+    /// Creates a new Graph session factory.
+    /// </summary>
+    public GraphSessionFactory(
+        IMailSecretStore secretStore,
+        Func<MailProfile, GraphCredential, CancellationToken, Task<OAuthCredential>>? acquireCredentialAsync = null,
+        Func<MailProfile, CancellationToken, Task<OAuthCredential?>>? acquireSilentCredentialAsync = null,
+        Func<GraphSessionRequest, CancellationToken, Task<GraphSession>>? connectAsync = null) {
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+        _acquireCredentialAsync = acquireCredentialAsync ?? DefaultAcquireCredentialAsync;
+        _acquireSilentCredentialAsync = acquireSilentCredentialAsync ?? DefaultAcquireSilentCredentialAsync;
+        _connectAsync = connectAsync ?? DefaultConnectAsync;
+    }
+
+    /// <inheritdoc />
+    public async Task<GraphSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+        if (profile == null) {
+            throw new ArgumentNullException(nameof(profile));
+        }
+
+        var userId = ResolveUserId(profile);
+        var credential = await ResolveCredentialAsync(profile, userId, cancellationToken).ConfigureAwait(false);
+        var graphCredential = await TryBuildGraphCredentialAsync(profile, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(credential.UserName)) {
+            credential.UserName = userId;
+        }
+        if (credential.ExpiresOn == default) {
+            credential.ExpiresOn = DateTimeOffset.MaxValue;
+        }
+
+        return await _connectAsync(new GraphSessionRequest {
+            UserId = userId,
+            Credential = credential,
+            GraphCredential = graphCredential
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<OAuthCredential> ResolveCredentialAsync(MailProfile profile, string userId, CancellationToken cancellationToken) {
+        var accessToken = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.AccessToken, cancellationToken).ConfigureAwait(false);
+        var tokenExpiresOn = TryResolveTokenExpiration(profile);
+        if (!string.IsNullOrWhiteSpace(accessToken)) {
+            if (!ShouldRefreshToken(tokenExpiresOn)) {
+                return new OAuthCredential {
+                    UserName = userId,
+                    AccessToken = accessToken!.Trim(),
+                    RefreshToken = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.RefreshToken, cancellationToken).ConfigureAwait(false),
+                    ClientId = profile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientId) ? clientId : null,
+                    ClientSecret = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false),
+                    ExpiresOn = tokenExpiresOn ?? DateTimeOffset.MaxValue
+                };
+            }
+        }
+
+        if (CanUseInteractiveSilentRefresh(profile)) {
+            var refreshedCredential = await _acquireSilentCredentialAsync(profile, cancellationToken).ConfigureAwait(false);
+            if (refreshedCredential != null && !string.IsNullOrWhiteSpace(refreshedCredential.AccessToken)) {
+                refreshedCredential.UserName = string.IsNullOrWhiteSpace(refreshedCredential.UserName) ? userId : refreshedCredential.UserName;
+                if (refreshedCredential.ExpiresOn == default) {
+                    refreshedCredential.ExpiresOn = DateTimeOffset.MaxValue;
+                }
+                return refreshedCredential;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(accessToken)) {
+            return new OAuthCredential {
+                UserName = userId,
+                AccessToken = accessToken!.Trim(),
+                RefreshToken = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.RefreshToken, cancellationToken).ConfigureAwait(false),
+                ClientId = profile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientId) ? clientId : null,
+                ClientSecret = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false),
+                ExpiresOn = tokenExpiresOn ?? DateTimeOffset.MaxValue
+            };
+        }
+
+        var graphCredential = await BuildGraphCredentialAsync(profile, cancellationToken).ConfigureAwait(false);
+        var credential = await _acquireCredentialAsync(profile, graphCredential, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(credential.AccessToken)) {
+            throw new InvalidOperationException($"Graph profile '{profile.Id}' did not produce an access token.");
+        }
+
+        return credential;
+    }
+
+    private async Task<GraphCredential> BuildGraphCredentialAsync(MailProfile profile, CancellationToken cancellationToken) {
+        var clientId = GetRequiredSetting(profile, MailProfileSettingsKeys.ClientId);
+        var tenantId = GetRequiredSetting(profile, MailProfileSettingsKeys.TenantId);
+        var clientSecret = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false);
+        var certificatePassword = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.CertificatePassword, cancellationToken).ConfigureAwait(false);
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.CertificatePath, out var certificatePath);
+
+        if (string.IsNullOrWhiteSpace(clientSecret) && string.IsNullOrWhiteSpace(certificatePath)) {
+            throw new InvalidOperationException(
+                $"Graph profile '{profile.Id}' requires either secret '{MailSecretNames.AccessToken}', secret '{MailSecretNames.ClientSecret}', or setting '{MailProfileSettingsKeys.CertificatePath}'.");
+        }
+
+        return new GraphCredential {
+            ClientId = clientId,
+            DirectoryId = tenantId,
+            ClientSecret = string.IsNullOrWhiteSpace(clientSecret) ? null : clientSecret!.Trim(),
+            CertificatePath = string.IsNullOrWhiteSpace(certificatePath) ? null : certificatePath!.Trim(),
+            CertificatePassword = string.IsNullOrWhiteSpace(certificatePassword) ? null : certificatePassword!.Trim()
+        };
+    }
+
+    private async Task<GraphCredential?> TryBuildGraphCredentialAsync(MailProfile profile, CancellationToken cancellationToken) {
+        if (!profile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientId) ||
+            string.IsNullOrWhiteSpace(clientId) ||
+            !profile.Settings.TryGetValue(MailProfileSettingsKeys.TenantId, out var tenantId) ||
+            string.IsNullOrWhiteSpace(tenantId)) {
+            return null;
+        }
+
+        var clientSecret = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false);
+        var certificatePassword = await _secretStore.GetSecretAsync(profile.Id, MailSecretNames.CertificatePassword, cancellationToken).ConfigureAwait(false);
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.CertificatePath, out var certificatePath);
+
+        if (string.IsNullOrWhiteSpace(clientSecret) && string.IsNullOrWhiteSpace(certificatePath)) {
+            return null;
+        }
+
+        return new GraphCredential {
+            ClientId = clientId.Trim(),
+            DirectoryId = tenantId.Trim(),
+            ClientSecret = string.IsNullOrWhiteSpace(clientSecret) ? null : clientSecret!.Trim(),
+            CertificatePath = string.IsNullOrWhiteSpace(certificatePath) ? null : certificatePath!.Trim(),
+            CertificatePassword = string.IsNullOrWhiteSpace(certificatePassword) ? null : certificatePassword!.Trim()
+        };
+    }
+
+    private static async Task<OAuthCredential> DefaultAcquireCredentialAsync(
+        MailProfile profile,
+        GraphCredential graphCredential,
+        CancellationToken cancellationToken) {
+        var authorization = await MicrosoftGraphUtils.ConnectO365GraphAsync(
+            graphCredential,
+            graphCredential.DirectoryId,
+            "https://graph.microsoft.com",
+            cancellationToken).ConfigureAwait(false);
+        var accessToken = NormalizeAccessToken(authorization);
+        return new OAuthCredential {
+            UserName = ResolveUserId(profile),
+            AccessToken = accessToken,
+            ClientId = graphCredential.ClientId,
+            ClientSecret = graphCredential.ClientSecret,
+            ExpiresOn = DateTimeOffset.MaxValue
+        };
+    }
+
+    private static Task<OAuthCredential?> DefaultAcquireSilentCredentialAsync(MailProfile profile, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!profile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientId) ||
+            string.IsNullOrWhiteSpace(clientId) ||
+            !profile.Settings.TryGetValue(MailProfileSettingsKeys.TenantId, out var tenantId) ||
+            string.IsNullOrWhiteSpace(tenantId)) {
+            return Task.FromResult<OAuthCredential?>(null);
+        }
+
+        var redirectUri = profile.Settings.TryGetValue(MailProfileSettingsKeys.RedirectUri, out var storedRedirectUri) &&
+                          !string.IsNullOrWhiteSpace(storedRedirectUri)
+            ? storedRedirectUri.Trim()
+            : MailProfileAuthDefaults.GraphRedirectUri;
+        var login = ResolveLoginHint(profile);
+        return OAuthHelpers.TryAcquireO365TokenSilentAsync(
+            login,
+            clientId.Trim(),
+            tenantId.Trim(),
+            redirectUri,
+            MailProfileAuthDefaults.GraphScopes);
+    }
+
+    private static Task<GraphSession> DefaultConnectAsync(GraphSessionRequest request, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(new GraphSession(
+            new GraphApiClient(request.Credential),
+            request.UserId,
+            request.Credential,
+            request.GraphCredential));
+    }
+
+    private static string ResolveUserId(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) &&
+            !string.IsNullOrWhiteSpace(mailbox)) {
+            return mailbox.Trim();
+        }
+        if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
+            return profile.DefaultMailbox!.Trim();
+        }
+
+        return "me";
+    }
+
+    private static string? ResolveLoginHint(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.LoginHint, out var loginHint) &&
+            !string.IsNullOrWhiteSpace(loginHint)) {
+            return loginHint.Trim();
+        }
+
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) &&
+            !string.IsNullOrWhiteSpace(mailbox)) {
+            return mailbox.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
+            return profile.DefaultMailbox!.Trim();
+        }
+
+        return null;
+    }
+
+    private static DateTimeOffset? TryResolveTokenExpiration(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.TokenExpiresOn, out var expiresOnValue) &&
+            !string.IsNullOrWhiteSpace(expiresOnValue) &&
+            DateTimeOffset.TryParse(expiresOnValue, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var expiresOn)) {
+            return expiresOn;
+        }
+
+        return null;
+    }
+
+    private static bool ShouldRefreshToken(DateTimeOffset? expiresOn) =>
+        expiresOn.HasValue && expiresOn.Value <= DateTimeOffset.UtcNow.Add(MailProfileAuthDefaults.TokenRefreshWindow);
+
+    private static bool CanUseInteractiveSilentRefresh(MailProfile profile) {
+        if (!profile.Settings.TryGetValue(MailProfileSettingsKeys.AuthFlow, out var authFlow) ||
+            !string.Equals(authFlow, MailProfileAuthFlowNames.Interactive, StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        return profile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientId) &&
+               !string.IsNullOrWhiteSpace(clientId) &&
+               profile.Settings.TryGetValue(MailProfileSettingsKeys.TenantId, out var tenantId) &&
+               !string.IsNullOrWhiteSpace(tenantId);
+    }
+
+    private static string GetRequiredSetting(MailProfile profile, string key) {
+        if (profile.Settings.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            return value.Trim();
+        }
+
+        throw new InvalidOperationException($"Graph profile '{profile.Id}' is missing required setting '{key}'.");
+    }
+
+    private static string NormalizeAccessToken(string authorizationHeaderValue) {
+        if (string.IsNullOrWhiteSpace(authorizationHeaderValue)) {
+            throw new InvalidOperationException("Graph authorization did not return a token.");
+        }
+
+        var trimmed = authorizationHeaderValue.Trim();
+        const string bearerPrefix = "Bearer ";
+        return trimmed.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase)
+            ? trimmed.Substring(bearerPrefix.Length).Trim()
+            : trimmed;
+    }
+}

--- a/Sources/Mailozaurr.Application/GraphSessionRequest.cs
+++ b/Sources/Mailozaurr.Application/GraphSessionRequest.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents the resolved session input required to connect to Microsoft Graph.
+/// </summary>
+public sealed class GraphSessionRequest {
+    /// <summary>Resolved Graph mailbox user id.</summary>
+    public string UserId { get; set; } = "me";
+
+    /// <summary>OAuth credential used to authenticate Graph requests.</summary>
+    public OAuthCredential Credential { get; set; } = new();
+
+    /// <summary>Optional Graph credential metadata used to mint new access tokens.</summary>
+    public GraphCredential? GraphCredential { get; set; }
+}

--- a/Sources/Mailozaurr.Application/IDraftMimeMessageFactory.cs
+++ b/Sources/Mailozaurr.Application/IDraftMimeMessageFactory.cs
@@ -1,0 +1,13 @@
+using MimeKit;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Builds reusable MIME messages from normalized draft contracts.
+/// </summary>
+public interface IDraftMimeMessageFactory {
+    /// <summary>
+    /// Creates a MIME message for the provided profile and draft.
+    /// </summary>
+    Task<MimeMessage> CreateAsync(MailProfile profile, DraftMessage draft, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IGmailSessionFactory.cs
+++ b/Sources/Mailozaurr.Application/IGmailSessionFactory.cs
@@ -1,0 +1,9 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Creates authenticated Gmail API sessions from reusable profile definitions.
+/// </summary>
+public interface IGmailSessionFactory {
+    /// <summary>Creates an authenticated Gmail session.</summary>
+    Task<GmailSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IGraphSessionFactory.cs
+++ b/Sources/Mailozaurr.Application/IGraphSessionFactory.cs
@@ -1,0 +1,9 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Creates authenticated Graph API sessions from reusable profile definitions.
+/// </summary>
+public interface IGraphSessionFactory {
+    /// <summary>Creates an authenticated Graph session.</summary>
+    Task<GraphSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IImapSessionFactory.cs
+++ b/Sources/Mailozaurr.Application/IImapSessionFactory.cs
@@ -1,0 +1,13 @@
+using MailKit.Net.Imap;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Creates authenticated IMAP sessions from stored profiles.
+/// </summary>
+public interface IImapSessionFactory {
+    /// <summary>
+    /// Connects an authenticated IMAP client for the provided profile.
+    /// </summary>
+    Task<ImapClient> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailDraftExchangeService.cs
+++ b/Sources/Mailozaurr.Application/IMailDraftExchangeService.cs
@@ -1,0 +1,12 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Imports and exports reusable drafts to stable external files.
+/// </summary>
+public interface IMailDraftExchangeService {
+    /// <summary>Loads a draft from an external file.</summary>
+    Task<MailDraft> LoadAsync(string path, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves a draft to an external file.</summary>
+    Task SaveAsync(string path, MailDraft draft, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailDraftService.cs
+++ b/Sources/Mailozaurr.Application/IMailDraftService.cs
@@ -1,0 +1,24 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Provides reusable draft lifecycle operations.
+/// </summary>
+public interface IMailDraftService {
+    /// <summary>Lists all saved drafts.</summary>
+    Task<IReadOnlyList<MailDraft>> GetDraftsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Lists all saved drafts using a lightweight projection.</summary>
+    Task<IReadOnlyList<MailDraftCompact>> GetDraftsCompactAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Gets a draft by id.</summary>
+    Task<MailDraft?> GetDraftAsync(string draftId, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets a draft by id using a lightweight projection.</summary>
+    Task<MailDraftCompact?> GetDraftCompactAsync(string draftId, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves or updates a draft.</summary>
+    Task<OperationResult> SaveAsync(MailDraft draft, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes a draft by id.</summary>
+    Task<OperationResult> DeleteAsync(string draftId, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailDraftStore.cs
+++ b/Sources/Mailozaurr.Application/IMailDraftStore.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Persists reusable outbound drafts.
+/// </summary>
+public interface IMailDraftStore {
+    /// <summary>Lists all saved drafts.</summary>
+    Task<IReadOnlyList<MailDraft>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Gets a saved draft by id.</summary>
+    Task<MailDraft?> GetByIdAsync(string draftId, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves or updates a draft.</summary>
+    Task SaveAsync(MailDraft draft, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a saved draft by id.</summary>
+    Task<bool> RemoveAsync(string draftId, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailProfileAuthService.cs
+++ b/Sources/Mailozaurr.Application/IMailProfileAuthService.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Performs reusable profile authentication flows and persists resulting credentials.
+/// </summary>
+public interface IMailProfileAuthService {
+    /// <summary>Returns the current persisted authentication status for a saved profile.</summary>
+    Task<MailProfileAuthStatus?> GetStatusAsync(string profileId, CancellationToken cancellationToken = default);
+
+    /// <summary>Authenticates a saved Gmail profile and persists the resulting tokens.</summary>
+    Task<MailProfileAuthenticationResult> LoginGmailAsync(GmailProfileLoginRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Authenticates a saved Microsoft Graph profile and persists the resulting access token.</summary>
+    Task<MailProfileAuthenticationResult> LoginGraphAsync(GraphProfileLoginRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Refreshes or reauthenticates a saved profile using its persisted metadata.</summary>
+    Task<MailProfileAuthenticationResult> RefreshAsync(string profileId, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailProfileBootstrapService.cs
+++ b/Sources/Mailozaurr.Application/IMailProfileBootstrapService.cs
@@ -1,0 +1,12 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Creates or updates reusable provider profiles using higher-level bootstrap requests.
+/// </summary>
+public interface IMailProfileBootstrapService {
+    /// <summary>Creates or updates a Microsoft Graph profile and any associated secrets.</summary>
+    Task<OperationResult> SaveGraphProfileAsync(GraphProfileBootstrapRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Creates or updates a Gmail profile and any associated secrets.</summary>
+    Task<OperationResult> SaveGmailProfileAsync(GmailProfileBootstrapRequest request, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailProfileConnectionService.cs
+++ b/Sources/Mailozaurr.Application/IMailProfileConnectionService.cs
@@ -1,0 +1,12 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Tests whether saved profiles can establish a live provider connection.
+/// </summary>
+public interface IMailProfileConnectionService {
+    /// <summary>Runs a connection test for a saved profile.</summary>
+    Task<MailProfileConnectionTestResult> TestAsync(
+        string profileId,
+        MailProfileConnectionTestScope scope = MailProfileConnectionTestScope.Auto,
+        CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailProfileOverviewService.cs
+++ b/Sources/Mailozaurr.Application/IMailProfileOverviewService.cs
@@ -1,0 +1,22 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Produces reusable high-level summaries for saved profiles.
+/// </summary>
+public interface IMailProfileOverviewService {
+    /// <summary>Builds summary views for all saved profiles.</summary>
+    Task<IReadOnlyList<MailProfileOverview>> GetOverviewsAsync(
+        MailProfileOverviewQuery? query = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Builds lightweight summary views for all saved profiles.</summary>
+    Task<IReadOnlyList<MailProfileOverviewCompact>> GetCompactOverviewsAsync(
+        MailProfileOverviewQuery? query = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Builds a summary view for a saved profile.</summary>
+    Task<MailProfileOverview?> GetOverviewAsync(string profileId, CancellationToken cancellationToken = default);
+
+    /// <summary>Builds a lightweight summary view for a saved profile.</summary>
+    Task<MailProfileOverviewCompact?> GetCompactOverviewAsync(string profileId, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailProfileSecretService.cs
+++ b/Sources/Mailozaurr.Application/IMailProfileSecretService.cs
@@ -1,0 +1,12 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Manages secrets associated with saved mail profiles.
+/// </summary>
+public interface IMailProfileSecretService {
+    /// <summary>Saves or replaces a secret for an existing profile.</summary>
+    Task<OperationResult> SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a secret from an existing profile.</summary>
+    Task<OperationResult> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailProfileService.cs
+++ b/Sources/Mailozaurr.Application/IMailProfileService.cs
@@ -1,0 +1,30 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Manages profile lifecycle operations for application adapters.
+/// </summary>
+public interface IMailProfileService {
+    /// <summary>Returns all profiles.</summary>
+    Task<IReadOnlyList<MailProfile>> GetProfilesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Returns a profile by identifier.</summary>
+    Task<MailProfile?> GetProfileAsync(string profileId, CancellationToken cancellationToken = default);
+
+    /// <summary>Validates a profile definition.</summary>
+    Task<MailProfileValidationResult> ValidateAsync(MailProfile profile, CancellationToken cancellationToken = default);
+
+    /// <summary>Inspects a saved profile and reports configuration or authentication gaps.</summary>
+    Task<MailProfileValidationResult> DiagnoseAsync(string profileId, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves or updates a profile.</summary>
+    Task<OperationResult> SaveAsync(MailProfile profile, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes a profile.</summary>
+    Task<OperationResult> DeleteAsync(string profileId, CancellationToken cancellationToken = default);
+
+    /// <summary>Marks a profile as the default profile.</summary>
+    Task<OperationResult> SetDefaultAsync(string profileId, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the effective capabilities for a profile.</summary>
+    Task<ProfileCapabilities?> GetCapabilitiesAsync(string profileId, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailProfileStore.cs
+++ b/Sources/Mailozaurr.Application/IMailProfileStore.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Persists reusable mail profiles.
+/// </summary>
+public interface IMailProfileStore {
+    /// <summary>Returns all known profiles.</summary>
+    Task<IReadOnlyList<MailProfile>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Returns a profile by identifier.</summary>
+    Task<MailProfile?> GetByIdAsync(string profileId, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves or updates a profile.</summary>
+    Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a profile by identifier.</summary>
+    Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailQueueService.cs
+++ b/Sources/Mailozaurr.Application/IMailQueueService.cs
@@ -1,0 +1,36 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Provides reusable access to queued outbound messages.
+/// </summary>
+public interface IMailQueueService {
+    /// <summary>
+    /// Lists queued messages.
+    /// </summary>
+    Task<IReadOnlyList<QueuedMessageSummary>> ListAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists queued messages using a lightweight projection.
+    /// </summary>
+    Task<IReadOnlyList<QueuedMessageCompact>> ListCompactAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a queued message by its message identifier.
+    /// </summary>
+    Task<QueuedMessageSummary?> GetAsync(string messageId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a queued message by its message identifier using a lightweight projection.
+    /// </summary>
+    Task<QueuedMessageCompact?> GetCompactAsync(string messageId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a queued message.
+    /// </summary>
+    Task<OperationResult> RemoveAsync(string messageId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Processes all due queued messages.
+    /// </summary>
+    Task<QueueProcessResult> ProcessAsync(CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailReadHandler.cs
+++ b/Sources/Mailozaurr.Application/IMailReadHandler.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Handles normalized read operations for a specific profile kind.
+/// </summary>
+public interface IMailReadHandler {
+    /// <summary>Profile kind handled by this instance.</summary>
+    MailProfileKind Kind { get; }
+
+    /// <summary>Lists folders.</summary>
+    Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailProfile profile, MailFolderQuery query, CancellationToken cancellationToken = default);
+
+    /// <summary>Searches messages.</summary>
+    Task<IReadOnlyList<MessageSummary>> SearchAsync(MailProfile profile, MailSearchRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets a detailed message view.</summary>
+    Task<MessageDetail?> GetMessageAsync(MailProfile profile, GetMessageRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves an attachment.</summary>
+    Task<OperationResult> SaveAttachmentAsync(MailProfile profile, SaveAttachmentRequest request, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailReadService.cs
+++ b/Sources/Mailozaurr.Application/IMailReadService.cs
@@ -1,0 +1,33 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Provides normalized read-oriented mailbox operations.
+/// </summary>
+public interface IMailReadService {
+    /// <summary>Lists folders or folder-like containers.</summary>
+    Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailFolderQuery query, CancellationToken cancellationToken = default);
+
+    /// <summary>Lists folders or folder-like containers using a lightweight projection.</summary>
+    Task<IReadOnlyList<FolderRefCompact>> GetFoldersCompactAsync(MailFolderQuery query, CancellationToken cancellationToken = default);
+
+    /// <summary>Searches for messages.</summary>
+    Task<IReadOnlyList<MessageSummary>> SearchAsync(MailSearchRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Searches for messages using a lightweight projection.</summary>
+    Task<IReadOnlyList<MessageSummaryCompact>> SearchCompactAsync(MailSearchRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Lists attachments associated with a specific message.</summary>
+    Task<IReadOnlyList<AttachmentSummary>> GetAttachmentsAsync(ListAttachmentsRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves a detailed message view.</summary>
+    Task<MessageDetail?> GetMessageAsync(GetMessageRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves a lightweight detailed message view.</summary>
+    Task<MessageDetailCompact?> GetMessageCompactAsync(GetMessageRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves one or more attachments associated with a specific message.</summary>
+    Task<SaveAttachmentsResult> SaveAttachmentsAsync(SaveAttachmentsRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves an attachment to the requested destination.</summary>
+    Task<OperationResult> SaveAttachmentAsync(SaveAttachmentRequest request, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailSecretStore.cs
+++ b/Sources/Mailozaurr.Application/IMailSecretStore.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Stores secrets associated with mail profiles.
+/// </summary>
+public interface IMailSecretStore {
+    /// <summary>Retrieves a secret value by profile id and secret name.</summary>
+    Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default);
+
+    /// <summary>Stores or replaces a secret value.</summary>
+    Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a secret value.</summary>
+    Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/IMailSendHandler.cs
@@ -1,0 +1,12 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Handles normalized send operations for a specific profile kind.
+/// </summary>
+public interface IMailSendHandler {
+    /// <summary>Profile kind handled by this instance.</summary>
+    MailProfileKind Kind { get; }
+
+    /// <summary>Sends or queues the message for the provided profile.</summary>
+    Task<SendResult> SendAsync(MailProfile profile, SendMessageRequest request, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailSendService.cs
+++ b/Sources/Mailozaurr.Application/IMailSendService.cs
@@ -1,0 +1,9 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Provides normalized send-oriented mailbox operations.
+/// </summary>
+public interface IMailSendService {
+    /// <summary>Sends or queues a message based on the request.</summary>
+    Task<SendResult> SendAsync(SendMessageRequest request, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/ISmtpSessionFactory.cs
+++ b/Sources/Mailozaurr.Application/ISmtpSessionFactory.cs
@@ -1,0 +1,11 @@
+using Mailozaurr;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Creates authenticated SMTP sessions from reusable profile definitions.
+/// </summary>
+public interface ISmtpSessionFactory {
+    /// <summary>Creates an authenticated SMTP session.</summary>
+    Task<Smtp> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/ImapMailReadHandler.cs
+++ b/Sources/Mailozaurr.Application/ImapMailReadHandler.cs
@@ -1,0 +1,280 @@
+using MailKit;
+using MailKit.Net.Imap;
+using MimeKit;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Normalized IMAP read handler backed by Mailozaurr IMAP helpers.
+/// </summary>
+public sealed class ImapMailReadHandler : IMailReadHandler {
+    private readonly IImapSessionFactory _sessionFactory;
+    private readonly Func<ImapClient, MailFolderQuery, CancellationToken, Task<IReadOnlyList<FolderRef>>> _getFoldersAsync;
+    private readonly Func<ImapClient, MailProfile, MailSearchRequest, CancellationToken, Task<IReadOnlyList<MessageSummary>>> _searchAsync;
+    private readonly Func<ImapClient, MailProfile, GetMessageRequest, CancellationToken, Task<MessageDetail?>> _getMessageAsync;
+    private readonly Func<ImapClient, MailProfile, SaveAttachmentRequest, CancellationToken, Task<OperationResult>> _saveAttachmentAsync;
+
+    /// <summary>
+    /// Creates a new IMAP read handler.
+    /// </summary>
+    public ImapMailReadHandler(
+        IImapSessionFactory sessionFactory,
+        Func<ImapClient, MailFolderQuery, CancellationToken, Task<IReadOnlyList<FolderRef>>>? getFoldersAsync = null,
+        Func<ImapClient, MailProfile, MailSearchRequest, CancellationToken, Task<IReadOnlyList<MessageSummary>>>? searchAsync = null,
+        Func<ImapClient, MailProfile, GetMessageRequest, CancellationToken, Task<MessageDetail?>>? getMessageAsync = null,
+        Func<ImapClient, MailProfile, SaveAttachmentRequest, CancellationToken, Task<OperationResult>>? saveAttachmentAsync = null) {
+        _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
+        _getFoldersAsync = getFoldersAsync ?? DefaultGetFoldersAsync;
+        _searchAsync = searchAsync ?? DefaultSearchAsync;
+        _getMessageAsync = getMessageAsync ?? DefaultGetMessageAsync;
+        _saveAttachmentAsync = saveAttachmentAsync ?? DefaultSaveAttachmentAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Imap;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailProfile profile, MailFolderQuery query, CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _getFoldersAsync(client, query, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MessageSummary>> SearchAsync(MailProfile profile, MailSearchRequest request, CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _searchAsync(client, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageDetail?> GetMessageAsync(MailProfile profile, GetMessageRequest request, CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _getMessageAsync(client, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SaveAttachmentAsync(MailProfile profile, SaveAttachmentRequest request, CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _saveAttachmentAsync(client, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<IReadOnlyList<FolderRef>> DefaultGetFoldersAsync(
+        ImapClient client,
+        MailFolderQuery query,
+        CancellationToken cancellationToken) {
+        var results = new List<FolderRef>();
+        if (query.RootOnly) {
+            await foreach (var folder in ImapRootFolderEnumerator.EnumerateAsync(client, cancellationToken).ConfigureAwait(false)) {
+                results.Add(MapFolder(folder, query.ProfileId));
+            }
+            return results;
+        }
+
+        var root = client.PersonalNamespaces.Count > 0
+            ? client.GetFolder(client.PersonalNamespaces[0])
+            : client.GetFolder(string.Empty);
+        await CollectFoldersAsync(root, results, query.ProfileId, query.ParentFolderId, cancellationToken).ConfigureAwait(false);
+        return results;
+    }
+
+    private static async Task CollectFoldersAsync(
+        IMailFolder root,
+        List<FolderRef> results,
+        string profileId,
+        string? parentFolderId,
+        CancellationToken cancellationToken) {
+        var folders = await root.GetSubfoldersAsync(false, cancellationToken).ConfigureAwait(false);
+        foreach (var folder in folders) {
+            if (!string.IsNullOrWhiteSpace(parentFolderId) &&
+                !string.Equals(folder.ParentFolder?.FullName, parentFolderId, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(folder.FullName, parentFolderId, StringComparison.OrdinalIgnoreCase)) {
+                if (folder.Attributes.HasFlag(FolderAttributes.HasChildren)) {
+                    await CollectFoldersAsync(folder, results, profileId, parentFolderId, cancellationToken).ConfigureAwait(false);
+                }
+                continue;
+            }
+
+            results.Add(MapFolder(folder, profileId));
+            if (folder.Attributes.HasFlag(FolderAttributes.HasChildren)) {
+                await CollectFoldersAsync(folder, results, profileId, null, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static FolderRef MapFolder(IMailFolder folder, string profileId) => new() {
+        ProfileId = profileId,
+        Id = folder.FullName,
+        DisplayName = folder.Name,
+        Path = folder.FullName,
+        MailboxId = null,
+        SpecialUse = folder.Attributes.HasFlag(FolderAttributes.Inbox) ? "Inbox" : null,
+        MessageCount = folder.IsOpen ? folder.Count : (int?)null,
+        UnreadCount = folder.IsOpen ? folder.Unread : (int?)null
+    };
+
+    private static async Task<IReadOnlyList<MessageSummary>> DefaultSearchAsync(
+        ImapClient client,
+        MailProfile profile,
+        MailSearchRequest request,
+        CancellationToken cancellationToken) {
+        var messages = await MailboxSearcher.SearchImapAsync(
+            client,
+            folder: ResolveFolder(request.FolderId, profile),
+            subject: request.SubjectContains,
+            fromContains: request.FromContains,
+            toContains: request.ToContains,
+            hasAttachment: request.HasAttachments,
+            since: request.Since?.UtcDateTime,
+            before: request.Before?.UtcDateTime,
+            maxResults: request.Limit ?? 0,
+            cancellationToken: cancellationToken,
+            queryString: request.QueryText).ConfigureAwait(false);
+
+        return messages.Select(message => MapSummary(profile.Id, ResolveFolder(request.FolderId, profile), message)).ToArray();
+    }
+
+    private static async Task<MessageDetail?> DefaultGetMessageAsync(
+        ImapClient client,
+        MailProfile profile,
+        GetMessageRequest request,
+        CancellationToken cancellationToken) {
+        var folder = ResolveFolder(request.FolderId, profile);
+        var uid = ParseUid(request.MessageId);
+        var maxBodyBytes = GetMaxBodyBytes(profile);
+        var result = await ImapMessageReader.ReadAsync(
+            client,
+            new ImapMessageReadRequest(uid, folder, maxBodyBytes),
+            cancellationToken).ConfigureAwait(false);
+
+        var summary = new MessageSummary {
+            ProfileId = profile.Id,
+            Id = result.Uid.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            FolderId = result.Folder,
+            Subject = result.Subject,
+            From = SplitAddresses(result.From),
+            To = SplitAddresses(result.To),
+            ReceivedAt = result.DateUtc,
+            HasAttachments = result.HasAttachments
+        };
+
+        var detail = new MessageDetail {
+            ProfileId = profile.Id,
+            Id = summary.Id,
+            Summary = summary,
+            TextBody = result.TextBody,
+            HtmlBody = result.HtmlBody,
+            Attachments = result.Attachments.Select((attachment, index) => new AttachmentSummary {
+                MessageId = summary.Id,
+                Id = index.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                FileName = attachment.FileName,
+                ContentType = attachment.ContentType
+            }).ToList()
+        };
+
+        if (request.IncludeRawContent) {
+            var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
+            var message = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
+            using var stream = new MemoryStream();
+            message.WriteTo(stream);
+            stream.Position = 0;
+            using var reader = new StreamReader(stream);
+            detail.RawContent = reader.ReadToEnd();
+        }
+
+        return detail;
+    }
+
+    private static async Task<OperationResult> DefaultSaveAttachmentAsync(
+        ImapClient client,
+        MailProfile profile,
+        SaveAttachmentRequest request,
+        CancellationToken cancellationToken) {
+        var folder = ResolveFolder(request.FolderId, profile);
+        var uid = ParseUid(request.MessageId);
+        var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
+        var message = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
+        var attachments = message.Attachments.ToList();
+        if (attachments.Count == 0) {
+            return OperationResult.Failure("attachment_not_found", "Message has no attachments.");
+        }
+
+        var attachment = ResolveAttachment(attachments, request.AttachmentId);
+        if (attachment == null) {
+            return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
+        }
+
+        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(request.DestinationPath, attachment);
+        if (File.Exists(destinationPath) && !request.Overwrite) {
+            return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
+        }
+
+        MimeAttachmentStorage.SaveAttachment(attachment, destinationPath);
+        return OperationResult.Success($"Attachment saved to '{destinationPath}'.");
+    }
+
+    private static MessageSummary MapSummary(string profileId, string folder, ImapEmailMessage message) => new() {
+        ProfileId = profileId,
+        Id = message.Uid.Id.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        FolderId = folder,
+        Subject = message.Message.Subject,
+        Preview = message.Message.TextBody,
+        From = message.Message.From.Mailboxes.Select(mailbox => new MessageRecipient {
+            Name = mailbox.Name,
+            Address = mailbox.Address ?? string.Empty
+        }).ToList(),
+        To = message.Message.To.Mailboxes.Select(mailbox => new MessageRecipient {
+            Name = mailbox.Name,
+            Address = mailbox.Address ?? string.Empty
+        }).ToList(),
+        SentAt = message.Message.Date,
+        ReceivedAt = message.Message.Date,
+        HasAttachments = message.Message.Attachments.Any(),
+        Priority = message.Message.Priority switch {
+            MimeKit.MessagePriority.Urgent => MessagePriority.High,
+            MimeKit.MessagePriority.NonUrgent => MessagePriority.Low,
+            _ => MessagePriority.Normal
+        }
+    };
+
+    private static UniqueId ParseUid(string value) {
+        if (uint.TryParse(value, out var uid)) {
+            return new UniqueId(uid);
+        }
+
+        throw new InvalidOperationException($"Message id '{value}' is not a valid IMAP UID.");
+    }
+
+    private static string ResolveFolder(string? folderId, MailProfile profile) {
+        if (!string.IsNullOrWhiteSpace(folderId)) {
+            return folderId!.Trim();
+        }
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Folder, out var folder) && !string.IsNullOrWhiteSpace(folder)) {
+            return folder!.Trim();
+        }
+        return "INBOX";
+    }
+
+    private static long GetMaxBodyBytes(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.MaxBodyBytes, out var raw) &&
+            long.TryParse(raw, out var value) &&
+            value > 0) {
+            return value;
+        }
+
+        return 256 * 1024;
+    }
+
+    private static List<MessageRecipient> SplitAddresses(string? addresses) {
+        if (string.IsNullOrWhiteSpace(addresses)) {
+            return new List<MessageRecipient>();
+        }
+
+        var normalized = addresses!;
+        return normalized
+            .Split(new[] { ", " }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(address => new MessageRecipient { Address = address })
+            .ToList();
+    }
+
+    private static MimeEntity? ResolveAttachment(IReadOnlyList<MimeEntity> attachments, string attachmentId) =>
+        MimeAttachmentStorage.ResolveAttachment(attachments, attachmentId);
+}

--- a/Sources/Mailozaurr.Application/ImapSessionFactory.cs
+++ b/Sources/Mailozaurr.Application/ImapSessionFactory.cs
@@ -1,0 +1,154 @@
+using MailKit.Net.Imap;
+using MailKit.Security;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Creates authenticated IMAP sessions using profile settings and stored secrets.
+/// </summary>
+public sealed class ImapSessionFactory : IImapSessionFactory {
+    private readonly IMailSecretStore? _secretStore;
+    private readonly Func<ImapSessionRequest, CancellationToken, Task<ImapClient>> _connectAsync;
+
+    /// <summary>
+    /// Creates a new IMAP session factory.
+    /// </summary>
+    public ImapSessionFactory(
+        IMailSecretStore? secretStore = null,
+        Func<ImapSessionRequest, CancellationToken, Task<ImapClient>>? connectAsync = null) {
+        _secretStore = secretStore;
+        _connectAsync = connectAsync ?? ((request, cancellationToken) => ImapSessionService.ConnectAsync(request, cancellationToken));
+    }
+
+    /// <inheritdoc />
+    public async Task<ImapClient> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+        if (profile == null) {
+            throw new ArgumentNullException(nameof(profile));
+        }
+        if (profile.Kind != MailProfileKind.Imap) {
+            throw new InvalidOperationException($"Profile '{profile.Id}' is not an IMAP profile.");
+        }
+
+        var request = await CreateRequestAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _connectAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<ImapSessionRequest> CreateRequestAsync(MailProfile profile, CancellationToken cancellationToken) {
+        var server = RequireSetting(profile, MailProfileSettingsKeys.Server);
+        var port = GetIntSetting(profile, MailProfileSettingsKeys.Port) ?? 993;
+        var authMode = GetAuthMode(profile);
+        var userName = ResolveUserName(profile);
+        var secret = await ResolveSecretAsync(profile, authMode, cancellationToken).ConfigureAwait(false);
+
+        return new ImapSessionRequest {
+            Connection = new ImapConnectionRequest(
+                server,
+                port,
+                GetSecureSocketOptions(profile),
+                GetIntSetting(profile, MailProfileSettingsKeys.Timeout) ?? 30000,
+                GetBoolSetting(profile, MailProfileSettingsKeys.SkipCertificateRevocation) ?? false,
+                GetBoolSetting(profile, MailProfileSettingsKeys.SkipCertificateValidation) ?? false,
+                GetIntSetting(profile, MailProfileSettingsKeys.RetryCount) ?? 3,
+                GetIntSetting(profile, MailProfileSettingsKeys.RetryDelayMilliseconds) ?? 500,
+                GetDoubleSetting(profile, MailProfileSettingsKeys.RetryDelayBackoff) ?? 2.0),
+            UserName = userName,
+            Secret = secret,
+            AuthMode = authMode
+        };
+    }
+
+    private async Task<string> ResolveSecretAsync(MailProfile profile, ProtocolAuthMode authMode, CancellationToken cancellationToken) {
+        var primarySecretName = authMode == ProtocolAuthMode.OAuth2
+            ? MailSecretNames.AccessToken
+            : MailSecretNames.Password;
+        var fallbackSecretName = authMode == ProtocolAuthMode.OAuth2
+            ? MailSecretNames.Password
+            : null;
+
+        var secret = _secretStore == null
+            ? null
+            : await _secretStore.GetSecretAsync(profile.Id, primarySecretName, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(secret) && fallbackSecretName != null && _secretStore != null) {
+            secret = await _secretStore.GetSecretAsync(profile.Id, fallbackSecretName, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrWhiteSpace(secret)) {
+            throw new InvalidOperationException($"Secret '{primarySecretName}' is required for profile '{profile.Id}'.");
+        }
+
+        return secret!;
+    }
+
+    private static string ResolveUserName(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.UserName, out var userName) && !string.IsNullOrWhiteSpace(userName)) {
+            return userName.Trim();
+        }
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) && !string.IsNullOrWhiteSpace(mailbox)) {
+            return mailbox.Trim();
+        }
+        if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
+            var defaultMailbox = profile.DefaultMailbox;
+            return defaultMailbox!.Trim();
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' requires '{MailProfileSettingsKeys.UserName}' or a mailbox value.");
+    }
+
+    private static string RequireSetting(MailProfile profile, string key) {
+        if (profile.Settings.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            return value.Trim();
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' requires setting '{key}'.");
+    }
+
+    private static ProtocolAuthMode GetAuthMode(MailProfile profile) {
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.AuthMode, out var rawMode);
+        return ProtocolAuth.ParseMode(rawMode, ProtocolAuthMode.Basic);
+    }
+
+    private static SecureSocketOptions GetSecureSocketOptions(MailProfile profile) {
+        if (!profile.Settings.TryGetValue(MailProfileSettingsKeys.SecureSocketOptions, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return SecureSocketOptions.Auto;
+        }
+
+        if (Enum.TryParse<SecureSocketOptions>(raw, ignoreCase: true, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid secure socket option '{raw}'.");
+    }
+
+    private static int? GetIntSetting(MailProfile profile, string key) {
+        if (!profile.Settings.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+        if (int.TryParse(raw, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid integer setting '{key}'.");
+    }
+
+    private static double? GetDoubleSetting(MailProfile profile, string key) {
+        if (!profile.Settings.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+        if (double.TryParse(raw, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid numeric setting '{key}'.");
+    }
+
+    private static bool? GetBoolSetting(MailProfile profile, string key) {
+        if (!profile.Settings.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+        if (bool.TryParse(raw, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid boolean setting '{key}'.");
+    }
+}

--- a/Sources/Mailozaurr.Application/JsonMailDraftExchangeService.cs
+++ b/Sources/Mailozaurr.Application/JsonMailDraftExchangeService.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Imports and exports drafts as JSON documents.
+/// </summary>
+public sealed class JsonMailDraftExchangeService : IMailDraftExchangeService {
+    private static readonly JsonSerializerOptions SerializerOptions = new() {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    /// <inheritdoc />
+    public async Task<MailDraft> LoadAsync(string path, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            throw new ArgumentException("Draft path is required.", nameof(path));
+        }
+
+        var fullPath = Path.GetFullPath(path);
+        using var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var draft = await JsonSerializer.DeserializeAsync<MailDraft>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        if (draft == null) {
+            throw new InvalidDataException($"Draft file '{fullPath}' did not contain a valid draft document.");
+        }
+
+        return draft;
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(string path, MailDraft draft, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            throw new ArgumentException("Draft path is required.", nameof(path));
+        }
+        if (draft == null) {
+            throw new ArgumentNullException(nameof(draft));
+        }
+
+        var fullPath = Path.GetFullPath(path);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrWhiteSpace(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var stream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        await JsonSerializer.SerializeAsync(stream, draft, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/Sources/Mailozaurr.Application/ListAttachmentsRequest.cs
+++ b/Sources/Mailozaurr.Application/ListAttachmentsRequest.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for listing attachments associated with a message.
+/// </summary>
+public sealed class ListAttachmentsRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional folder identifier when the provider requires folder scoping.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifier.</summary>
+    public string MessageId { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MailApplication.cs
+++ b/Sources/Mailozaurr.Application/MailApplication.cs
@@ -1,0 +1,89 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents a composed Mailozaurr application service graph for adapters.
+/// </summary>
+public sealed class MailApplication {
+    internal MailApplication(
+        IMailProfileStore profileStore,
+        IMailSecretStore secretStore,
+        IMailDraftStore draftStore,
+        IMailProfileService profiles,
+        IMailProfileOverviewService profileOverview,
+        IMailProfileConnectionService profileConnections,
+        IMailProfileSecretService profileSecrets,
+        IMailProfileBootstrapService profileBootstrap,
+        IMailProfileAuthService profileAuth,
+        IMailDraftService drafts,
+        IMailDraftExchangeService draftExchange,
+        IMailReadService read,
+        IMailSendService send,
+        IMailQueueService queue,
+        IReadOnlyList<IMailReadHandler> readHandlers,
+        IReadOnlyList<IMailSendHandler> sendHandlers) {
+        ProfileStore = profileStore;
+        SecretStore = secretStore;
+        DraftStore = draftStore;
+        Profiles = profiles;
+        ProfileOverview = profileOverview;
+        ProfileConnections = profileConnections;
+        ProfileSecrets = profileSecrets;
+        ProfileBootstrap = profileBootstrap;
+        ProfileAuth = profileAuth;
+        Drafts = drafts;
+        DraftExchange = draftExchange;
+        Read = read;
+        Send = send;
+        Queue = queue;
+        ReadHandlers = readHandlers;
+        SendHandlers = sendHandlers;
+    }
+
+    /// <summary>Profile persistence service.</summary>
+    public IMailProfileStore ProfileStore { get; }
+
+    /// <summary>Secret persistence service.</summary>
+    public IMailSecretStore SecretStore { get; }
+
+    /// <summary>Draft persistence service.</summary>
+    public IMailDraftStore DraftStore { get; }
+
+    /// <summary>Profile lifecycle service.</summary>
+    public IMailProfileService Profiles { get; }
+
+    /// <summary>Aggregated profile overview service.</summary>
+    public IMailProfileOverviewService ProfileOverview { get; }
+
+    /// <summary>Live profile connection-test service.</summary>
+    public IMailProfileConnectionService ProfileConnections { get; }
+
+    /// <summary>Profile secret lifecycle service.</summary>
+    public IMailProfileSecretService ProfileSecrets { get; }
+
+    /// <summary>Higher-level profile bootstrap workflows.</summary>
+    public IMailProfileBootstrapService ProfileBootstrap { get; }
+
+    /// <summary>Higher-level profile authentication workflows.</summary>
+    public IMailProfileAuthService ProfileAuth { get; }
+
+    /// <summary>Draft lifecycle service.</summary>
+    public IMailDraftService Drafts { get; }
+
+    /// <summary>Draft import/export service.</summary>
+    public IMailDraftExchangeService DraftExchange { get; }
+
+    /// <summary>Normalized read service.</summary>
+    public IMailReadService Read { get; }
+
+    /// <summary>Normalized send service.</summary>
+    public IMailSendService Send { get; }
+
+    /// <summary>Normalized outbound queue service.</summary>
+    public IMailQueueService Queue { get; }
+
+    /// <summary>Registered read handlers.</summary>
+    public IReadOnlyList<IMailReadHandler> ReadHandlers { get; }
+
+    /// <summary>Registered send handlers.</summary>
+    public IReadOnlyList<IMailSendHandler> SendHandlers { get; }
+}

--- a/Sources/Mailozaurr.Application/MailApplicationBuilder.cs
+++ b/Sources/Mailozaurr.Application/MailApplicationBuilder.cs
@@ -1,0 +1,248 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Builds a composed <see cref="MailApplication" /> with reusable default services.
+/// </summary>
+public sealed class MailApplicationBuilder {
+    private readonly List<IMailReadHandler> _readHandlers = new();
+    private readonly List<IMailSendHandler> _sendHandlers = new();
+    private MailApplicationOptions _options = new();
+    private IMailProfileStore? _profileStore;
+    private IMailSecretStore? _secretStore;
+    private IMailDraftStore? _draftStore;
+    private IMailProfileService? _profileService;
+    private IMailProfileOverviewService? _profileOverviewService;
+    private IMailProfileConnectionService? _profileConnectionService;
+    private IMailProfileSecretService? _profileSecretService;
+    private IMailProfileBootstrapService? _profileBootstrapService;
+    private IMailProfileAuthService? _profileAuthService;
+    private IMailDraftService? _draftService;
+    private IMailDraftExchangeService? _draftExchangeService;
+    private IMailReadService? _readService;
+    private IMailSendService? _sendService;
+    private IMailQueueService? _queueService;
+    private IDraftMimeMessageFactory? _draftMimeMessageFactory;
+    private IPendingMessageRepository? _pendingMessageRepository;
+    private IImapSessionFactory? _imapSessionFactory;
+    private IGraphSessionFactory? _graphSessionFactory;
+    private IGmailSessionFactory? _gmailSessionFactory;
+    private ISmtpSessionFactory? _smtpSessionFactory;
+
+    /// <summary>
+    /// Creates a new builder with default options.
+    /// </summary>
+    public MailApplicationBuilder() {
+    }
+
+    /// <summary>
+    /// Creates a new builder with the provided options.
+    /// </summary>
+    public MailApplicationBuilder(MailApplicationOptions options) {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <summary>Replaces the current options.</summary>
+    public MailApplicationBuilder Configure(MailApplicationOptions options) {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        return this;
+    }
+
+    /// <summary>Uses an explicit profile store.</summary>
+    public MailApplicationBuilder UseProfileStore(IMailProfileStore profileStore) {
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        return this;
+    }
+
+    /// <summary>Uses an explicit secret store.</summary>
+    public MailApplicationBuilder UseSecretStore(IMailSecretStore secretStore) {
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+        return this;
+    }
+
+    /// <summary>Uses an explicit draft store.</summary>
+    public MailApplicationBuilder UseDraftStore(IMailDraftStore draftStore) {
+        _draftStore = draftStore ?? throw new ArgumentNullException(nameof(draftStore));
+        return this;
+    }
+
+    /// <summary>Uses an explicit profile service.</summary>
+    public MailApplicationBuilder UseProfileService(IMailProfileService profileService) {
+        _profileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit profile overview service.</summary>
+    public MailApplicationBuilder UseProfileOverviewService(IMailProfileOverviewService profileOverviewService) {
+        _profileOverviewService = profileOverviewService ?? throw new ArgumentNullException(nameof(profileOverviewService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit profile connection-test service.</summary>
+    public MailApplicationBuilder UseProfileConnectionService(IMailProfileConnectionService profileConnectionService) {
+        _profileConnectionService = profileConnectionService ?? throw new ArgumentNullException(nameof(profileConnectionService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit profile secret service.</summary>
+    public MailApplicationBuilder UseProfileSecretService(IMailProfileSecretService profileSecretService) {
+        _profileSecretService = profileSecretService ?? throw new ArgumentNullException(nameof(profileSecretService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit profile bootstrap service.</summary>
+    public MailApplicationBuilder UseProfileBootstrapService(IMailProfileBootstrapService profileBootstrapService) {
+        _profileBootstrapService = profileBootstrapService ?? throw new ArgumentNullException(nameof(profileBootstrapService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit profile authentication service.</summary>
+    public MailApplicationBuilder UseProfileAuthService(IMailProfileAuthService profileAuthService) {
+        _profileAuthService = profileAuthService ?? throw new ArgumentNullException(nameof(profileAuthService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit draft service.</summary>
+    public MailApplicationBuilder UseDraftService(IMailDraftService draftService) {
+        _draftService = draftService ?? throw new ArgumentNullException(nameof(draftService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit draft exchange service.</summary>
+    public MailApplicationBuilder UseDraftExchangeService(IMailDraftExchangeService draftExchangeService) {
+        _draftExchangeService = draftExchangeService ?? throw new ArgumentNullException(nameof(draftExchangeService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit read service.</summary>
+    public MailApplicationBuilder UseReadService(IMailReadService readService) {
+        _readService = readService ?? throw new ArgumentNullException(nameof(readService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit send service.</summary>
+    public MailApplicationBuilder UseSendService(IMailSendService sendService) {
+        _sendService = sendService ?? throw new ArgumentNullException(nameof(sendService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit queue service.</summary>
+    public MailApplicationBuilder UseQueueService(IMailQueueService queueService) {
+        _queueService = queueService ?? throw new ArgumentNullException(nameof(queueService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit draft MIME message factory.</summary>
+    public MailApplicationBuilder UseDraftMimeMessageFactory(IDraftMimeMessageFactory draftMimeMessageFactory) {
+        _draftMimeMessageFactory = draftMimeMessageFactory ?? throw new ArgumentNullException(nameof(draftMimeMessageFactory));
+        return this;
+    }
+
+    /// <summary>Uses an explicit pending-message repository.</summary>
+    public MailApplicationBuilder UsePendingMessageRepository(IPendingMessageRepository pendingMessageRepository) {
+        _pendingMessageRepository = pendingMessageRepository ?? throw new ArgumentNullException(nameof(pendingMessageRepository));
+        return this;
+    }
+
+    /// <summary>Uses an explicit IMAP session factory.</summary>
+    public MailApplicationBuilder UseImapSessionFactory(IImapSessionFactory imapSessionFactory) {
+        _imapSessionFactory = imapSessionFactory ?? throw new ArgumentNullException(nameof(imapSessionFactory));
+        return this;
+    }
+
+    /// <summary>Uses an explicit Graph session factory.</summary>
+    public MailApplicationBuilder UseGraphSessionFactory(IGraphSessionFactory graphSessionFactory) {
+        _graphSessionFactory = graphSessionFactory ?? throw new ArgumentNullException(nameof(graphSessionFactory));
+        return this;
+    }
+
+    /// <summary>Uses an explicit Gmail session factory.</summary>
+    public MailApplicationBuilder UseGmailSessionFactory(IGmailSessionFactory gmailSessionFactory) {
+        _gmailSessionFactory = gmailSessionFactory ?? throw new ArgumentNullException(nameof(gmailSessionFactory));
+        return this;
+    }
+
+    /// <summary>Uses an explicit SMTP session factory.</summary>
+    public MailApplicationBuilder UseSmtpSessionFactory(ISmtpSessionFactory smtpSessionFactory) {
+        _smtpSessionFactory = smtpSessionFactory ?? throw new ArgumentNullException(nameof(smtpSessionFactory));
+        return this;
+    }
+
+    /// <summary>Adds a read handler.</summary>
+    public MailApplicationBuilder AddReadHandler(IMailReadHandler handler) {
+        _readHandlers.Add(handler ?? throw new ArgumentNullException(nameof(handler)));
+        return this;
+    }
+
+    /// <summary>Adds a send handler.</summary>
+    public MailApplicationBuilder AddSendHandler(IMailSendHandler handler) {
+        _sendHandlers.Add(handler ?? throw new ArgumentNullException(nameof(handler)));
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the composed application.
+    /// </summary>
+    public MailApplication Build() {
+        var profileStore = _profileStore ?? new FileMailProfileStore(_options.ProfileStore);
+        var secretStore = _secretStore ?? new FileMailSecretStore(_options.SecretStore);
+        var draftStore = _draftStore ?? new FileMailDraftStore(_options.DraftStore);
+        var profileService = _profileService ?? new MailProfileService(profileStore, secretStore);
+        var imapSessionFactory = _imapSessionFactory ?? new ImapSessionFactory(secretStore);
+        var graphSessionFactory = _graphSessionFactory ?? new GraphSessionFactory(secretStore);
+        var gmailSessionFactory = _gmailSessionFactory ?? new GmailSessionFactory(secretStore);
+        var smtpSessionFactory = _smtpSessionFactory ?? new SmtpSessionFactory(secretStore);
+        var profileSecretService = _profileSecretService ?? new MailProfileSecretService(profileStore, secretStore);
+        var profileBootstrapService = _profileBootstrapService ?? new MailProfileBootstrapService(profileService, profileSecretService, secretStore);
+        var profileAuthService = _profileAuthService ?? new MailProfileAuthService(profileService, profileSecretService, secretStore);
+        var profileOverviewService = _profileOverviewService ?? new MailProfileOverviewService(profileService, profileAuthService);
+        var profileConnectionService = _profileConnectionService ?? new MailProfileConnectionService(profileStore, imapSessionFactory, graphSessionFactory, gmailSessionFactory, smtpSessionFactory);
+        var draftService = _draftService ?? new MailDraftService(draftStore, profileStore);
+        var draftExchangeService = _draftExchangeService ?? new JsonMailDraftExchangeService();
+        var draftMimeMessageFactory = _draftMimeMessageFactory ?? new DraftMimeMessageFactory();
+        var pendingMessageRepository = _pendingMessageRepository ?? new FilePendingMessageRepository(_options.PendingMessageStore);
+
+        var readHandlers = new List<IMailReadHandler>(_readHandlers);
+        if (_options.EnableImapReadHandler && !readHandlers.Any(handler => handler.Kind == MailProfileKind.Imap)) {
+            readHandlers.Add(new ImapMailReadHandler(imapSessionFactory));
+        }
+        if (_options.EnableGraphReadHandler && !readHandlers.Any(handler => handler.Kind == MailProfileKind.Graph)) {
+            readHandlers.Add(new GraphMailReadHandler(graphSessionFactory));
+        }
+        if (_options.EnableGmailReadHandler && !readHandlers.Any(handler => handler.Kind == MailProfileKind.Gmail)) {
+            readHandlers.Add(new GmailMailReadHandler(gmailSessionFactory));
+        }
+
+        var sendHandlers = new List<IMailSendHandler>(_sendHandlers);
+        if (_options.EnableGraphSendHandler && !sendHandlers.Any(handler => handler.Kind == MailProfileKind.Graph)) {
+            sendHandlers.Add(new GraphMailSendHandler(graphSessionFactory, draftMimeMessageFactory, pendingMessageRepository));
+        }
+        if (_options.EnableGmailSendHandler && !sendHandlers.Any(handler => handler.Kind == MailProfileKind.Gmail)) {
+            sendHandlers.Add(new GmailMailSendHandler(gmailSessionFactory, draftMimeMessageFactory, pendingMessageRepository));
+        }
+        if (_options.EnableSmtpSendHandler && !sendHandlers.Any(handler => handler.Kind == MailProfileKind.Smtp)) {
+            sendHandlers.Add(new SmtpMailSendHandler(smtpSessionFactory, draftMimeMessageFactory, pendingMessageRepository));
+        }
+
+        var readService = _readService ?? new RoutedMailReadService(profileStore, readHandlers);
+        var sendService = _sendService ?? new RoutedMailSendService(profileStore, sendHandlers);
+        var queueService = _queueService ?? new PendingMailQueueService(pendingMessageRepository);
+
+        return new MailApplication(
+            profileStore,
+            secretStore,
+            draftStore,
+            profileService,
+            profileOverviewService,
+            profileConnectionService,
+            profileSecretService,
+            profileBootstrapService,
+            profileAuthService,
+            draftService,
+            draftExchangeService,
+            readService,
+            sendService,
+            queueService,
+            readHandlers.AsReadOnly(),
+            sendHandlers.AsReadOnly());
+    }
+}

--- a/Sources/Mailozaurr.Application/MailApplicationOptions.cs
+++ b/Sources/Mailozaurr.Application/MailApplicationOptions.cs
@@ -1,0 +1,36 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Configures the default Mailozaurr application composition.
+/// </summary>
+public sealed class MailApplicationOptions {
+    /// <summary>Options used for the default profile store.</summary>
+    public MailProfileStoreOptions ProfileStore { get; set; } = new();
+
+    /// <summary>Options used for the default secret store.</summary>
+    public MailSecretStoreOptions SecretStore { get; set; } = new();
+
+    /// <summary>Options used for the default draft store.</summary>
+    public MailDraftStoreOptions DraftStore { get; set; } = new();
+
+    /// <summary>Options used for the default pending-message repository.</summary>
+    public PendingMessageRepositoryOptions PendingMessageStore { get; set; } = new();
+
+    /// <summary>Whether the built-in IMAP read handler should be registered.</summary>
+    public bool EnableImapReadHandler { get; set; } = true;
+
+    /// <summary>Whether the built-in Graph read handler should be registered.</summary>
+    public bool EnableGraphReadHandler { get; set; } = true;
+
+    /// <summary>Whether the built-in Graph send handler should be registered.</summary>
+    public bool EnableGraphSendHandler { get; set; } = true;
+
+    /// <summary>Whether the built-in Gmail read handler should be registered.</summary>
+    public bool EnableGmailReadHandler { get; set; } = true;
+
+    /// <summary>Whether the built-in Gmail send handler should be registered.</summary>
+    public bool EnableGmailSendHandler { get; set; } = true;
+
+    /// <summary>Whether the built-in SMTP send handler should be registered.</summary>
+    public bool EnableSmtpSendHandler { get; set; } = true;
+}

--- a/Sources/Mailozaurr.Application/MailApplicationPaths.cs
+++ b/Sources/Mailozaurr.Application/MailApplicationPaths.cs
@@ -1,0 +1,61 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Resolves default storage paths used by application-layer services.
+/// </summary>
+public static class MailApplicationPaths {
+    private const string RootDirectoryName = "Mailozaurr";
+    private const string ProfilesSubDirectoryName = "Profiles";
+    private const string SecretsSubDirectoryName = "Secrets";
+    private const string DraftsSubDirectoryName = "Drafts";
+    private const string ProfilesOverrideDirectoryVariable = "MAILOZAURR_PROFILE_DIRECTORY";
+    private const string SecretsOverrideDirectoryVariable = "MAILOZAURR_SECRET_DIRECTORY";
+    private const string DraftsOverrideDirectoryVariable = "MAILOZAURR_DRAFT_DIRECTORY";
+
+    /// <summary>
+    /// Resolves the default directory used to store profile configuration.
+    /// </summary>
+    public static string ResolveProfilesDirectory() => ResolveDirectory(
+        ProfilesOverrideDirectoryVariable,
+        ProfilesSubDirectoryName);
+
+    /// <summary>
+    /// Resolves the default directory used to store protected secrets.
+    /// </summary>
+    public static string ResolveSecretsDirectory() => ResolveDirectory(
+        SecretsOverrideDirectoryVariable,
+        SecretsSubDirectoryName);
+
+    /// <summary>
+    /// Resolves the default directory used to store reusable drafts.
+    /// </summary>
+    public static string ResolveDraftsDirectory() => ResolveDirectory(
+        DraftsOverrideDirectoryVariable,
+        DraftsSubDirectoryName);
+
+    private static string ResolveDirectory(string overrideVariableName, string subDirectoryName) {
+        var overrideDirectory = Environment.GetEnvironmentVariable(overrideVariableName);
+        if (!string.IsNullOrWhiteSpace(overrideDirectory)) {
+            return Path.GetFullPath(overrideDirectory);
+        }
+
+        var baseDirectory = GetBaseDirectory();
+        return Path.Combine(baseDirectory, RootDirectoryName, subDirectoryName);
+    }
+
+    private static string GetBaseDirectory() {
+        var candidates = new[] {
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+        };
+
+        foreach (var candidate in candidates) {
+            if (!string.IsNullOrWhiteSpace(candidate)) {
+                return candidate;
+            }
+        }
+
+        return AppContext.BaseDirectory;
+    }
+}

--- a/Sources/Mailozaurr.Application/MailCapability.cs
+++ b/Sources/Mailozaurr.Application/MailCapability.cs
@@ -1,0 +1,52 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Describes normalized capabilities that a profile can expose across adapters.
+/// </summary>
+[Flags]
+public enum MailCapability {
+    /// <summary>No capabilities.</summary>
+    None = 0,
+
+    /// <summary>List folders or mailbox containers.</summary>
+    ListFolders = 1 << 0,
+
+    /// <summary>Search messages.</summary>
+    SearchMessages = 1 << 1,
+
+    /// <summary>Read message details.</summary>
+    ReadMessages = 1 << 2,
+
+    /// <summary>Save attachments to disk or other storage.</summary>
+    SaveAttachments = 1 << 3,
+
+    /// <summary>Mark messages read, unread, flagged, or equivalent.</summary>
+    MarkMessages = 1 << 4,
+
+    /// <summary>Move messages between folders or labels.</summary>
+    MoveMessages = 1 << 5,
+
+    /// <summary>Delete messages.</summary>
+    DeleteMessages = 1 << 6,
+
+    /// <summary>Send messages.</summary>
+    SendMessages = 1 << 7,
+
+    /// <summary>Wait for or subscribe to new messages.</summary>
+    WaitForMessages = 1 << 8,
+
+    /// <summary>Manage inbox rules or equivalent server-side rules.</summary>
+    ManageRules = 1 << 9,
+
+    /// <summary>Manage calendar events exposed through the same provider.</summary>
+    ManageEvents = 1 << 10,
+
+    /// <summary>Manage mailbox permissions.</summary>
+    ManagePermissions = 1 << 11,
+
+    /// <summary>Work with threaded conversations.</summary>
+    UseThreads = 1 << 12,
+
+    /// <summary>Work with labels or label-like grouping.</summary>
+    UseLabels = 1 << 13,
+}

--- a/Sources/Mailozaurr.Application/MailCapabilityCatalog.cs
+++ b/Sources/Mailozaurr.Application/MailCapabilityCatalog.cs
@@ -1,0 +1,54 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Provides the default normalized capability map for each profile kind.
+/// </summary>
+public static class MailCapabilityCatalog {
+    /// <summary>
+    /// Returns the default capabilities for a given profile kind.
+    /// </summary>
+    public static ProfileCapabilities For(MailProfileKind kind) {
+        var capabilities = kind switch {
+            MailProfileKind.Imap => MailCapability.ListFolders
+                | MailCapability.SearchMessages
+                | MailCapability.ReadMessages
+                | MailCapability.SaveAttachments
+                | MailCapability.MarkMessages
+                | MailCapability.MoveMessages
+                | MailCapability.DeleteMessages
+                | MailCapability.WaitForMessages,
+            MailProfileKind.Pop3 => MailCapability.SearchMessages
+                | MailCapability.ReadMessages
+                | MailCapability.SaveAttachments
+                | MailCapability.DeleteMessages
+                | MailCapability.WaitForMessages,
+            MailProfileKind.Graph => MailCapability.ListFolders
+                | MailCapability.SearchMessages
+                | MailCapability.ReadMessages
+                | MailCapability.SaveAttachments
+                | MailCapability.MarkMessages
+                | MailCapability.MoveMessages
+                | MailCapability.DeleteMessages
+                | MailCapability.SendMessages
+                | MailCapability.WaitForMessages
+                | MailCapability.ManageRules
+                | MailCapability.ManageEvents
+                | MailCapability.ManagePermissions,
+            MailProfileKind.Gmail => MailCapability.ListFolders
+                | MailCapability.SearchMessages
+                | MailCapability.ReadMessages
+                | MailCapability.SaveAttachments
+                | MailCapability.DeleteMessages
+                | MailCapability.SendMessages
+                | MailCapability.UseThreads
+                | MailCapability.UseLabels,
+            MailProfileKind.Smtp => MailCapability.SendMessages,
+            MailProfileKind.SendGrid => MailCapability.SendMessages,
+            MailProfileKind.Mailgun => MailCapability.SendMessages,
+            MailProfileKind.Ses => MailCapability.SendMessages,
+            _ => MailCapability.None,
+        };
+
+        return new ProfileCapabilities(kind, capabilities);
+    }
+}

--- a/Sources/Mailozaurr.Application/MailDraft.cs
+++ b/Sources/Mailozaurr.Application/MailDraft.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents a persisted reusable draft.
+/// </summary>
+public sealed class MailDraft {
+    /// <summary>Stable draft identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>User-facing draft name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>When the draft was first created.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>When the draft was last updated.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>Normalized draft message payload.</summary>
+    public DraftMessage Message { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/MailDraftCompact.cs
+++ b/Sources/Mailozaurr.Application/MailDraftCompact.cs
@@ -1,0 +1,30 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Lightweight projection of a persisted reusable draft.
+/// </summary>
+public sealed class MailDraftCompact {
+    /// <summary>Stable draft identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>User-facing draft name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Associated profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional subject line.</summary>
+    public string? Subject { get; set; }
+
+    /// <summary>Primary recipient count.</summary>
+    public int ToCount { get; set; }
+
+    /// <summary>Attachment count.</summary>
+    public int AttachmentCount { get; set; }
+
+    /// <summary>When the draft was last updated.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>Short human-readable summary line.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MailDraftService.cs
+++ b/Sources/Mailozaurr.Application/MailDraftService.cs
@@ -1,0 +1,96 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Implements reusable draft lifecycle operations.
+/// </summary>
+public sealed class MailDraftService : IMailDraftService {
+    private readonly IMailDraftStore _store;
+    private readonly IMailProfileStore _profileStore;
+
+    /// <summary>
+    /// Creates a new draft service.
+    /// </summary>
+    public MailDraftService(IMailDraftStore store, IMailProfileStore profileStore) {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<MailDraft>> GetDraftsAsync(CancellationToken cancellationToken = default) =>
+        _store.GetAllAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailDraftCompact>> GetDraftsCompactAsync(CancellationToken cancellationToken = default) =>
+        (await _store.GetAllAsync(cancellationToken).ConfigureAwait(false))
+        .Select(ToCompact)
+        .ToArray();
+
+    /// <inheritdoc />
+    public Task<MailDraft?> GetDraftAsync(string draftId, CancellationToken cancellationToken = default) =>
+        _store.GetByIdAsync(draftId, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<MailDraftCompact?> GetDraftCompactAsync(string draftId, CancellationToken cancellationToken = default) {
+        var draft = await _store.GetByIdAsync(draftId, cancellationToken).ConfigureAwait(false);
+        return draft == null ? null : ToCompact(draft);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SaveAsync(MailDraft draft, CancellationToken cancellationToken = default) {
+        var validation = await ValidateAsync(draft, cancellationToken).ConfigureAwait(false);
+        if (!validation.Succeeded) {
+            return validation;
+        }
+
+        await _store.SaveAsync(draft, cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success($"Draft '{draft.Id}' saved.");
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> DeleteAsync(string draftId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(draftId)) {
+            throw new ArgumentException("Draft id is required.", nameof(draftId));
+        }
+
+        var removed = await _store.RemoveAsync(draftId.Trim(), cancellationToken).ConfigureAwait(false);
+        return removed
+            ? OperationResult.Success($"Draft '{draftId.Trim()}' deleted.")
+            : OperationResult.Failure("draft_not_found", $"Draft '{draftId.Trim()}' was not found.");
+    }
+
+    private async Task<OperationResult> ValidateAsync(MailDraft? draft, CancellationToken cancellationToken) {
+        if (draft == null) {
+            return OperationResult.Failure("draft_invalid", "Draft is required.");
+        }
+        if (string.IsNullOrWhiteSpace(draft.Id)) {
+            return OperationResult.Failure("draft_invalid", "Draft id is required.");
+        }
+        if (string.IsNullOrWhiteSpace(draft.Name)) {
+            return OperationResult.Failure("draft_invalid", "Draft name is required.");
+        }
+        if (draft.Message == null) {
+            return OperationResult.Failure("draft_invalid", "Draft message is required.");
+        }
+        if (string.IsNullOrWhiteSpace(draft.Message.ProfileId)) {
+            return OperationResult.Failure("draft_invalid", "Draft profile id is required.");
+        }
+
+        var profile = await _profileStore.GetByIdAsync(draft.Message.ProfileId, cancellationToken).ConfigureAwait(false);
+        if (profile == null) {
+            return OperationResult.Failure("draft_profile_not_found", $"Profile '{draft.Message.ProfileId}' was not found.");
+        }
+
+        return OperationResult.Success();
+    }
+
+    private static MailDraftCompact ToCompact(MailDraft draft) => new() {
+        Id = draft.Id,
+        Name = draft.Name,
+        ProfileId = draft.Message.ProfileId,
+        Subject = draft.Message.Subject,
+        ToCount = draft.Message.To.Count,
+        AttachmentCount = draft.Message.Attachments.Count,
+        UpdatedAt = draft.UpdatedAt,
+        Summary = $"{draft.Id} [{draft.Message.ProfileId}] {draft.Name}"
+    };
+}

--- a/Sources/Mailozaurr.Application/MailDraftStoreOptions.cs
+++ b/Sources/Mailozaurr.Application/MailDraftStoreOptions.cs
@@ -1,0 +1,22 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Configures where persisted drafts are stored.
+/// </summary>
+public sealed class MailDraftStoreOptions {
+    /// <summary>Directory containing the draft store file.</summary>
+    public string? DirectoryPath { get; set; }
+
+    /// <summary>File name used to persist drafts.</summary>
+    public string FileName { get; set; } = "drafts.json";
+
+    /// <summary>
+    /// Resolves the file path that should be used by the draft store.
+    /// </summary>
+    public string GetFilePath() {
+        var directory = string.IsNullOrWhiteSpace(DirectoryPath)
+            ? MailApplicationPaths.ResolveDraftsDirectory()
+            : Path.GetFullPath(DirectoryPath);
+        return Path.Combine(directory, FileName);
+    }
+}

--- a/Sources/Mailozaurr.Application/MailFolderQuery.cs
+++ b/Sources/Mailozaurr.Application/MailFolderQuery.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for listing folders or folder-like mailbox containers.
+/// </summary>
+public sealed class MailFolderQuery {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional parent folder identifier.</summary>
+    public string? ParentFolderId { get; set; }
+
+    /// <summary>Whether only top-level folders should be returned.</summary>
+    public bool RootOnly { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MailProfile.cs
+++ b/Sources/Mailozaurr.Application/MailProfile.cs
@@ -1,0 +1,40 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents a reusable profile definition that can be shared by CLI, MCP, GUI, and PowerShell adapters.
+/// </summary>
+public sealed class MailProfile {
+    /// <summary>Stable profile identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>User-facing profile name.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Optional description for human operators.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Technology or provider behind the profile.</summary>
+    public MailProfileKind Kind { get; set; } = MailProfileKind.Unknown;
+
+    /// <summary>Default sender address when the profile supports sending.</summary>
+    public string? DefaultSender { get; set; }
+
+    /// <summary>Default mailbox address or principal name, where applicable.</summary>
+    public string? DefaultMailbox { get; set; }
+
+    /// <summary>Whether this profile should be treated as the default choice.</summary>
+    public bool IsDefault { get; set; }
+
+    /// <summary>Non-secret profile settings.</summary>
+    public Dictionary<string, string> Settings { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Explicit capability override when present.
+    /// </summary>
+    public ProfileCapabilities? Capabilities { get; set; }
+
+    /// <summary>
+    /// Returns the effective capabilities for this profile.
+    /// </summary>
+    public ProfileCapabilities GetCapabilities() => Capabilities ?? ProfileCapabilities.CreateDefault(Kind);
+}

--- a/Sources/Mailozaurr.Application/MailProfileAuthDefaults.cs
+++ b/Sources/Mailozaurr.Application/MailProfileAuthDefaults.cs
@@ -1,0 +1,23 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Shared defaults used by profile-based authentication flows.
+/// </summary>
+public static class MailProfileAuthDefaults {
+    /// <summary>Default Gmail mail scope.</summary>
+    public static readonly IReadOnlyList<string> GmailScopes = new[] { "https://mail.google.com/" };
+
+    /// <summary>Default Microsoft Graph mail scopes.</summary>
+    public static readonly IReadOnlyList<string> GraphScopes = new[] {
+        "email",
+        "offline_access",
+        "https://graph.microsoft.com/Mail.ReadWrite",
+        "https://graph.microsoft.com/Mail.Send"
+    };
+
+    /// <summary>Default redirect URI used by native Microsoft identity flows.</summary>
+    public const string GraphRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+
+    /// <summary>Refresh window used when deciding whether a token should be reacquired.</summary>
+    public static readonly TimeSpan TokenRefreshWindow = TimeSpan.FromMinutes(5);
+}

--- a/Sources/Mailozaurr.Application/MailProfileAuthFlowNames.cs
+++ b/Sources/Mailozaurr.Application/MailProfileAuthFlowNames.cs
@@ -1,0 +1,12 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Well-known authentication flow names persisted with reusable profiles.
+/// </summary>
+public static class MailProfileAuthFlowNames {
+    /// <summary>Interactive user login backed by provider token cache.</summary>
+    public const string Interactive = "interactive";
+
+    /// <summary>Manually supplied access token.</summary>
+    public const string ManualToken = "manualToken";
+}

--- a/Sources/Mailozaurr.Application/MailProfileAuthService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileAuthService.cs
@@ -1,0 +1,466 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Default implementation of reusable profile authentication workflows.
+/// </summary>
+public sealed class MailProfileAuthService : IMailProfileAuthService {
+    private readonly IMailProfileService _profiles;
+    private readonly IMailProfileSecretService _profileSecrets;
+    private readonly IMailSecretStore _secretStore;
+    private readonly Func<GmailProfileLoginRequest, CancellationToken, Task<OAuthCredential>> _loginGmailAsync;
+    private readonly Func<GraphProfileLoginRequest, CancellationToken, Task<OAuthCredential>> _loginGraphAsync;
+
+    /// <summary>
+    /// Creates a new profile authentication service.
+    /// </summary>
+    public MailProfileAuthService(
+        IMailProfileService profiles,
+        IMailProfileSecretService profileSecrets,
+        IMailSecretStore secretStore,
+        Func<GmailProfileLoginRequest, CancellationToken, Task<OAuthCredential>>? loginGmailAsync = null,
+        Func<GraphProfileLoginRequest, CancellationToken, Task<OAuthCredential>>? loginGraphAsync = null) {
+        _profiles = profiles ?? throw new ArgumentNullException(nameof(profiles));
+        _profileSecrets = profileSecrets ?? throw new ArgumentNullException(nameof(profileSecrets));
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+        _loginGmailAsync = loginGmailAsync ?? DefaultLoginGmailAsync;
+        _loginGraphAsync = loginGraphAsync ?? DefaultLoginGraphAsync;
+    }
+
+    /// <inheritdoc />
+    public async Task<MailProfileAuthStatus?> GetStatusAsync(string profileId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            throw new ArgumentException("Profile id is required.", nameof(profileId));
+        }
+
+        var profile = await _profiles.GetProfileAsync(profileId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (profile == null) {
+            return null;
+        }
+
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.AuthFlow, out var authFlow);
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.LoginHint, out var loginHint);
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailboxSetting);
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientId);
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.TenantId, out var tenantId);
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.CertificatePath, out var certificatePath);
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.AuthMode, out var authMode);
+
+        var accessToken = await TryReadSecretAsync(profile.Id, MailSecretNames.AccessToken, cancellationToken).ConfigureAwait(false);
+        var refreshToken = await TryReadSecretAsync(profile.Id, MailSecretNames.RefreshToken, cancellationToken).ConfigureAwait(false);
+        var clientSecret = await TryReadSecretAsync(profile.Id, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false);
+        var certificatePassword = await TryReadSecretAsync(profile.Id, MailSecretNames.CertificatePassword, cancellationToken).ConfigureAwait(false);
+        var password = await TryReadSecretAsync(profile.Id, MailSecretNames.Password, cancellationToken).ConfigureAwait(false);
+
+        var tokenExpiresOn = TryParseTimestamp(profile.Settings.TryGetValue(MailProfileSettingsKeys.TokenExpiresOn, out var rawTokenExpiresOn) ? rawTokenExpiresOn : null);
+        var mailbox = FirstNonEmpty(mailboxSetting, profile.DefaultMailbox, profile.DefaultSender);
+        var hasAccessToken = !string.IsNullOrWhiteSpace(accessToken);
+        var hasRefreshToken = !string.IsNullOrWhiteSpace(refreshToken);
+        var hasClientSecret = !string.IsNullOrWhiteSpace(clientSecret);
+        var hasCertificatePath = !string.IsNullOrWhiteSpace(certificatePath);
+        var hasCertificatePassword = !string.IsNullOrWhiteSpace(certificatePassword);
+        var hasPassword = !string.IsNullOrWhiteSpace(password);
+        var hasClientId = !string.IsNullOrWhiteSpace(clientId);
+        var hasTenantId = !string.IsNullOrWhiteSpace(tenantId);
+        var isTokenExpired = tokenExpiresOn.HasValue && tokenExpiresOn.Value <= DateTimeOffset.UtcNow;
+
+        var mode = DetermineMode(profile, authFlow, authMode, hasAccessToken, hasRefreshToken, hasClientSecret, hasCertificatePath, hasPassword);
+        var canLoginInteractively = DetermineCanLoginInteractively(profile.Kind, hasClientId, hasTenantId, hasClientSecret, mailbox);
+        var canRefresh = DetermineCanRefresh(profile.Kind, authFlow, hasClientId, hasTenantId, hasClientSecret, mailbox);
+
+        return new MailProfileAuthStatus {
+            ProfileId = profile.Id,
+            ProfileKind = profile.Kind,
+            AuthFlow = authFlow,
+            Mode = mode,
+            LoginHint = loginHint,
+            Mailbox = mailbox,
+            TokenExpiresOn = tokenExpiresOn,
+            HasAccessToken = hasAccessToken,
+            HasRefreshToken = hasRefreshToken,
+            HasClientSecret = hasClientSecret,
+            HasCertificatePath = hasCertificatePath,
+            HasCertificatePassword = hasCertificatePassword,
+            HasPassword = hasPassword,
+            HasClientId = hasClientId,
+            HasTenantId = hasTenantId,
+            IsTokenExpired = isTokenExpired,
+            CanRefresh = canRefresh,
+            CanLoginInteractively = canLoginInteractively,
+            Summary = BuildSummary(profile, mode, mailbox, hasAccessToken, tokenExpiresOn, isTokenExpired, canRefresh)
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<MailProfileAuthenticationResult> LoginGmailAsync(GmailProfileLoginRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var profileResult = await LoadProfileAsync(request.ProfileId, MailProfileKind.Gmail, cancellationToken).ConfigureAwait(false);
+        if (profileResult.Error != null) {
+            return profileResult.Error;
+        }
+
+        var profile = profileResult.Profile!;
+        var gmailAccount = FirstNonEmpty(
+            request.GmailAccount,
+            profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailboxSetting) ? mailboxSetting : null,
+            profile.DefaultMailbox);
+        var clientId = FirstNonEmpty(
+            request.ClientId,
+            profile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientIdSetting) ? clientIdSetting : null);
+        var clientSecret = FirstNonEmpty(
+            request.ClientSecret,
+            await TryReadSecretAsync(profile.Id, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false));
+
+        if (string.IsNullOrWhiteSpace(gmailAccount)) {
+            return Failure("gmail_account_required", "Gmail login requires an account address.", profile.Id, MailProfileKind.Gmail);
+        }
+        if (string.IsNullOrWhiteSpace(clientId)) {
+            return Failure("client_id_required", "Gmail login requires a client id.", profile.Id, MailProfileKind.Gmail);
+        }
+        if (string.IsNullOrWhiteSpace(clientSecret)) {
+            return Failure("client_secret_required", "Gmail login requires a client secret.", profile.Id, MailProfileKind.Gmail);
+        }
+
+        var effectiveRequest = new GmailProfileLoginRequest {
+            ProfileId = profile.Id,
+            GmailAccount = gmailAccount,
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+            Scopes = NormalizeScopes(request.Scopes, MailProfileAuthDefaults.GmailScopes)
+        };
+        var credential = await _loginGmailAsync(effectiveRequest, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(credential.AccessToken)) {
+            return Failure("access_token_missing", "Gmail authentication did not return an access token.", profile.Id, MailProfileKind.Gmail);
+        }
+
+        profile.Settings[MailProfileSettingsKeys.Mailbox] = gmailAccount!;
+        profile.Settings[MailProfileSettingsKeys.ClientId] = clientId!;
+        profile.Settings[MailProfileSettingsKeys.AuthFlow] = MailProfileAuthFlowNames.Interactive;
+        profile.Settings[MailProfileSettingsKeys.LoginHint] = gmailAccount!;
+        UpsertTokenExpiration(profile, credential.ExpiresOn);
+        profile.DefaultMailbox ??= gmailAccount;
+        profile.DefaultSender ??= gmailAccount;
+
+        var saveResult = await _profiles.SaveAsync(profile, cancellationToken).ConfigureAwait(false);
+        if (!saveResult.Succeeded) {
+            return FromOperation(saveResult, profile.Id, MailProfileKind.Gmail);
+        }
+
+        var secretResult = await PersistSecretAsync(profile.Id, MailSecretNames.ClientSecret, clientSecret, cancellationToken).ConfigureAwait(false);
+        if (secretResult != null) {
+            return secretResult;
+        }
+        secretResult = await PersistSecretAsync(profile.Id, MailSecretNames.AccessToken, credential.AccessToken, cancellationToken).ConfigureAwait(false);
+        if (secretResult != null) {
+            return secretResult;
+        }
+        if (!string.IsNullOrWhiteSpace(credential.RefreshToken)) {
+            secretResult = await PersistSecretAsync(profile.Id, MailSecretNames.RefreshToken, credential.RefreshToken, cancellationToken).ConfigureAwait(false);
+            if (secretResult != null) {
+                return secretResult;
+            }
+        }
+
+        return Success("Gmail login completed.", profile.Id, MailProfileKind.Gmail, credential);
+    }
+
+    /// <inheritdoc />
+    public async Task<MailProfileAuthenticationResult> LoginGraphAsync(GraphProfileLoginRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var profileResult = await LoadProfileAsync(request.ProfileId, MailProfileKind.Graph, cancellationToken).ConfigureAwait(false);
+        if (profileResult.Error != null) {
+            return profileResult.Error;
+        }
+
+        var profile = profileResult.Profile!;
+        var login = FirstNonEmpty(request.Login, profile.DefaultMailbox, profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailboxSetting) ? mailboxSetting : null);
+        var mailbox = FirstNonEmpty(request.Mailbox, profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var existingMailbox) ? existingMailbox : null, profile.DefaultMailbox, login);
+        var clientId = FirstNonEmpty(request.ClientId, profile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientIdSetting) ? clientIdSetting : null);
+        var tenantId = FirstNonEmpty(request.TenantId, profile.Settings.TryGetValue(MailProfileSettingsKeys.TenantId, out var tenantIdSetting) ? tenantIdSetting : null);
+        var redirectUri = FirstNonEmpty(request.RedirectUri, profile.Settings.TryGetValue(MailProfileSettingsKeys.RedirectUri, out var redirectUriSetting) ? redirectUriSetting : null)
+            ?? MailProfileAuthDefaults.GraphRedirectUri;
+
+        if (string.IsNullOrWhiteSpace(clientId)) {
+            return Failure("client_id_required", "Graph login requires a client id.", profile.Id, MailProfileKind.Graph);
+        }
+        if (string.IsNullOrWhiteSpace(tenantId)) {
+            return Failure("tenant_id_required", "Graph login requires a tenant id.", profile.Id, MailProfileKind.Graph);
+        }
+
+        var effectiveRequest = new GraphProfileLoginRequest {
+            ProfileId = profile.Id,
+            Login = login,
+            Mailbox = mailbox,
+            ClientId = clientId,
+            TenantId = tenantId,
+            RedirectUri = redirectUri,
+            Scopes = NormalizeScopes(request.Scopes, MailProfileAuthDefaults.GraphScopes)
+        };
+        var credential = await _loginGraphAsync(effectiveRequest, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(credential.AccessToken)) {
+            return Failure("access_token_missing", "Graph authentication did not return an access token.", profile.Id, MailProfileKind.Graph);
+        }
+
+        profile.Settings[MailProfileSettingsKeys.ClientId] = clientId!;
+        profile.Settings[MailProfileSettingsKeys.TenantId] = tenantId!;
+        profile.Settings[MailProfileSettingsKeys.RedirectUri] = redirectUri;
+        profile.Settings[MailProfileSettingsKeys.AuthFlow] = MailProfileAuthFlowNames.Interactive;
+        UpsertSetting(profile.Settings, MailProfileSettingsKeys.LoginHint, login);
+        UpsertTokenExpiration(profile, credential.ExpiresOn);
+        if (!string.IsNullOrWhiteSpace(mailbox)) {
+            profile.Settings[MailProfileSettingsKeys.Mailbox] = mailbox!;
+            profile.DefaultMailbox ??= mailbox;
+            profile.DefaultSender ??= mailbox;
+        } else if (!string.IsNullOrWhiteSpace(credential.UserName)) {
+            profile.DefaultMailbox ??= credential.UserName;
+        }
+
+        var saveResult = await _profiles.SaveAsync(profile, cancellationToken).ConfigureAwait(false);
+        if (!saveResult.Succeeded) {
+            return FromOperation(saveResult, profile.Id, MailProfileKind.Graph);
+        }
+
+        var secretResult = await PersistSecretAsync(profile.Id, MailSecretNames.AccessToken, credential.AccessToken, cancellationToken).ConfigureAwait(false);
+        if (secretResult != null) {
+            return secretResult;
+        }
+
+        return Success("Graph login completed.", profile.Id, MailProfileKind.Graph, credential);
+    }
+
+    /// <inheritdoc />
+    public async Task<MailProfileAuthenticationResult> RefreshAsync(string profileId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            return Failure("profile_required", "Profile id is required.", profileId, MailProfileKind.Unknown);
+        }
+
+        var profile = await _profiles.GetProfileAsync(profileId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (profile == null) {
+            return Failure("profile_not_found", "Profile was not found.", profileId, MailProfileKind.Unknown);
+        }
+
+        switch (profile.Kind) {
+            case MailProfileKind.Gmail:
+                return await LoginGmailAsync(new GmailProfileLoginRequest {
+                    ProfileId = profile.Id
+                }, cancellationToken).ConfigureAwait(false);
+            case MailProfileKind.Graph:
+                return await LoginGraphAsync(new GraphProfileLoginRequest {
+                    ProfileId = profile.Id
+                }, cancellationToken).ConfigureAwait(false);
+            default:
+                return Failure(
+                    "refresh_not_supported",
+                    $"Profile kind '{profile.Kind}' does not support shared refresh-auth.",
+                    profile.Id,
+                    profile.Kind);
+        }
+    }
+
+    private async Task<(MailProfile? Profile, MailProfileAuthenticationResult? Error)> LoadProfileAsync(string profileId, MailProfileKind expectedKind, CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            return (null, Failure("profile_required", "Profile id is required.", profileId, expectedKind));
+        }
+
+        var profile = await _profiles.GetProfileAsync(profileId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (profile == null) {
+            return (null, Failure("profile_not_found", "Profile was not found.", profileId, expectedKind));
+        }
+        if (profile.Kind != expectedKind) {
+            return (null, Failure("profile_kind_mismatch", $"Profile '{profile.Id}' is not a {expectedKind} profile.", profile.Id, profile.Kind));
+        }
+
+        return (CloneProfile(profile), null);
+    }
+
+    private Task<string?> TryReadSecretAsync(string profileId, string secretName, CancellationToken cancellationToken) =>
+        _secretStore.GetSecretAsync(profileId, secretName, cancellationToken);
+
+    private async Task<MailProfileAuthenticationResult?> PersistSecretAsync(string profileId, string secretName, string? secretValue, CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(secretValue)) {
+            return null;
+        }
+
+        var normalizedSecretValue = secretValue!.Trim();
+        var result = await _profileSecrets.SetSecretAsync(profileId, secretName, normalizedSecretValue, cancellationToken).ConfigureAwait(false);
+        return result.Succeeded
+            ? null
+            : FromOperation(result, profileId, MailProfileKind.Unknown);
+    }
+
+    private static Task<OAuthCredential> DefaultLoginGmailAsync(GmailProfileLoginRequest request, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return OAuthHelpers.AcquireGoogleTokenCachedAsync(
+            request.GmailAccount!,
+            request.ClientId!,
+            request.ClientSecret!,
+            request.Scopes ?? MailProfileAuthDefaults.GmailScopes);
+    }
+
+    private static Task<OAuthCredential> DefaultLoginGraphAsync(GraphProfileLoginRequest request, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return OAuthHelpers.AcquireO365TokenCachedAsync(
+            request.Login,
+            request.ClientId!,
+            request.TenantId!,
+            request.RedirectUri!,
+            request.Scopes ?? MailProfileAuthDefaults.GraphScopes);
+    }
+
+    private static MailProfile CloneProfile(MailProfile profile) => new() {
+        Id = profile.Id,
+        DisplayName = profile.DisplayName,
+        Description = profile.Description,
+        Kind = profile.Kind,
+        DefaultSender = profile.DefaultSender,
+        DefaultMailbox = profile.DefaultMailbox,
+        IsDefault = profile.IsDefault,
+        Settings = new Dictionary<string, string>(profile.Settings, StringComparer.OrdinalIgnoreCase),
+        Capabilities = profile.Capabilities == null
+            ? null
+            : new ProfileCapabilities(profile.Capabilities.Kind, profile.Capabilities.Capabilities)
+    };
+
+    private static IReadOnlyList<string> NormalizeScopes(IReadOnlyList<string>? scopes, IReadOnlyList<string> fallback) =>
+        (scopes == null || scopes.Count == 0
+            ? fallback
+            : scopes.Where(scope => !string.IsNullOrWhiteSpace(scope)).Select(scope => scope.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToArray())!;
+
+    private static string? FirstNonEmpty(params string?[] values) {
+        foreach (var value in values) {
+            if (!string.IsNullOrWhiteSpace(value)) {
+                return value!.Trim();
+            }
+        }
+
+        return null;
+    }
+
+    private static DateTimeOffset? TryParseTimestamp(string? value) =>
+        DateTimeOffset.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var timestamp)
+            ? timestamp
+            : null;
+
+    private static string DetermineMode(
+        MailProfile profile,
+        string? authFlow,
+        string? authMode,
+        bool hasAccessToken,
+        bool hasRefreshToken,
+        bool hasClientSecret,
+        bool hasCertificatePath,
+        bool hasPassword) {
+        if (string.Equals(authFlow, MailProfileAuthFlowNames.Interactive, StringComparison.OrdinalIgnoreCase)) {
+            return "interactive";
+        }
+
+        if (string.Equals(authFlow, MailProfileAuthFlowNames.ManualToken, StringComparison.OrdinalIgnoreCase)) {
+            return "manualToken";
+        }
+
+        return profile.Kind switch {
+            MailProfileKind.Graph when hasClientSecret || hasCertificatePath => "appOnly",
+            MailProfileKind.Graph when hasAccessToken => "manualToken",
+            MailProfileKind.Gmail when hasRefreshToken && hasClientSecret => "interactive",
+            MailProfileKind.Gmail when hasAccessToken => "manualToken",
+            MailProfileKind.Imap or MailProfileKind.Pop3 or MailProfileKind.Smtp
+                when string.Equals(authMode, "oauth2", StringComparison.OrdinalIgnoreCase) => "oauth2",
+            MailProfileKind.Imap or MailProfileKind.Pop3 or MailProfileKind.Smtp
+                when hasPassword => "basic",
+            _ => "unknown"
+        };
+    }
+
+    private static bool DetermineCanLoginInteractively(
+        MailProfileKind kind,
+        bool hasClientId,
+        bool hasTenantId,
+        bool hasClientSecret,
+        string? mailbox) =>
+        kind switch {
+            MailProfileKind.Gmail => hasClientId && hasClientSecret && !string.IsNullOrWhiteSpace(mailbox),
+            MailProfileKind.Graph => hasClientId && hasTenantId,
+            _ => false
+        };
+
+    private static bool DetermineCanRefresh(
+        MailProfileKind kind,
+        string? authFlow,
+        bool hasClientId,
+        bool hasTenantId,
+        bool hasClientSecret,
+        string? mailbox) =>
+        kind switch {
+            MailProfileKind.Gmail => hasClientId && hasClientSecret && !string.IsNullOrWhiteSpace(mailbox),
+            MailProfileKind.Graph => string.Equals(authFlow, MailProfileAuthFlowNames.Interactive, StringComparison.OrdinalIgnoreCase) && hasClientId && hasTenantId,
+            _ => false
+        };
+
+    private static string BuildSummary(
+        MailProfile profile,
+        string mode,
+        string? mailbox,
+        bool hasAccessToken,
+        DateTimeOffset? tokenExpiresOn,
+        bool isTokenExpired,
+        bool canRefresh) {
+        var mailboxSegment = string.IsNullOrWhiteSpace(mailbox) ? "mailbox not set" : $"mailbox={mailbox}";
+        var tokenSegment = !hasAccessToken
+            ? "token missing"
+            : tokenExpiresOn == null
+                ? "token present"
+                : isTokenExpired
+                    ? $"token expired {tokenExpiresOn:O}"
+                    : $"token expires {tokenExpiresOn:O}";
+        var refreshSegment = canRefresh ? "refresh available" : "refresh unavailable";
+        return $"{profile.Id} [{profile.Kind}] auth={mode}, {mailboxSegment}, {tokenSegment}, {refreshSegment}.";
+    }
+
+    private static void UpsertSetting(IDictionary<string, string> settings, string key, string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            settings.Remove(key);
+            return;
+        }
+
+        settings[key] = value!.Trim();
+    }
+
+    private static void UpsertTokenExpiration(MailProfile profile, DateTimeOffset expiresOn) {
+        if (expiresOn == default || expiresOn == DateTimeOffset.MaxValue) {
+            profile.Settings.Remove(MailProfileSettingsKeys.TokenExpiresOn);
+            return;
+        }
+
+        profile.Settings[MailProfileSettingsKeys.TokenExpiresOn] = expiresOn.ToString("o", System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static MailProfileAuthenticationResult Success(string message, string profileId, MailProfileKind kind, OAuthCredential credential) => new() {
+        Succeeded = true,
+        Message = message,
+        ProfileId = profileId,
+        ProfileKind = kind,
+        UserName = credential.UserName,
+        ExpiresOn = credential.ExpiresOn == default ? null : credential.ExpiresOn
+    };
+
+    private static MailProfileAuthenticationResult Failure(string code, string message, string? profileId, MailProfileKind kind) => new() {
+        Succeeded = false,
+        Code = code,
+        Message = message,
+        ProfileId = string.IsNullOrWhiteSpace(profileId) ? null : profileId,
+        ProfileKind = kind
+    };
+
+    private static MailProfileAuthenticationResult FromOperation(OperationResult result, string profileId, MailProfileKind kind) => new() {
+        Succeeded = result.Succeeded,
+        Code = result.Code,
+        Message = result.Message,
+        ProfileId = profileId,
+        ProfileKind = kind
+    };
+}

--- a/Sources/Mailozaurr.Application/MailProfileAuthStatus.cs
+++ b/Sources/Mailozaurr.Application/MailProfileAuthStatus.cs
@@ -1,0 +1,63 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Describes the persisted authentication state for a reusable Mailozaurr profile.
+/// </summary>
+public sealed class MailProfileAuthStatus {
+    /// <summary>The stable profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>The provider kind associated with the profile.</summary>
+    public MailProfileKind ProfileKind { get; set; }
+
+    /// <summary>The persisted shared auth-flow marker, when available.</summary>
+    public string? AuthFlow { get; set; }
+
+    /// <summary>A normalized auth mode summary such as interactive, appOnly, manualToken, basic, or unknown.</summary>
+    public string Mode { get; set; } = "unknown";
+
+    /// <summary>An optional persisted login hint used by interactive OAuth flows.</summary>
+    public string? LoginHint { get; set; }
+
+    /// <summary>The effective mailbox or account identifier associated with the profile.</summary>
+    public string? Mailbox { get; set; }
+
+    /// <summary>The persisted access-token expiration timestamp, when known.</summary>
+    public DateTimeOffset? TokenExpiresOn { get; set; }
+
+    /// <summary>Whether an access token is currently stored.</summary>
+    public bool HasAccessToken { get; set; }
+
+    /// <summary>Whether a refresh token is currently stored.</summary>
+    public bool HasRefreshToken { get; set; }
+
+    /// <summary>Whether a client secret is currently stored.</summary>
+    public bool HasClientSecret { get; set; }
+
+    /// <summary>Whether a certificate path is configured.</summary>
+    public bool HasCertificatePath { get; set; }
+
+    /// <summary>Whether a certificate password is currently stored.</summary>
+    public bool HasCertificatePassword { get; set; }
+
+    /// <summary>Whether a basic password secret is currently stored.</summary>
+    public bool HasPassword { get; set; }
+
+    /// <summary>Whether a client id is configured.</summary>
+    public bool HasClientId { get; set; }
+
+    /// <summary>Whether a tenant id is configured.</summary>
+    public bool HasTenantId { get; set; }
+
+    /// <summary>Whether the persisted token is already expired.</summary>
+    public bool IsTokenExpired { get; set; }
+
+    /// <summary>Whether the shared auth service can perform refresh-auth for this profile.</summary>
+    public bool CanRefresh { get; set; }
+
+    /// <summary>Whether the shared auth service has enough information to run an interactive login flow.</summary>
+    public bool CanLoginInteractively { get; set; }
+
+    /// <summary>A short human-readable summary of the current auth posture.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MailProfileAuthenticationResult.cs
+++ b/Sources/Mailozaurr.Application/MailProfileAuthenticationResult.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents the result of an authentication flow for a saved profile.
+/// </summary>
+public sealed class MailProfileAuthenticationResult : OperationResult {
+    /// <summary>The profile identifier the login result applies to.</summary>
+    public string? ProfileId { get; set; }
+
+    /// <summary>The provider kind associated with the authenticated profile.</summary>
+    public MailProfileKind ProfileKind { get; set; } = MailProfileKind.Unknown;
+
+    /// <summary>The resolved user/account name returned by the authentication flow.</summary>
+    public string? UserName { get; set; }
+
+    /// <summary>The access-token expiry when known.</summary>
+    public DateTimeOffset? ExpiresOn { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MailProfileBootstrapService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileBootstrapService.cs
@@ -1,0 +1,221 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Default implementation of reusable provider bootstrap workflows.
+/// </summary>
+public sealed class MailProfileBootstrapService : IMailProfileBootstrapService {
+    private readonly IMailProfileService _profiles;
+    private readonly IMailProfileSecretService _profileSecrets;
+    private readonly IMailSecretStore _secretStore;
+
+    /// <summary>
+    /// Creates a new profile bootstrap service.
+    /// </summary>
+    public MailProfileBootstrapService(IMailProfileService profiles, IMailProfileSecretService profileSecrets, IMailSecretStore secretStore) {
+        _profiles = profiles ?? throw new ArgumentNullException(nameof(profiles));
+        _profileSecrets = profileSecrets ?? throw new ArgumentNullException(nameof(profileSecrets));
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SaveGraphProfileAsync(GraphProfileBootstrapRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var profileId = request.ProfileId.Trim();
+        var displayName = request.DisplayName.Trim();
+        var mailbox = request.Mailbox.Trim();
+        var defaultSender = string.IsNullOrWhiteSpace(request.DefaultSender) ? mailbox : request.DefaultSender!.Trim();
+        var existing = await _profiles.GetProfileAsync(profileId, cancellationToken).ConfigureAwait(false);
+
+        var effectiveClientId = FirstNonEmpty(request.ClientId, existing?.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var existingClientId) == true ? existingClientId : null);
+        var effectiveTenantId = FirstNonEmpty(request.TenantId, existing?.Settings.TryGetValue(MailProfileSettingsKeys.TenantId, out var existingTenantId) == true ? existingTenantId : null);
+        var effectiveCertificatePath = FirstNonEmpty(request.CertificatePath, existing?.Settings.TryGetValue(MailProfileSettingsKeys.CertificatePath, out var existingCertificatePath) == true ? existingCertificatePath : null);
+        var hasAccessToken = !string.IsNullOrWhiteSpace(request.AccessToken) ||
+                             await HasStoredSecretAsync(profileId, MailSecretNames.AccessToken, cancellationToken).ConfigureAwait(false);
+        var hasClientSecret = !string.IsNullOrWhiteSpace(request.ClientSecret) ||
+                              await HasStoredSecretAsync(profileId, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false);
+        var hasCertificate = !string.IsNullOrWhiteSpace(effectiveCertificatePath);
+
+        if (profileId.Length == 0) {
+            return OperationResult.Failure("profile_required", "Profile id is required.");
+        }
+        if (displayName.Length == 0) {
+            return OperationResult.Failure("display_name_required", "Display name is required.");
+        }
+        if (mailbox.Length == 0) {
+            return OperationResult.Failure("mailbox_required", "Mailbox is required.");
+        }
+        if (!hasAccessToken &&
+            (string.IsNullOrWhiteSpace(effectiveClientId) || string.IsNullOrWhiteSpace(effectiveTenantId) || (!hasClientSecret && !hasCertificate))) {
+            return OperationResult.Failure(
+                "graph_auth_required",
+                "Graph profiles require either an access token or a client-id and tenant-id with a client secret or certificate path.");
+        }
+        if (!string.IsNullOrWhiteSpace(request.CertificatePassword) && !hasCertificate) {
+            return OperationResult.Failure("certificate_path_required", "Certificate password requires a certificate path.");
+        }
+
+        var profile = existing == null
+            ? new MailProfile {
+                Id = profileId,
+                Kind = MailProfileKind.Graph
+            }
+            : CloneProfile(existing);
+
+        profile.DisplayName = displayName;
+        profile.Description = request.Description ?? profile.Description;
+        profile.Kind = MailProfileKind.Graph;
+        profile.DefaultMailbox = mailbox;
+        profile.DefaultSender = defaultSender;
+        profile.IsDefault = request.IsDefault;
+        profile.Settings[MailProfileSettingsKeys.Mailbox] = mailbox;
+
+        UpsertSetting(profile.Settings, MailProfileSettingsKeys.ClientId, effectiveClientId);
+        UpsertSetting(profile.Settings, MailProfileSettingsKeys.TenantId, effectiveTenantId);
+        UpsertSetting(profile.Settings, MailProfileSettingsKeys.CertificatePath, effectiveCertificatePath);
+
+        var saveResult = await _profiles.SaveAsync(profile, cancellationToken).ConfigureAwait(false);
+        if (!saveResult.Succeeded) {
+            return saveResult;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ClientSecret)) {
+            var clientSecretResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.ClientSecret, request.ClientSecret!.Trim(), cancellationToken).ConfigureAwait(false);
+            if (!clientSecretResult.Succeeded) {
+                return clientSecretResult;
+            }
+        }
+        if (!string.IsNullOrWhiteSpace(request.AccessToken)) {
+            var accessTokenResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.AccessToken, request.AccessToken!.Trim(), cancellationToken).ConfigureAwait(false);
+            if (!accessTokenResult.Succeeded) {
+                return accessTokenResult;
+            }
+        }
+        if (!string.IsNullOrWhiteSpace(request.CertificatePassword)) {
+            var certificatePasswordResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.CertificatePassword, request.CertificatePassword!.Trim(), cancellationToken).ConfigureAwait(false);
+            if (!certificatePasswordResult.Succeeded) {
+                return certificatePasswordResult;
+            }
+        }
+
+        return OperationResult.Success("Graph profile saved.");
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SaveGmailProfileAsync(GmailProfileBootstrapRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var profileId = request.ProfileId.Trim();
+        var displayName = request.DisplayName.Trim();
+        var mailbox = string.IsNullOrWhiteSpace(request.Mailbox) ? "me" : request.Mailbox!.Trim();
+        var existing = await _profiles.GetProfileAsync(profileId, cancellationToken).ConfigureAwait(false);
+        var effectiveClientId = FirstNonEmpty(request.ClientId, existing?.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var existingClientId) == true ? existingClientId : null);
+        var hasAccessToken = !string.IsNullOrWhiteSpace(request.AccessToken) ||
+                             await HasStoredSecretAsync(profileId, MailSecretNames.AccessToken, cancellationToken).ConfigureAwait(false);
+        var hasRefreshToken = !string.IsNullOrWhiteSpace(request.RefreshToken) ||
+                              await HasStoredSecretAsync(profileId, MailSecretNames.RefreshToken, cancellationToken).ConfigureAwait(false);
+        var hasClientSecret = !string.IsNullOrWhiteSpace(request.ClientSecret) ||
+                              await HasStoredSecretAsync(profileId, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false);
+
+        if (profileId.Length == 0) {
+            return OperationResult.Failure("profile_required", "Profile id is required.");
+        }
+        if (displayName.Length == 0) {
+            return OperationResult.Failure("display_name_required", "Display name is required.");
+        }
+        if (!hasAccessToken && (!hasRefreshToken || string.IsNullOrWhiteSpace(effectiveClientId) || !hasClientSecret)) {
+            return OperationResult.Failure(
+                "gmail_auth_required",
+                "Gmail profiles require either an access token or a refresh token with a client id and client secret.");
+        }
+
+        var defaultSender = string.IsNullOrWhiteSpace(request.DefaultSender)
+            ? (string.Equals(mailbox, "me", StringComparison.OrdinalIgnoreCase) ? existing?.DefaultSender : mailbox)
+            : request.DefaultSender!.Trim();
+
+        var profile = existing == null
+            ? new MailProfile {
+                Id = profileId,
+                Kind = MailProfileKind.Gmail
+            }
+            : CloneProfile(existing);
+
+        profile.DisplayName = displayName;
+        profile.Description = request.Description ?? profile.Description;
+        profile.Kind = MailProfileKind.Gmail;
+        profile.DefaultMailbox = mailbox;
+        profile.DefaultSender = defaultSender;
+        profile.IsDefault = request.IsDefault;
+        profile.Settings[MailProfileSettingsKeys.Mailbox] = mailbox;
+
+        UpsertSetting(profile.Settings, MailProfileSettingsKeys.ClientId, effectiveClientId);
+
+        var saveResult = await _profiles.SaveAsync(profile, cancellationToken).ConfigureAwait(false);
+        if (!saveResult.Succeeded) {
+            return saveResult;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ClientSecret)) {
+            var clientSecretResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.ClientSecret, request.ClientSecret!.Trim(), cancellationToken).ConfigureAwait(false);
+            if (!clientSecretResult.Succeeded) {
+                return clientSecretResult;
+            }
+        }
+        if (!string.IsNullOrWhiteSpace(request.RefreshToken)) {
+            var refreshTokenResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.RefreshToken, request.RefreshToken!.Trim(), cancellationToken).ConfigureAwait(false);
+            if (!refreshTokenResult.Succeeded) {
+                return refreshTokenResult;
+            }
+        }
+        if (!string.IsNullOrWhiteSpace(request.AccessToken)) {
+            var accessTokenResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.AccessToken, request.AccessToken!.Trim(), cancellationToken).ConfigureAwait(false);
+            if (!accessTokenResult.Succeeded) {
+                return accessTokenResult;
+            }
+        }
+
+        return OperationResult.Success("Gmail profile saved.");
+    }
+
+    private static MailProfile CloneProfile(MailProfile profile) => new() {
+        Id = profile.Id,
+        DisplayName = profile.DisplayName,
+        Description = profile.Description,
+        Kind = profile.Kind,
+        DefaultSender = profile.DefaultSender,
+        DefaultMailbox = profile.DefaultMailbox,
+        IsDefault = profile.IsDefault,
+        Settings = new Dictionary<string, string>(profile.Settings, StringComparer.OrdinalIgnoreCase),
+        Capabilities = profile.Capabilities == null
+            ? null
+            : new ProfileCapabilities(profile.Capabilities.Kind, profile.Capabilities.Capabilities)
+    };
+
+    private static void UpsertSetting(IDictionary<string, string> settings, string key, string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            settings.Remove(key);
+            return;
+        }
+
+        var normalizedValue = value!.Trim();
+        settings[key] = normalizedValue;
+    }
+
+    private static string? FirstNonEmpty(params string?[] values) {
+        foreach (var value in values) {
+            if (!string.IsNullOrWhiteSpace(value)) {
+                var normalizedValue = value!.Trim();
+                return normalizedValue;
+            }
+        }
+
+        return null;
+    }
+
+    private async Task<bool> HasStoredSecretAsync(string profileId, string secretName, CancellationToken cancellationToken) =>
+        !string.IsNullOrWhiteSpace(await _secretStore.GetSecretAsync(profileId, secretName, cancellationToken).ConfigureAwait(false));
+}

--- a/Sources/Mailozaurr.Application/MailProfileConnectionService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileConnectionService.cs
@@ -1,0 +1,281 @@
+using MailKit.Net.Imap;
+using MailKit;
+using Mailozaurr;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Default implementation of live profile connection tests.
+/// </summary>
+public sealed class MailProfileConnectionService : IMailProfileConnectionService {
+    private readonly IMailProfileStore _profileStore;
+    private readonly IImapSessionFactory? _imapSessionFactory;
+    private readonly IGraphSessionFactory? _graphSessionFactory;
+    private readonly IGmailSessionFactory? _gmailSessionFactory;
+    private readonly ISmtpSessionFactory? _smtpSessionFactory;
+    private readonly Func<ImapClient, CancellationToken, Task> _probeImapAsync;
+    private readonly Func<ImapClient, CancellationToken, Task> _probeImapMailboxAsync;
+    private readonly Func<GraphSession, CancellationToken, Task> _probeGraphAsync;
+    private readonly Func<GraphSession, CancellationToken, Task> _probeGraphMailboxAsync;
+    private readonly Func<GmailSession, CancellationToken, Task> _probeGmailAsync;
+    private readonly Func<GmailSession, CancellationToken, Task> _probeGmailMailboxAsync;
+    private readonly Func<Smtp, CancellationToken, Task> _probeSmtpAsync;
+
+    /// <summary>
+    /// Creates a new connection-test service.
+    /// </summary>
+    public MailProfileConnectionService(
+        IMailProfileStore profileStore,
+        IImapSessionFactory? imapSessionFactory = null,
+        IGraphSessionFactory? graphSessionFactory = null,
+        IGmailSessionFactory? gmailSessionFactory = null,
+        ISmtpSessionFactory? smtpSessionFactory = null,
+        Func<ImapClient, CancellationToken, Task>? probeImapAsync = null,
+        Func<ImapClient, CancellationToken, Task>? probeImapMailboxAsync = null,
+        Func<GraphSession, CancellationToken, Task>? probeGraphAsync = null,
+        Func<GraphSession, CancellationToken, Task>? probeGraphMailboxAsync = null,
+        Func<GmailSession, CancellationToken, Task>? probeGmailAsync = null,
+        Func<GmailSession, CancellationToken, Task>? probeGmailMailboxAsync = null,
+        Func<Smtp, CancellationToken, Task>? probeSmtpAsync = null) {
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        _imapSessionFactory = imapSessionFactory;
+        _graphSessionFactory = graphSessionFactory;
+        _gmailSessionFactory = gmailSessionFactory;
+        _smtpSessionFactory = smtpSessionFactory;
+        _probeImapAsync = probeImapAsync ?? DefaultProbeImapAsync;
+        _probeImapMailboxAsync = probeImapMailboxAsync ?? DefaultProbeImapMailboxAsync;
+        _probeGraphAsync = probeGraphAsync ?? DefaultProbeGraphAsync;
+        _probeGraphMailboxAsync = probeGraphMailboxAsync ?? DefaultProbeGraphMailboxAsync;
+        _probeGmailAsync = probeGmailAsync ?? DefaultProbeGmailAsync;
+        _probeGmailMailboxAsync = probeGmailMailboxAsync ?? DefaultProbeGmailMailboxAsync;
+        _probeSmtpAsync = probeSmtpAsync ?? DefaultProbeSmtpAsync;
+    }
+
+    /// <inheritdoc />
+    public async Task<MailProfileConnectionTestResult> TestAsync(
+        string profileId,
+        MailProfileConnectionTestScope scope = MailProfileConnectionTestScope.Auto,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            return Failure("profile_required", "Profile id is required.", profileId, MailProfileKind.Unknown, scope, MailProfileConnectionTestScope.Auto);
+        }
+
+        var profile = await _profileStore.GetByIdAsync(profileId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (profile == null) {
+            return Failure("profile_not_found", "Profile was not found.", profileId, MailProfileKind.Unknown, scope, MailProfileConnectionTestScope.Auto);
+        }
+
+        var effectiveScope = ResolveScope(profile, scope);
+        try {
+            return profile.Kind switch {
+                MailProfileKind.Imap => await TestImapAsync(profile, scope, effectiveScope, cancellationToken).ConfigureAwait(false),
+                MailProfileKind.Graph => await TestGraphAsync(profile, scope, effectiveScope, cancellationToken).ConfigureAwait(false),
+                MailProfileKind.Gmail => await TestGmailAsync(profile, scope, effectiveScope, cancellationToken).ConfigureAwait(false),
+                MailProfileKind.Smtp => await TestSmtpAsync(profile, scope, effectiveScope, cancellationToken).ConfigureAwait(false),
+                _ => Failure("connection_test_not_supported", $"Live connection testing is not supported for profile kind '{profile.Kind}'.", profile.Id, profile.Kind, scope, effectiveScope)
+            };
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception ex) {
+            return Failure("connection_test_failed", ex.Message, profile.Id, profile.Kind, scope, effectiveScope);
+        }
+    }
+
+    private async Task<MailProfileConnectionTestResult> TestImapAsync(
+        MailProfile profile,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope effectiveScope,
+        CancellationToken cancellationToken) {
+        if (_imapSessionFactory == null) {
+            return Failure("connection_test_not_supported", "IMAP connection testing is not configured.", profile.Id, profile.Kind, requestedScope, effectiveScope);
+        }
+
+        using var client = await _imapSessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        if (effectiveScope == MailProfileConnectionTestScope.Mailbox) {
+            await _probeImapMailboxAsync(client, cancellationToken).ConfigureAwait(false);
+            return Success(profile, "openInbox", ResolveTarget(profile), "IMAP mailbox probe succeeded.", requestedScope, effectiveScope);
+        }
+
+        await _probeImapAsync(client, cancellationToken).ConfigureAwait(false);
+        return Success(profile, "connect", ResolveTarget(profile), "IMAP authentication succeeded.", requestedScope, effectiveScope);
+    }
+
+    private async Task<MailProfileConnectionTestResult> TestGraphAsync(
+        MailProfile profile,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope effectiveScope,
+        CancellationToken cancellationToken) {
+        if (_graphSessionFactory == null) {
+            return Failure("connection_test_not_supported", "Graph connection testing is not configured.", profile.Id, profile.Kind, requestedScope, effectiveScope);
+        }
+
+        using var session = await _graphSessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        if (effectiveScope == MailProfileConnectionTestScope.Mailbox) {
+            await _probeGraphMailboxAsync(session, cancellationToken).ConfigureAwait(false);
+            return Success(profile, "listFolders", session.UserId, "Graph mailbox probe succeeded.", requestedScope, effectiveScope);
+        }
+
+        await _probeGraphAsync(session, cancellationToken).ConfigureAwait(false);
+        return Success(profile, "connect", session.UserId, effectiveScope == MailProfileConnectionTestScope.Send ? "Graph send preflight succeeded." : "Graph authentication succeeded.", requestedScope, effectiveScope);
+    }
+
+    private async Task<MailProfileConnectionTestResult> TestGmailAsync(
+        MailProfile profile,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope effectiveScope,
+        CancellationToken cancellationToken) {
+        if (_gmailSessionFactory == null) {
+            return Failure("connection_test_not_supported", "Gmail connection testing is not configured.", profile.Id, profile.Kind, requestedScope, effectiveScope);
+        }
+
+        using var session = await _gmailSessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        if (effectiveScope == MailProfileConnectionTestScope.Mailbox) {
+            await _probeGmailMailboxAsync(session, cancellationToken).ConfigureAwait(false);
+            return Success(profile, "listFolders", session.UserId, "Gmail mailbox probe succeeded.", requestedScope, effectiveScope);
+        }
+
+        await _probeGmailAsync(session, cancellationToken).ConfigureAwait(false);
+        return Success(profile, "getProfile", session.UserId, effectiveScope == MailProfileConnectionTestScope.Send ? "Gmail send preflight succeeded." : "Gmail authentication succeeded.", requestedScope, effectiveScope);
+    }
+
+    private async Task<MailProfileConnectionTestResult> TestSmtpAsync(
+        MailProfile profile,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope effectiveScope,
+        CancellationToken cancellationToken) {
+        if (_smtpSessionFactory == null) {
+            return Failure("connection_test_not_supported", "SMTP connection testing is not configured.", profile.Id, profile.Kind, requestedScope, effectiveScope);
+        }
+
+        var smtp = await _smtpSessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        try {
+            await _probeSmtpAsync(smtp, cancellationToken).ConfigureAwait(false);
+            return Success(
+                profile,
+                "connect",
+                ResolveTarget(profile),
+                effectiveScope == MailProfileConnectionTestScope.Send ? "SMTP send preflight succeeded." : "SMTP authentication succeeded.",
+                requestedScope,
+                effectiveScope);
+        } finally {
+            smtp.Dispose();
+        }
+    }
+
+    private static Task DefaultProbeImapAsync(ImapClient client, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (!client.IsConnected || !client.IsAuthenticated) {
+            throw new InvalidOperationException("IMAP client is not connected and authenticated.");
+        }
+        return Task.CompletedTask;
+    }
+
+    private static async Task DefaultProbeImapMailboxAsync(ImapClient client, CancellationToken cancellationToken) {
+        await DefaultProbeImapAsync(client, cancellationToken).ConfigureAwait(false);
+        await client.Inbox.OpenAsync(FolderAccess.ReadOnly, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task DefaultProbeGraphAsync(GraphSession session, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        _ = session.UserId;
+        await Task.CompletedTask;
+    }
+
+    private static async Task DefaultProbeGraphMailboxAsync(GraphSession session, CancellationToken cancellationToken) {
+        var folders = await session.Client.ListMailFoldersRecursiveAsync(session.UserId, top: 1, maxRequests: 1, cancellationToken: cancellationToken).ConfigureAwait(false);
+        _ = folders.Count;
+    }
+
+    private static async Task DefaultProbeGmailAsync(GmailSession session, CancellationToken cancellationToken) {
+        var profile = await session.Browser.GetProfileAsync(cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(profile.EmailAddress)) {
+            throw new InvalidOperationException("Gmail profile probe did not return an email address.");
+        }
+    }
+
+    private static async Task DefaultProbeGmailMailboxAsync(GmailSession session, CancellationToken cancellationToken) {
+        var folders = await session.Browser.ListFoldersAsync(cancellationToken).ConfigureAwait(false);
+        _ = folders.Count;
+    }
+
+    private static Task DefaultProbeSmtpAsync(Smtp smtp, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (smtp == null) {
+            throw new ArgumentNullException(nameof(smtp));
+        }
+        if (!smtp.Client.IsConnected) {
+            throw new InvalidOperationException("SMTP client is not connected.");
+        }
+        return Task.CompletedTask;
+    }
+
+    private static string? ResolveTarget(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) &&
+            !string.IsNullOrWhiteSpace(mailbox)) {
+            return mailbox.Trim();
+        }
+        if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
+            return profile.DefaultMailbox!.Trim();
+        }
+        if (!string.IsNullOrWhiteSpace(profile.DefaultSender)) {
+            return profile.DefaultSender!.Trim();
+        }
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.UserName, out var userName) &&
+            !string.IsNullOrWhiteSpace(userName)) {
+            return userName.Trim();
+        }
+
+        return null;
+    }
+
+    private static MailProfileConnectionTestScope ResolveScope(MailProfile profile, MailProfileConnectionTestScope scope) =>
+        scope switch {
+            MailProfileConnectionTestScope.Auto => profile.Kind switch {
+                MailProfileKind.Imap => MailProfileConnectionTestScope.Mailbox,
+                MailProfileKind.Graph => MailProfileConnectionTestScope.Mailbox,
+                MailProfileKind.Gmail => MailProfileConnectionTestScope.Mailbox,
+                MailProfileKind.Smtp => MailProfileConnectionTestScope.Send,
+                _ => MailProfileConnectionTestScope.Auth
+            },
+            MailProfileConnectionTestScope.Mailbox when profile.Kind == MailProfileKind.Smtp => MailProfileConnectionTestScope.Send,
+            MailProfileConnectionTestScope.Send when profile.Kind == MailProfileKind.Imap => MailProfileConnectionTestScope.Auth,
+            MailProfileConnectionTestScope.Send when profile.Kind == MailProfileKind.Pop3 => MailProfileConnectionTestScope.Auth,
+            _ => scope
+        };
+
+    private static MailProfileConnectionTestResult Success(
+        MailProfile profile,
+        string probe,
+        string? target,
+        string message,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope executedScope) => new() {
+        Succeeded = true,
+        Message = message,
+        ProfileId = profile.Id,
+        ProfileKind = profile.Kind,
+        Probe = probe,
+        Target = target,
+        RequestedScope = requestedScope,
+        ExecutedScope = executedScope
+    };
+
+    private static MailProfileConnectionTestResult Failure(
+        string code,
+        string message,
+        string? profileId,
+        MailProfileKind kind,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope executedScope) => new() {
+        Succeeded = false,
+        Code = code,
+        Message = message,
+        ProfileId = string.IsNullOrWhiteSpace(profileId) ? null : profileId,
+        ProfileKind = kind,
+        RequestedScope = requestedScope,
+        ExecutedScope = executedScope
+    };
+}

--- a/Sources/Mailozaurr.Application/MailProfileConnectionTestResult.cs
+++ b/Sources/Mailozaurr.Application/MailProfileConnectionTestResult.cs
@@ -1,0 +1,24 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents the outcome of a reusable provider connection test.
+/// </summary>
+public sealed class MailProfileConnectionTestResult : OperationResult {
+    /// <summary>The tested profile identifier.</summary>
+    public string? ProfileId { get; set; }
+
+    /// <summary>The tested profile kind.</summary>
+    public MailProfileKind ProfileKind { get; set; }
+
+    /// <summary>The provider action used to verify connectivity.</summary>
+    public string? Probe { get; set; }
+
+    /// <summary>The resolved mailbox or account target used for the test, when applicable.</summary>
+    public string? Target { get; set; }
+
+    /// <summary>The requested test scope.</summary>
+    public MailProfileConnectionTestScope RequestedScope { get; set; }
+
+    /// <summary>The scope that was actually executed.</summary>
+    public MailProfileConnectionTestScope ExecutedScope { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MailProfileConnectionTestScope.cs
+++ b/Sources/Mailozaurr.Application/MailProfileConnectionTestScope.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Describes the depth of a live profile connection test.
+/// </summary>
+public enum MailProfileConnectionTestScope {
+    /// <summary>Uses the provider-appropriate default probe.</summary>
+    Auto,
+
+    /// <summary>Verifies session creation and authentication only.</summary>
+    Auth,
+
+    /// <summary>Verifies a lightweight mailbox read operation.</summary>
+    Mailbox,
+
+    /// <summary>Verifies a non-destructive send-path preflight.</summary>
+    Send
+}

--- a/Sources/Mailozaurr.Application/MailProfileKind.cs
+++ b/Sources/Mailozaurr.Application/MailProfileKind.cs
@@ -1,0 +1,33 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Identifies the mailbox or transport technology behind a profile.
+/// </summary>
+public enum MailProfileKind {
+    /// <summary>Unknown or not yet configured.</summary>
+    Unknown = 0,
+
+    /// <summary>IMAP mailbox access.</summary>
+    Imap,
+
+    /// <summary>POP3 mailbox access.</summary>
+    Pop3,
+
+    /// <summary>Microsoft Graph mailbox access.</summary>
+    Graph,
+
+    /// <summary>Gmail API mailbox access.</summary>
+    Gmail,
+
+    /// <summary>SMTP transport.</summary>
+    Smtp,
+
+    /// <summary>SendGrid transport.</summary>
+    SendGrid,
+
+    /// <summary>Mailgun transport.</summary>
+    Mailgun,
+
+    /// <summary>Amazon SES transport.</summary>
+    Ses,
+}

--- a/Sources/Mailozaurr.Application/MailProfileKindParser.cs
+++ b/Sources/Mailozaurr.Application/MailProfileKindParser.cs
@@ -1,0 +1,61 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Parses human-friendly profile kind values.
+/// </summary>
+public static class MailProfileKindParser {
+    /// <summary>
+    /// Parses a profile kind string.
+    /// </summary>
+    public static MailProfileKind Parse(string? value) {
+        if (TryParse(value, out var kind)) {
+            return kind;
+        }
+
+        throw new InvalidOperationException($"Unknown profile kind '{value}'.");
+    }
+
+    /// <summary>
+    /// Attempts to parse a profile kind string.
+    /// </summary>
+    public static bool TryParse(string? value, out MailProfileKind kind) {
+        var normalized = (value ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            kind = MailProfileKind.Unknown;
+            return false;
+        }
+
+        switch (normalized.ToLowerInvariant()) {
+            case "imap":
+                kind = MailProfileKind.Imap;
+                return true;
+            case "pop3":
+                kind = MailProfileKind.Pop3;
+                return true;
+            case "graph":
+            case "microsoft-graph":
+            case "msgraph":
+                kind = MailProfileKind.Graph;
+                return true;
+            case "gmail":
+                kind = MailProfileKind.Gmail;
+                return true;
+            case "smtp":
+                kind = MailProfileKind.Smtp;
+                return true;
+            case "sendgrid":
+                kind = MailProfileKind.SendGrid;
+                return true;
+            case "mailgun":
+                kind = MailProfileKind.Mailgun;
+                return true;
+            case "ses":
+            case "amazon-ses":
+                kind = MailProfileKind.Ses;
+                return true;
+            default:
+                kind = MailProfileKind.Unknown;
+                return false;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Application/MailProfileOverview.cs
+++ b/Sources/Mailozaurr.Application/MailProfileOverview.cs
@@ -1,0 +1,36 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Aggregated summary of a saved Mailozaurr profile for operator and agent surfaces.
+/// </summary>
+public sealed class MailProfileOverview {
+    /// <summary>The saved profile.</summary>
+    public MailProfile Profile { get; set; } = new();
+
+    /// <summary>Normalized capability map for the profile.</summary>
+    public ProfileCapabilities? Capabilities { get; set; }
+
+    /// <summary>Whether the profile supports mailbox read/search operations.</summary>
+    public bool SupportsRead { get; set; }
+
+    /// <summary>Whether the profile supports outbound sending.</summary>
+    public bool SupportsSend { get; set; }
+
+    /// <summary>Persisted authentication status when available.</summary>
+    public MailProfileAuthStatus? AuthStatus { get; set; }
+
+    /// <summary>Provider-readiness diagnosis.</summary>
+    public MailProfileValidationResult? Readiness { get; set; }
+
+    /// <summary>Whether the saved profile currently appears ready to use.</summary>
+    public bool IsReady { get; set; }
+
+    /// <summary>Total validation or readiness errors surfaced for the profile.</summary>
+    public int ErrorCount { get; set; }
+
+    /// <summary>Total validation or readiness warnings surfaced for the profile.</summary>
+    public int WarningCount { get; set; }
+
+    /// <summary>Short human-readable summary line.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MailProfileOverviewCompact.cs
+++ b/Sources/Mailozaurr.Application/MailProfileOverviewCompact.cs
@@ -1,0 +1,39 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Lightweight projection of a profile overview for list and agent scenarios.
+/// </summary>
+public sealed class MailProfileOverviewCompact {
+    /// <summary>The stable profile identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>The human-readable profile name.</summary>
+    public string? DisplayName { get; set; }
+
+    /// <summary>The profile provider kind.</summary>
+    public MailProfileKind Kind { get; set; }
+
+    /// <summary>Whether the profile is marked as default.</summary>
+    public bool IsDefault { get; set; }
+
+    /// <summary>Whether the profile supports mailbox reads.</summary>
+    public bool SupportsRead { get; set; }
+
+    /// <summary>Whether the profile supports sending.</summary>
+    public bool SupportsSend { get; set; }
+
+    /// <summary>The persisted auth mode when known.</summary>
+    public string? AuthMode { get; set; }
+
+    /// <summary>Whether the profile currently appears ready to use.</summary>
+    public bool IsReady { get; set; }
+
+    /// <summary>Total readiness or validation errors.</summary>
+    public int ErrorCount { get; set; }
+
+    /// <summary>Total readiness or validation warnings.</summary>
+    public int WarningCount { get; set; }
+
+    /// <summary>Short human-readable summary line.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MailProfileOverviewQuery.cs
+++ b/Sources/Mailozaurr.Application/MailProfileOverviewQuery.cs
@@ -1,0 +1,27 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Optional filters for bulk profile overview queries.
+/// </summary>
+public sealed class MailProfileOverviewQuery {
+    /// <summary>Optional profile kind filter.</summary>
+    public MailProfileKind? Kind { get; set; }
+
+    /// <summary>Optional sort key for the returned overviews.</summary>
+    public MailProfileOverviewSortBy SortBy { get; set; } = MailProfileOverviewSortBy.Id;
+
+    /// <summary>When true, reverses the selected sort order.</summary>
+    public bool Descending { get; set; }
+
+    /// <summary>When true, only returns ready profiles.</summary>
+    public bool ReadyOnly { get; set; }
+
+    /// <summary>When true, only returns profiles that support reading.</summary>
+    public bool CanReadOnly { get; set; }
+
+    /// <summary>When true, only returns profiles that support sending.</summary>
+    public bool CanSendOnly { get; set; }
+
+    /// <summary>When true, only returns profiles marked as default.</summary>
+    public bool DefaultOnly { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MailProfileOverviewService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileOverviewService.cs
@@ -1,0 +1,192 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Default implementation of reusable profile overview aggregation.
+/// </summary>
+public sealed class MailProfileOverviewService : IMailProfileOverviewService {
+    private readonly IMailProfileService _profiles;
+    private readonly IMailProfileAuthService _profileAuth;
+
+    /// <summary>
+    /// Creates a new overview service.
+    /// </summary>
+    public MailProfileOverviewService(IMailProfileService profiles, IMailProfileAuthService profileAuth) {
+        _profiles = profiles ?? throw new ArgumentNullException(nameof(profiles));
+        _profileAuth = profileAuth ?? throw new ArgumentNullException(nameof(profileAuth));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailProfileOverview>> GetOverviewsAsync(
+        MailProfileOverviewQuery? query = null,
+        CancellationToken cancellationToken = default) {
+        var profiles = await _profiles.GetProfilesAsync(cancellationToken).ConfigureAwait(false);
+        var results = new List<MailProfileOverview>(profiles.Count);
+        foreach (var profile in profiles) {
+            if (!MatchesProfileFilter(profile, query)) {
+                continue;
+            }
+
+            var overview = await BuildOverviewAsync(profile, cancellationToken).ConfigureAwait(false);
+            if (!MatchesOverviewFilter(overview, query)) {
+                continue;
+            }
+
+            results.Add(overview);
+        }
+
+        return SortOverviews(results, query);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailProfileOverviewCompact>> GetCompactOverviewsAsync(
+        MailProfileOverviewQuery? query = null,
+        CancellationToken cancellationToken = default) =>
+        (await GetOverviewsAsync(query, cancellationToken).ConfigureAwait(false))
+        .Select(ToCompact)
+        .ToArray();
+
+    /// <inheritdoc />
+    public async Task<MailProfileOverview?> GetOverviewAsync(string profileId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            throw new ArgumentException("Profile id is required.", nameof(profileId));
+        }
+
+        var profile = await _profiles.GetProfileAsync(profileId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (profile == null) {
+            return null;
+        }
+
+        return await BuildOverviewAsync(profile, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MailProfileOverviewCompact?> GetCompactOverviewAsync(string profileId, CancellationToken cancellationToken = default) {
+        var overview = await GetOverviewAsync(profileId, cancellationToken).ConfigureAwait(false);
+        return overview == null ? null : ToCompact(overview);
+    }
+
+    private async Task<MailProfileOverview> BuildOverviewAsync(MailProfile profile, CancellationToken cancellationToken) {
+        var capabilities = await _profiles.GetCapabilitiesAsync(profile.Id, cancellationToken).ConfigureAwait(false);
+        var authStatus = await _profileAuth.GetStatusAsync(profile.Id, cancellationToken).ConfigureAwait(false);
+        var readiness = await _profiles.DiagnoseAsync(profile.Id, cancellationToken).ConfigureAwait(false);
+        var supportsRead = capabilities?.Supports(MailCapability.SearchMessages | MailCapability.ReadMessages) == true;
+        var supportsSend = capabilities?.Supports(MailCapability.SendMessages) == true;
+
+        return new MailProfileOverview {
+            Profile = profile,
+            Capabilities = capabilities,
+            SupportsRead = supportsRead,
+            SupportsSend = supportsSend,
+            AuthStatus = authStatus,
+            Readiness = readiness,
+            IsReady = readiness.Succeeded,
+            ErrorCount = readiness.Errors.Count,
+            WarningCount = readiness.Warnings.Count,
+            Summary = BuildSummary(profile, authStatus, readiness, supportsRead, supportsSend)
+        };
+    }
+
+    private static string BuildSummary(
+        MailProfile profile,
+        MailProfileAuthStatus? authStatus,
+        MailProfileValidationResult readiness,
+        bool supportsRead,
+        bool supportsSend) {
+        var authMode = authStatus?.Mode ?? "unknown";
+        var readinessState = readiness.Succeeded ? "ready" : "needs-attention";
+        var readState = supportsRead ? "yes" : "no";
+        var sendState = supportsSend ? "yes" : "no";
+        var warningSuffix = readiness.Warnings.Count > 0 ? $", warnings={readiness.Warnings.Count}" : string.Empty;
+        var errorSuffix = readiness.Errors.Count > 0 ? $", errors={readiness.Errors.Count}" : string.Empty;
+        return $"{profile.Id} [{profile.Kind}] read={readState}, send={sendState}, auth={authMode}, readiness={readinessState}{warningSuffix}{errorSuffix}.";
+    }
+
+    private static bool MatchesProfileFilter(MailProfile profile, MailProfileOverviewQuery? query) {
+        if (query == null) {
+            return true;
+        }
+
+        if (query.Kind.HasValue && profile.Kind != query.Kind.Value) {
+            return false;
+        }
+
+        if (query.DefaultOnly && !profile.IsDefault) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool MatchesOverviewFilter(MailProfileOverview overview, MailProfileOverviewQuery? query) {
+        if (query == null) {
+            return true;
+        }
+
+        if (query.ReadyOnly && !overview.IsReady) {
+            return false;
+        }
+
+        if (query.CanReadOnly && !overview.SupportsRead) {
+            return false;
+        }
+
+        if (query.CanSendOnly && !overview.SupportsSend) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static IReadOnlyList<MailProfileOverview> SortOverviews(
+        IReadOnlyList<MailProfileOverview> overviews,
+        MailProfileOverviewQuery? query) {
+        if (overviews.Count <= 1) {
+            return overviews;
+        }
+
+        var sortBy = query?.SortBy ?? MailProfileOverviewSortBy.Id;
+        var descending = query?.Descending == true;
+
+        IOrderedEnumerable<MailProfileOverview> ordered = sortBy switch {
+            MailProfileOverviewSortBy.Kind => overviews
+                .OrderBy(overview => overview.Profile.Kind)
+                .ThenBy(overview => overview.Profile.Id, StringComparer.OrdinalIgnoreCase),
+            MailProfileOverviewSortBy.Readiness => overviews
+                .OrderBy(overview => overview.IsReady)
+                .ThenByDescending(overview => overview.ErrorCount)
+                .ThenByDescending(overview => overview.WarningCount)
+                .ThenBy(overview => overview.Profile.Id, StringComparer.OrdinalIgnoreCase),
+            _ => overviews.OrderBy(overview => overview.Profile.Id, StringComparer.OrdinalIgnoreCase)
+        };
+
+        if (descending) {
+            ordered = sortBy switch {
+                MailProfileOverviewSortBy.Kind => overviews
+                    .OrderByDescending(overview => overview.Profile.Kind)
+                    .ThenByDescending(overview => overview.Profile.Id, StringComparer.OrdinalIgnoreCase),
+                MailProfileOverviewSortBy.Readiness => overviews
+                    .OrderByDescending(overview => overview.IsReady)
+                    .ThenBy(overview => overview.ErrorCount)
+                    .ThenBy(overview => overview.WarningCount)
+                    .ThenBy(overview => overview.Profile.Id, StringComparer.OrdinalIgnoreCase),
+                _ => overviews.OrderByDescending(overview => overview.Profile.Id, StringComparer.OrdinalIgnoreCase)
+            };
+        }
+
+        return ordered.ToArray();
+    }
+
+    private static MailProfileOverviewCompact ToCompact(MailProfileOverview overview) => new() {
+        Id = overview.Profile.Id,
+        DisplayName = overview.Profile.DisplayName,
+        Kind = overview.Profile.Kind,
+        IsDefault = overview.Profile.IsDefault,
+        SupportsRead = overview.SupportsRead,
+        SupportsSend = overview.SupportsSend,
+        AuthMode = overview.AuthStatus?.Mode,
+        IsReady = overview.IsReady,
+        ErrorCount = overview.ErrorCount,
+        WarningCount = overview.WarningCount,
+        Summary = overview.Summary
+    };
+}

--- a/Sources/Mailozaurr.Application/MailProfileOverviewSortBy.cs
+++ b/Sources/Mailozaurr.Application/MailProfileOverviewSortBy.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Supported sort keys for bulk profile overview queries.
+/// </summary>
+public enum MailProfileOverviewSortBy {
+    /// <summary>Sort by profile identifier.</summary>
+    Id = 0,
+
+    /// <summary>Sort by profile kind, then identifier.</summary>
+    Kind = 1,
+
+    /// <summary>Sort by readiness, with profiles needing attention first.</summary>
+    Readiness = 2,
+}

--- a/Sources/Mailozaurr.Application/MailProfileSecretService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileSecretService.cs
@@ -1,0 +1,61 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Default implementation of profile secret lifecycle operations.
+/// </summary>
+public sealed class MailProfileSecretService : IMailProfileSecretService {
+    private readonly IMailProfileStore _profileStore;
+    private readonly IMailSecretStore _secretStore;
+
+    /// <summary>
+    /// Creates a new profile secret service.
+    /// </summary>
+    public MailProfileSecretService(IMailProfileStore profileStore, IMailSecretStore secretStore) {
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(secretValue)) {
+            return OperationResult.Failure("secret_value_required", "Secret value is required.");
+        }
+
+        var validationResult = await ValidateAsync(profileId, secretName, cancellationToken).ConfigureAwait(false);
+        if (!validationResult.Succeeded) {
+            return validationResult;
+        }
+
+        await _secretStore.SetSecretAsync(profileId, secretName, secretValue, cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success("Secret saved.");
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+        var validationResult = await ValidateAsync(profileId, secretName, cancellationToken).ConfigureAwait(false);
+        if (!validationResult.Succeeded) {
+            return validationResult;
+        }
+
+        var removed = await _secretStore.RemoveSecretAsync(profileId, secretName, cancellationToken).ConfigureAwait(false);
+        return removed
+            ? OperationResult.Success("Secret removed.")
+            : OperationResult.Failure("secret_not_found", "Secret was not found.");
+    }
+
+    private async Task<OperationResult> ValidateAsync(string profileId, string secretName, CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            return OperationResult.Failure("profile_required", "Profile id is required.");
+        }
+        if (string.IsNullOrWhiteSpace(secretName)) {
+            return OperationResult.Failure("secret_name_required", "Secret name is required.");
+        }
+
+        var profile = await _profileStore.GetByIdAsync(profileId, cancellationToken).ConfigureAwait(false);
+        if (profile == null) {
+            return OperationResult.Failure("profile_not_found", "Profile was not found.");
+        }
+
+        return OperationResult.Success();
+    }
+}

--- a/Sources/Mailozaurr.Application/MailProfileService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileService.cs
@@ -1,0 +1,153 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Default implementation of profile lifecycle operations.
+/// </summary>
+public sealed class MailProfileService : IMailProfileService {
+    private readonly IMailProfileStore _profileStore;
+    private readonly IMailSecretStore? _secretStore;
+
+    /// <summary>
+    /// Creates a new profile service.
+    /// </summary>
+    public MailProfileService(IMailProfileStore profileStore, IMailSecretStore? secretStore = null) {
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        _secretStore = secretStore;
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<MailProfile>> GetProfilesAsync(CancellationToken cancellationToken = default) =>
+        _profileStore.GetAllAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public Task<MailProfile?> GetProfileAsync(string profileId, CancellationToken cancellationToken = default) =>
+        _profileStore.GetByIdAsync(profileId, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<MailProfileValidationResult> ValidateAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+        Task.FromResult(MailProfileValidator.Validate(profile));
+
+    /// <inheritdoc />
+    public async Task<MailProfileValidationResult> DiagnoseAsync(string profileId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            return CreateFailure("profile_required", "Profile id is required.");
+        }
+
+        var profile = await _profileStore.GetByIdAsync(profileId, cancellationToken).ConfigureAwait(false);
+        if (profile == null) {
+            return CreateFailure("profile_not_found", "Profile was not found.");
+        }
+
+        var result = MailProfileValidator.Validate(profile);
+        await AddProviderReadinessChecksAsync(profile, result, cancellationToken).ConfigureAwait(false);
+        result.Succeeded = result.Errors.Count == 0;
+        result.Code = result.Succeeded ? null : "profile_not_ready";
+        result.Message = result.Succeeded
+            ? (result.Warnings.Count == 0 ? "Profile is ready." : "Profile is ready with warnings.")
+            : result.Errors[0];
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+        var validation = MailProfileValidator.Validate(profile);
+        if (!validation.Succeeded) {
+            return validation;
+        }
+
+        await _profileStore.SaveAsync(profile, cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success("Profile saved.");
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> DeleteAsync(string profileId, CancellationToken cancellationToken = default) {
+        var removed = await _profileStore.RemoveAsync(profileId, cancellationToken).ConfigureAwait(false);
+        if (!removed) {
+            return OperationResult.Failure("profile_not_found", "Profile was not found.");
+        }
+
+        if (_secretStore != null) {
+            await RemoveKnownSecretsAsync(profileId, cancellationToken).ConfigureAwait(false);
+        }
+
+        return OperationResult.Success("Profile deleted.");
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SetDefaultAsync(string profileId, CancellationToken cancellationToken = default) {
+        var profiles = await _profileStore.GetAllAsync(cancellationToken).ConfigureAwait(false);
+        var profile = profiles.FirstOrDefault(p => string.Equals(p.Id, profileId, StringComparison.OrdinalIgnoreCase));
+        if (profile == null) {
+            return OperationResult.Failure("profile_not_found", "Profile was not found.");
+        }
+
+        profile.IsDefault = true;
+        await _profileStore.SaveAsync(profile, cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success("Default profile updated.");
+    }
+
+    /// <inheritdoc />
+    public async Task<ProfileCapabilities?> GetCapabilitiesAsync(string profileId, CancellationToken cancellationToken = default) {
+        var profile = await _profileStore.GetByIdAsync(profileId, cancellationToken).ConfigureAwait(false);
+        return profile?.GetCapabilities();
+    }
+
+    private async Task AddProviderReadinessChecksAsync(MailProfile profile, MailProfileValidationResult result, CancellationToken cancellationToken) {
+        if (_secretStore == null) {
+            result.Warnings.Add("Secret store is unavailable, so authentication readiness could not be fully verified.");
+            return;
+        }
+
+        switch (profile.Kind) {
+            case MailProfileKind.Graph:
+                var hasGraphAccessToken = await HasSecretAsync(profile.Id, MailSecretNames.AccessToken, cancellationToken).ConfigureAwait(false);
+                var hasGraphClientSecret = await HasSecretAsync(profile.Id, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false);
+                var hasGraphClientId = HasSetting(profile, MailProfileSettingsKeys.ClientId);
+                var hasGraphTenantId = HasSetting(profile, MailProfileSettingsKeys.TenantId);
+                var hasGraphCertificate = HasSetting(profile, MailProfileSettingsKeys.CertificatePath);
+                if (!hasGraphAccessToken && (!hasGraphClientId || !hasGraphTenantId || (!hasGraphClientSecret && !hasGraphCertificate))) {
+                    result.Errors.Add("Graph profiles need an access token or a client id and tenant id with a client secret or certificate path.");
+                }
+                break;
+            case MailProfileKind.Gmail:
+                var hasGmailAccessToken = await HasSecretAsync(profile.Id, MailSecretNames.AccessToken, cancellationToken).ConfigureAwait(false);
+                var hasGmailRefreshToken = await HasSecretAsync(profile.Id, MailSecretNames.RefreshToken, cancellationToken).ConfigureAwait(false);
+                var hasGmailClientSecret = await HasSecretAsync(profile.Id, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false);
+                var hasGmailClientId = HasSetting(profile, MailProfileSettingsKeys.ClientId);
+                if (!hasGmailAccessToken && (!hasGmailRefreshToken || !hasGmailClientId || !hasGmailClientSecret)) {
+                    result.Errors.Add("Gmail profiles need an access token or a refresh token with a client id and client secret.");
+                }
+                break;
+        }
+    }
+
+    private async Task RemoveKnownSecretsAsync(string profileId, CancellationToken cancellationToken) {
+        var secretNames = new[] {
+            MailSecretNames.Password,
+            MailSecretNames.ClientSecret,
+            MailSecretNames.AccessToken,
+            MailSecretNames.RefreshToken,
+            MailSecretNames.CertificatePassword
+        };
+
+        foreach (var secretName in secretNames) {
+            await _secretStore!.RemoveSecretAsync(profileId, secretName, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<bool> HasSecretAsync(string profileId, string secretName, CancellationToken cancellationToken) =>
+        !string.IsNullOrWhiteSpace(await _secretStore!.GetSecretAsync(profileId, secretName, cancellationToken).ConfigureAwait(false));
+
+    private static bool HasSetting(MailProfile profile, string key) =>
+        profile.Settings.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value);
+
+    private static MailProfileValidationResult CreateFailure(string code, string message) {
+        var result = new MailProfileValidationResult {
+            Succeeded = false,
+            Code = code,
+            Message = message
+        };
+        result.Errors.Add(message);
+        return result;
+    }
+}

--- a/Sources/Mailozaurr.Application/MailProfileSettingsKeys.cs
+++ b/Sources/Mailozaurr.Application/MailProfileSettingsKeys.cs
@@ -1,0 +1,72 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Common well-known setting keys used by profile-based adapters.
+/// </summary>
+public static class MailProfileSettingsKeys {
+    /// <summary>User name used for authentication.</summary>
+    public const string UserName = "userName";
+
+    /// <summary>Server host name.</summary>
+    public const string Server = "server";
+
+    /// <summary>Server port number.</summary>
+    public const string Port = "port";
+
+    /// <summary>Default folder or folder path.</summary>
+    public const string Folder = "folder";
+
+    /// <summary>Tenant identifier or directory id.</summary>
+    public const string TenantId = "tenantId";
+
+    /// <summary>Client or application identifier.</summary>
+    public const string ClientId = "clientId";
+
+    /// <summary>Certificate path for certificate-based authentication.</summary>
+    public const string CertificatePath = "certificatePath";
+
+    /// <summary>Redirect URI used by interactive OAuth flows.</summary>
+    public const string RedirectUri = "redirectUri";
+
+    /// <summary>Authentication flow identifier for provider-specific login orchestration.</summary>
+    public const string AuthFlow = "authFlow";
+
+    /// <summary>Preferred login hint used by interactive authentication flows.</summary>
+    public const string LoginHint = "loginHint";
+
+    /// <summary>Access-token expiration timestamp in round-trip format.</summary>
+    public const string TokenExpiresOn = "tokenExpiresOn";
+
+    /// <summary>Mailbox address or user principal name.</summary>
+    public const string Mailbox = "mailbox";
+
+    /// <summary>Authentication mode identifier.</summary>
+    public const string AuthMode = "authMode";
+
+    /// <summary>Secure socket options mode.</summary>
+    public const string SecureSocketOptions = "secureSocketOptions";
+
+    /// <summary>Compatibility flag that requests SSL/TLS when explicit socket options are not supplied.</summary>
+    public const string UseSsl = "useSsl";
+
+    /// <summary>Connection timeout in milliseconds.</summary>
+    public const string Timeout = "timeout";
+
+    /// <summary>Retry count for transient connection failures.</summary>
+    public const string RetryCount = "retryCount";
+
+    /// <summary>Retry delay in milliseconds.</summary>
+    public const string RetryDelayMilliseconds = "retryDelayMilliseconds";
+
+    /// <summary>Retry backoff multiplier.</summary>
+    public const string RetryDelayBackoff = "retryDelayBackoff";
+
+    /// <summary>Whether certificate revocation checks should be skipped.</summary>
+    public const string SkipCertificateRevocation = "skipCertificateRevocation";
+
+    /// <summary>Whether certificate validation should be skipped.</summary>
+    public const string SkipCertificateValidation = "skipCertificateValidation";
+
+    /// <summary>Maximum message body size used when reading messages.</summary>
+    public const string MaxBodyBytes = "maxBodyBytes";
+}

--- a/Sources/Mailozaurr.Application/MailProfileStoreOptions.cs
+++ b/Sources/Mailozaurr.Application/MailProfileStoreOptions.cs
@@ -1,0 +1,22 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Configures where mail profiles are stored.
+/// </summary>
+public sealed class MailProfileStoreOptions {
+    /// <summary>Directory containing the profile store file.</summary>
+    public string? DirectoryPath { get; set; }
+
+    /// <summary>File name used to persist profiles.</summary>
+    public string FileName { get; set; } = "profiles.json";
+
+    /// <summary>
+    /// Resolves the file path that should be used by the profile store.
+    /// </summary>
+    public string GetFilePath() {
+        var directory = string.IsNullOrWhiteSpace(DirectoryPath)
+            ? MailApplicationPaths.ResolveProfilesDirectory()
+            : Path.GetFullPath(DirectoryPath);
+        return Path.Combine(directory, FileName);
+    }
+}

--- a/Sources/Mailozaurr.Application/MailProfileValidationResult.cs
+++ b/Sources/Mailozaurr.Application/MailProfileValidationResult.cs
@@ -1,0 +1,12 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents the result of validating a mail profile definition.
+/// </summary>
+public sealed class MailProfileValidationResult : OperationResult {
+    /// <summary>Validation errors.</summary>
+    public List<string> Errors { get; } = new();
+
+    /// <summary>Validation warnings.</summary>
+    public List<string> Warnings { get; } = new();
+}

--- a/Sources/Mailozaurr.Application/MailProfileValidator.cs
+++ b/Sources/Mailozaurr.Application/MailProfileValidator.cs
@@ -1,0 +1,97 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Validates profile definitions before they are saved or used.
+/// </summary>
+public static class MailProfileValidator {
+    /// <summary>
+    /// Validates a profile and returns errors and warnings.
+    /// </summary>
+    public static MailProfileValidationResult Validate(MailProfile? profile) {
+        var result = new MailProfileValidationResult();
+        if (profile == null) {
+            result.Succeeded = false;
+            result.Code = "profile_missing";
+            result.Errors.Add("Profile is required.");
+            result.Message = result.Errors[0];
+            return result;
+        }
+
+        if (string.IsNullOrWhiteSpace(profile.Id)) {
+            result.Errors.Add("Profile id is required.");
+        } else if (profile.Id.Any(char.IsWhiteSpace)) {
+            result.Warnings.Add("Profile id contains whitespace. Hyphenated identifiers are recommended.");
+        }
+
+        if (string.IsNullOrWhiteSpace(profile.DisplayName)) {
+            result.Errors.Add("Profile display name is required.");
+        }
+
+        if (profile.Kind == MailProfileKind.Unknown) {
+            result.Errors.Add("Profile kind must be specified.");
+        }
+
+        switch (profile.Kind) {
+            case MailProfileKind.Imap:
+            case MailProfileKind.Pop3:
+            case MailProfileKind.Smtp:
+                RequireSetting(profile, MailProfileSettingsKeys.Server, result);
+                ValidateOptionalPort(profile, result);
+                break;
+            case MailProfileKind.Graph:
+                RequireOneOf(profile, result, MailProfileSettingsKeys.Mailbox, "defaultMailbox");
+                break;
+            case MailProfileKind.Gmail:
+                RequireOneOf(profile, result, MailProfileSettingsKeys.Mailbox, "defaultMailbox");
+                break;
+        }
+
+        if (profile.GetCapabilities().Supports(MailCapability.SendMessages) &&
+            string.IsNullOrWhiteSpace(profile.DefaultSender)) {
+            result.Warnings.Add("Send-capable profiles should define DefaultSender.");
+        }
+
+        if (profile.GetCapabilities().Supports(MailCapability.ReadMessages) &&
+            string.IsNullOrWhiteSpace(profile.DefaultMailbox) &&
+            !profile.Settings.ContainsKey(MailProfileSettingsKeys.Mailbox)) {
+            result.Warnings.Add("Read-capable profiles should define DefaultMailbox or a mailbox setting.");
+        }
+
+        result.Succeeded = result.Errors.Count == 0;
+        result.Code = result.Succeeded ? null : "profile_invalid";
+        result.Message = result.Succeeded
+            ? (result.Warnings.Count == 0 ? "Profile is valid." : "Profile is valid with warnings.")
+            : result.Errors[0];
+        return result;
+    }
+
+    private static void RequireSetting(MailProfile profile, string key, MailProfileValidationResult result) {
+        if (!profile.Settings.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value)) {
+            result.Errors.Add($"Profile setting '{key}' is required for {profile.Kind} profiles.");
+        }
+    }
+
+    private static void RequireOneOf(MailProfile profile, MailProfileValidationResult result, params string[] keys) {
+        foreach (var key in keys) {
+            if (string.Equals(key, "defaultMailbox", StringComparison.OrdinalIgnoreCase)) {
+                if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
+                    return;
+                }
+            } else if (profile.Settings.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)) {
+                return;
+            }
+        }
+
+        result.Warnings.Add($"Profile should define one of: {string.Join(", ", keys)}.");
+    }
+
+    private static void ValidateOptionalPort(MailProfile profile, MailProfileValidationResult result) {
+        if (!profile.Settings.TryGetValue(MailProfileSettingsKeys.Port, out var value) || string.IsNullOrWhiteSpace(value)) {
+            return;
+        }
+
+        if (!int.TryParse(value, out var port) || port <= 0 || port > 65535) {
+            result.Errors.Add($"Profile setting '{MailProfileSettingsKeys.Port}' must be a valid TCP port.");
+        }
+    }
+}

--- a/Sources/Mailozaurr.Application/MailSearchRequest.cs
+++ b/Sources/Mailozaurr.Application/MailSearchRequest.cs
@@ -1,0 +1,42 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for searching or listing messages.
+/// </summary>
+public sealed class MailSearchRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional folder identifier.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Optional free-text query.</summary>
+    public string? QueryText { get; set; }
+
+    /// <summary>Optional subject filter.</summary>
+    public string? SubjectContains { get; set; }
+
+    /// <summary>Optional sender filter.</summary>
+    public string? FromContains { get; set; }
+
+    /// <summary>Optional recipient filter.</summary>
+    public string? ToContains { get; set; }
+
+    /// <summary>Only include messages with attachments.</summary>
+    public bool HasAttachments { get; set; }
+
+    /// <summary>Only include unread messages when set to <c>true</c>.</summary>
+    public bool? IsRead { get; set; }
+
+    /// <summary>Optional lower date bound.</summary>
+    public DateTimeOffset? Since { get; set; }
+
+    /// <summary>Optional upper date bound.</summary>
+    public DateTimeOffset? Before { get; set; }
+
+    /// <summary>Maximum number of results to return.</summary>
+    public int? Limit { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MailSecretNames.cs
+++ b/Sources/Mailozaurr.Application/MailSecretNames.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Common well-known secret names used by profile-based adapters.
+/// </summary>
+public static class MailSecretNames {
+    /// <summary>Password for username/password authentication.</summary>
+    public const string Password = "password";
+
+    /// <summary>Client secret for confidential client auth flows.</summary>
+    public const string ClientSecret = "clientSecret";
+
+    /// <summary>Access token for temporary explicit sessions.</summary>
+    public const string AccessToken = "accessToken";
+
+    /// <summary>Refresh token when stored explicitly.</summary>
+    public const string RefreshToken = "refreshToken";
+
+    /// <summary>Certificate password when certificate auth is used.</summary>
+    public const string CertificatePassword = "certificatePassword";
+}

--- a/Sources/Mailozaurr.Application/MailSecretStoreOptions.cs
+++ b/Sources/Mailozaurr.Application/MailSecretStoreOptions.cs
@@ -1,0 +1,22 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Configures where protected secrets are stored.
+/// </summary>
+public sealed class MailSecretStoreOptions {
+    /// <summary>Directory containing the secret store file.</summary>
+    public string? DirectoryPath { get; set; }
+
+    /// <summary>File name used to persist secrets.</summary>
+    public string FileName { get; set; } = "profile-secrets.json";
+
+    /// <summary>
+    /// Resolves the file path that should be used by the secret store.
+    /// </summary>
+    public string GetFilePath() {
+        var directory = string.IsNullOrWhiteSpace(DirectoryPath)
+            ? MailApplicationPaths.ResolveSecretsDirectory()
+            : Path.GetFullPath(DirectoryPath);
+        return Path.Combine(directory, FileName);
+    }
+}

--- a/Sources/Mailozaurr.Application/MailboxRef.cs
+++ b/Sources/Mailozaurr.Application/MailboxRef.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Identifies a mailbox or account container.
+/// </summary>
+public sealed class MailboxRef {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Provider-specific mailbox identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>User-facing mailbox name.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Mailbox address or principal name when known.</summary>
+    public string? Address { get; set; }
+}

--- a/Sources/Mailozaurr.Application/Mailozaurr.Application.csproj
+++ b/Sources/Mailozaurr.Application/Mailozaurr.Application.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Company>Evotec</Company>
+        <Authors>Przemyslaw Klys</Authors>
+        <AssemblyName>Mailozaurr.Application</AssemblyName>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Mailozaurr\Mailozaurr.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="..\..\Mailozaurr.png" Pack="true" PackagePath="\" />
+        <None Include="..\..\README.MD" Pack="true" PackagePath="\" />
+    </ItemGroup>
+</Project>

--- a/Sources/Mailozaurr.Application/MessageDetail.cs
+++ b/Sources/Mailozaurr.Application/MessageDetail.cs
@@ -1,0 +1,27 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents normalized detailed message data.
+/// </summary>
+public sealed class MessageDetail {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Provider-specific message identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Optional normalized summary for the same message.</summary>
+    public MessageSummary? Summary { get; set; }
+
+    /// <summary>Plain text body.</summary>
+    public string? TextBody { get; set; }
+
+    /// <summary>HTML body.</summary>
+    public string? HtmlBody { get; set; }
+
+    /// <summary>Attachments associated with the message.</summary>
+    public List<AttachmentSummary> Attachments { get; set; } = new();
+
+    /// <summary>Optional raw MIME or provider-native payload.</summary>
+    public string? RawContent { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MessageDetailCompact.cs
+++ b/Sources/Mailozaurr.Application/MessageDetailCompact.cs
@@ -1,0 +1,30 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Lightweight projection of detailed message data for list and agent scenarios.
+/// </summary>
+public sealed class MessageDetailCompact {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Provider-specific message identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Optional normalized summary for the same message.</summary>
+    public MessageSummaryCompact? Summary { get; set; }
+
+    /// <summary>Plain-text body preview.</summary>
+    public string? TextBodyPreview { get; set; }
+
+    /// <summary>HTML body preview.</summary>
+    public string? HtmlBodyPreview { get; set; }
+
+    /// <summary>Attachments associated with the message.</summary>
+    public List<AttachmentSummary> Attachments { get; set; } = new();
+
+    /// <summary>Whether raw provider content was available.</summary>
+    public bool HasRawContent { get; set; }
+
+    /// <summary>Short human-readable summary line.</summary>
+    public string SummaryText { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MessageRecipient.cs
+++ b/Sources/Mailozaurr.Application/MessageRecipient.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents a normalized recipient or sender identity.
+/// </summary>
+public sealed class MessageRecipient {
+    /// <summary>Display name of the recipient.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>Email address of the recipient.</summary>
+    public string Address { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    public override string ToString() => string.IsNullOrWhiteSpace(Name) ? Address : $"{Name} <{Address}>";
+}

--- a/Sources/Mailozaurr.Application/MessageSummary.cs
+++ b/Sources/Mailozaurr.Application/MessageSummary.cs
@@ -1,0 +1,48 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents normalized summary data for a message returned by search or list operations.
+/// </summary>
+public sealed class MessageSummary {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Provider-specific message identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Provider-specific thread or conversation identifier.</summary>
+    public string? ThreadId { get; set; }
+
+    /// <summary>Folder identifier when known.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Message subject.</summary>
+    public string? Subject { get; set; }
+
+    /// <summary>Message preview or snippet when available.</summary>
+    public string? Preview { get; set; }
+
+    /// <summary>Message sender list.</summary>
+    public List<MessageRecipient> From { get; set; } = new();
+
+    /// <summary>Primary recipients.</summary>
+    public List<MessageRecipient> To { get; set; } = new();
+
+    /// <summary>Carbon-copy recipients.</summary>
+    public List<MessageRecipient> Cc { get; set; } = new();
+
+    /// <summary>When the message was sent.</summary>
+    public DateTimeOffset? SentAt { get; set; }
+
+    /// <summary>When the message was received or observed.</summary>
+    public DateTimeOffset? ReceivedAt { get; set; }
+
+    /// <summary>Whether the message is marked read.</summary>
+    public bool? IsRead { get; set; }
+
+    /// <summary>Whether the message has attachments.</summary>
+    public bool HasAttachments { get; set; }
+
+    /// <summary>Normalized priority when available.</summary>
+    public MessagePriority? Priority { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MessageSummaryCompact.cs
+++ b/Sources/Mailozaurr.Application/MessageSummaryCompact.cs
@@ -1,0 +1,36 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Lightweight projection of a message summary for list and agent scenarios.
+/// </summary>
+public sealed class MessageSummaryCompact {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Provider-specific message identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Folder identifier when known.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Message subject.</summary>
+    public string? Subject { get; set; }
+
+    /// <summary>Message preview or snippet when available.</summary>
+    public string? Preview { get; set; }
+
+    /// <summary>First sender display value when available.</summary>
+    public string? From { get; set; }
+
+    /// <summary>When the message was received or observed.</summary>
+    public DateTimeOffset? ReceivedAt { get; set; }
+
+    /// <summary>Whether the message is marked read.</summary>
+    public bool? IsRead { get; set; }
+
+    /// <summary>Whether the message has attachments.</summary>
+    public bool HasAttachments { get; set; }
+
+    /// <summary>Short human-readable summary line.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MimeAttachmentStorage.cs
+++ b/Sources/Mailozaurr.Application/MimeAttachmentStorage.cs
@@ -1,0 +1,59 @@
+using MimeKit;
+
+namespace Mailozaurr.Application;
+
+internal static class MimeAttachmentStorage {
+    public static MimeEntity? ResolveAttachment(IReadOnlyList<MimeEntity> attachments, string attachmentId) {
+        if (int.TryParse(attachmentId, out var index) && index >= 0 && index < attachments.Count) {
+            return attachments[index];
+        }
+
+        return attachments.FirstOrDefault(attachment =>
+            string.Equals(GetAttachmentFileName(attachment), attachmentId, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static string ResolveDestinationPath(string requestedPath, MimeEntity attachment) {
+        var destinationPath = Path.GetFullPath(requestedPath);
+        if (Directory.Exists(destinationPath)) {
+            return Path.Combine(destinationPath, GetAttachmentFileName(attachment));
+        }
+
+        var directory = Path.GetDirectoryName(destinationPath);
+        if (!string.IsNullOrWhiteSpace(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        return destinationPath;
+    }
+
+    public static string GetAttachmentFileName(MimeEntity attachment) => attachment switch {
+        MimePart part => part.FileName ?? Path.GetRandomFileName(),
+        MessagePart messagePart => messagePart.ContentDisposition?.FileName ?? messagePart.ContentType?.Name ?? Path.GetRandomFileName(),
+        _ => Path.GetRandomFileName()
+    };
+
+    public static void SaveAttachment(MimeEntity attachment, string destinationPath) {
+        switch (attachment) {
+            case MimePart part:
+                using (var stream = File.Create(destinationPath)) {
+                    if (part.Content != null) {
+                        part.Content.DecodeTo(stream);
+                    } else {
+                        part.WriteTo(stream);
+                    }
+                }
+                break;
+            case MessagePart messagePart:
+                if (messagePart.Message != null) {
+                    messagePart.Message.WriteTo(destinationPath);
+                } else {
+                    using (var stream = File.Create(destinationPath)) {
+                        messagePart.WriteTo(stream);
+                    }
+                }
+                break;
+            default:
+                throw new InvalidOperationException("Unsupported attachment type.");
+        }
+    }
+}

--- a/Sources/Mailozaurr.Application/OperationResult.cs
+++ b/Sources/Mailozaurr.Application/OperationResult.cs
@@ -1,0 +1,32 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents the result of an application-layer operation.
+/// </summary>
+public class OperationResult {
+    /// <summary>Whether the operation completed successfully.</summary>
+    public bool Succeeded { get; set; }
+
+    /// <summary>Stable machine-readable code when available.</summary>
+    public string? Code { get; set; }
+
+    /// <summary>Human-readable message for logs or UI surfaces.</summary>
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    public static OperationResult Success(string? message = null) => new() {
+        Succeeded = true,
+        Message = message
+    };
+
+    /// <summary>
+    /// Creates a failure result.
+    /// </summary>
+    public static OperationResult Failure(string code, string? message = null) => new() {
+        Succeeded = false,
+        Code = code,
+        Message = message
+    };
+}

--- a/Sources/Mailozaurr.Application/PendingMailQueueService.cs
+++ b/Sources/Mailozaurr.Application/PendingMailQueueService.cs
@@ -1,0 +1,162 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Reusable queue facade over Mailozaurr pending-message infrastructure.
+/// </summary>
+public sealed class PendingMailQueueService : IMailQueueService {
+    private readonly IPendingMessageRepository _repository;
+    private readonly Func<IPendingMessageRepository, IPendingMessageProcessorObserver, CancellationToken, Task> _processAsync;
+
+    /// <summary>
+    /// Creates a new queue service.
+    /// </summary>
+    public PendingMailQueueService(
+        IPendingMessageRepository repository,
+        Func<IPendingMessageRepository, IPendingMessageProcessorObserver, CancellationToken, Task>? processAsync = null) {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _processAsync = processAsync ?? DefaultProcessAsync;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<QueuedMessageSummary>> ListAsync(CancellationToken cancellationToken = default) {
+        var messages = new List<QueuedMessageSummary>();
+        await foreach (var record in _repository.GetAllAsync(cancellationToken).ConfigureAwait(false)) {
+            if (record == null) {
+                continue;
+            }
+
+            messages.Add(Map(record));
+        }
+
+        return messages
+            .OrderBy(message => message.NextAttemptAt)
+            .ThenBy(message => message.MessageId, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<QueuedMessageCompact>> ListCompactAsync(CancellationToken cancellationToken = default) =>
+        (await ListAsync(cancellationToken).ConfigureAwait(false))
+        .Select(ToCompact)
+        .ToArray();
+
+    /// <inheritdoc />
+    public async Task<QueuedMessageSummary?> GetAsync(string messageId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("Message id is required.", nameof(messageId));
+        }
+
+        var record = await _repository.GetByMessageIdAsync(messageId.Trim(), cancellationToken).ConfigureAwait(false);
+        return record == null ? null : Map(record);
+    }
+
+    /// <inheritdoc />
+    public async Task<QueuedMessageCompact?> GetCompactAsync(string messageId, CancellationToken cancellationToken = default) {
+        var message = await GetAsync(messageId, cancellationToken).ConfigureAwait(false);
+        return message == null ? null : ToCompact(message);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(messageId)) {
+            throw new ArgumentException("Message id is required.", nameof(messageId));
+        }
+
+        var normalizedMessageId = messageId.Trim();
+        var existing = await _repository.GetByMessageIdAsync(normalizedMessageId, cancellationToken).ConfigureAwait(false);
+        if (existing == null) {
+            return OperationResult.Failure("queue_message_not_found", $"Queued message '{normalizedMessageId}' was not found.");
+        }
+
+        await _repository.RemoveAsync(normalizedMessageId, cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success($"Queued message '{normalizedMessageId}' removed.");
+    }
+
+    /// <inheritdoc />
+    public async Task<QueueProcessResult> ProcessAsync(CancellationToken cancellationToken = default) {
+        var observer = new CountingObserver();
+        await _processAsync(_repository, observer, cancellationToken).ConfigureAwait(false);
+        return observer.CreateResult();
+    }
+
+    private static Task DefaultProcessAsync(
+        IPendingMessageRepository repository,
+        IPendingMessageProcessorObserver observer,
+        CancellationToken cancellationToken) {
+        var processor = new PendingMessageProcessor(repository, observer: observer);
+        return processor.ProcessAsync(cancellationToken);
+    }
+
+    private static QueuedMessageSummary Map(PendingMessageRecord record) => new() {
+        MessageId = record.MessageId,
+        Provider = record.Provider.ToString(),
+        ProfileKind = MapProfileKind(record.Provider),
+        QueuedAt = record.Timestamp,
+        NextAttemptAt = record.NextAttemptAt,
+        AttemptCount = record.AttemptCount,
+        HasProviderData = record.ProviderData.Count > 0
+    };
+
+    private static QueuedMessageCompact ToCompact(QueuedMessageSummary message) => new() {
+        MessageId = message.MessageId,
+        Provider = message.Provider,
+        ProfileKind = message.ProfileKind,
+        NextAttemptAt = message.NextAttemptAt,
+        AttemptCount = message.AttemptCount,
+        IsDue = message.NextAttemptAt <= DateTimeOffset.UtcNow,
+        HasProviderData = message.HasProviderData,
+        Summary = $"{message.MessageId} [{message.Provider}] attempts={message.AttemptCount} next={message.NextAttemptAt:O}"
+    };
+
+    private static MailProfileKind MapProfileKind(EmailProvider provider) => provider switch {
+        EmailProvider.Graph => MailProfileKind.Graph,
+        EmailProvider.Gmail => MailProfileKind.Gmail,
+        EmailProvider.SendGrid => MailProfileKind.SendGrid,
+        EmailProvider.Mailgun => MailProfileKind.Mailgun,
+        EmailProvider.SES => MailProfileKind.Ses,
+        _ => MailProfileKind.Smtp
+    };
+
+    private sealed class CountingObserver : IPendingMessageProcessorObserver {
+        private readonly QueueProcessResult _result = new() {
+            Succeeded = true,
+            Message = "Queue processing completed."
+        };
+
+        public void MessageSkipped(PendingMessageRecord record, PendingMessageSkipReason reason) {
+            _result.SkippedCount++;
+        }
+
+        public void MessageAttemptStarted(PendingMessageRecord record, int attempt) {
+            _result.AttemptedCount++;
+        }
+
+        public void MessageSent(PendingMessageRecord record, int attempt, TimeSpan duration) {
+            _result.SentCount++;
+        }
+
+        public void MessageFailed(
+            PendingMessageRecord record,
+            int attempt,
+            Exception exception,
+            TimeSpan duration,
+            bool willRetry,
+            TimeSpan? retryDelay) {
+            _result.FailedCount++;
+            _result.Message = exception.Message;
+        }
+
+        public void MessageDropped(
+            PendingMessageRecord record,
+            int attempt,
+            PendingMessageDropReason reason,
+            Exception? exception) {
+            _result.DroppedCount++;
+            if (exception != null) {
+                _result.Message = exception.Message;
+            }
+        }
+
+        public QueueProcessResult CreateResult() => _result;
+    }
+}

--- a/Sources/Mailozaurr.Application/ProfileCapabilities.cs
+++ b/Sources/Mailozaurr.Application/ProfileCapabilities.cs
@@ -1,0 +1,32 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Describes the capabilities available for a given mail profile kind.
+/// </summary>
+public sealed class ProfileCapabilities {
+    /// <summary>
+    /// Creates a new capability description.
+    /// </summary>
+    /// <param name="kind">Profile kind the capabilities apply to.</param>
+    /// <param name="capabilities">Supported operations.</param>
+    public ProfileCapabilities(MailProfileKind kind, MailCapability capabilities) {
+        Kind = kind;
+        Capabilities = capabilities;
+    }
+
+    /// <summary>Profile kind the capabilities apply to.</summary>
+    public MailProfileKind Kind { get; }
+
+    /// <summary>Flags describing supported operations.</summary>
+    public MailCapability Capabilities { get; }
+
+    /// <summary>
+    /// Returns <c>true</c> when all requested capabilities are supported.
+    /// </summary>
+    public bool Supports(MailCapability capability) => (Capabilities & capability) == capability;
+
+    /// <summary>
+    /// Creates a new instance using the default capability map for <paramref name="kind" />.
+    /// </summary>
+    public static ProfileCapabilities CreateDefault(MailProfileKind kind) => MailCapabilityCatalog.For(kind);
+}

--- a/Sources/Mailozaurr.Application/QueueProcessResult.cs
+++ b/Sources/Mailozaurr.Application/QueueProcessResult.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents the outcome of processing queued outbound messages.
+/// </summary>
+public sealed class QueueProcessResult : OperationResult {
+    /// <summary>Messages skipped before delivery was attempted.</summary>
+    public int SkippedCount { get; set; }
+
+    /// <summary>Messages for which a delivery attempt started.</summary>
+    public int AttemptedCount { get; set; }
+
+    /// <summary>Messages successfully sent.</summary>
+    public int SentCount { get; set; }
+
+    /// <summary>Messages whose current attempt failed.</summary>
+    public int FailedCount { get; set; }
+
+    /// <summary>Messages removed from the queue without being delivered.</summary>
+    public int DroppedCount { get; set; }
+}

--- a/Sources/Mailozaurr.Application/QueuedMessageCompact.cs
+++ b/Sources/Mailozaurr.Application/QueuedMessageCompact.cs
@@ -1,0 +1,30 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Lightweight projection of a queued outbound message for list and agent scenarios.
+/// </summary>
+public sealed class QueuedMessageCompact {
+    /// <summary>Stable queued message identifier.</summary>
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>Underlying transport/provider recorded for the message.</summary>
+    public string Provider { get; set; } = string.Empty;
+
+    /// <summary>Normalized profile kind inferred from the queued provider.</summary>
+    public MailProfileKind ProfileKind { get; set; } = MailProfileKind.Unknown;
+
+    /// <summary>When the next delivery attempt is scheduled.</summary>
+    public DateTimeOffset NextAttemptAt { get; set; }
+
+    /// <summary>Number of delivery attempts already performed.</summary>
+    public int AttemptCount { get; set; }
+
+    /// <summary>Whether the queued message is currently due for processing.</summary>
+    public bool IsDue { get; set; }
+
+    /// <summary>Whether provider-specific metadata is present.</summary>
+    public bool HasProviderData { get; set; }
+
+    /// <summary>Short human-readable summary line.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/QueuedMessageSummary.cs
+++ b/Sources/Mailozaurr.Application/QueuedMessageSummary.cs
@@ -1,0 +1,27 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents normalized metadata for a queued outbound message.
+/// </summary>
+public sealed class QueuedMessageSummary {
+    /// <summary>Stable queued message identifier.</summary>
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>Underlying transport/provider recorded for the message.</summary>
+    public string Provider { get; set; } = string.Empty;
+
+    /// <summary>Normalized profile kind inferred from the queued provider.</summary>
+    public MailProfileKind ProfileKind { get; set; } = MailProfileKind.Unknown;
+
+    /// <summary>When the message was first queued.</summary>
+    public DateTimeOffset QueuedAt { get; set; }
+
+    /// <summary>When the next delivery attempt is scheduled.</summary>
+    public DateTimeOffset NextAttemptAt { get; set; }
+
+    /// <summary>Number of delivery attempts already performed.</summary>
+    public int AttemptCount { get; set; }
+
+    /// <summary>Whether provider-specific metadata is present.</summary>
+    public bool HasProviderData { get; set; }
+}

--- a/Sources/Mailozaurr.Application/RoutedMailReadService.cs
+++ b/Sources/Mailozaurr.Application/RoutedMailReadService.cs
@@ -1,0 +1,284 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Resolves a profile and routes read operations to the matching provider handler.
+/// </summary>
+public sealed class RoutedMailReadService : IMailReadService {
+    private readonly IMailProfileStore _profileStore;
+    private readonly IReadOnlyDictionary<MailProfileKind, IMailReadHandler> _handlers;
+
+    /// <summary>
+    /// Creates a new routed read service.
+    /// </summary>
+    public RoutedMailReadService(IMailProfileStore profileStore, IEnumerable<IMailReadHandler> handlers) {
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        if (handlers == null) {
+            throw new ArgumentNullException(nameof(handlers));
+        }
+
+        _handlers = handlers.ToDictionary(handler => handler.Kind);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailFolderQuery query, CancellationToken cancellationToken = default) {
+        var profile = await GetProfileAsync(query.ProfileId, cancellationToken).ConfigureAwait(false);
+        EnsureCapability(profile, MailCapability.ListFolders);
+        return await GetHandler(profile.Kind).GetFoldersAsync(profile, query, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FolderRefCompact>> GetFoldersCompactAsync(MailFolderQuery query, CancellationToken cancellationToken = default) {
+        var folders = await GetFoldersAsync(query, cancellationToken).ConfigureAwait(false);
+        return folders.Select(ToCompact).ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MessageSummary>> SearchAsync(MailSearchRequest request, CancellationToken cancellationToken = default) {
+        var profile = await GetProfileAsync(request.ProfileId, cancellationToken).ConfigureAwait(false);
+        EnsureCapability(profile, MailCapability.SearchMessages);
+        return await GetHandler(profile.Kind).SearchAsync(profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MessageSummaryCompact>> SearchCompactAsync(MailSearchRequest request, CancellationToken cancellationToken = default) {
+        var results = await SearchAsync(request, cancellationToken).ConfigureAwait(false);
+        return results.Select(ToCompact).ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AttachmentSummary>> GetAttachmentsAsync(ListAttachmentsRequest request, CancellationToken cancellationToken = default) {
+        var detail = await GetMessageAsync(new GetMessageRequest {
+            ProfileId = request.ProfileId,
+            MailboxId = request.MailboxId,
+            FolderId = request.FolderId,
+            MessageId = request.MessageId,
+            IncludeRawContent = false
+        }, cancellationToken).ConfigureAwait(false);
+
+        return detail?.Attachments?.ToArray() ?? Array.Empty<AttachmentSummary>();
+    }
+
+    /// <inheritdoc />
+    public async Task<SaveAttachmentsResult> SaveAttachmentsAsync(SaveAttachmentsRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var attachments = await GetAttachmentsAsync(new ListAttachmentsRequest {
+            ProfileId = request.ProfileId,
+            MailboxId = request.MailboxId,
+            FolderId = request.FolderId,
+            MessageId = request.MessageId
+        }, cancellationToken).ConfigureAwait(false);
+
+        var selectedAttachments = FilterAttachments(attachments, request).ToArray();
+        if (selectedAttachments.Length == 0) {
+            return new SaveAttachmentsResult {
+                Succeeded = false,
+                Code = "attachments_not_found",
+                Message = "No attachments matched the requested filters.",
+                ProfileId = request.ProfileId,
+                MessageId = request.MessageId,
+                MatchedCount = 0
+            };
+        }
+
+        var result = new SaveAttachmentsResult {
+            ProfileId = request.ProfileId,
+            MessageId = request.MessageId,
+            MatchedCount = selectedAttachments.Length
+        };
+
+        foreach (var attachment in selectedAttachments) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var saveResult = await SaveAttachmentAsync(new SaveAttachmentRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                MessageId = request.MessageId,
+                AttachmentId = attachment.Id,
+                DestinationPath = request.DestinationPath,
+                Overwrite = request.Overwrite
+            }, cancellationToken).ConfigureAwait(false);
+
+            result.AttemptedCount++;
+            if (saveResult.Succeeded) {
+                result.SavedCount++;
+            } else {
+                result.FailedCount++;
+            }
+
+            result.Results.Add(new SavedAttachmentResult {
+                Succeeded = saveResult.Succeeded,
+                Code = saveResult.Code,
+                Message = saveResult.Message,
+                AttachmentId = attachment.Id,
+                FileName = attachment.FileName,
+                ContentType = attachment.ContentType
+            });
+        }
+
+        result.Succeeded = result.FailedCount == 0 && result.SavedCount > 0;
+        result.Code = result.Succeeded ? null : "attachment_save_failed";
+        result.Message = result.Succeeded
+            ? $"Saved {result.SavedCount} attachment(s)."
+            : $"Saved {result.SavedCount} attachment(s); {result.FailedCount} failed.";
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageDetail?> GetMessageAsync(GetMessageRequest request, CancellationToken cancellationToken = default) {
+        var profile = await GetProfileAsync(request.ProfileId, cancellationToken).ConfigureAwait(false);
+        EnsureCapability(profile, MailCapability.ReadMessages);
+        return await GetHandler(profile.Kind).GetMessageAsync(profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageDetailCompact?> GetMessageCompactAsync(GetMessageRequest request, CancellationToken cancellationToken = default) {
+        var detail = await GetMessageAsync(request, cancellationToken).ConfigureAwait(false);
+        return detail == null ? null : ToCompact(detail);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SaveAttachmentAsync(SaveAttachmentRequest request, CancellationToken cancellationToken = default) {
+        var profile = await GetProfileAsync(request.ProfileId, cancellationToken).ConfigureAwait(false);
+        EnsureCapability(profile, MailCapability.SaveAttachments);
+        return await GetHandler(profile.Kind).SaveAttachmentAsync(profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<MailProfile> GetProfileAsync(string profileId, CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            throw new ArgumentException("Profile id is required.", nameof(profileId));
+        }
+
+        var profile = await _profileStore.GetByIdAsync(profileId, cancellationToken).ConfigureAwait(false);
+        return profile ?? throw new InvalidOperationException($"Profile '{profileId}' was not found.");
+    }
+
+    private IMailReadHandler GetHandler(MailProfileKind kind) =>
+        _handlers.TryGetValue(kind, out var handler)
+            ? handler
+            : throw new NotSupportedException($"No read handler is registered for profile kind '{kind}'.");
+
+    private static void EnsureCapability(MailProfile profile, MailCapability capability) {
+        if (!profile.GetCapabilities().Supports(capability)) {
+            throw new NotSupportedException($"Profile '{profile.Id}' does not support '{capability}'.");
+        }
+    }
+
+    private static MessageSummaryCompact ToCompact(MessageSummary summary) => new() {
+        ProfileId = summary.ProfileId,
+        Id = summary.Id,
+        FolderId = summary.FolderId,
+        Subject = summary.Subject,
+        Preview = summary.Preview,
+        From = summary.From.Count > 0 ? FormatRecipient(summary.From[0]) : null,
+        ReceivedAt = summary.ReceivedAt,
+        IsRead = summary.IsRead,
+        HasAttachments = summary.HasAttachments,
+        Summary = $"{summary.Id} {summary.Subject ?? "(no subject)"}"
+    };
+
+    private static MessageDetailCompact ToCompact(MessageDetail detail) => new() {
+        ProfileId = detail.ProfileId,
+        Id = detail.Id,
+        Summary = detail.Summary == null ? null : ToCompact(detail.Summary),
+        TextBodyPreview = CreatePreview(detail.TextBody),
+        HtmlBodyPreview = CreatePreview(detail.HtmlBody),
+        Attachments = detail.Attachments.Select(ToCopy).ToList(),
+        HasRawContent = !string.IsNullOrWhiteSpace(detail.RawContent),
+        SummaryText = $"{detail.Id} {detail.Summary?.Subject ?? "(no subject)"}"
+    };
+
+    private static IEnumerable<AttachmentSummary> FilterAttachments(
+        IEnumerable<AttachmentSummary> attachments,
+        SaveAttachmentsRequest request) {
+        var explicitIds = new HashSet<string>(
+            request.AttachmentIds
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id!.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+        var fileNameContains = request.FileNameContains?.Trim();
+        var contentTypeContains = request.ContentTypeContains?.Trim();
+        var hasFileNameFilter = !string.IsNullOrWhiteSpace(fileNameContains);
+        var hasContentTypeFilter = !string.IsNullOrWhiteSpace(contentTypeContains);
+        var requiredFileName = fileNameContains ?? string.Empty;
+        var requiredContentType = contentTypeContains ?? string.Empty;
+
+        foreach (var attachment in attachments) {
+            var attachmentFileName = attachment.FileName ?? string.Empty;
+            if (explicitIds.Count > 0 &&
+                !explicitIds.Contains(attachment.Id) &&
+                (attachmentFileName.Length == 0 || !explicitIds.Contains(attachmentFileName))) {
+                continue;
+            }
+
+            if (hasFileNameFilter) {
+                if (attachmentFileName.Length == 0 ||
+                    attachmentFileName.IndexOf(requiredFileName, StringComparison.OrdinalIgnoreCase) < 0) {
+                    continue;
+                }
+            }
+
+            if (hasContentTypeFilter) {
+                var contentType = attachment.ContentType ?? string.Empty;
+                if (contentType.Length == 0) {
+                    continue;
+                }
+
+                if (contentType.IndexOf(requiredContentType, StringComparison.OrdinalIgnoreCase) < 0) {
+                    continue;
+                }
+            }
+
+            yield return attachment;
+        }
+    }
+
+    private static FolderRefCompact ToCompact(FolderRef folder) => new() {
+        ProfileId = folder.ProfileId,
+        MailboxId = folder.MailboxId,
+        Id = folder.Id,
+        DisplayName = folder.DisplayName,
+        Path = folder.Path,
+        SpecialUse = folder.SpecialUse,
+        MessageCount = folder.MessageCount,
+        UnreadCount = folder.UnreadCount,
+        Summary = $"{folder.Id} {folder.Path ?? folder.DisplayName}"
+    };
+
+    private static AttachmentSummary ToCopy(AttachmentSummary attachment) => new() {
+        MessageId = attachment.MessageId,
+        Id = attachment.Id,
+        FileName = attachment.FileName,
+        ContentType = attachment.ContentType,
+        SizeInBytes = attachment.SizeInBytes,
+        IsInline = attachment.IsInline,
+        ContentId = attachment.ContentId
+    };
+
+    private static string? CreatePreview(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return value;
+        }
+
+        const int maxLength = 512;
+        var trimmed = (value ?? string.Empty).Trim();
+        return trimmed.Length <= maxLength
+            ? trimmed
+            : trimmed.Substring(0, maxLength);
+    }
+
+    private static string? FormatRecipient(MessageRecipient recipient) {
+        if (!string.IsNullOrWhiteSpace(recipient.Name) && !string.IsNullOrWhiteSpace(recipient.Address)) {
+            return $"{recipient.Name} <{recipient.Address}>";
+        }
+
+        if (!string.IsNullOrWhiteSpace(recipient.Name)) {
+            return recipient.Name;
+        }
+
+        return string.IsNullOrWhiteSpace(recipient.Address) ? null : recipient.Address;
+    }
+}

--- a/Sources/Mailozaurr.Application/RoutedMailSendService.cs
+++ b/Sources/Mailozaurr.Application/RoutedMailSendService.cs
@@ -1,0 +1,43 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Resolves a profile and routes send operations to the matching provider handler.
+/// </summary>
+public sealed class RoutedMailSendService : IMailSendService {
+    private readonly IMailProfileStore _profileStore;
+    private readonly IReadOnlyDictionary<MailProfileKind, IMailSendHandler> _handlers;
+
+    /// <summary>
+    /// Creates a new routed send service.
+    /// </summary>
+    public RoutedMailSendService(IMailProfileStore profileStore, IEnumerable<IMailSendHandler> handlers) {
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        if (handlers == null) {
+            throw new ArgumentNullException(nameof(handlers));
+        }
+
+        _handlers = handlers.ToDictionary(handler => handler.Kind);
+    }
+
+    /// <inheritdoc />
+    public async Task<SendResult> SendAsync(SendMessageRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var profile = await _profileStore.GetByIdAsync(request.ProfileId, cancellationToken).ConfigureAwait(false);
+        if (profile == null) {
+            throw new InvalidOperationException($"Profile '{request.ProfileId}' was not found.");
+        }
+
+        if (!profile.GetCapabilities().Supports(MailCapability.SendMessages)) {
+            throw new NotSupportedException($"Profile '{profile.Id}' does not support '{MailCapability.SendMessages}'.");
+        }
+
+        if (!_handlers.TryGetValue(profile.Kind, out var handler)) {
+            throw new NotSupportedException($"No send handler is registered for profile kind '{profile.Kind}'.");
+        }
+
+        return await handler.SendAsync(profile, request, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/Sources/Mailozaurr.Application/SaveAttachmentRequest.cs
+++ b/Sources/Mailozaurr.Application/SaveAttachmentRequest.cs
@@ -1,0 +1,27 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for saving an attachment.
+/// </summary>
+public sealed class SaveAttachmentRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifier.</summary>
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>Provider-specific attachment identifier.</summary>
+    public string AttachmentId { get; set; } = string.Empty;
+
+    /// <summary>Destination path.</summary>
+    public string DestinationPath { get; set; } = string.Empty;
+
+    /// <summary>Whether existing files may be overwritten.</summary>
+    public bool Overwrite { get; set; }
+}

--- a/Sources/Mailozaurr.Application/SaveAttachmentsRequest.cs
+++ b/Sources/Mailozaurr.Application/SaveAttachmentsRequest.cs
@@ -1,0 +1,33 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for saving one or more attachments associated with a message.
+/// </summary>
+public sealed class SaveAttachmentsRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifier.</summary>
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>Destination path or directory.</summary>
+    public string DestinationPath { get; set; } = string.Empty;
+
+    /// <summary>Optional explicit attachment identifiers to include.</summary>
+    public List<string> AttachmentIds { get; set; } = new();
+
+    /// <summary>Optional case-insensitive file-name filter.</summary>
+    public string? FileNameContains { get; set; }
+
+    /// <summary>Optional case-insensitive content-type filter.</summary>
+    public string? ContentTypeContains { get; set; }
+
+    /// <summary>Whether existing files may be overwritten.</summary>
+    public bool Overwrite { get; set; }
+}

--- a/Sources/Mailozaurr.Application/SaveAttachmentsResult.cs
+++ b/Sources/Mailozaurr.Application/SaveAttachmentsResult.cs
@@ -1,0 +1,27 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents the outcome of saving multiple attachments from a single message.
+/// </summary>
+public sealed class SaveAttachmentsResult : OperationResult {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Owning message identifier.</summary>
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>Total attachments matched for processing.</summary>
+    public int MatchedCount { get; set; }
+
+    /// <summary>Total save attempts performed.</summary>
+    public int AttemptedCount { get; set; }
+
+    /// <summary>Total attachments saved successfully.</summary>
+    public int SavedCount { get; set; }
+
+    /// <summary>Total attachments whose save attempt failed.</summary>
+    public int FailedCount { get; set; }
+
+    /// <summary>Per-attachment outcomes.</summary>
+    public List<SavedAttachmentResult> Results { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/SavedAttachmentResult.cs
+++ b/Sources/Mailozaurr.Application/SavedAttachmentResult.cs
@@ -1,0 +1,15 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Outcome of saving a single attachment as part of a batch attachment operation.
+/// </summary>
+public sealed class SavedAttachmentResult : OperationResult {
+    /// <summary>Provider-specific attachment identifier.</summary>
+    public string AttachmentId { get; set; } = string.Empty;
+
+    /// <summary>Attachment file name.</summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>Attachment content type when known.</summary>
+    public string? ContentType { get; set; }
+}

--- a/Sources/Mailozaurr.Application/SendMessageRequest.cs
+++ b/Sources/Mailozaurr.Application/SendMessageRequest.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for sending or queueing a message.
+/// </summary>
+public sealed class SendMessageRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Draft to send or queue.</summary>
+    public DraftMessage Message { get; set; } = new();
+
+    /// <summary>Whether queueing should be preferred when supported.</summary>
+    public bool PreferQueue { get; set; } = true;
+
+    /// <summary>Whether sending immediately is required.</summary>
+    public bool RequireImmediateSend { get; set; }
+
+    /// <summary>Optional scheduled send time for queue-capable implementations.</summary>
+    public DateTimeOffset? NotBefore { get; set; }
+}

--- a/Sources/Mailozaurr.Application/SendResult.cs
+++ b/Sources/Mailozaurr.Application/SendResult.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents the result of a normalized send or queue operation.
+/// </summary>
+public sealed class SendResult : OperationResult {
+    /// <summary>Profile that was used for the send attempt.</summary>
+    public string? ProfileId { get; set; }
+
+    /// <summary>Profile kind that handled the operation.</summary>
+    public MailProfileKind ProfileKind { get; set; } = MailProfileKind.Unknown;
+
+    /// <summary>Whether the message was queued instead of sent immediately.</summary>
+    public bool Queued { get; set; }
+
+    /// <summary>Queued message identifier when the message was enqueued.</summary>
+    public string? QueueMessageId { get; set; }
+
+    /// <summary>Provider-native message identifier when available.</summary>
+    public string? ProviderMessageId { get; set; }
+}

--- a/Sources/Mailozaurr.Application/SmtpMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/SmtpMailSendHandler.cs
@@ -1,0 +1,101 @@
+using Mailozaurr;
+using MimeKit;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Normalized SMTP send handler backed by Mailozaurr SMTP helpers.
+/// </summary>
+public sealed class SmtpMailSendHandler : IMailSendHandler {
+    private readonly ISmtpSessionFactory _sessionFactory;
+    private readonly IDraftMimeMessageFactory _draftMimeMessageFactory;
+    private readonly IPendingMessageRepository? _pendingMessageRepository;
+    private readonly Func<Smtp, MailProfile, SendMessageRequest, MimeMessage, CancellationToken, Task<SmtpResult>> _sendAsync;
+
+    /// <summary>
+    /// Creates a new SMTP send handler.
+    /// </summary>
+    public SmtpMailSendHandler(
+        ISmtpSessionFactory sessionFactory,
+        IDraftMimeMessageFactory? draftMimeMessageFactory = null,
+        IPendingMessageRepository? pendingMessageRepository = null,
+        Func<Smtp, MailProfile, SendMessageRequest, MimeMessage, CancellationToken, Task<SmtpResult>>? sendAsync = null) {
+        _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
+        _draftMimeMessageFactory = draftMimeMessageFactory ?? new DraftMimeMessageFactory();
+        _pendingMessageRepository = pendingMessageRepository;
+        _sendAsync = sendAsync ?? DefaultSendAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Smtp;
+
+    /// <inheritdoc />
+    public async Task<SendResult> SendAsync(MailProfile profile, SendMessageRequest request, CancellationToken cancellationToken = default) {
+        if (profile == null) {
+            throw new ArgumentNullException(nameof(profile));
+        }
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+        if (request.NotBefore.HasValue) {
+            throw new NotSupportedException("Scheduled SMTP sends are not yet supported by the application send handler.");
+        }
+
+        var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        try {
+            var message = await _draftMimeMessageFactory.CreateAsync(profile, request.Message, cancellationToken).ConfigureAwait(false);
+            var queueEnabled = _pendingMessageRepository != null && request.PreferQueue && !request.RequireImmediateSend;
+            session.PendingMessageRepository = queueEnabled ? _pendingMessageRepository : null;
+
+            var providerResult = await _sendAsync(session, profile, request, message, cancellationToken).ConfigureAwait(false);
+            if (providerResult.Status) {
+                return new SendResult {
+                    Succeeded = true,
+                    ProfileId = profile.Id,
+                    ProfileKind = profile.Kind,
+                    ProviderMessageId = providerResult.MessageId ?? message.MessageId,
+                    QueueMessageId = providerResult.MessageId ?? message.MessageId,
+                    Message = "Message sent successfully."
+                };
+            }
+
+            if (queueEnabled) {
+                var queuedId = providerResult.MessageId ?? message.MessageId;
+                if (!string.IsNullOrWhiteSpace(queuedId)) {
+                    var queued = await _pendingMessageRepository!.GetByMessageIdAsync(queuedId!, cancellationToken).ConfigureAwait(false);
+                    if (queued != null) {
+                        return new SendResult {
+                            Succeeded = true,
+                            ProfileId = profile.Id,
+                            ProfileKind = profile.Kind,
+                            Queued = true,
+                            QueueMessageId = queued.MessageId,
+                            Message = $"Message queued after send failure: {providerResult.Error ?? providerResult.Message ?? "SMTP send failed."}"
+                        };
+                    }
+                }
+            }
+
+            return new SendResult {
+                Succeeded = false,
+                ProfileId = profile.Id,
+                ProfileKind = profile.Kind,
+                ProviderMessageId = providerResult.MessageId ?? message.MessageId,
+                Message = providerResult.Error ?? providerResult.Message ?? "SMTP send failed."
+            };
+        } finally {
+            SmtpSessionService.DisposeQuietly(session);
+        }
+    }
+
+    private static Task<SmtpResult> DefaultSendAsync(
+        Smtp session,
+        MailProfile profile,
+        SendMessageRequest request,
+        MimeMessage message,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        session.Message = message;
+        return session.SendAsync(cancellationToken);
+    }
+}

--- a/Sources/Mailozaurr.Application/SmtpSessionFactory.cs
+++ b/Sources/Mailozaurr.Application/SmtpSessionFactory.cs
@@ -1,0 +1,169 @@
+using MailKit.Security;
+using Mailozaurr;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Creates authenticated SMTP sessions using profile settings and stored secrets.
+/// </summary>
+public sealed class SmtpSessionFactory : ISmtpSessionFactory {
+    private readonly IMailSecretStore? _secretStore;
+    private readonly Func<SmtpSessionRequest, CancellationToken, Task<Smtp>> _connectAsync;
+
+    /// <summary>
+    /// Creates a new SMTP session factory.
+    /// </summary>
+    public SmtpSessionFactory(
+        IMailSecretStore? secretStore = null,
+        Func<SmtpSessionRequest, CancellationToken, Task<Smtp>>? connectAsync = null) {
+        _secretStore = secretStore;
+        _connectAsync = connectAsync ?? DefaultConnectAsync;
+    }
+
+    /// <inheritdoc />
+    public async Task<Smtp> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+        if (profile == null) {
+            throw new ArgumentNullException(nameof(profile));
+        }
+        if (profile.Kind != MailProfileKind.Smtp) {
+            throw new InvalidOperationException($"Profile '{profile.Id}' is not an SMTP profile.");
+        }
+
+        var request = await CreateRequestAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _connectAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<SmtpSessionRequest> CreateRequestAsync(MailProfile profile, CancellationToken cancellationToken) {
+        var server = RequireSetting(profile, MailProfileSettingsKeys.Server);
+        var port = GetIntSetting(profile, MailProfileSettingsKeys.Port) ?? 587;
+        var authMode = GetAuthMode(profile);
+        var userName = ResolveUserName(profile);
+        var secret = await ResolveSecretAsync(profile, authMode, cancellationToken).ConfigureAwait(false);
+
+        return new SmtpSessionRequest {
+            Server = server,
+            Port = port,
+            SecureSocketOptions = GetSecureSocketOptions(profile),
+            UseSsl = GetBoolSetting(profile, MailProfileSettingsKeys.UseSsl) ?? false,
+            TimeoutMs = GetIntSetting(profile, MailProfileSettingsKeys.Timeout) ?? 30000,
+            RetryCount = GetIntSetting(profile, MailProfileSettingsKeys.RetryCount) ?? 3,
+            RetryDelayMilliseconds = GetIntSetting(profile, MailProfileSettingsKeys.RetryDelayMilliseconds) ?? 500,
+            RetryDelayBackoff = GetDoubleSetting(profile, MailProfileSettingsKeys.RetryDelayBackoff) ?? 2.0,
+            SkipCertificateValidation = GetBoolSetting(profile, MailProfileSettingsKeys.SkipCertificateValidation) ?? false,
+            SkipCertificateRevocation = GetBoolSetting(profile, MailProfileSettingsKeys.SkipCertificateRevocation) ?? false,
+            UserName = userName,
+            Password = secret,
+            AuthMode = authMode
+        };
+    }
+
+    private async Task<string> ResolveSecretAsync(MailProfile profile, ProtocolAuthMode authMode, CancellationToken cancellationToken) {
+        var primarySecretName = authMode == ProtocolAuthMode.OAuth2
+            ? MailSecretNames.AccessToken
+            : MailSecretNames.Password;
+        var fallbackSecretName = authMode == ProtocolAuthMode.OAuth2
+            ? MailSecretNames.Password
+            : null;
+
+        var secret = _secretStore == null
+            ? null
+            : await _secretStore.GetSecretAsync(profile.Id, primarySecretName, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(secret) && fallbackSecretName != null && _secretStore != null) {
+            secret = await _secretStore.GetSecretAsync(profile.Id, fallbackSecretName, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrWhiteSpace(secret)) {
+            throw new InvalidOperationException($"Secret '{primarySecretName}' is required for profile '{profile.Id}'.");
+        }
+
+        return secret!;
+    }
+
+    private static async Task<Smtp> DefaultConnectAsync(SmtpSessionRequest request, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var smtp = new Smtp();
+        var result = await SmtpSessionService.ConnectAndAuthenticateAsync(smtp, request, cancellationToken).ConfigureAwait(false);
+        if (result.IsSuccess) {
+            return smtp;
+        }
+
+        SmtpSessionService.DisposeQuietly(smtp);
+        throw new InvalidOperationException($"SMTP connection/authentication failed ({result.ErrorCode}): {result.Error}");
+    }
+
+    private static string ResolveUserName(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.UserName, out var userName) && !string.IsNullOrWhiteSpace(userName)) {
+            return userName.Trim();
+        }
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) && !string.IsNullOrWhiteSpace(mailbox)) {
+            return mailbox.Trim();
+        }
+        if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
+            return profile.DefaultMailbox!.Trim();
+        }
+        if (!string.IsNullOrWhiteSpace(profile.DefaultSender)) {
+            return profile.DefaultSender!.Trim();
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' requires '{MailProfileSettingsKeys.UserName}' or a mailbox value.");
+    }
+
+    private static string RequireSetting(MailProfile profile, string key) {
+        if (profile.Settings.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            return value.Trim();
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' requires setting '{key}'.");
+    }
+
+    private static ProtocolAuthMode GetAuthMode(MailProfile profile) {
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.AuthMode, out var rawMode);
+        return ProtocolAuth.ParseMode(rawMode, ProtocolAuthMode.Basic);
+    }
+
+    private static SecureSocketOptions GetSecureSocketOptions(MailProfile profile) {
+        if (!profile.Settings.TryGetValue(MailProfileSettingsKeys.SecureSocketOptions, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return SecureSocketOptions.Auto;
+        }
+
+        if (Enum.TryParse<SecureSocketOptions>(raw, ignoreCase: true, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid secure socket option '{raw}'.");
+    }
+
+    private static int? GetIntSetting(MailProfile profile, string key) {
+        if (!profile.Settings.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+        if (int.TryParse(raw, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid integer setting '{key}'.");
+    }
+
+    private static double? GetDoubleSetting(MailProfile profile, string key) {
+        if (!profile.Settings.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+        if (double.TryParse(raw, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid numeric setting '{key}'.");
+    }
+
+    private static bool? GetBoolSetting(MailProfile profile, string key) {
+        if (!profile.Settings.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+        if (bool.TryParse(raw, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid boolean setting '{key}'.");
+    }
+}

--- a/Sources/Mailozaurr.Cli/CliArguments.cs
+++ b/Sources/Mailozaurr.Cli/CliArguments.cs
@@ -1,0 +1,67 @@
+namespace Mailozaurr.Cli;
+
+internal sealed class CliArguments {
+    public List<string> Positionals { get; } = new();
+
+    public Dictionary<string, List<string?>> Options { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public bool ShowHelp { get; private set; }
+
+    public bool HasFlag(string name) {
+        var value = GetOption(name);
+        return value != null && value.Equals("true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public string? GetOption(string name) =>
+        Options.TryGetValue(name, out var values) && values.Count > 0
+            ? values[^1]
+            : null;
+
+    public IReadOnlyList<string?> GetOptionValues(string name) =>
+        Options.TryGetValue(name, out var values)
+            ? values.AsReadOnly()
+            : Array.Empty<string?>();
+
+    public int? GetIntOption(string name) {
+        var value = GetOption(name);
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+        if (int.TryParse(value, out var parsed)) {
+            return parsed;
+        }
+
+        throw new InvalidOperationException($"Option '--{name}' must be an integer.");
+    }
+
+    public static CliArguments Parse(IReadOnlyList<string> args) {
+        var result = new CliArguments();
+        for (var i = 0; i < args.Count; i++) {
+            var arg = args[i];
+            if (string.Equals(arg, "--help", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(arg, "-h", StringComparison.OrdinalIgnoreCase)) {
+                result.ShowHelp = true;
+                continue;
+            }
+
+            if (arg.StartsWith("--", StringComparison.Ordinal)) {
+                var key = arg.Substring(2);
+                string? value = null;
+                if (i + 1 < args.Count && !args[i + 1].StartsWith("--", StringComparison.Ordinal)) {
+                    value = args[++i];
+                }
+                if (!result.Options.TryGetValue(key, out var values)) {
+                    values = new List<string?>();
+                    result.Options[key] = values;
+                }
+
+                values.Add(value ?? "true");
+                continue;
+            }
+
+            result.Positionals.Add(arg);
+        }
+
+        return result;
+    }
+}

--- a/Sources/Mailozaurr.Cli/CliRunner.cs
+++ b/Sources/Mailozaurr.Cli/CliRunner.cs
@@ -1,0 +1,858 @@
+using System.Text.Json;
+using Mailozaurr.Application;
+using Mailozaurr.Cli.Mcp;
+
+namespace Mailozaurr.Cli;
+
+public static class CliRunner {
+    private static readonly JsonSerializerOptions JsonOptions = new() {
+        WriteIndented = true
+    };
+
+    public static async Task<int> RunAsync(
+        string[] args,
+        TextWriter output,
+        TextWriter error,
+        Func<MailApplicationOptions, MailApplicationBuilder>? builderFactory = null) {
+        if (args == null) {
+            throw new ArgumentNullException(nameof(args));
+        }
+        if (output == null) {
+            throw new ArgumentNullException(nameof(output));
+        }
+        if (error == null) {
+            throw new ArgumentNullException(nameof(error));
+        }
+
+        var parseResult = CliArguments.Parse(args);
+        if (parseResult.ShowHelp || parseResult.Positionals.Count == 0) {
+            WriteHelp(output);
+            return 0;
+        }
+
+        var options = new MailApplicationOptions();
+        var profilesDir = parseResult.GetOption("profiles-dir");
+        if (!string.IsNullOrWhiteSpace(profilesDir)) {
+            options.ProfileStore.DirectoryPath = profilesDir;
+        }
+        var secretsDir = parseResult.GetOption("secrets-dir");
+        if (!string.IsNullOrWhiteSpace(secretsDir)) {
+            options.SecretStore.DirectoryPath = secretsDir;
+        }
+        var draftsDir = parseResult.GetOption("drafts-dir");
+        if (!string.IsNullOrWhiteSpace(draftsDir)) {
+            options.DraftStore.DirectoryPath = draftsDir;
+        }
+
+        var application = (builderFactory ?? (appOptions => new MailApplicationBuilder(appOptions)))
+            .Invoke(options)
+            .Build();
+
+        try {
+            return await ExecuteAsync(application, parseResult, output, error).ConfigureAwait(false);
+        } catch (Exception ex) {
+            await error.WriteLineAsync(ex.Message).ConfigureAwait(false);
+            return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteAsync(
+        MailApplication application,
+        CliArguments parseResult,
+        TextWriter output,
+        TextWriter error) {
+        var command = parseResult.Positionals[0];
+        return command switch {
+            "profile" => await ExecuteProfileAsync(application, parseResult, output, error).ConfigureAwait(false),
+            "draft" => await ExecuteDraftAsync(application, parseResult, output, error).ConfigureAwait(false),
+            "mail" => await ExecuteMailAsync(application, parseResult, output, error).ConfigureAwait(false),
+            "mcp" => await ExecuteMcpAsync(application, parseResult, error).ConfigureAwait(false),
+            "send" => await ExecuteSendAsync(application, parseResult, output, error).ConfigureAwait(false),
+            "queue" => await ExecuteQueueAsync(application, parseResult, output, error).ConfigureAwait(false),
+            _ => await WriteUnknownCommandAsync(command, error).ConfigureAwait(false)
+        };
+    }
+
+    private static async Task<int> ExecuteProfileAsync(
+        MailApplication application,
+        CliArguments parseResult,
+        TextWriter output,
+        TextWriter error) {
+        if (parseResult.Positionals.Count < 2) {
+            await error.WriteLineAsync("Missing profile command. Use 'profile list', 'profile create', 'profile graph-bootstrap', 'profile gmail-bootstrap', 'profile graph-login', 'profile gmail-login', 'profile refresh-auth', 'profile auth-status', 'profile test', 'profile summary', 'profile capabilities', 'profile show', 'profile validate', 'profile doctor', 'profile delete', 'profile set-default', 'profile set-secret', or 'profile remove-secret'.").ConfigureAwait(false);
+            return 1;
+        }
+
+        var subCommand = parseResult.Positionals[1];
+        var json = parseResult.HasFlag("json");
+        switch (subCommand) {
+            case "list":
+                if (parseResult.HasFlag("summary")) {
+                    if (parseResult.HasFlag("compact")) {
+                        var compactOverviews = await application.ProfileOverview.GetCompactOverviewsAsync(BuildProfileOverviewQuery(parseResult)).ConfigureAwait(false);
+                        await WriteSequenceAsync(output, compactOverviews, json, value => value.Summary).ConfigureAwait(false);
+                        return compactOverviews.All(value => value.IsReady) ? 0 : 1;
+                    }
+                    var overviews = await application.ProfileOverview.GetOverviewsAsync(BuildProfileOverviewQuery(parseResult)).ConfigureAwait(false);
+                    await WriteSequenceAsync(output, overviews, json, value => value.Summary).ConfigureAwait(false);
+                    return overviews.All(value => value.IsReady) ? 0 : 1;
+                }
+                var profiles = await application.Profiles.GetProfilesAsync().ConfigureAwait(false);
+                await WriteSequenceAsync(output, profiles, json, profile => $"{profile.Id} [{profile.Kind}] {profile.DisplayName}").ConfigureAwait(false);
+                return 0;
+            case "create":
+                var createdProfile = BuildProfile(parseResult);
+                var createResult = await application.Profiles.SaveAsync(createdProfile).ConfigureAwait(false);
+                await WriteItemAsync(output, createResult, json, value => value.Message ?? "Profile saved.").ConfigureAwait(false);
+                return createResult.Succeeded ? 0 : 1;
+            case "graph-bootstrap":
+                var graphBootstrapResult = await application.ProfileBootstrap.SaveGraphProfileAsync(new GraphProfileBootstrapRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    DisplayName = RequireOption(parseResult, "name"),
+                    Description = parseResult.GetOption("description"),
+                    Mailbox = RequireOption(parseResult, "mailbox"),
+                    DefaultSender = parseResult.GetOption("default-sender"),
+                    IsDefault = parseResult.HasFlag("is-default"),
+                    ClientId = parseResult.GetOption("client-id"),
+                    TenantId = parseResult.GetOption("tenant-id"),
+                    ClientSecret = parseResult.GetOption("client-secret"),
+                    AccessToken = parseResult.GetOption("access-token"),
+                    CertificatePath = parseResult.GetOption("certificate-path"),
+                    CertificatePassword = parseResult.GetOption("certificate-password")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, graphBootstrapResult, json, value => value.Message ?? "Graph profile saved.").ConfigureAwait(false);
+                return graphBootstrapResult.Succeeded ? 0 : 1;
+            case "gmail-bootstrap":
+                var gmailBootstrapResult = await application.ProfileBootstrap.SaveGmailProfileAsync(new GmailProfileBootstrapRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    DisplayName = RequireOption(parseResult, "name"),
+                    Description = parseResult.GetOption("description"),
+                    Mailbox = parseResult.GetOption("mailbox"),
+                    DefaultSender = parseResult.GetOption("default-sender"),
+                    IsDefault = parseResult.HasFlag("is-default"),
+                    ClientId = parseResult.GetOption("client-id"),
+                    ClientSecret = parseResult.GetOption("client-secret"),
+                    RefreshToken = parseResult.GetOption("refresh-token"),
+                    AccessToken = parseResult.GetOption("access-token")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, gmailBootstrapResult, json, value => value.Message ?? "Gmail profile saved.").ConfigureAwait(false);
+                return gmailBootstrapResult.Succeeded ? 0 : 1;
+            case "graph-login":
+                var graphLoginResult = await application.ProfileAuth.LoginGraphAsync(new GraphProfileLoginRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    Login = parseResult.GetOption("login"),
+                    Mailbox = parseResult.GetOption("mailbox"),
+                    ClientId = parseResult.GetOption("client-id"),
+                    TenantId = parseResult.GetOption("tenant-id"),
+                    RedirectUri = parseResult.GetOption("redirect-uri"),
+                    Scopes = parseResult.GetOptionValues("scope")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!)
+                        .ToArray()
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, graphLoginResult, json, value => value.Message ?? (value.Succeeded ? "Graph login completed." : "Graph login failed.")).ConfigureAwait(false);
+                return graphLoginResult.Succeeded ? 0 : 1;
+            case "gmail-login":
+                var gmailLoginResult = await application.ProfileAuth.LoginGmailAsync(new GmailProfileLoginRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    GmailAccount = parseResult.GetOption("mailbox"),
+                    ClientId = parseResult.GetOption("client-id"),
+                    ClientSecret = parseResult.GetOption("client-secret"),
+                    Scopes = parseResult.GetOptionValues("scope")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!)
+                        .ToArray()
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, gmailLoginResult, json, value => value.Message ?? (value.Succeeded ? "Gmail login completed." : "Gmail login failed.")).ConfigureAwait(false);
+                return gmailLoginResult.Succeeded ? 0 : 1;
+            case "refresh-auth":
+                var refreshAuthResult = await application.ProfileAuth.RefreshAsync(RequireOption(parseResult, "profile")).ConfigureAwait(false);
+                await WriteItemAsync(output, refreshAuthResult, json, value => value.Message ?? (value.Succeeded ? "Profile auth refreshed." : "Profile auth refresh failed.")).ConfigureAwait(false);
+                return refreshAuthResult.Succeeded ? 0 : 1;
+            case "auth-status":
+                var authStatusProfileId = RequireOption(parseResult, "profile");
+                var authStatus = await application.ProfileAuth.GetStatusAsync(authStatusProfileId).ConfigureAwait(false);
+                if (authStatus == null) {
+                    await error.WriteLineAsync($"Profile '{authStatusProfileId}' was not found.").ConfigureAwait(false);
+                    return 1;
+                }
+                await WriteItemAsync(output, authStatus, json, value => value.Summary).ConfigureAwait(false);
+                return 0;
+            case "test":
+                var connectionResult = await application.ProfileConnections.TestAsync(
+                    RequireOption(parseResult, "profile"),
+                    ParseConnectionTestScope(parseResult.GetOption("scope"))).ConfigureAwait(false);
+                await WriteItemAsync(output, connectionResult, json, value => value.Message ?? (value.Succeeded ? "Profile connection succeeded." : "Profile connection failed.")).ConfigureAwait(false);
+                return connectionResult.Succeeded ? 0 : 1;
+            case "summary":
+                var summaryProfileId = RequireOption(parseResult, "profile");
+                if (parseResult.HasFlag("compact")) {
+                    var compactOverview = await application.ProfileOverview.GetCompactOverviewAsync(summaryProfileId).ConfigureAwait(false);
+                    if (compactOverview == null) {
+                        await error.WriteLineAsync($"Profile '{summaryProfileId}' was not found.").ConfigureAwait(false);
+                        return 1;
+                    }
+                    await WriteItemAsync(output, compactOverview, json, value => value.Summary).ConfigureAwait(false);
+                    return compactOverview.IsReady ? 0 : 1;
+                }
+                var overview = await application.ProfileOverview.GetOverviewAsync(summaryProfileId).ConfigureAwait(false);
+                if (overview == null) {
+                    await error.WriteLineAsync($"Profile '{summaryProfileId}' was not found.").ConfigureAwait(false);
+                    return 1;
+                }
+                await WriteItemAsync(output, overview, json, value => value.Summary).ConfigureAwait(false);
+                return overview.IsReady ? 0 : 1;
+            case "show":
+                var profileId = RequireOption(parseResult, "profile");
+                var profile = await application.Profiles.GetProfileAsync(profileId).ConfigureAwait(false);
+                if (profile == null) {
+                    await error.WriteLineAsync($"Profile '{profileId}' was not found.").ConfigureAwait(false);
+                    return 1;
+                }
+                await WriteItemAsync(output, profile, json, p => $"{p.Id} [{p.Kind}] {p.DisplayName}").ConfigureAwait(false);
+                return 0;
+            case "capabilities":
+                var capabilitiesProfileId = RequireOption(parseResult, "profile");
+                var capabilities = await application.Profiles.GetCapabilitiesAsync(capabilitiesProfileId).ConfigureAwait(false);
+                if (capabilities == null) {
+                    await error.WriteLineAsync($"Profile '{capabilitiesProfileId}' was not found.").ConfigureAwait(false);
+                    return 1;
+                }
+                await WriteItemAsync(output, capabilities, json, value => $"{value.Kind}: {value.Capabilities}").ConfigureAwait(false);
+                return 0;
+            case "validate":
+                var validateId = RequireOption(parseResult, "profile");
+                var profileToValidate = await application.Profiles.GetProfileAsync(validateId).ConfigureAwait(false);
+                if (profileToValidate == null) {
+                    await error.WriteLineAsync($"Profile '{validateId}' was not found.").ConfigureAwait(false);
+                    return 1;
+                }
+                var result = await application.Profiles.ValidateAsync(profileToValidate).ConfigureAwait(false);
+                await WriteItemAsync(output, result, json, r => r.Message ?? (r.Succeeded ? "Profile is valid." : "Profile is invalid.")).ConfigureAwait(false);
+                return result.Succeeded ? 0 : 1;
+            case "doctor":
+                var doctorResult = await application.Profiles.DiagnoseAsync(RequireOption(parseResult, "profile")).ConfigureAwait(false);
+                await WriteItemAsync(output, doctorResult, json, value => value.Message ?? (value.Succeeded ? "Profile is ready." : "Profile is not ready.")).ConfigureAwait(false);
+                return doctorResult.Succeeded ? 0 : 1;
+            case "delete":
+                var deleteResult = await application.Profiles.DeleteAsync(RequireOption(parseResult, "profile")).ConfigureAwait(false);
+                await WriteItemAsync(output, deleteResult, json, value => value.Message ?? "Profile deleted.").ConfigureAwait(false);
+                return deleteResult.Succeeded ? 0 : 1;
+            case "set-default":
+                var setDefaultResult = await application.Profiles.SetDefaultAsync(RequireOption(parseResult, "profile")).ConfigureAwait(false);
+                await WriteItemAsync(output, setDefaultResult, json, value => value.Message ?? "Default profile updated.").ConfigureAwait(false);
+                return setDefaultResult.Succeeded ? 0 : 1;
+            case "set-secret":
+                var setSecretResult = await application.ProfileSecrets.SetSecretAsync(
+                    RequireOption(parseResult, "profile"),
+                    RequireOption(parseResult, "name"),
+                    RequireOption(parseResult, "value")).ConfigureAwait(false);
+                await WriteItemAsync(output, setSecretResult, json, value => value.Message ?? "Secret saved.").ConfigureAwait(false);
+                return setSecretResult.Succeeded ? 0 : 1;
+            case "remove-secret":
+                var removeSecretResult = await application.ProfileSecrets.RemoveSecretAsync(
+                    RequireOption(parseResult, "profile"),
+                    RequireOption(parseResult, "name")).ConfigureAwait(false);
+                await WriteItemAsync(output, removeSecretResult, json, value => value.Message ?? "Secret removed.").ConfigureAwait(false);
+                return removeSecretResult.Succeeded ? 0 : 1;
+            default:
+                await error.WriteLineAsync($"Unknown profile command '{subCommand}'.").ConfigureAwait(false);
+                return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteMailAsync(
+        MailApplication application,
+        CliArguments parseResult,
+        TextWriter output,
+        TextWriter error) {
+        if (parseResult.Positionals.Count < 2) {
+            await error.WriteLineAsync("Missing mail command. Use 'mail folders', 'mail search', 'mail attachments', 'mail get', 'mail save-attachment', or 'mail save-attachments'.").ConfigureAwait(false);
+            return 1;
+        }
+
+        var subCommand = parseResult.Positionals[1];
+        var json = parseResult.HasFlag("json");
+        switch (subCommand) {
+            case "folders":
+                var folderQuery = new MailFolderQuery {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    ParentFolderId = parseResult.GetOption("parent-folder"),
+                    RootOnly = parseResult.HasFlag("root-only")
+                };
+                if (parseResult.HasFlag("compact")) {
+                    var compactFolders = await application.Read.GetFoldersCompactAsync(folderQuery).ConfigureAwait(false);
+                    await WriteSequenceAsync(output, compactFolders, json, folder =>
+                        folder.Summary).ConfigureAwait(false);
+                    return 0;
+                }
+                var folders = await application.Read.GetFoldersAsync(folderQuery).ConfigureAwait(false);
+                await WriteSequenceAsync(output, folders, json, folder =>
+                    $"{folder.Id} {folder.Path ?? folder.DisplayName}").ConfigureAwait(false);
+                return 0;
+            case "search":
+                var searchRequest = new MailSearchRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    QueryText = parseResult.GetOption("query"),
+                    SubjectContains = parseResult.GetOption("subject"),
+                    FromContains = parseResult.GetOption("from"),
+                    ToContains = parseResult.GetOption("to"),
+                    HasAttachments = parseResult.HasFlag("has-attachments"),
+                    Limit = parseResult.GetIntOption("limit")
+                };
+                if (parseResult.HasFlag("compact")) {
+                    var compactMessages = await application.Read.SearchCompactAsync(searchRequest).ConfigureAwait(false);
+                    await WriteSequenceAsync(output, compactMessages, json, message =>
+                        message.Summary).ConfigureAwait(false);
+                    return 0;
+                }
+                var messages = await application.Read.SearchAsync(searchRequest).ConfigureAwait(false);
+                await WriteSequenceAsync(output, messages, json, message =>
+                    $"{message.Id} {message.Subject ?? "(no subject)"}").ConfigureAwait(false);
+                return 0;
+            case "get":
+                var getRequest = new GetMessageRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageId = RequireOption(parseResult, "message-id"),
+                    IncludeRawContent = parseResult.HasFlag("include-raw")
+                };
+                if (parseResult.HasFlag("compact")) {
+                    var compactDetail = await application.Read.GetMessageCompactAsync(getRequest).ConfigureAwait(false);
+                    if (compactDetail == null) {
+                        await error.WriteLineAsync("Message was not found.").ConfigureAwait(false);
+                        return 1;
+                    }
+                    await WriteItemAsync(output, compactDetail, json, value => value.SummaryText).ConfigureAwait(false);
+                    return 0;
+                }
+                var detail = await application.Read.GetMessageAsync(getRequest).ConfigureAwait(false);
+                if (detail == null) {
+                    await error.WriteLineAsync("Message was not found.").ConfigureAwait(false);
+                    return 1;
+                }
+                await WriteItemAsync(output, detail, json, value => value.Summary?.Subject ?? value.Id).ConfigureAwait(false);
+                return 0;
+            case "attachments":
+                var attachments = await application.Read.GetAttachmentsAsync(new ListAttachmentsRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageId = RequireOption(parseResult, "message-id")
+                }).ConfigureAwait(false);
+                await WriteSequenceAsync(output, attachments, json, attachment =>
+                    $"{attachment.Id} {attachment.FileName}").ConfigureAwait(false);
+                return 0;
+            case "save-attachment":
+                var saveRequest = new SaveAttachmentRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageId = RequireOption(parseResult, "message-id"),
+                    AttachmentId = RequireOption(parseResult, "attachment-id"),
+                    DestinationPath = RequireOption(parseResult, "path"),
+                    Overwrite = parseResult.HasFlag("overwrite")
+                };
+                var saveResult = await application.Read.SaveAttachmentAsync(saveRequest).ConfigureAwait(false);
+                await WriteItemAsync(output, saveResult, json, value => value.Message ?? "Attachment saved.").ConfigureAwait(false);
+                return saveResult.Succeeded ? 0 : 1;
+            case "save-attachments":
+                var saveAttachmentsResult = await application.Read.SaveAttachmentsAsync(new SaveAttachmentsRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageId = RequireOption(parseResult, "message-id"),
+                    DestinationPath = RequireOption(parseResult, "path"),
+                    AttachmentIds = parseResult.GetOptionValues("attachment-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    FileNameContains = parseResult.GetOption("name-contains"),
+                    ContentTypeContains = parseResult.GetOption("content-type"),
+                    Overwrite = parseResult.HasFlag("overwrite")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, saveAttachmentsResult, json, value =>
+                    value.Message ?? $"Saved {value.SavedCount} attachment(s).").ConfigureAwait(false);
+                return saveAttachmentsResult.Succeeded ? 0 : 1;
+            default:
+                await error.WriteLineAsync($"Unknown mail command '{subCommand}'.").ConfigureAwait(false);
+                return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteDraftAsync(
+        MailApplication application,
+        CliArguments parseResult,
+        TextWriter output,
+        TextWriter error) {
+        if (parseResult.Positionals.Count < 2) {
+            await error.WriteLineAsync("Missing draft command. Use 'draft list', 'draft save', 'draft get', 'draft delete', or 'draft export'.").ConfigureAwait(false);
+            return 1;
+        }
+
+        var subCommand = parseResult.Positionals[1];
+        var json = parseResult.HasFlag("json");
+        switch (subCommand) {
+            case "list":
+                if (parseResult.HasFlag("compact")) {
+                    var compactDrafts = await application.Drafts.GetDraftsCompactAsync().ConfigureAwait(false);
+                    await WriteSequenceAsync(output, compactDrafts, json, draft =>
+                        draft.Summary).ConfigureAwait(false);
+                    return 0;
+                }
+                var drafts = await application.Drafts.GetDraftsAsync().ConfigureAwait(false);
+                await WriteSequenceAsync(output, drafts, json, draft =>
+                    $"{draft.Id} [{draft.Message.ProfileId}] {draft.Name}").ConfigureAwait(false);
+                return 0;
+            case "save":
+                var draft = await BuildMailDraftAsync(application, parseResult).ConfigureAwait(false);
+                var saveResult = await application.Drafts.SaveAsync(draft).ConfigureAwait(false);
+                await WriteItemAsync(output, saveResult, json, value => value.Message ?? "Draft saved.").ConfigureAwait(false);
+                return saveResult.Succeeded ? 0 : 1;
+            case "get":
+                if (parseResult.HasFlag("compact")) {
+                    var compactStoredDraft = await application.Drafts.GetDraftCompactAsync(RequireOption(parseResult, "draft")).ConfigureAwait(false);
+                    if (compactStoredDraft == null) {
+                        await error.WriteLineAsync("Draft was not found.").ConfigureAwait(false);
+                        return 1;
+                    }
+                    await WriteItemAsync(output, compactStoredDraft, json, value => value.Summary).ConfigureAwait(false);
+                    return 0;
+                }
+                var storedDraft = await application.Drafts.GetDraftAsync(RequireOption(parseResult, "draft")).ConfigureAwait(false);
+                if (storedDraft == null) {
+                    await error.WriteLineAsync("Draft was not found.").ConfigureAwait(false);
+                    return 1;
+                }
+                await WriteItemAsync(output, storedDraft, json, value => $"{value.Id} [{value.Message.ProfileId}] {value.Name}").ConfigureAwait(false);
+                return 0;
+            case "delete":
+                var deleteResult = await application.Drafts.DeleteAsync(RequireOption(parseResult, "draft")).ConfigureAwait(false);
+                await WriteItemAsync(output, deleteResult, json, value => value.Message ?? "Draft deleted.").ConfigureAwait(false);
+                return deleteResult.Succeeded ? 0 : 1;
+            case "export":
+                var draftToExport = await application.Drafts.GetDraftAsync(RequireOption(parseResult, "draft")).ConfigureAwait(false);
+                if (draftToExport == null) {
+                    await error.WriteLineAsync("Draft was not found.").ConfigureAwait(false);
+                    return 1;
+                }
+                await application.DraftExchange.SaveAsync(RequireOption(parseResult, "path"), draftToExport).ConfigureAwait(false);
+                await WriteItemAsync(output, OperationResult.Success("Draft exported."), json, value => value.Message ?? "Draft exported.").ConfigureAwait(false);
+                return 0;
+            default:
+                await error.WriteLineAsync($"Unknown draft command '{subCommand}'.").ConfigureAwait(false);
+                return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteQueueAsync(
+        MailApplication application,
+        CliArguments parseResult,
+        TextWriter output,
+        TextWriter error) {
+        if (parseResult.Positionals.Count < 2) {
+            await error.WriteLineAsync("Missing queue command. Use 'queue list', 'queue get', 'queue remove', or 'queue process'.").ConfigureAwait(false);
+            return 1;
+        }
+
+        var subCommand = parseResult.Positionals[1];
+        var json = parseResult.HasFlag("json");
+        switch (subCommand) {
+            case "list":
+                if (parseResult.HasFlag("compact")) {
+                    var compactQueuedMessages = await application.Queue.ListCompactAsync().ConfigureAwait(false);
+                    await WriteSequenceAsync(output, compactQueuedMessages, json, message => message.Summary).ConfigureAwait(false);
+                    return 0;
+                }
+                var queuedMessages = await application.Queue.ListAsync().ConfigureAwait(false);
+                await WriteSequenceAsync(output, queuedMessages, json, message =>
+                    $"{message.MessageId} [{message.Provider}] attempts={message.AttemptCount} next={message.NextAttemptAt:O}").ConfigureAwait(false);
+                return 0;
+            case "get":
+                if (parseResult.HasFlag("compact")) {
+                    var compactQueuedMessage = await application.Queue.GetCompactAsync(RequireOption(parseResult, "message-id")).ConfigureAwait(false);
+                    if (compactQueuedMessage == null) {
+                        await error.WriteLineAsync("Queued message was not found.").ConfigureAwait(false);
+                        return 1;
+                    }
+                    await WriteItemAsync(output, compactQueuedMessage, json, message => message.Summary).ConfigureAwait(false);
+                    return 0;
+                }
+                var queuedMessage = await application.Queue.GetAsync(RequireOption(parseResult, "message-id")).ConfigureAwait(false);
+                if (queuedMessage == null) {
+                    await error.WriteLineAsync("Queued message was not found.").ConfigureAwait(false);
+                    return 1;
+                }
+                await WriteItemAsync(output, queuedMessage, json, message =>
+                    $"{message.MessageId} [{message.Provider}] attempts={message.AttemptCount}").ConfigureAwait(false);
+                return 0;
+            case "remove":
+                var removeResult = await application.Queue.RemoveAsync(RequireOption(parseResult, "message-id")).ConfigureAwait(false);
+                await WriteItemAsync(output, removeResult, json, value => value.Message ?? "Queued message removed.").ConfigureAwait(false);
+                return removeResult.Succeeded ? 0 : 1;
+            case "process":
+                var processResult = await application.Queue.ProcessAsync().ConfigureAwait(false);
+                await WriteItemAsync(output, processResult, json, value =>
+                    value.Message ?? $"Processed queue: attempted={value.AttemptedCount}, sent={value.SentCount}, failed={value.FailedCount}.").ConfigureAwait(false);
+                return processResult.Succeeded ? 0 : 1;
+            default:
+                await error.WriteLineAsync($"Unknown queue command '{subCommand}'.").ConfigureAwait(false);
+                return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteSendAsync(
+        MailApplication application,
+        CliArguments parseResult,
+        TextWriter output,
+        TextWriter error) {
+        var json = parseResult.HasFlag("json");
+        var request = await BuildSendRequestAsync(application, parseResult).ConfigureAwait(false);
+        var result = await application.Send.SendAsync(request).ConfigureAwait(false);
+        await WriteItemAsync(output, result, json, value => value.Message ?? (value.Queued
+            ? $"Message queued: {value.QueueMessageId ?? "(unknown-id)"}"
+            : $"Message sent: {value.ProviderMessageId ?? "(provider-id unavailable)"}")).ConfigureAwait(false);
+        return result.Succeeded ? 0 : 1;
+    }
+
+    private static async Task<int> ExecuteMcpAsync(
+        MailApplication application,
+        CliArguments parseResult,
+        TextWriter error) {
+        if (parseResult.Positionals.Count < 2) {
+            await error.WriteLineAsync("Missing mcp command. Use 'mcp serve'.").ConfigureAwait(false);
+            return 1;
+        }
+
+        var subCommand = parseResult.Positionals[1];
+        if (!string.Equals(subCommand, "serve", StringComparison.OrdinalIgnoreCase)) {
+            await error.WriteLineAsync($"Unknown mcp command '{subCommand}'.").ConfigureAwait(false);
+            return 1;
+        }
+
+        await McpServerHost.RunAsync(application).ConfigureAwait(false);
+        return 0;
+    }
+
+    private static async Task<int> WriteUnknownCommandAsync(string command, TextWriter error) {
+        await error.WriteLineAsync($"Unknown command '{command}'.").ConfigureAwait(false);
+        return 1;
+    }
+
+    private static string RequireOption(CliArguments parseResult, string name) {
+        var value = parseResult.GetOption(name);
+        if (!string.IsNullOrWhiteSpace(value)) {
+            return value!;
+        }
+
+        throw new InvalidOperationException($"Missing required option '--{name}'.");
+    }
+
+    private static MailProfile BuildProfile(CliArguments parseResult) {
+        var profile = new MailProfile {
+            Id = RequireOption(parseResult, "profile"),
+            DisplayName = RequireOption(parseResult, "name"),
+            Kind = MailProfileKindParser.Parse(RequireOption(parseResult, "kind")),
+            Description = parseResult.GetOption("description"),
+            DefaultSender = parseResult.GetOption("default-sender"),
+            DefaultMailbox = parseResult.GetOption("default-mailbox"),
+            IsDefault = parseResult.HasFlag("is-default")
+        };
+
+        foreach (var setting in parseResult.GetOptionValues("setting")) {
+            if (string.IsNullOrWhiteSpace(setting)) {
+                continue;
+            }
+
+            var separatorIndex = setting.IndexOf('=');
+            if (separatorIndex <= 0 || separatorIndex == setting.Length - 1) {
+                throw new InvalidOperationException("Option '--setting' must use the format key=value.");
+            }
+
+            var key = setting[..separatorIndex].Trim();
+            var value = setting[(separatorIndex + 1)..].Trim();
+            if (key.Length == 0 || value.Length == 0) {
+                throw new InvalidOperationException("Option '--setting' must use the format key=value.");
+            }
+
+            profile.Settings[key] = value;
+        }
+
+        return profile;
+    }
+
+    private static async Task<SendMessageRequest> BuildSendRequestAsync(MailApplication application, CliArguments parseResult) {
+        if (application == null) {
+            throw new ArgumentNullException(nameof(application));
+        }
+
+        var existingDraftId = parseResult.GetOption("draft");
+        var draftFilePath = parseResult.GetOption("file");
+        if (!string.IsNullOrWhiteSpace(existingDraftId) && !string.IsNullOrWhiteSpace(draftFilePath)) {
+            throw new InvalidOperationException("Options '--draft' and '--file' cannot be used together.");
+        }
+
+        var sendNow = parseResult.HasFlag("send-now");
+        if (!string.IsNullOrWhiteSpace(draftFilePath)) {
+            var importedDraft = await application.DraftExchange.LoadAsync(draftFilePath!).ConfigureAwait(false);
+            return CreateSendRequestFromDraft(importedDraft.Message, sendNow);
+        }
+
+        if (!string.IsNullOrWhiteSpace(existingDraftId)) {
+            var existingDraft = await application.Drafts.GetDraftAsync(existingDraftId!).ConfigureAwait(false);
+            if (existingDraft == null) {
+                throw new InvalidOperationException($"Draft '{existingDraftId}' was not found.");
+            }
+
+            return CreateSendRequestFromDraft(existingDraft.Message, sendNow);
+        }
+
+        var profileId = RequireOption(parseResult, "profile");
+        var draft = BuildDraftMessage(parseResult, profileId);
+
+        return new SendMessageRequest {
+            ProfileId = profileId,
+            Message = draft,
+            PreferQueue = !sendNow,
+            RequireImmediateSend = sendNow
+        };
+    }
+
+    private static async Task<MailDraft> BuildMailDraftAsync(MailApplication application, CliArguments parseResult) {
+        if (application == null) {
+            throw new ArgumentNullException(nameof(application));
+        }
+
+        var filePath = parseResult.GetOption("file");
+        if (!string.IsNullOrWhiteSpace(filePath)) {
+            var importedDraft = await application.DraftExchange.LoadAsync(filePath!).ConfigureAwait(false);
+            var overrideDraftId = parseResult.GetOption("draft");
+            var overrideName = parseResult.GetOption("name");
+            if (!string.IsNullOrWhiteSpace(overrideDraftId)) {
+                importedDraft.Id = overrideDraftId!.Trim();
+            }
+            if (!string.IsNullOrWhiteSpace(overrideName)) {
+                importedDraft.Name = overrideName!.Trim();
+            }
+
+            return importedDraft;
+        }
+
+        var draftId = RequireOption(parseResult, "draft");
+        var draftName = RequireOption(parseResult, "name");
+
+        return new MailDraft {
+            Id = draftId,
+            Name = draftName,
+            Message = BuildDraftMessage(parseResult, RequireOption(parseResult, "profile"))
+        };
+    }
+
+    private static SendMessageRequest CreateSendRequestFromDraft(DraftMessage draft, bool sendNow) =>
+        new() {
+            ProfileId = draft.ProfileId,
+            Message = CloneDraftMessage(draft),
+            PreferQueue = !sendNow,
+            RequireImmediateSend = sendNow
+        };
+
+    private static MessageRecipient ToRecipient(string value) => new() {
+        Address = value.Trim()
+    };
+
+    private static DraftMessage BuildDraftMessage(CliArguments parseResult, string profileId) {
+        var draft = new DraftMessage {
+            ProfileId = profileId,
+            Subject = parseResult.GetOption("subject"),
+            TextBody = parseResult.GetOption("text"),
+            HtmlBody = parseResult.GetOption("html")
+        };
+
+        var from = parseResult.GetOption("from");
+        if (!string.IsNullOrWhiteSpace(from)) {
+            draft.From = ToRecipient(from!);
+        }
+
+        draft.To.AddRange(parseResult.GetOptionValues("to").Where(value => !string.IsNullOrWhiteSpace(value)).Select(value => ToRecipient(value!)));
+        draft.Cc.AddRange(parseResult.GetOptionValues("cc").Where(value => !string.IsNullOrWhiteSpace(value)).Select(value => ToRecipient(value!)));
+        draft.Bcc.AddRange(parseResult.GetOptionValues("bcc").Where(value => !string.IsNullOrWhiteSpace(value)).Select(value => ToRecipient(value!)));
+        draft.ReplyTo.AddRange(parseResult.GetOptionValues("reply-to").Where(value => !string.IsNullOrWhiteSpace(value)).Select(value => ToRecipient(value!)));
+
+        foreach (var header in parseResult.GetOptionValues("header")) {
+            if (string.IsNullOrWhiteSpace(header)) {
+                continue;
+            }
+
+            var separatorIndex = header.IndexOf('=');
+            if (separatorIndex <= 0 || separatorIndex == header.Length - 1) {
+                throw new InvalidOperationException("Option '--header' must use the format key=value.");
+            }
+
+            draft.Headers[header[..separatorIndex].Trim()] = header[(separatorIndex + 1)..].Trim();
+        }
+
+        foreach (var attachmentPath in parseResult.GetOptionValues("attachment")) {
+            if (string.IsNullOrWhiteSpace(attachmentPath)) {
+                continue;
+            }
+
+            draft.Attachments.Add(new DraftAttachment {
+                Path = attachmentPath!.Trim()
+            });
+        }
+
+        return draft;
+    }
+
+    private static DraftMessage CloneDraftMessage(DraftMessage draft) => new() {
+        ProfileId = draft.ProfileId,
+        From = draft.From == null ? null : new MessageRecipient {
+            Name = draft.From.Name,
+            Address = draft.From.Address
+        },
+        To = draft.To.Select(ToRecipientCopy).ToList(),
+        Cc = draft.Cc.Select(ToRecipientCopy).ToList(),
+        Bcc = draft.Bcc.Select(ToRecipientCopy).ToList(),
+        ReplyTo = draft.ReplyTo.Select(ToRecipientCopy).ToList(),
+        Subject = draft.Subject,
+        TextBody = draft.TextBody,
+        HtmlBody = draft.HtmlBody,
+        Headers = new Dictionary<string, string>(draft.Headers, StringComparer.OrdinalIgnoreCase),
+        Attachments = draft.Attachments.Select(attachment => new DraftAttachment {
+            Path = attachment.Path,
+            FileName = attachment.FileName,
+            ContentType = attachment.ContentType,
+            IsInline = attachment.IsInline,
+            ContentId = attachment.ContentId
+        }).ToList()
+    };
+
+    private static MessageRecipient ToRecipientCopy(MessageRecipient recipient) => new() {
+        Name = recipient.Name,
+        Address = recipient.Address
+    };
+
+    private static async Task WriteItemAsync<T>(
+        TextWriter output,
+        T value,
+        bool json,
+        Func<T, string> formatter) {
+        if (json) {
+            await output.WriteLineAsync(JsonSerializer.Serialize(value, JsonOptions)).ConfigureAwait(false);
+            return;
+        }
+
+        await output.WriteLineAsync(formatter(value)).ConfigureAwait(false);
+    }
+
+    private static async Task WriteSequenceAsync<T>(
+        TextWriter output,
+        IReadOnlyList<T> values,
+        bool json,
+        Func<T, string> formatter) {
+        if (json) {
+            await output.WriteLineAsync(JsonSerializer.Serialize(values, JsonOptions)).ConfigureAwait(false);
+            return;
+        }
+
+        foreach (var value in values) {
+            await output.WriteLineAsync(formatter(value)).ConfigureAwait(false);
+        }
+    }
+
+    private static void WriteHelp(TextWriter output) {
+        output.WriteLine("Mailozaurr CLI");
+        output.WriteLine();
+        output.WriteLine("Commands:");
+        output.WriteLine("  profile list [--summary] [--compact] [--kind <kind>] [--ready-only] [--can-read] [--can-send] [--default-only] [--sort <id|kind|readiness>] [--desc] [--json]");
+        output.WriteLine("  profile create --profile <id> --kind <kind> --name <display-name> [--description <text>] [--default-sender <email>] [--default-mailbox <value>] [--is-default] [--setting <key=value>] [--json]");
+        output.WriteLine("  profile graph-bootstrap --profile <id> --name <display-name> --mailbox <address> [--description <text>] [--default-sender <email>] [--is-default] [--client-id <id>] [--tenant-id <id>] [--client-secret <secret>] [--access-token <token>] [--certificate-path <path>] [--certificate-password <secret>] [--json]");
+        output.WriteLine("  profile gmail-bootstrap --profile <id> --name <display-name> [--mailbox <address|me>] [--description <text>] [--default-sender <email>] [--is-default] [--client-id <id>] [--client-secret <secret>] [--refresh-token <token>] [--access-token <token>] [--json]");
+        output.WriteLine("  profile graph-login --profile <id> [--login <upn>] [--mailbox <address>] [--client-id <id>] [--tenant-id <id>] [--redirect-uri <uri>] [--scope <value>] [--scope <value>] [--json]");
+        output.WriteLine("  profile gmail-login --profile <id> [--mailbox <address>] [--client-id <id>] [--client-secret <secret>] [--scope <value>] [--scope <value>] [--json]");
+        output.WriteLine("  profile refresh-auth --profile <id> [--json]");
+        output.WriteLine("  profile auth-status --profile <id> [--json]");
+        output.WriteLine("  profile test --profile <id> [--scope <auto|auth|mailbox|send>] [--json]");
+        output.WriteLine("  profile summary --profile <id> [--compact] [--json]");
+        output.WriteLine("  profile capabilities --profile <id> [--json]");
+        output.WriteLine("  profile show --profile <id> [--json]");
+        output.WriteLine("  profile validate --profile <id> [--json]");
+        output.WriteLine("  profile doctor --profile <id> [--json]");
+        output.WriteLine("  profile delete --profile <id> [--json]");
+        output.WriteLine("  profile set-default --profile <id> [--json]");
+        output.WriteLine("  profile set-secret --profile <id> --name <secret-name> --value <secret-value> [--json]");
+        output.WriteLine("  profile remove-secret --profile <id> --name <secret-name> [--json]");
+        output.WriteLine("  draft list [--compact] [--json]");
+        output.WriteLine("  draft save --file <path> [--draft <id>] [--name <display-name>] [--json]");
+        output.WriteLine("  draft save --draft <id> --name <display-name> --profile <id> --to <address> [--to <address>] [--cc <address>] [--bcc <address>] [--reply-to <address>] [--from <address>] [--subject <text>] [--text <text>] [--html <html>] [--attachment <path>] [--header <key=value>] [--json]");
+        output.WriteLine("  draft get --draft <id> [--compact] [--json]");
+        output.WriteLine("  draft delete --draft <id> [--json]");
+        output.WriteLine("  draft export --draft <id> --path <file> [--json]");
+        output.WriteLine("  mail folders --profile <id> [--mailbox <id>] [--parent-folder <id>] [--root-only] [--compact] [--json]");
+        output.WriteLine("  mail search --profile <id> [--mailbox <id>] [--folder <name>] [--query <text>] [--subject <text>] [--from <text>] [--to <text>] [--limit <n>] [--compact] [--json]");
+        output.WriteLine("  mail get --profile <id> --message-id <id> [--mailbox <id>] [--folder <name>] [--include-raw] [--compact] [--json]");
+        output.WriteLine("  mail attachments --profile <id> --message-id <id> [--mailbox <id>] [--folder <name>] [--json]");
+        output.WriteLine("  mail save-attachment --profile <id> --message-id <id> --attachment-id <id> --path <destination> [--mailbox <id>] [--folder <name>] [--overwrite] [--json]");
+        output.WriteLine("  mail save-attachments --profile <id> --message-id <id> --path <destination> [--mailbox <id>] [--folder <name>] [--attachment-id <id>] [--attachment-id <id>] [--name-contains <text>] [--content-type <text>] [--overwrite] [--json]");
+        output.WriteLine("  mcp serve");
+        output.WriteLine("  send --draft <id> [--send-now] [--json]");
+        output.WriteLine("  send --file <path> [--send-now] [--json]");
+        output.WriteLine("  send --profile <id> --to <address> [--to <address>] [--cc <address>] [--bcc <address>] [--reply-to <address>] [--from <address>] [--subject <text>] [--text <text>] [--html <html>] [--attachment <path>] [--header <key=value>] [--send-now] [--json]");
+        output.WriteLine("  queue list [--compact] [--json]");
+        output.WriteLine("  queue get --message-id <id> [--compact] [--json]");
+        output.WriteLine("  queue remove --message-id <id> [--json]");
+        output.WriteLine("  queue process [--json]");
+        output.WriteLine();
+        output.WriteLine("Global options:");
+        output.WriteLine("  --profiles-dir <path>");
+        output.WriteLine("  --secrets-dir <path>");
+        output.WriteLine("  --drafts-dir <path>");
+        output.WriteLine("  --help");
+    }
+
+    private static MailProfileConnectionTestScope ParseConnectionTestScope(string? rawScope) {
+        if (string.IsNullOrWhiteSpace(rawScope)) {
+            return MailProfileConnectionTestScope.Auto;
+        }
+
+        if (Enum.TryParse<MailProfileConnectionTestScope>(rawScope.Trim(), ignoreCase: true, out var scope)) {
+            return scope;
+        }
+
+        throw new InvalidOperationException($"Unsupported connection test scope '{rawScope}'.");
+    }
+
+    private static MailProfileOverviewQuery BuildProfileOverviewQuery(CliArguments parseResult) {
+        var query = new MailProfileOverviewQuery {
+            Descending = parseResult.HasFlag("desc"),
+            ReadyOnly = parseResult.HasFlag("ready-only"),
+            CanReadOnly = parseResult.HasFlag("can-read"),
+            CanSendOnly = parseResult.HasFlag("can-send"),
+            DefaultOnly = parseResult.HasFlag("default-only")
+        };
+
+        var kind = parseResult.GetOption("kind");
+        if (!string.IsNullOrWhiteSpace(kind)) {
+            query.Kind = MailProfileKindParser.Parse(kind);
+        }
+
+        var sort = parseResult.GetOption("sort");
+        if (!string.IsNullOrWhiteSpace(sort)) {
+            query.SortBy = ParseProfileOverviewSortBy(sort);
+        }
+
+        return query;
+    }
+
+    private static MailProfileOverviewSortBy ParseProfileOverviewSortBy(string rawSort) {
+        if (Enum.TryParse<MailProfileOverviewSortBy>(rawSort.Trim(), ignoreCase: true, out var sortBy)) {
+            return sortBy;
+        }
+
+        throw new InvalidOperationException($"Unsupported profile overview sort '{rawSort}'.");
+    }
+}

--- a/Sources/Mailozaurr.Cli/Mailozaurr.Cli.csproj
+++ b/Sources/Mailozaurr.Cli/Mailozaurr.Cli.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Mailozaurr.Application\Mailozaurr.Application.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+      <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
+    </ItemGroup>
+</Project>

--- a/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.cs
+++ b/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.cs
@@ -1,0 +1,766 @@
+using System.ComponentModel;
+using Mailozaurr.Application;
+using ModelContextProtocol.Server;
+
+namespace Mailozaurr.Cli.Mcp;
+
+[McpServerToolType]
+public sealed class MailMcpTools {
+    private readonly MailApplication _application;
+
+    public MailMcpTools(MailApplication application) {
+        _application = application ?? throw new ArgumentNullException(nameof(application));
+    }
+
+    [McpServerTool]
+    [Description("Lists configured Mailozaurr profiles that can be used for mailbox and send operations.")]
+    public Task<IReadOnlyList<MailProfile>> mail_profiles_list(CancellationToken cancellationToken = default) =>
+        _application.Profiles.GetProfilesAsync(cancellationToken);
+
+    [McpServerTool]
+    [Description("Lists higher-level summaries for all configured Mailozaurr profiles, including kind, capabilities, auth posture, and readiness.")]
+    public Task<IReadOnlyList<MailProfileOverview>> mail_profiles_summary_list(
+        [Description("Optional provider kind filter, such as imap, graph, gmail, smtp, or pop3.")] string? kind = null,
+        [Description("When true, only returns ready profiles.")] bool readyOnly = false,
+        [Description("When true, only returns profiles that support reading.")] bool canReadOnly = false,
+        [Description("When true, only returns profiles that support sending.")] bool canSendOnly = false,
+        [Description("When true, only returns profiles marked as default.")] bool defaultOnly = false,
+        [Description("Optional sort key: id, kind, or readiness.")] string? sortBy = null,
+        [Description("When true, reverses the selected sort order.")] bool descending = false,
+        CancellationToken cancellationToken = default) =>
+        _application.ProfileOverview.GetOverviewsAsync(new MailProfileOverviewQuery {
+            Kind = string.IsNullOrWhiteSpace(kind) ? null : MailProfileKindParser.Parse(kind),
+            SortBy = string.IsNullOrWhiteSpace(sortBy)
+                ? MailProfileOverviewSortBy.Id
+                : Enum.Parse<MailProfileOverviewSortBy>(sortBy, ignoreCase: true),
+            Descending = descending,
+            ReadyOnly = readyOnly,
+            CanReadOnly = canReadOnly,
+            CanSendOnly = canSendOnly,
+            DefaultOnly = defaultOnly
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Lists lightweight profile summaries for all configured Mailozaurr profiles.")]
+    public Task<IReadOnlyList<MailProfileOverviewCompact>> mail_profiles_summary_compact_list(
+        [Description("Optional provider kind filter, such as imap, graph, gmail, smtp, or pop3.")] string? kind = null,
+        [Description("When true, only returns ready profiles.")] bool readyOnly = false,
+        [Description("When true, only returns profiles that support reading.")] bool canReadOnly = false,
+        [Description("When true, only returns profiles that support sending.")] bool canSendOnly = false,
+        [Description("When true, only returns profiles marked as default.")] bool defaultOnly = false,
+        [Description("Optional sort key: id, kind, or readiness.")] string? sortBy = null,
+        [Description("When true, reverses the selected sort order.")] bool descending = false,
+        CancellationToken cancellationToken = default) =>
+        _application.ProfileOverview.GetCompactOverviewsAsync(new MailProfileOverviewQuery {
+            Kind = string.IsNullOrWhiteSpace(kind) ? null : MailProfileKindParser.Parse(kind),
+            SortBy = string.IsNullOrWhiteSpace(sortBy)
+                ? MailProfileOverviewSortBy.Id
+                : Enum.Parse<MailProfileOverviewSortBy>(sortBy, ignoreCase: true),
+            Descending = descending,
+            ReadyOnly = readyOnly,
+            CanReadOnly = canReadOnly,
+            CanSendOnly = canSendOnly,
+            DefaultOnly = defaultOnly
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Returns the effective capabilities for a configured Mailozaurr profile.")]
+    public async Task<ProfileCapabilities> mail_capabilities_get(
+        [Description("The profile identifier to inspect.")] string profileId,
+        CancellationToken cancellationToken = default) {
+        var capabilities = await _application.Profiles.GetCapabilitiesAsync(profileId, cancellationToken).ConfigureAwait(false);
+        return capabilities ?? throw new InvalidOperationException($"Profile '{profileId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Gets a configured Mailozaurr profile by identifier.")]
+    public async Task<MailProfile> mail_profile_get(
+        [Description("The profile identifier to retrieve.")] string profileId,
+        CancellationToken cancellationToken = default) {
+        var profile = await _application.Profiles.GetProfileAsync(profileId, cancellationToken).ConfigureAwait(false);
+        return profile ?? throw new InvalidOperationException($"Profile '{profileId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Inspects whether a configured Mailozaurr profile is ready to use, including provider-specific auth prerequisites.")]
+    public Task<MailProfileValidationResult> mail_profile_doctor(
+        [Description("The profile identifier to inspect.")] string profileId,
+        CancellationToken cancellationToken = default) =>
+        _application.Profiles.DiagnoseAsync(profileId, cancellationToken);
+
+    [McpServerTool]
+    [Description("Returns a higher-level summary for a configured Mailozaurr profile, combining kind, capabilities, auth posture, and readiness.")]
+    public async Task<MailProfileOverview> mail_profile_summary(
+        [Description("The profile identifier to summarize.")] string profileId,
+        CancellationToken cancellationToken = default) {
+        var overview = await _application.ProfileOverview.GetOverviewAsync(profileId, cancellationToken).ConfigureAwait(false);
+        return overview ?? throw new InvalidOperationException($"Profile '{profileId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Returns a lightweight summary for a configured Mailozaurr profile.")]
+    public async Task<MailProfileOverviewCompact> mail_profile_summary_compact(
+        [Description("The profile identifier to summarize.")] string profileId,
+        CancellationToken cancellationToken = default) {
+        var overview = await _application.ProfileOverview.GetCompactOverviewAsync(profileId, cancellationToken).ConfigureAwait(false);
+        return overview ?? throw new InvalidOperationException($"Profile '{profileId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Runs structural validation for a configured Mailozaurr profile without provider-specific readiness checks.")]
+    public async Task<MailProfileValidationResult> mail_profile_validate(
+        [Description("The profile identifier to validate.")] string profileId,
+        CancellationToken cancellationToken = default) {
+        var profile = await _application.Profiles.GetProfileAsync(profileId, cancellationToken).ConfigureAwait(false);
+        if (profile == null) {
+            throw new InvalidOperationException($"Profile '{profileId}' was not found.");
+        }
+
+        return await _application.Profiles.ValidateAsync(profile, cancellationToken).ConfigureAwait(false);
+    }
+
+    [McpServerTool]
+    [Description("Creates or updates a Mailozaurr profile using shared profile storage.")]
+    public async Task<MailProfile> mail_profile_save(
+        [Description("The stable profile identifier to create or update.")] string profileId,
+        [Description("The provider kind, such as imap, graph, gmail, smtp, or pop3.")] string kind,
+        [Description("The human-readable display name for the profile.")] string displayName,
+        [Description("Optional description for operators.")] string? description = null,
+        [Description("Optional default sender email address.")] string? defaultSender = null,
+        [Description("Optional default mailbox identifier or address.")] string? defaultMailbox = null,
+        [Description("When true, marks this profile as the default profile.")] bool isDefault = false,
+        [Description("Optional non-secret settings to persist with the profile.")] Dictionary<string, string>? settings = null,
+        CancellationToken cancellationToken = default) {
+        var profile = new MailProfile {
+            Id = profileId,
+            DisplayName = displayName,
+            Kind = MailProfileKindParser.Parse(kind),
+            Description = description,
+            DefaultSender = defaultSender,
+            DefaultMailbox = defaultMailbox,
+            IsDefault = isDefault,
+            Settings = settings == null
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(settings, StringComparer.OrdinalIgnoreCase)
+        };
+
+        var result = await _application.Profiles.SaveAsync(profile, cancellationToken).ConfigureAwait(false);
+        if (!result.Succeeded) {
+            throw new InvalidOperationException(result.Message ?? $"Profile '{profileId}' could not be saved.");
+        }
+
+        return await mail_profile_get(profileId, cancellationToken).ConfigureAwait(false);
+    }
+
+    [McpServerTool]
+    [Description("Creates or updates a Microsoft Graph profile using the shared Graph bootstrap workflow.")]
+    public async Task<MailProfile> mail_profile_graph_bootstrap(
+        [Description("The stable profile identifier to create or update.")] string profileId,
+        [Description("The human-readable display name for the profile.")] string displayName,
+        [Description("The mailbox address or user principal name for Graph operations.")] string mailbox,
+        [Description("Optional description for operators.")] string? description = null,
+        [Description("Optional default sender email address. Defaults to the mailbox when omitted.")] string? defaultSender = null,
+        [Description("When true, marks this profile as the default profile.")] bool isDefault = false,
+        [Description("Optional Graph client/application identifier.")] string? clientId = null,
+        [Description("Optional Graph tenant/directory identifier.")] string? tenantId = null,
+        [Description("Optional confidential client secret to store securely.")] string? clientSecret = null,
+        [Description("Optional explicit access token to store securely.")] string? accessToken = null,
+        [Description("Optional certificate path for certificate-based auth.")] string? certificatePath = null,
+        [Description("Optional certificate password to store securely.")] string? certificatePassword = null,
+        CancellationToken cancellationToken = default) {
+        var result = await _application.ProfileBootstrap.SaveGraphProfileAsync(new GraphProfileBootstrapRequest {
+            ProfileId = profileId,
+            DisplayName = displayName,
+            Description = description,
+            Mailbox = mailbox,
+            DefaultSender = defaultSender,
+            IsDefault = isDefault,
+            ClientId = clientId,
+            TenantId = tenantId,
+            ClientSecret = clientSecret,
+            AccessToken = accessToken,
+            CertificatePath = certificatePath,
+            CertificatePassword = certificatePassword
+        }, cancellationToken).ConfigureAwait(false);
+        if (!result.Succeeded) {
+            throw new InvalidOperationException(result.Message ?? $"Graph profile '{profileId}' could not be saved.");
+        }
+
+        return await mail_profile_get(profileId, cancellationToken).ConfigureAwait(false);
+    }
+
+    [McpServerTool]
+    [Description("Creates or updates a Gmail profile using the shared Gmail bootstrap workflow.")]
+    public async Task<MailProfile> mail_profile_gmail_bootstrap(
+        [Description("The stable profile identifier to create or update.")] string profileId,
+        [Description("The human-readable display name for the profile.")] string displayName,
+        [Description("Optional Gmail mailbox address or user id. Defaults to 'me' when omitted.")] string? mailbox = null,
+        [Description("Optional description for operators.")] string? description = null,
+        [Description("Optional default sender email address. Defaults to the mailbox when appropriate.")] string? defaultSender = null,
+        [Description("When true, marks this profile as the default profile.")] bool isDefault = false,
+        [Description("Optional Google OAuth client identifier.")] string? clientId = null,
+        [Description("Optional Google OAuth client secret to store securely.")] string? clientSecret = null,
+        [Description("Optional Google OAuth refresh token to store securely.")] string? refreshToken = null,
+        [Description("Optional explicit access token to store securely.")] string? accessToken = null,
+        CancellationToken cancellationToken = default) {
+        var result = await _application.ProfileBootstrap.SaveGmailProfileAsync(new GmailProfileBootstrapRequest {
+            ProfileId = profileId,
+            DisplayName = displayName,
+            Description = description,
+            Mailbox = mailbox,
+            DefaultSender = defaultSender,
+            IsDefault = isDefault,
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+            RefreshToken = refreshToken,
+            AccessToken = accessToken
+        }, cancellationToken).ConfigureAwait(false);
+        if (!result.Succeeded) {
+            throw new InvalidOperationException(result.Message ?? $"Gmail profile '{profileId}' could not be saved.");
+        }
+
+        return await mail_profile_get(profileId, cancellationToken).ConfigureAwait(false);
+    }
+
+    [McpServerTool]
+    [Description("Authenticates a saved Microsoft Graph profile using the shared interactive login workflow and persists the resulting token.")]
+    public Task<MailProfileAuthenticationResult> mail_profile_graph_login(
+        [Description("The saved Graph profile identifier to authenticate.")] string profileId,
+        [Description("Optional login hint for the interactive flow.")] string? login = null,
+        [Description("Optional mailbox override to persist on the profile.")] string? mailbox = null,
+        [Description("Optional client/application identifier override.")] string? clientId = null,
+        [Description("Optional tenant/directory identifier override.")] string? tenantId = null,
+        [Description("Optional redirect URI override for the interactive flow.")] string? redirectUri = null,
+        [Description("Optional scopes override.")] string[]? scopes = null,
+        CancellationToken cancellationToken = default) =>
+        _application.ProfileAuth.LoginGraphAsync(new GraphProfileLoginRequest {
+            ProfileId = profileId,
+            Login = login,
+            Mailbox = mailbox,
+            ClientId = clientId,
+            TenantId = tenantId,
+            RedirectUri = redirectUri,
+            Scopes = scopes
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Authenticates a saved Gmail profile using the shared interactive login workflow and persists the resulting tokens.")]
+    public Task<MailProfileAuthenticationResult> mail_profile_gmail_login(
+        [Description("The saved Gmail profile identifier to authenticate.")] string profileId,
+        [Description("Optional Gmail account override used for the login flow.")] string? mailbox = null,
+        [Description("Optional OAuth client identifier override.")] string? clientId = null,
+        [Description("Optional OAuth client secret override.")] string? clientSecret = null,
+        [Description("Optional scopes override.")] string[]? scopes = null,
+        CancellationToken cancellationToken = default) =>
+        _application.ProfileAuth.LoginGmailAsync(new GmailProfileLoginRequest {
+            ProfileId = profileId,
+            GmailAccount = mailbox,
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+            Scopes = scopes
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Refreshes or reauthenticates a saved profile using its persisted Mailozaurr auth metadata.")]
+    public Task<MailProfileAuthenticationResult> mail_profile_refresh_auth(
+        [Description("The saved profile identifier to refresh.")] string profileId,
+        CancellationToken cancellationToken = default) =>
+        _application.ProfileAuth.RefreshAsync(profileId, cancellationToken);
+
+    [McpServerTool]
+    [Description("Returns the persisted authentication status for a saved Mailozaurr profile, including auth mode, token presence, and refreshability.")]
+    public async Task<MailProfileAuthStatus> mail_profile_auth_status(
+        [Description("The saved profile identifier to inspect.")] string profileId,
+        CancellationToken cancellationToken = default) {
+        var status = await _application.ProfileAuth.GetStatusAsync(profileId, cancellationToken).ConfigureAwait(false);
+        return status ?? throw new InvalidOperationException($"Profile '{profileId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Runs a live provider connection test for a saved Mailozaurr profile.")]
+    public Task<MailProfileConnectionTestResult> mail_profile_test(
+        [Description("The saved profile identifier to test.")] string profileId,
+        [Description("Optional test scope: auto, auth, mailbox, or send.")] string? scope = null,
+        CancellationToken cancellationToken = default) =>
+        _application.ProfileConnections.TestAsync(profileId, ParseConnectionTestScope(scope), cancellationToken);
+
+    [McpServerTool]
+    [Description("Deletes a Mailozaurr profile from shared profile storage.")]
+    public Task<OperationResult> mail_profile_delete(
+        [Description("The profile identifier to delete.")] string profileId,
+        CancellationToken cancellationToken = default) =>
+        _application.Profiles.DeleteAsync(profileId, cancellationToken);
+
+    [McpServerTool]
+    [Description("Marks a Mailozaurr profile as the shared default profile.")]
+    public Task<OperationResult> mail_profile_set_default(
+        [Description("The profile identifier to mark as default.")] string profileId,
+        CancellationToken cancellationToken = default) =>
+        _application.Profiles.SetDefaultAsync(profileId, cancellationToken);
+
+    [McpServerTool]
+    [Description("Stores or replaces a secret for an existing Mailozaurr profile.")]
+    public Task<OperationResult> mail_profile_secret_set(
+        [Description("The profile identifier that owns the secret.")] string profileId,
+        [Description("The stable secret name, such as password, client-secret, or refresh-token.")] string secretName,
+        [Description("The secret value to store.")] string secretValue,
+        CancellationToken cancellationToken = default) =>
+        _application.ProfileSecrets.SetSecretAsync(profileId, secretName, secretValue, cancellationToken);
+
+    [McpServerTool]
+    [Description("Removes a secret associated with an existing Mailozaurr profile.")]
+    public Task<OperationResult> mail_profile_secret_remove(
+        [Description("The profile identifier that owns the secret.")] string profileId,
+        [Description("The stable secret name to remove.")] string secretName,
+        CancellationToken cancellationToken = default) =>
+        _application.ProfileSecrets.RemoveSecretAsync(profileId, secretName, cancellationToken);
+
+    [McpServerTool]
+    [Description("Lists folders or folder-like mailbox containers for a profile.")]
+    public Task<IReadOnlyList<FolderRef>> mail_folders_list(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional parent folder identifier to scope the listing.")] string? parentFolderId = null,
+        [Description("When true, limits the result to root-level folders only.")] bool rootOnly = false,
+        CancellationToken cancellationToken = default) =>
+        _application.Read.GetFoldersAsync(new MailFolderQuery {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            ParentFolderId = parentFolderId,
+            RootOnly = rootOnly
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Lists folders or folder-like mailbox containers for a profile using a lightweight projection.")]
+    public Task<IReadOnlyList<FolderRefCompact>> mail_folders_compact_list(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional parent folder identifier to scope the listing.")] string? parentFolderId = null,
+        [Description("When true, limits the result to root-level folders only.")] bool rootOnly = false,
+        CancellationToken cancellationToken = default) =>
+        _application.Read.GetFoldersCompactAsync(new MailFolderQuery {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            ParentFolderId = parentFolderId,
+            RootOnly = rootOnly
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Searches messages in a mailbox using normalized Mailozaurr filters.")]
+    public Task<IReadOnlyList<MessageSummary>> mail_search(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier to scope the search.")] string? folderId = null,
+        [Description("Optional free-text query to match across provider-specific searchable content.")] string? queryText = null,
+        [Description("Optional subject text filter.")] string? subjectContains = null,
+        [Description("Optional sender text filter.")] string? fromContains = null,
+        [Description("Optional recipient text filter.")] string? toContains = null,
+        [Description("When true, only returns messages with attachments.")] bool hasAttachments = false,
+        [Description("Optional maximum number of messages to return.")] int? limit = null,
+        CancellationToken cancellationToken = default) =>
+        _application.Read.SearchAsync(new MailSearchRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            QueryText = queryText,
+            SubjectContains = subjectContains,
+            FromContains = fromContains,
+            ToContains = toContains,
+            HasAttachments = hasAttachments,
+            Limit = limit
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Searches messages in a mailbox using a lightweight Mailozaurr message projection.")]
+    public Task<IReadOnlyList<MessageSummaryCompact>> mail_search_compact(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier to scope the search.")] string? folderId = null,
+        [Description("Optional free-text query to match across provider-specific searchable content.")] string? queryText = null,
+        [Description("Optional subject text filter.")] string? subjectContains = null,
+        [Description("Optional sender text filter.")] string? fromContains = null,
+        [Description("Optional recipient text filter.")] string? toContains = null,
+        [Description("When true, only returns messages with attachments.")] bool hasAttachments = false,
+        [Description("Optional maximum number of messages to return.")] int? limit = null,
+        CancellationToken cancellationToken = default) =>
+        _application.Read.SearchCompactAsync(new MailSearchRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            QueryText = queryText,
+            SubjectContains = subjectContains,
+            FromContains = fromContains,
+            ToContains = toContains,
+            HasAttachments = hasAttachments,
+            Limit = limit
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Gets a detailed message view for a specific message identifier.")]
+    public async Task<MessageDetail> mail_get(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifier to retrieve.")] string messageId,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("When true, includes raw provider content where supported.")] bool includeRawContent = false,
+        CancellationToken cancellationToken = default) {
+        var message = await _application.Read.GetMessageAsync(new GetMessageRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageId = messageId,
+            IncludeRawContent = includeRawContent
+        }, cancellationToken).ConfigureAwait(false);
+
+        return message ?? throw new InvalidOperationException($"Message '{messageId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Gets a lightweight detailed message view for a specific message identifier.")]
+    public async Task<MessageDetailCompact> mail_get_compact(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifier to retrieve.")] string messageId,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("When true, allows the provider to include raw-content presence in the projection.")] bool includeRawContent = false,
+        CancellationToken cancellationToken = default) {
+        var message = await _application.Read.GetMessageCompactAsync(new GetMessageRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageId = messageId,
+            IncludeRawContent = includeRawContent
+        }, cancellationToken).ConfigureAwait(false);
+
+        return message ?? throw new InvalidOperationException($"Message '{messageId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Lists attachment metadata for a specific message without returning the full message body.")]
+    public Task<IReadOnlyList<AttachmentSummary>> mail_attachments_list(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifier that owns the attachments.")] string messageId,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        CancellationToken cancellationToken = default) =>
+        _application.Read.GetAttachmentsAsync(new ListAttachmentsRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageId = messageId
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Saves a message attachment to a local path that the Mailozaurr server can access.")]
+    public Task<OperationResult> mail_attachment_save(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifier that owns the attachment.")] string messageId,
+        [Description("The provider-specific attachment identifier to save.")] string attachmentId,
+        [Description("The destination file path on the server filesystem.")] string destinationPath,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("When true, allows an existing destination file to be overwritten.")] bool overwrite = false,
+        CancellationToken cancellationToken = default) =>
+        _application.Read.SaveAttachmentAsync(new SaveAttachmentRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageId = messageId,
+            AttachmentId = attachmentId,
+            DestinationPath = destinationPath,
+            Overwrite = overwrite
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Saves one or more attachments from a message using shared Mailozaurr filtering and batching logic.")]
+    public Task<SaveAttachmentsResult> mail_attachments_save(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifier that owns the attachments.")] string messageId,
+        [Description("The destination path or directory on the server filesystem.")] string destinationPath,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional explicit attachment identifiers to save.")] string[]? attachmentIds = null,
+        [Description("Optional case-insensitive file-name filter.")] string? fileNameContains = null,
+        [Description("Optional case-insensitive content-type filter.")] string? contentTypeContains = null,
+        [Description("When true, allows existing destination files to be overwritten.")] bool overwrite = false,
+        CancellationToken cancellationToken = default) =>
+        _application.Read.SaveAttachmentsAsync(new SaveAttachmentsRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageId = messageId,
+            DestinationPath = destinationPath,
+            AttachmentIds = attachmentIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            FileNameContains = fileNameContains,
+            ContentTypeContains = contentTypeContains,
+            Overwrite = overwrite
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Sends or queues a message using a configured Mailozaurr profile. Queueing is the default unless sendNow is true.")]
+    public Task<SendResult> mail_send(
+        [Description("The profile identifier to use for sending.")] string profileId,
+        [Description("Primary recipient email addresses.")] string[] to,
+        [Description("Optional subject line.")] string? subject = null,
+        [Description("Optional plain text body.")] string? textBody = null,
+        [Description("Optional HTML body.")] string? htmlBody = null,
+        [Description("Optional CC recipient email addresses.")] string[]? cc = null,
+        [Description("Optional BCC recipient email addresses.")] string[]? bcc = null,
+        [Description("Optional Reply-To recipient email addresses.")] string[]? replyTo = null,
+        [Description("Optional From email address override.")] string? from = null,
+        [Description("Optional attachment file paths on the server filesystem.")] string[]? attachmentPaths = null,
+        [Description("When true, sends immediately instead of preferring the queue.")] bool sendNow = false,
+        CancellationToken cancellationToken = default) =>
+        _application.Send.SendAsync(new SendMessageRequest {
+            ProfileId = profileId,
+            PreferQueue = !sendNow,
+            RequireImmediateSend = sendNow,
+            Message = BuildDraftMessage(profileId, to, subject, textBody, htmlBody, cc, bcc, replyTo, from, attachmentPaths)
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Lists reusable drafts stored by Mailozaurr.")]
+    public Task<IReadOnlyList<MailDraft>> mail_draft_list(CancellationToken cancellationToken = default) =>
+        _application.Drafts.GetDraftsAsync(cancellationToken);
+
+    [McpServerTool]
+    [Description("Lists reusable drafts stored by Mailozaurr using a lightweight projection.")]
+    public Task<IReadOnlyList<MailDraftCompact>> mail_draft_compact_list(CancellationToken cancellationToken = default) =>
+        _application.Drafts.GetDraftsCompactAsync(cancellationToken);
+
+    [McpServerTool]
+    [Description("Gets a reusable draft by identifier.")]
+    public async Task<MailDraft> mail_draft_get(
+        [Description("The stored draft identifier to retrieve.")] string draftId,
+        CancellationToken cancellationToken = default) {
+        var draft = await _application.Drafts.GetDraftAsync(draftId, cancellationToken).ConfigureAwait(false);
+        return draft ?? throw new InvalidOperationException($"Draft '{draftId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Gets a reusable draft by identifier using a lightweight projection.")]
+    public async Task<MailDraftCompact> mail_draft_compact_get(
+        [Description("The stored draft identifier to retrieve.")] string draftId,
+        CancellationToken cancellationToken = default) {
+        var draft = await _application.Drafts.GetDraftCompactAsync(draftId, cancellationToken).ConfigureAwait(false);
+        return draft ?? throw new InvalidOperationException($"Draft '{draftId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Creates or updates a reusable draft using the shared Mailozaurr draft store.")]
+    public Task<OperationResult> mail_draft_save(
+        [Description("The stable draft identifier to create or update.")] string draftId,
+        [Description("A human-readable draft name.")] string name,
+        [Description("The profile identifier that should eventually send this draft.")] string profileId,
+        [Description("Primary recipient email addresses.")] string[] to,
+        [Description("Optional subject line.")] string? subject = null,
+        [Description("Optional plain text body.")] string? textBody = null,
+        [Description("Optional HTML body.")] string? htmlBody = null,
+        [Description("Optional CC recipient email addresses.")] string[]? cc = null,
+        [Description("Optional BCC recipient email addresses.")] string[]? bcc = null,
+        [Description("Optional Reply-To recipient email addresses.")] string[]? replyTo = null,
+        [Description("Optional From email address override.")] string? from = null,
+        [Description("Optional attachment file paths on the server filesystem.")] string[]? attachmentPaths = null,
+        CancellationToken cancellationToken = default) =>
+        _application.Drafts.SaveAsync(new MailDraft {
+            Id = draftId,
+            Name = name,
+            Message = BuildDraftMessage(profileId, to, subject, textBody, htmlBody, cc, bcc, replyTo, from, attachmentPaths)
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Deletes a reusable draft from the shared Mailozaurr draft store.")]
+    public Task<OperationResult> mail_draft_delete(
+        [Description("The stored draft identifier to delete.")] string draftId,
+        CancellationToken cancellationToken = default) =>
+        _application.Drafts.DeleteAsync(draftId, cancellationToken);
+
+    [McpServerTool]
+    [Description("Imports a draft JSON file into the shared Mailozaurr draft store.")]
+    public async Task<MailDraft> mail_draft_import(
+        [Description("The draft file path on the server filesystem.")] string path,
+        [Description("Optional replacement draft identifier to use after import.")] string? draftId = null,
+        [Description("Optional replacement draft name to use after import.")] string? name = null,
+        CancellationToken cancellationToken = default) {
+        var draft = await _application.DraftExchange.LoadAsync(path, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(draftId)) {
+            draft.Id = draftId.Trim();
+        }
+        if (!string.IsNullOrWhiteSpace(name)) {
+            draft.Name = name.Trim();
+        }
+
+        var result = await _application.Drafts.SaveAsync(draft, cancellationToken).ConfigureAwait(false);
+        if (!result.Succeeded) {
+            throw new InvalidOperationException(result.Message ?? $"Draft '{draft.Id}' could not be imported.");
+        }
+
+        return draft;
+    }
+
+    [McpServerTool]
+    [Description("Exports a stored Mailozaurr draft to a draft JSON file.")]
+    public async Task<OperationResult> mail_draft_export(
+        [Description("The stored draft identifier to export.")] string draftId,
+        [Description("The destination draft file path on the server filesystem.")] string path,
+        CancellationToken cancellationToken = default) {
+        var draft = await _application.Drafts.GetDraftAsync(draftId, cancellationToken).ConfigureAwait(false);
+        if (draft == null) {
+            throw new InvalidOperationException($"Draft '{draftId}' was not found.");
+        }
+
+        await _application.DraftExchange.SaveAsync(path, draft, cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success("Draft exported.");
+    }
+
+    [McpServerTool]
+    [Description("Sends or queues a previously stored Mailozaurr draft. Queueing is the default unless sendNow is true.")]
+    public async Task<SendResult> mail_draft_send(
+        [Description("The stored draft identifier to send.")] string draftId,
+        [Description("When true, sends immediately instead of preferring the queue.")] bool sendNow = false,
+        CancellationToken cancellationToken = default) {
+        var draft = await _application.Drafts.GetDraftAsync(draftId, cancellationToken).ConfigureAwait(false);
+        if (draft == null) {
+            throw new InvalidOperationException($"Draft '{draftId}' was not found.");
+        }
+
+        return await _application.Send.SendAsync(new SendMessageRequest {
+            ProfileId = draft.Message.ProfileId,
+            PreferQueue = !sendNow,
+            RequireImmediateSend = sendNow,
+            Message = CloneDraftMessage(draft.Message)
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    [McpServerTool]
+    [Description("Lists outbound messages currently waiting in Mailozaurr's pending queue.")]
+    public Task<IReadOnlyList<QueuedMessageSummary>> mail_queue_list(CancellationToken cancellationToken = default) =>
+        _application.Queue.ListAsync(cancellationToken);
+
+    [McpServerTool]
+    [Description("Lists outbound messages currently waiting in Mailozaurr's pending queue using a lightweight projection.")]
+    public Task<IReadOnlyList<QueuedMessageCompact>> mail_queue_compact_list(CancellationToken cancellationToken = default) =>
+        _application.Queue.ListCompactAsync(cancellationToken);
+
+    [McpServerTool]
+    [Description("Gets a queued outbound message by identifier.")]
+    public async Task<QueuedMessageSummary> mail_queue_get(
+        [Description("The queued message identifier to inspect.")] string messageId,
+        CancellationToken cancellationToken = default) {
+        var message = await _application.Queue.GetAsync(messageId, cancellationToken).ConfigureAwait(false);
+        return message ?? throw new InvalidOperationException($"Queued message '{messageId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Gets a queued outbound message by identifier using a lightweight projection.")]
+    public async Task<QueuedMessageCompact> mail_queue_compact_get(
+        [Description("The queued message identifier to inspect.")] string messageId,
+        CancellationToken cancellationToken = default) {
+        var message = await _application.Queue.GetCompactAsync(messageId, cancellationToken).ConfigureAwait(false);
+        return message ?? throw new InvalidOperationException($"Queued message '{messageId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Removes a queued outbound message without sending it.")]
+    public Task<OperationResult> mail_queue_remove(
+        [Description("The queued message identifier to remove.")] string messageId,
+        CancellationToken cancellationToken = default) =>
+        _application.Queue.RemoveAsync(messageId, cancellationToken);
+
+    [McpServerTool]
+    [Description("Processes all due queued outbound messages.")]
+    public Task<QueueProcessResult> mail_queue_process(CancellationToken cancellationToken = default) =>
+        _application.Queue.ProcessAsync(cancellationToken);
+
+    private static DraftMessage BuildDraftMessage(
+        string profileId,
+        IEnumerable<string> to,
+        string? subject,
+        string? textBody,
+        string? htmlBody,
+        IEnumerable<string>? cc,
+        IEnumerable<string>? bcc,
+        IEnumerable<string>? replyTo,
+        string? from,
+        IEnumerable<string>? attachmentPaths) {
+        var draft = new DraftMessage {
+            ProfileId = profileId,
+            Subject = subject,
+            TextBody = textBody,
+            HtmlBody = htmlBody
+        };
+
+        if (!string.IsNullOrWhiteSpace(from)) {
+            draft.From = new MessageRecipient {
+                Address = from.Trim()
+            };
+        }
+
+        AddRecipients(draft.To, to);
+        AddRecipients(draft.Cc, cc);
+        AddRecipients(draft.Bcc, bcc);
+        AddRecipients(draft.ReplyTo, replyTo);
+
+        if (attachmentPaths != null) {
+            foreach (var attachmentPath in attachmentPaths.Where(path => !string.IsNullOrWhiteSpace(path))) {
+                draft.Attachments.Add(new DraftAttachment {
+                    Path = attachmentPath.Trim()
+                });
+            }
+        }
+
+        return draft;
+    }
+
+    private static DraftMessage CloneDraftMessage(DraftMessage draft) => new() {
+        ProfileId = draft.ProfileId,
+        From = draft.From == null ? null : new MessageRecipient {
+            Name = draft.From.Name,
+            Address = draft.From.Address
+        },
+        To = draft.To.Select(ToRecipientCopy).ToList(),
+        Cc = draft.Cc.Select(ToRecipientCopy).ToList(),
+        Bcc = draft.Bcc.Select(ToRecipientCopy).ToList(),
+        ReplyTo = draft.ReplyTo.Select(ToRecipientCopy).ToList(),
+        Subject = draft.Subject,
+        TextBody = draft.TextBody,
+        HtmlBody = draft.HtmlBody,
+        Headers = new Dictionary<string, string>(draft.Headers, StringComparer.OrdinalIgnoreCase),
+        Attachments = draft.Attachments.Select(attachment => new DraftAttachment {
+            Path = attachment.Path,
+            FileName = attachment.FileName,
+            ContentType = attachment.ContentType,
+            IsInline = attachment.IsInline,
+            ContentId = attachment.ContentId
+        }).ToList()
+    };
+
+    private static void AddRecipients(ICollection<MessageRecipient> destination, IEnumerable<string>? addresses) {
+        if (addresses == null) {
+            return;
+        }
+
+        foreach (var address in addresses.Where(value => !string.IsNullOrWhiteSpace(value))) {
+            destination.Add(new MessageRecipient {
+                Address = address.Trim()
+            });
+        }
+    }
+
+    private static MessageRecipient ToRecipientCopy(MessageRecipient recipient) => new() {
+        Name = recipient.Name,
+        Address = recipient.Address
+    };
+
+    private static MailProfileConnectionTestScope ParseConnectionTestScope(string? rawScope) {
+        if (string.IsNullOrWhiteSpace(rawScope)) {
+            return MailProfileConnectionTestScope.Auto;
+        }
+
+        if (Enum.TryParse<MailProfileConnectionTestScope>(rawScope.Trim(), ignoreCase: true, out var scope)) {
+            return scope;
+        }
+
+        throw new InvalidOperationException($"Unsupported connection test scope '{rawScope}'.");
+    }
+}

--- a/Sources/Mailozaurr.Cli/Mcp/McpServerHost.cs
+++ b/Sources/Mailozaurr.Cli/Mcp/McpServerHost.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Cli.Mcp;
+
+internal static class McpServerHost {
+    public static async Task RunAsync(MailApplication application, CancellationToken cancellationToken = default) {
+        ArgumentNullException.ThrowIfNull(application);
+
+        var builder = Host.CreateEmptyApplicationBuilder(settings: null);
+        builder.Services.AddSingleton(application);
+        builder.Services
+            .AddMcpServer()
+            .WithStdioServerTransport()
+            .WithToolsFromAssembly(typeof(MailMcpTools).Assembly);
+
+        using var host = builder.Build();
+        await host.RunAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/Sources/Mailozaurr.Cli/Program.cs
+++ b/Sources/Mailozaurr.Cli/Program.cs
@@ -1,0 +1,8 @@
+using Mailozaurr.Application;
+using Mailozaurr.Cli;
+
+return await CliRunner.RunAsync(
+    args,
+    Console.Out,
+    Console.Error,
+    builderFactory: options => new MailApplicationBuilder(options));

--- a/Sources/Mailozaurr.Tests/ApplicationBuilderTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationBuilderTests.cs
@@ -1,0 +1,151 @@
+using MailKit.Net.Imap;
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationBuilderTests {
+    [Fact]
+    public void BuildCreatesDefaultApplicationWithBuiltInReadAndSendHandlers() {
+        var profileDirectory = CreateTemporaryDirectory();
+        var secretDirectory = CreateTemporaryDirectory();
+        var builder = new MailApplicationBuilder(new MailApplicationOptions {
+            ProfileStore = new MailProfileStoreOptions { DirectoryPath = profileDirectory },
+            SecretStore = new MailSecretStoreOptions { DirectoryPath = secretDirectory }
+        });
+
+        var app = builder.Build();
+
+        Assert.NotNull(app.ProfileStore);
+        Assert.NotNull(app.SecretStore);
+        Assert.NotNull(app.DraftStore);
+        Assert.NotNull(app.Profiles);
+        Assert.NotNull(app.ProfileOverview);
+        Assert.NotNull(app.ProfileConnections);
+        Assert.NotNull(app.Drafts);
+        Assert.NotNull(app.DraftExchange);
+        Assert.NotNull(app.ProfileBootstrap);
+        Assert.NotNull(app.ProfileAuth);
+        Assert.NotNull(app.Read);
+        Assert.NotNull(app.Send);
+        Assert.NotNull(app.Queue);
+        Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Imap);
+        Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Graph);
+        Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Gmail);
+        Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Graph);
+        Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Gmail);
+        Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Smtp);
+    }
+
+    [Fact]
+    public void BuildHonorsDisabledImapHandlerOption() {
+        var builder = new MailApplicationBuilder(new MailApplicationOptions {
+            EnableImapReadHandler = false,
+            EnableGraphReadHandler = false,
+            EnableGraphSendHandler = false,
+            EnableGmailReadHandler = false,
+            EnableGmailSendHandler = false,
+            EnableSmtpSendHandler = false,
+            ProfileStore = new MailProfileStoreOptions { DirectoryPath = CreateTemporaryDirectory() },
+            SecretStore = new MailSecretStoreOptions { DirectoryPath = CreateTemporaryDirectory() }
+        });
+
+        var app = builder.Build();
+
+        Assert.DoesNotContain(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Imap);
+        Assert.DoesNotContain(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Graph);
+        Assert.DoesNotContain(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Gmail);
+        Assert.DoesNotContain(app.SendHandlers, handler => handler.Kind == MailProfileKind.Graph);
+        Assert.DoesNotContain(app.SendHandlers, handler => handler.Kind == MailProfileKind.Gmail);
+        Assert.DoesNotContain(app.SendHandlers, handler => handler.Kind == MailProfileKind.Smtp);
+    }
+
+    [Fact]
+    public void BuildUsesInjectedHandlersAndFactories() {
+        var builder = new MailApplicationBuilder(new MailApplicationOptions {
+            EnableImapReadHandler = false,
+            EnableGraphReadHandler = false,
+            EnableGraphSendHandler = false,
+            EnableGmailReadHandler = false,
+            EnableGmailSendHandler = false,
+            EnableSmtpSendHandler = false,
+            ProfileStore = new MailProfileStoreOptions { DirectoryPath = CreateTemporaryDirectory() },
+            SecretStore = new MailSecretStoreOptions { DirectoryPath = CreateTemporaryDirectory() }
+        });
+        builder.UseImapSessionFactory(new FakeImapSessionFactory());
+        builder.UseGraphSessionFactory(new FakeGraphSessionFactory());
+        builder.UseGmailSessionFactory(new FakeGmailSessionFactory());
+        builder.UseSmtpSessionFactory(new FakeSmtpSessionFactory());
+        builder.AddReadHandler(new FakeReadHandler(MailProfileKind.Graph));
+        builder.AddSendHandler(new FakeSendHandler(MailProfileKind.Graph));
+
+        var app = builder.Build();
+
+        Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Graph);
+        Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Graph);
+    }
+
+    private static string CreateTemporaryDirectory() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private sealed class FakeImapSessionFactory : IImapSessionFactory {
+        public Task<ImapClient> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ImapClient());
+    }
+
+    private sealed class FakeGraphSessionFactory : IGraphSessionFactory {
+        public Task<GraphSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GraphSession(new GraphApiClient(new OAuthCredential {
+                UserName = profile.DefaultMailbox ?? "me",
+                AccessToken = "token",
+                ExpiresOn = DateTimeOffset.MaxValue
+            }), profile.DefaultMailbox ?? "me"));
+    }
+
+    private sealed class FakeGmailSessionFactory : IGmailSessionFactory {
+        public Task<GmailSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GmailSession(new GmailApiClient(new OAuthCredential {
+                UserName = profile.DefaultMailbox ?? "me",
+                AccessToken = "token",
+                ExpiresOn = DateTimeOffset.MaxValue
+            }), profile.DefaultMailbox ?? "me"));
+    }
+
+    private sealed class FakeSmtpSessionFactory : ISmtpSessionFactory {
+        public Task<Smtp> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new Smtp());
+    }
+
+    private sealed class FakeReadHandler : IMailReadHandler {
+        public FakeReadHandler(MailProfileKind kind) {
+            Kind = kind;
+        }
+
+        public MailProfileKind Kind { get; }
+
+        public Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailProfile profile, MailFolderQuery query, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<FolderRef>>(Array.Empty<FolderRef>());
+
+        public Task<MessageDetail?> GetMessageAsync(MailProfile profile, GetMessageRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MessageDetail?>(null);
+
+        public Task<OperationResult> SaveAttachmentAsync(MailProfile profile, SaveAttachmentRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success());
+
+        public Task<IReadOnlyList<MessageSummary>> SearchAsync(MailProfile profile, MailSearchRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MessageSummary>>(Array.Empty<MessageSummary>());
+    }
+
+    private sealed class FakeSendHandler : IMailSendHandler {
+        public FakeSendHandler(MailProfileKind kind) {
+            Kind = kind;
+        }
+
+        public MailProfileKind Kind { get; }
+
+        public Task<SendResult> SendAsync(MailProfile profile, SendMessageRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new SendResult { Succeeded = true, ProfileKind = Kind });
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationCapabilitiesTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationCapabilitiesTests.cs
@@ -1,0 +1,45 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationCapabilitiesTests {
+    [Theory]
+    [InlineData(MailProfileKind.Imap, MailCapability.ListFolders | MailCapability.SearchMessages | MailCapability.ReadMessages | MailCapability.MoveMessages | MailCapability.WaitForMessages)]
+    [InlineData(MailProfileKind.Pop3, MailCapability.SearchMessages | MailCapability.ReadMessages | MailCapability.DeleteMessages)]
+    [InlineData(MailProfileKind.Graph, MailCapability.ListFolders | MailCapability.SendMessages | MailCapability.ManageRules | MailCapability.ManageEvents | MailCapability.ManagePermissions)]
+    [InlineData(MailProfileKind.Gmail, MailCapability.SearchMessages | MailCapability.SendMessages | MailCapability.UseThreads | MailCapability.UseLabels)]
+    [InlineData(MailProfileKind.Smtp, MailCapability.SendMessages)]
+    [InlineData(MailProfileKind.SendGrid, MailCapability.SendMessages)]
+    public void CatalogExposesExpectedCapabilities(MailProfileKind kind, MailCapability required) {
+        var capabilities = MailCapabilityCatalog.For(kind);
+
+        Assert.Equal(kind, capabilities.Kind);
+        Assert.True(capabilities.Supports(required));
+    }
+
+    [Fact]
+    public void ProfileFallsBackToDefaultCapabilitiesWhenOverrideIsMissing() {
+        var profile = new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap
+        };
+
+        var capabilities = profile.GetCapabilities();
+
+        Assert.True(capabilities.Supports(MailCapability.SearchMessages));
+        Assert.True(capabilities.Supports(MailCapability.WaitForMessages));
+        Assert.False(capabilities.Supports(MailCapability.SendMessages));
+    }
+
+    [Fact]
+    public void OperationResultHelpersProduceExpectedStatus() {
+        var success = OperationResult.Success("Queued");
+        var failure = OperationResult.Failure("auth_failed", "Authentication failed.");
+
+        Assert.True(success.Succeeded);
+        Assert.Equal("Queued", success.Message);
+        Assert.False(failure.Succeeded);
+        Assert.Equal("auth_failed", failure.Code);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationDraftServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationDraftServiceTests.cs
@@ -1,0 +1,84 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationDraftServiceTests {
+    [Fact]
+    public async Task SaveAsyncRejectsDraftWhenProfileIsMissing() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var draftStore = new FileMailDraftStore(CreateTemporaryFilePath("drafts.json"));
+        var service = new MailDraftService(draftStore, profileStore);
+
+        var result = await service.SaveAsync(new MailDraft {
+            Id = "draft-1",
+            Name = "Draft 1",
+            Message = new DraftMessage {
+                ProfileId = "missing-profile"
+            }
+        });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("draft_profile_not_found", result.Code);
+    }
+
+    [Fact]
+    public async Task SaveAsyncStoresDraftWhenProfileExists() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var draftStore = new FileMailDraftStore(CreateTemporaryFilePath("drafts.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail,
+            DefaultMailbox = "me"
+        });
+        var service = new MailDraftService(draftStore, profileStore);
+
+        var result = await service.SaveAsync(new MailDraft {
+            Id = "draft-1",
+            Name = "Draft 1",
+            Message = new DraftMessage {
+                ProfileId = "work-gmail",
+                Subject = "Hello"
+            }
+        });
+        var saved = await service.GetDraftAsync("draft-1");
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(saved);
+        Assert.Equal("Hello", saved!.Message.Subject);
+    }
+
+    [Fact]
+    public async Task GetDraftsCompactReturnsLightweightProjection() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var draftStore = new FileMailDraftStore(CreateTemporaryFilePath("drafts.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail,
+            DefaultMailbox = "me"
+        });
+        var service = new MailDraftService(draftStore, profileStore);
+        await service.SaveAsync(new MailDraft {
+            Id = "draft-1",
+            Name = "Draft 1",
+            Message = new DraftMessage {
+                ProfileId = "work-gmail",
+                Subject = "Hello"
+            }
+        });
+
+        var drafts = await service.GetDraftsCompactAsync();
+
+        var draft = Assert.Single(drafts);
+        Assert.Equal("draft-1", draft.Id);
+        Assert.Equal("work-gmail", draft.ProfileId);
+        Assert.Equal("Hello", draft.Subject);
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationDraftStoreTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationDraftStoreTests.cs
@@ -1,0 +1,38 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationDraftStoreTests {
+    [Fact]
+    public async Task FileDraftStoreRoundTripsDrafts() {
+        var store = new FileMailDraftStore(CreateTemporaryFilePath("drafts.json"));
+        var draft = new MailDraft {
+            Id = "report-draft",
+            Name = "Quarterly report",
+            Message = new DraftMessage {
+                ProfileId = "work-gmail",
+                Subject = "Report",
+                TextBody = "Hello",
+                To = {
+                    new MessageRecipient { Address = "alice@example.com" }
+                }
+            }
+        };
+
+        await store.SaveAsync(draft);
+        var saved = await store.GetByIdAsync("report-draft");
+
+        Assert.NotNull(saved);
+        Assert.Equal("Quarterly report", saved!.Name);
+        Assert.Equal("work-gmail", saved.Message.ProfileId);
+        Assert.Equal("alice@example.com", saved.Message.To[0].Address);
+        Assert.NotEqual(default, saved.CreatedAt);
+        Assert.NotEqual(default, saved.UpdatedAt);
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationGmailMailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationGmailMailReadHandlerTests.cs
@@ -1,0 +1,72 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationGmailMailReadHandlerTests {
+    [Fact]
+    public async Task HandlerUsesInjectedFolderDelegate() {
+        var handler = new GmailMailReadHandler(
+            new FakeGmailSessionFactory(),
+            getFoldersAsync: (session, profile, query, cancellationToken) => Task.FromResult<IReadOnlyList<FolderRef>>(new[] {
+                new FolderRef {
+                    ProfileId = profile.Id,
+                    MailboxId = session.UserId,
+                    Id = "INBOX",
+                    DisplayName = "Inbox",
+                    Path = "Inbox"
+                }
+            }));
+
+        var results = await handler.GetFoldersAsync(
+            new MailProfile {
+                Id = "personal-gmail",
+                DisplayName = "Personal Gmail",
+                Kind = MailProfileKind.Gmail,
+                DefaultMailbox = "me"
+            },
+            new MailFolderQuery {
+                ProfileId = "personal-gmail"
+            });
+
+        Assert.Single(results);
+        Assert.Equal("INBOX", results[0].Id);
+    }
+
+    [Fact]
+    public async Task HandlerUsesInjectedSearchDelegate() {
+        var handler = new GmailMailReadHandler(
+            new FakeGmailSessionFactory(),
+            searchAsync: (session, profile, request, cancellationToken) => Task.FromResult<IReadOnlyList<MessageSummary>>(new[] {
+                new MessageSummary {
+                    ProfileId = profile.Id,
+                    Id = "gmail-42",
+                    Subject = request.QueryText
+                }
+            }));
+
+        var results = await handler.SearchAsync(
+            new MailProfile {
+                Id = "personal-gmail",
+                DisplayName = "Personal Gmail",
+                Kind = MailProfileKind.Gmail,
+                DefaultMailbox = "me"
+            },
+            new MailSearchRequest {
+                ProfileId = "personal-gmail",
+                QueryText = "reports"
+            });
+
+        Assert.Single(results);
+        Assert.Equal("gmail-42", results[0].Id);
+        Assert.Equal("reports", results[0].Subject);
+    }
+
+    private sealed class FakeGmailSessionFactory : IGmailSessionFactory {
+        public Task<GmailSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GmailSession(new GmailApiClient(new OAuthCredential {
+                UserName = profile.DefaultMailbox ?? "me",
+                AccessToken = "token",
+                ExpiresOn = DateTimeOffset.MaxValue
+            }), profile.DefaultMailbox ?? "me"));
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationGmailMailSendHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationGmailMailSendHandlerTests.cs
@@ -1,0 +1,108 @@
+using System.Net.Http;
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationGmailMailSendHandlerTests {
+    [Fact]
+    public async Task HandlerUsesInjectedSendDelegate() {
+        var handler = new GmailMailSendHandler(
+            new FakeGmailSessionFactory(),
+            sendAsync: (session, profile, request, message, cancellationToken) => {
+                Assert.Equal("sender@example.com", message.From.Mailboxes.First().Address);
+                Assert.Equal("alice@example.com", message.To.Mailboxes.First().Address);
+                Assert.Equal("Hello Gmail", message.Subject);
+                return Task.FromResult(new GmailMessage {
+                    Id = "gmail-123",
+                    ThreadId = "thread-123"
+                });
+            });
+
+        var result = await handler.SendAsync(
+            new MailProfile {
+                Id = "personal-gmail",
+                DisplayName = "Personal Gmail",
+                Kind = MailProfileKind.Gmail,
+                DefaultSender = "sender@example.com",
+                DefaultMailbox = "me"
+            },
+            new SendMessageRequest {
+                ProfileId = "personal-gmail",
+                Message = new DraftMessage {
+                    Subject = "Hello Gmail",
+                    TextBody = "hello",
+                    To = {
+                        new MessageRecipient { Address = "alice@example.com" }
+                    }
+                }
+            });
+
+        Assert.True(result.Succeeded);
+        Assert.False(result.Queued);
+        Assert.Equal("personal-gmail", result.ProfileId);
+        Assert.Equal(MailProfileKind.Gmail, result.ProfileKind);
+        Assert.Equal("gmail-123", result.ProviderMessageId);
+    }
+
+    [Fact]
+    public async Task HandlerReturnsQueuedResultWhenRepositoryCapturesFailedSend() {
+        var repository = new FilePendingMessageRepository(new PendingMessageRepositoryOptions {
+            DirectoryPath = CreateTemporaryDirectory()
+        });
+
+        var handler = new GmailMailSendHandler(
+            new FakeGmailSessionFactory(),
+            pendingMessageRepository: repository,
+            sendAsync: async (session, profile, request, message, cancellationToken) => {
+                await repository.SaveAsync(new PendingMessageRecord {
+                    MessageId = message.MessageId ?? "queued-1",
+                    Timestamp = DateTimeOffset.UtcNow,
+                    NextAttemptAt = DateTimeOffset.UtcNow,
+                    Provider = EmailProvider.Gmail,
+                    MimeMessage = Convert.ToBase64String(Array.Empty<byte>())
+                }, cancellationToken).ConfigureAwait(false);
+
+                throw new HttpRequestException("temporary gmail failure");
+            });
+
+        var result = await handler.SendAsync(
+            new MailProfile {
+                Id = "personal-gmail",
+                DisplayName = "Personal Gmail",
+                Kind = MailProfileKind.Gmail,
+                DefaultSender = "sender@example.com",
+                DefaultMailbox = "me"
+            },
+            new SendMessageRequest {
+                ProfileId = "personal-gmail",
+                PreferQueue = true,
+                Message = new DraftMessage {
+                    Subject = "Hello Gmail",
+                    TextBody = "hello",
+                    To = {
+                        new MessageRecipient { Address = "alice@example.com" }
+                    }
+                }
+            });
+
+        Assert.True(result.Succeeded);
+        Assert.True(result.Queued);
+        Assert.NotNull(result.QueueMessageId);
+        Assert.Contains("queued", result.Message ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string CreateTemporaryDirectory() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private sealed class FakeGmailSessionFactory : IGmailSessionFactory {
+        public Task<GmailSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GmailSession(new GmailApiClient(new OAuthCredential {
+                UserName = profile.DefaultMailbox ?? "me",
+                AccessToken = "token",
+                ExpiresOn = DateTimeOffset.MaxValue
+            }), profile.DefaultMailbox ?? "me"));
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationGmailSessionFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationGmailSessionFactoryTests.cs
@@ -1,0 +1,132 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationGmailSessionFactoryTests {
+    [Fact]
+    public async Task FactoryUsesAccessTokenSecretWhenAvailable() {
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("personal-gmail", MailSecretNames.AccessToken, "gmail-token");
+
+        GmailSessionRequest? captured = null;
+        var factory = new GmailSessionFactory(
+            secretStore,
+            connectAsync: (request, cancellationToken) => {
+                captured = request;
+                return Task.FromResult(new GmailSession(new GmailApiClient(request.Credential, request.RefreshAccessTokenAsync), request.UserId));
+            });
+
+        using var session = await factory.ConnectAsync(new MailProfile {
+            Id = "personal-gmail",
+            DisplayName = "Personal Gmail",
+            Kind = MailProfileKind.Gmail,
+            DefaultMailbox = "me"
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal("me", captured!.UserId);
+        Assert.Equal("gmail-token", captured.Credential.AccessToken);
+        Assert.Equal("me", captured.Credential.UserName);
+    }
+
+    [Fact]
+    public async Task FactoryRefreshesAccessTokenWhenOnlyRefreshTokenIsAvailable() {
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("personal-gmail", MailSecretNames.RefreshToken, "refresh-token");
+        await secretStore.SetSecretAsync("personal-gmail", MailSecretNames.ClientSecret, "client-secret");
+
+        GmailSessionFactory.GmailRefreshRequest? captured = null;
+        GmailSessionRequest? connected = null;
+        var factory = new GmailSessionFactory(
+            secretStore,
+            refreshCredentialAsync: (request, cancellationToken) => {
+                captured = request;
+                return Task.FromResult(new OAuthCredential {
+                    UserName = request.UserId,
+                    AccessToken = "issued-token",
+                    RefreshToken = request.RefreshToken,
+                    ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+                });
+            },
+            connectAsync: (request, cancellationToken) => {
+                connected = request;
+                return Task.FromResult(new GmailSession(new GmailApiClient(request.Credential, request.RefreshAccessTokenAsync), request.UserId));
+            });
+
+        using var session = await factory.ConnectAsync(new MailProfile {
+            Id = "personal-gmail",
+            DisplayName = "Personal Gmail",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.ClientId] = "client-id",
+                [MailProfileSettingsKeys.Mailbox] = "me"
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal("client-id", captured!.ClientId);
+        Assert.Equal("client-secret", captured.ClientSecret);
+        Assert.Equal("refresh-token", captured.RefreshToken);
+        Assert.NotNull(connected);
+        Assert.Equal("issued-token", connected!.Credential.AccessToken);
+    }
+
+    [Fact]
+    public async Task FactoryRefreshesExpiredAccessTokenWhenRefreshTokenIsAvailable() {
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("personal-gmail", MailSecretNames.AccessToken, "expired-token");
+        await secretStore.SetSecretAsync("personal-gmail", MailSecretNames.RefreshToken, "refresh-token");
+        await secretStore.SetSecretAsync("personal-gmail", MailSecretNames.ClientSecret, "client-secret");
+
+        GmailSessionFactory.GmailRefreshRequest? captured = null;
+        GmailSessionRequest? connected = null;
+        var factory = new GmailSessionFactory(
+            secretStore,
+            refreshCredentialAsync: (request, cancellationToken) => {
+                captured = request;
+                return Task.FromResult(new OAuthCredential {
+                    UserName = request.UserId,
+                    AccessToken = "renewed-token",
+                    RefreshToken = request.RefreshToken,
+                    ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+                });
+            },
+            connectAsync: (request, cancellationToken) => {
+                connected = request;
+                return Task.FromResult(new GmailSession(new GmailApiClient(request.Credential, request.RefreshAccessTokenAsync), request.UserId));
+            });
+
+        using var session = await factory.ConnectAsync(new MailProfile {
+            Id = "personal-gmail",
+            DisplayName = "Personal Gmail",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.ClientId] = "client-id",
+                [MailProfileSettingsKeys.Mailbox] = "me",
+                [MailProfileSettingsKeys.TokenExpiresOn] = DateTimeOffset.UtcNow.AddMinutes(-10).ToString("o", System.Globalization.CultureInfo.InvariantCulture)
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal("refresh-token", captured!.RefreshToken);
+        Assert.NotNull(connected);
+        Assert.Equal("renewed-token", connected!.Credential.AccessToken);
+    }
+
+    private sealed class InMemorySecretStore : IMailSecretStore {
+        private readonly Dictionary<string, string> _values = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            _values.TryGetValue($"{profileId}::{secretName}", out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_values.Remove($"{profileId}::{secretName}"));
+
+        public Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+            _values[$"{profileId}::{secretName}"] = secretValue;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationGraphMailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationGraphMailReadHandlerTests.cs
@@ -1,0 +1,73 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationGraphMailReadHandlerTests {
+    [Fact]
+    public async Task HandlerUsesInjectedFolderDelegate() {
+        var handler = new GraphMailReadHandler(
+            new FakeGraphSessionFactory(),
+            getFoldersAsync: (session, profile, query, cancellationToken) => Task.FromResult<IReadOnlyList<FolderRef>>(new[] {
+                new FolderRef {
+                    ProfileId = profile.Id,
+                    MailboxId = query.MailboxId ?? session.UserId,
+                    Id = "inbox",
+                    DisplayName = "Inbox",
+                    Path = "Inbox"
+                }
+            }));
+
+        var results = await handler.GetFoldersAsync(
+            new MailProfile {
+                Id = "work-graph",
+                DisplayName = "Work Graph",
+                Kind = MailProfileKind.Graph,
+                DefaultMailbox = "user@example.com"
+            },
+            new MailFolderQuery {
+                ProfileId = "work-graph"
+            });
+
+        Assert.Single(results);
+        Assert.Equal("inbox", results[0].Id);
+        Assert.Equal("Inbox", results[0].DisplayName);
+    }
+
+    [Fact]
+    public async Task HandlerUsesInjectedSearchDelegate() {
+        var handler = new GraphMailReadHandler(
+            new FakeGraphSessionFactory(),
+            searchAsync: (session, profile, request, cancellationToken) => Task.FromResult<IReadOnlyList<MessageSummary>>(new[] {
+                new MessageSummary {
+                    ProfileId = profile.Id,
+                    Id = "graph-42",
+                    Subject = request.QueryText
+                }
+            }));
+
+        var results = await handler.SearchAsync(
+            new MailProfile {
+                Id = "work-graph",
+                DisplayName = "Work Graph",
+                Kind = MailProfileKind.Graph,
+                DefaultMailbox = "user@example.com"
+            },
+            new MailSearchRequest {
+                ProfileId = "work-graph",
+                QueryText = "reports"
+            });
+
+        Assert.Single(results);
+        Assert.Equal("graph-42", results[0].Id);
+        Assert.Equal("reports", results[0].Subject);
+    }
+
+    private sealed class FakeGraphSessionFactory : IGraphSessionFactory {
+        public Task<GraphSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GraphSession(new GraphApiClient(new OAuthCredential {
+                UserName = profile.DefaultMailbox ?? "me",
+                AccessToken = "token",
+                ExpiresOn = DateTimeOffset.MaxValue
+            }), profile.DefaultMailbox ?? "me"));
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationGraphMailSendHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationGraphMailSendHandlerTests.cs
@@ -1,0 +1,159 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationGraphMailSendHandlerTests {
+    [Fact]
+    public async Task HandlerUsesInjectedSendDelegate() {
+        var handler = new GraphMailSendHandler(
+            new FakeGraphSessionFactory(),
+            sendAsync: (session, profile, request, message, cancellationToken) => {
+                Assert.Equal("sender@example.com", message.From.Mailboxes.First().Address);
+                Assert.Equal("alice@example.com", message.To.Mailboxes.First().Address);
+                Assert.Equal("Hello Graph", message.Subject);
+                return Task.FromResult(new GraphMessage {
+                    Id = "graph-123"
+                });
+            });
+
+        var result = await handler.SendAsync(
+            new MailProfile {
+                Id = "work-graph",
+                DisplayName = "Work Graph",
+                Kind = MailProfileKind.Graph,
+                DefaultSender = "sender@example.com",
+                DefaultMailbox = "user@example.com"
+            },
+            new SendMessageRequest {
+                ProfileId = "work-graph",
+                RequireImmediateSend = true,
+                Message = new DraftMessage {
+                    Subject = "Hello Graph",
+                    TextBody = "hello",
+                    To = {
+                        new MessageRecipient { Address = "alice@example.com" }
+                    }
+                }
+            });
+
+        Assert.True(result.Succeeded);
+        Assert.False(result.Queued);
+        Assert.Equal("work-graph", result.ProfileId);
+        Assert.Equal(MailProfileKind.Graph, result.ProfileKind);
+        Assert.Equal("graph-123", result.ProviderMessageId);
+        Assert.NotNull(result.QueueMessageId);
+    }
+
+    [Fact]
+    public async Task HandlerQueuesMessageWhenQueueIsPreferred() {
+        var repository = new FilePendingMessageRepository(new PendingMessageRepositoryOptions {
+            DirectoryPath = CreateTemporaryDirectory()
+        });
+        var handler = new GraphMailSendHandler(
+            new FakeGraphSessionFactory(),
+            pendingMessageRepository: repository,
+            sendAsync: (session, profile, request, message, cancellationToken) => Task.FromResult(new GraphMessage {
+                Id = "graph-123"
+            }));
+
+        var result = await handler.SendAsync(
+            new MailProfile {
+                Id = "work-graph",
+                DisplayName = "Work Graph",
+                Kind = MailProfileKind.Graph,
+                DefaultSender = "sender@example.com",
+                DefaultMailbox = "user@example.com"
+            },
+            new SendMessageRequest {
+                ProfileId = "work-graph",
+                Message = new DraftMessage {
+                    Subject = "Hello Graph",
+                    TextBody = "hello",
+                    To = {
+                        new MessageRecipient { Address = "alice@example.com" }
+                    }
+                }
+            });
+
+        Assert.True(result.Succeeded);
+        Assert.True(result.Queued);
+        Assert.NotNull(result.QueueMessageId);
+        var queued = await repository.GetByMessageIdAsync(result.QueueMessageId!, CancellationToken.None);
+        Assert.NotNull(queued);
+        Assert.Equal(EmailProvider.Graph, queued!.Provider);
+        Assert.Equal("user@example.com", queued.ProviderData[GraphPendingMessageSender.UserIdKey]);
+    }
+
+    [Fact]
+    public async Task HandlerQueuesScheduledSendRequests() {
+        var repository = new FilePendingMessageRepository(new PendingMessageRepositoryOptions {
+            DirectoryPath = CreateTemporaryDirectory()
+        });
+        var handler = new GraphMailSendHandler(
+            new FakeGraphSessionFactory(),
+            pendingMessageRepository: repository,
+            sendAsync: (session, profile, request, message, cancellationToken) => Task.FromResult(new GraphMessage {
+                Id = "graph-123"
+            }));
+
+        var scheduledFor = DateTimeOffset.UtcNow.AddMinutes(15);
+        var result = await handler.SendAsync(
+            new MailProfile {
+                Id = "work-graph",
+                DisplayName = "Work Graph",
+                Kind = MailProfileKind.Graph,
+                DefaultSender = "sender@example.com",
+                DefaultMailbox = "user@example.com",
+                Settings = new Dictionary<string, string> {
+                    [MailProfileSettingsKeys.ClientId] = "client-id",
+                    [MailProfileSettingsKeys.TenantId] = "tenant-id"
+                }
+            },
+            new SendMessageRequest {
+                ProfileId = "work-graph",
+                NotBefore = scheduledFor,
+                Message = new DraftMessage {
+                    Subject = "Hello Graph",
+                    TextBody = "hello",
+                    To = {
+                        new MessageRecipient { Address = "alice@example.com" }
+                    }
+                }
+            });
+
+        Assert.True(result.Succeeded);
+        Assert.True(result.Queued);
+        var queued = await repository.GetByMessageIdAsync(result.QueueMessageId!, CancellationToken.None);
+        Assert.NotNull(queued);
+        Assert.Equal(EmailProvider.Graph, queued!.Provider);
+        Assert.Equal("tenant-id", queued.ProviderData[GraphPendingMessageSender.TenantIdKey]);
+        Assert.True(queued.NextAttemptAt >= scheduledFor.ToUniversalTime().AddSeconds(-1));
+    }
+
+    private sealed class FakeGraphSessionFactory : IGraphSessionFactory {
+        public Task<GraphSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GraphSession(
+                new GraphApiClient(new OAuthCredential {
+                    UserName = profile.DefaultMailbox ?? "me",
+                    AccessToken = "token",
+                    ExpiresOn = DateTimeOffset.MaxValue
+                }),
+                profile.DefaultMailbox ?? "me",
+                new OAuthCredential {
+                    UserName = profile.DefaultMailbox ?? "me",
+                    AccessToken = "token",
+                    ExpiresOn = DateTimeOffset.MaxValue
+                },
+                new GraphCredential {
+                    ClientId = "client-id",
+                    DirectoryId = "tenant-id",
+                    ClientSecret = "secret"
+                }));
+    }
+
+    private static string CreateTemporaryDirectory() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationGraphSessionFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationGraphSessionFactoryTests.cs
@@ -1,0 +1,122 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationGraphSessionFactoryTests {
+    [Fact]
+    public async Task FactoryUsesAccessTokenSecretWhenAvailable() {
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("work-graph", MailSecretNames.AccessToken, "graph-token");
+
+        GraphSessionRequest? captured = null;
+        var factory = new GraphSessionFactory(
+            secretStore,
+            connectAsync: (request, cancellationToken) => {
+                captured = request;
+                return Task.FromResult(new GraphSession(new GraphApiClient(request.Credential), request.UserId));
+            });
+
+        using var session = await factory.ConnectAsync(new MailProfile {
+            Id = "work-graph",
+            DisplayName = "Work Graph",
+            Kind = MailProfileKind.Graph,
+            DefaultMailbox = "user@example.com"
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal("user@example.com", captured!.UserId);
+        Assert.Equal("graph-token", captured.Credential.AccessToken);
+        Assert.Equal("user@example.com", captured.Credential.UserName);
+    }
+
+    [Fact]
+    public async Task FactoryBuildsClientCredentialRequestWhenAccessTokenIsMissing() {
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("tenant-graph", MailSecretNames.ClientSecret, "top-secret");
+
+        GraphCredential? captured = null;
+        var factory = new GraphSessionFactory(
+            secretStore,
+            acquireCredentialAsync: (profile, credential, cancellationToken) => {
+                captured = credential;
+                return Task.FromResult(new OAuthCredential {
+                    AccessToken = "issued-token",
+                    ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+                });
+            },
+            connectAsync: (request, cancellationToken) =>
+                Task.FromResult(new GraphSession(new GraphApiClient(request.Credential), request.UserId)));
+
+        using var session = await factory.ConnectAsync(new MailProfile {
+            Id = "tenant-graph",
+            DisplayName = "Tenant Graph",
+            Kind = MailProfileKind.Graph,
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.ClientId] = "client-id",
+                [MailProfileSettingsKeys.TenantId] = "tenant-id",
+                [MailProfileSettingsKeys.Mailbox] = "shared@example.com"
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal("client-id", captured!.ClientId);
+        Assert.Equal("tenant-id", captured.DirectoryId);
+        Assert.Equal("top-secret", captured.ClientSecret);
+        Assert.Equal("shared@example.com", session.UserId);
+    }
+
+    [Fact]
+    public async Task FactoryUsesSilentInteractiveRefreshWhenStoredTokenIsExpired() {
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("work-graph", MailSecretNames.AccessToken, "expired-token");
+        GraphSessionRequest? captured = null;
+
+        var factory = new GraphSessionFactory(
+            secretStore,
+            acquireSilentCredentialAsync: (profile, cancellationToken) =>
+                Task.FromResult<OAuthCredential?>(new OAuthCredential {
+                    UserName = "user@example.com",
+                    AccessToken = "silent-token",
+                    ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+                }),
+            connectAsync: (request, cancellationToken) => {
+                captured = request;
+                return Task.FromResult(new GraphSession(new GraphApiClient(request.Credential), request.UserId, request.Credential, request.GraphCredential));
+            });
+
+        using var session = await factory.ConnectAsync(new MailProfile {
+            Id = "work-graph",
+            DisplayName = "Work Graph",
+            Kind = MailProfileKind.Graph,
+            DefaultMailbox = "user@example.com",
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.AuthFlow] = MailProfileAuthFlowNames.Interactive,
+                [MailProfileSettingsKeys.ClientId] = "client-id",
+                [MailProfileSettingsKeys.TenantId] = "tenant-id",
+                [MailProfileSettingsKeys.RedirectUri] = MailProfileAuthDefaults.GraphRedirectUri,
+                [MailProfileSettingsKeys.TokenExpiresOn] = DateTimeOffset.UtcNow.AddMinutes(-10).ToString("o", System.Globalization.CultureInfo.InvariantCulture)
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal("silent-token", captured!.Credential.AccessToken);
+        Assert.Equal("user@example.com", session.UserId);
+    }
+
+    private sealed class InMemorySecretStore : IMailSecretStore {
+        private readonly Dictionary<string, string> _values = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            _values.TryGetValue($"{profileId}::{secretName}", out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_values.Remove($"{profileId}::{secretName}"));
+
+        public Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+            _values[$"{profileId}::{secretName}"] = secretValue;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationImapMailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationImapMailReadHandlerTests.cs
@@ -1,0 +1,69 @@
+using MailKit.Net.Imap;
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationImapMailReadHandlerTests {
+    [Fact]
+    public async Task HandlerUsesInjectedSearchDelegate() {
+        var handler = new ImapMailReadHandler(
+            new FakeImapSessionFactory(),
+            searchAsync: (client, profile, request, cancellationToken) => Task.FromResult<IReadOnlyList<MessageSummary>>(new[] {
+                new MessageSummary {
+                    ProfileId = profile.Id,
+                    Id = "42",
+                    Subject = request.QueryText
+                }
+            }));
+
+        var results = await handler.SearchAsync(
+            new MailProfile {
+                Id = "work-imap",
+                DisplayName = "Work IMAP",
+                Kind = MailProfileKind.Imap,
+                Settings = new Dictionary<string, string> {
+                    [MailProfileSettingsKeys.Server] = "imap.example.com"
+                }
+            },
+            new MailSearchRequest {
+                ProfileId = "work-imap",
+                QueryText = "reports"
+            });
+
+        Assert.Single(results);
+        Assert.Equal("42", results[0].Id);
+        Assert.Equal("reports", results[0].Subject);
+    }
+
+    [Fact]
+    public async Task HandlerUsesInjectedAttachmentDelegate() {
+        var handler = new ImapMailReadHandler(
+            new FakeImapSessionFactory(),
+            saveAttachmentAsync: (client, profile, request, cancellationToken) =>
+                Task.FromResult(OperationResult.Success($"Saved {request.AttachmentId}")));
+
+        var result = await handler.SaveAttachmentAsync(
+            new MailProfile {
+                Id = "work-imap",
+                DisplayName = "Work IMAP",
+                Kind = MailProfileKind.Imap,
+                Settings = new Dictionary<string, string> {
+                    [MailProfileSettingsKeys.Server] = "imap.example.com"
+                }
+            },
+            new SaveAttachmentRequest {
+                ProfileId = "work-imap",
+                MessageId = "10",
+                AttachmentId = "0",
+                DestinationPath = Path.Combine(Path.GetTempPath(), "attachment.bin")
+            });
+
+        Assert.True(result.Succeeded);
+        Assert.Contains("Saved 0", result.Message, StringComparison.Ordinal);
+    }
+
+    private sealed class FakeImapSessionFactory : IImapSessionFactory {
+        public Task<ImapClient> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ImapClient());
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationImapSessionFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationImapSessionFactoryTests.cs
@@ -1,0 +1,83 @@
+using MailKit.Net.Imap;
+using MailKit.Security;
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationImapSessionFactoryTests {
+    [Fact]
+    public async Task FactoryBuildsBasicAuthSessionRequestFromProfileAndSecrets() {
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("work-imap", MailSecretNames.Password, "super-secret");
+
+        ImapSessionRequest? captured = null;
+        var factory = new ImapSessionFactory(secretStore, (request, _) => {
+            captured = request;
+            return Task.FromResult(new ImapClient());
+        });
+
+        await factory.ConnectAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            DefaultMailbox = "user@example.com",
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Server] = "imap.example.com",
+                [MailProfileSettingsKeys.Port] = "1993",
+                [MailProfileSettingsKeys.SecureSocketOptions] = SecureSocketOptions.SslOnConnect.ToString()
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal("imap.example.com", captured!.Connection.Server);
+        Assert.Equal(1993, captured.Connection.Port);
+        Assert.Equal(SecureSocketOptions.SslOnConnect, captured.Connection.Options);
+        Assert.Equal("user@example.com", captured.UserName);
+        Assert.Equal("super-secret", captured.Secret);
+        Assert.Equal(ProtocolAuthMode.Basic, captured.AuthMode);
+    }
+
+    [Fact]
+    public async Task FactoryUsesOAuthAccessTokenWhenConfigured() {
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("gmail-imap", MailSecretNames.AccessToken, "oauth-token");
+
+        ImapSessionRequest? captured = null;
+        var factory = new ImapSessionFactory(secretStore, (request, _) => {
+            captured = request;
+            return Task.FromResult(new ImapClient());
+        });
+
+        await factory.ConnectAsync(new MailProfile {
+            Id = "gmail-imap",
+            DisplayName = "Gmail IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Server] = "imap.gmail.com",
+                [MailProfileSettingsKeys.UserName] = "user@gmail.com",
+                [MailProfileSettingsKeys.AuthMode] = "oauth2"
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal(ProtocolAuthMode.OAuth2, captured!.AuthMode);
+        Assert.Equal("oauth-token", captured.Secret);
+    }
+
+    private sealed class InMemorySecretStore : IMailSecretStore {
+        private readonly Dictionary<string, string> _values = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            _values.TryGetValue($"{profileId}::{secretName}", out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_values.Remove($"{profileId}::{secretName}"));
+
+        public Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+            _values[$"{profileId}::{secretName}"] = secretValue;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationProfileAuthServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileAuthServiceTests.cs
@@ -1,0 +1,277 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationProfileAuthServiceTests {
+    [Fact]
+    public async Task GetStatusAsyncReportsInteractiveGmailProfileState() {
+        var expiresOn = DateTimeOffset.UtcNow.AddHours(2);
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "gmail-work",
+                DisplayName = "Work Gmail",
+                Kind = MailProfileKind.Gmail,
+                DefaultMailbox = "user@gmail.com",
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Mailbox] = "user@gmail.com",
+                    [MailProfileSettingsKeys.ClientId] = "client-id",
+                    [MailProfileSettingsKeys.AuthFlow] = MailProfileAuthFlowNames.Interactive,
+                    [MailProfileSettingsKeys.LoginHint] = "user@gmail.com",
+                    [MailProfileSettingsKeys.TokenExpiresOn] = expiresOn.ToString("o", System.Globalization.CultureInfo.InvariantCulture)
+                }
+            }
+        });
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("gmail-work", MailSecretNames.AccessToken, "access-token");
+        await secretStore.SetSecretAsync("gmail-work", MailSecretNames.RefreshToken, "refresh-token");
+        await secretStore.SetSecretAsync("gmail-work", MailSecretNames.ClientSecret, "client-secret");
+        var service = new MailProfileAuthService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore);
+
+        var status = await service.GetStatusAsync("gmail-work");
+
+        Assert.NotNull(status);
+        Assert.Equal("interactive", status!.Mode);
+        Assert.Equal(MailProfileKind.Gmail, status.ProfileKind);
+        Assert.Equal("user@gmail.com", status.Mailbox);
+        Assert.True(status.HasAccessToken);
+        Assert.True(status.HasRefreshToken);
+        Assert.True(status.HasClientSecret);
+        Assert.True(status.CanRefresh);
+        Assert.True(status.CanLoginInteractively);
+        Assert.False(status.IsTokenExpired);
+        Assert.Equal(expiresOn, status.TokenExpiresOn);
+    }
+
+    [Fact]
+    public async Task GetStatusAsyncReportsGraphAppOnlyState() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "graph-app",
+                DisplayName = "Graph App",
+                Kind = MailProfileKind.Graph,
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.ClientId] = "client-id",
+                    [MailProfileSettingsKeys.TenantId] = "tenant-id",
+                    [MailProfileSettingsKeys.CertificatePath] = "C:\\certs\\graph.pfx"
+                }
+            }
+        });
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("graph-app", MailSecretNames.ClientSecret, "client-secret");
+        var service = new MailProfileAuthService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore);
+
+        var status = await service.GetStatusAsync("graph-app");
+
+        Assert.NotNull(status);
+        Assert.Equal("appOnly", status!.Mode);
+        Assert.True(status.HasClientId);
+        Assert.True(status.HasTenantId);
+        Assert.True(status.HasClientSecret);
+        Assert.True(status.HasCertificatePath);
+        Assert.False(status.CanRefresh);
+        Assert.True(status.CanLoginInteractively);
+    }
+
+    [Fact]
+    public async Task LoginGmailAsyncPersistsTokensAndProfileSettings() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "gmail-work",
+                DisplayName = "Work Gmail",
+                Kind = MailProfileKind.Gmail,
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Mailbox] = "user@gmail.com",
+                    [MailProfileSettingsKeys.ClientId] = "client-id"
+                }
+            }
+        });
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("gmail-work", MailSecretNames.ClientSecret, "client-secret");
+        var service = new MailProfileAuthService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore,
+            (request, _) => Task.FromResult(new OAuthCredential {
+                UserName = request.GmailAccount!,
+                AccessToken = "gmail-access-token",
+                RefreshToken = "gmail-refresh-token",
+                ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+            }));
+
+        var result = await service.LoginGmailAsync(new GmailProfileLoginRequest {
+            ProfileId = "gmail-work"
+        });
+
+        var profile = await profileStore.GetByIdAsync("gmail-work");
+        var accessToken = await secretStore.GetSecretAsync("gmail-work", MailSecretNames.AccessToken);
+        var refreshToken = await secretStore.GetSecretAsync("gmail-work", MailSecretNames.RefreshToken);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(profile);
+        Assert.Equal("user@gmail.com", profile!.DefaultMailbox);
+        Assert.Equal("user@gmail.com", profile.DefaultSender);
+        Assert.Equal(MailProfileAuthFlowNames.Interactive, profile.Settings[MailProfileSettingsKeys.AuthFlow]);
+        Assert.Equal("user@gmail.com", profile.Settings[MailProfileSettingsKeys.LoginHint]);
+        Assert.True(profile.Settings.ContainsKey(MailProfileSettingsKeys.TokenExpiresOn));
+        Assert.Equal("gmail-access-token", accessToken);
+        Assert.Equal("gmail-refresh-token", refreshToken);
+    }
+
+    [Fact]
+    public async Task LoginGraphAsyncPersistsAccessTokenAndProfileSettings() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "graph-work",
+                DisplayName = "Work Graph",
+                Kind = MailProfileKind.Graph,
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.ClientId] = "client-id",
+                    [MailProfileSettingsKeys.TenantId] = "tenant-id"
+                }
+            }
+        });
+        var secretStore = new InMemorySecretStore();
+        var service = new MailProfileAuthService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore,
+            loginGraphAsync: (request, _) => Task.FromResult(new OAuthCredential {
+                UserName = request.Login ?? "user@example.com",
+                AccessToken = "graph-access-token",
+                ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+            }));
+
+        var result = await service.LoginGraphAsync(new GraphProfileLoginRequest {
+            ProfileId = "graph-work",
+            Login = "user@example.com"
+        });
+
+        var profile = await profileStore.GetByIdAsync("graph-work");
+        var accessToken = await secretStore.GetSecretAsync("graph-work", MailSecretNames.AccessToken);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(profile);
+        Assert.Equal("user@example.com", profile!.Settings[MailProfileSettingsKeys.Mailbox]);
+        Assert.Equal(MailProfileAuthFlowNames.Interactive, profile.Settings[MailProfileSettingsKeys.AuthFlow]);
+        Assert.Equal("user@example.com", profile.Settings[MailProfileSettingsKeys.LoginHint]);
+        Assert.True(profile.Settings.ContainsKey(MailProfileSettingsKeys.TokenExpiresOn));
+        Assert.Equal("https://login.microsoftonline.com/common/oauth2/nativeclient", profile.Settings[MailProfileSettingsKeys.RedirectUri]);
+        Assert.Equal("graph-access-token", accessToken);
+    }
+
+    [Fact]
+    public async Task RefreshAsyncRoutesToSavedGmailProfile() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "gmail-work",
+                DisplayName = "Work Gmail",
+                Kind = MailProfileKind.Gmail,
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Mailbox] = "user@gmail.com",
+                    [MailProfileSettingsKeys.ClientId] = "client-id"
+                }
+            }
+        });
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("gmail-work", MailSecretNames.ClientSecret, "client-secret");
+        var service = new MailProfileAuthService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore,
+            (request, _) => Task.FromResult(new OAuthCredential {
+                UserName = request.GmailAccount!,
+                AccessToken = "gmail-access-token",
+                RefreshToken = "gmail-refresh-token",
+                ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+            }));
+
+        var result = await service.RefreshAsync("gmail-work");
+
+        var accessToken = await secretStore.GetSecretAsync("gmail-work", MailSecretNames.AccessToken);
+        Assert.True(result.Succeeded);
+        Assert.Equal(MailProfileKind.Gmail, result.ProfileKind);
+        Assert.Equal("gmail-access-token", accessToken);
+    }
+
+    [Fact]
+    public async Task RefreshAsyncReturnsUnsupportedForNonOauthProfiles() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "smtp-work",
+                DisplayName = "Work SMTP",
+                Kind = MailProfileKind.Smtp
+            }
+        });
+        var secretStore = new InMemorySecretStore();
+        var service = new MailProfileAuthService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore);
+
+        var result = await service.RefreshAsync("smtp-work");
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("refresh_not_supported", result.Code);
+    }
+
+    private sealed class InMemoryProfileStore : IMailProfileStore {
+        private readonly Dictionary<string, MailProfile> _profiles;
+
+        public InMemoryProfileStore(IEnumerable<MailProfile> profiles) {
+            _profiles = profiles.ToDictionary(profile => profile.Id, CloneProfile, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public Task<IReadOnlyList<MailProfile>> GetAllAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailProfile>>(_profiles.Values.Select(CloneProfile).ToArray());
+
+        public Task<MailProfile?> GetByIdAsync(string profileId, CancellationToken cancellationToken = default) {
+            _profiles.TryGetValue(profileId, out var profile);
+            return Task.FromResult(profile == null ? null : CloneProfile(profile));
+        }
+
+        public Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_profiles.Remove(profileId));
+
+        public Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+            _profiles[profile.Id] = CloneProfile(profile);
+            return Task.CompletedTask;
+        }
+
+        private static MailProfile CloneProfile(MailProfile profile) => new() {
+            Id = profile.Id,
+            DisplayName = profile.DisplayName,
+            Description = profile.Description,
+            Kind = profile.Kind,
+            DefaultSender = profile.DefaultSender,
+            DefaultMailbox = profile.DefaultMailbox,
+            IsDefault = profile.IsDefault,
+            Settings = new Dictionary<string, string>(profile.Settings, StringComparer.OrdinalIgnoreCase),
+            Capabilities = profile.Capabilities == null
+                ? null
+                : new ProfileCapabilities(profile.Capabilities.Kind, profile.Capabilities.Capabilities)
+        };
+    }
+
+    private sealed class InMemorySecretStore : IMailSecretStore {
+        private readonly Dictionary<string, string> _values = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            _values.TryGetValue($"{profileId}::{secretName}", out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_values.Remove($"{profileId}::{secretName}"));
+
+        public Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+            _values[$"{profileId}::{secretName}"] = secretValue;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationProfileBootstrapServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileBootstrapServiceTests.cs
@@ -1,0 +1,171 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationProfileBootstrapServiceTests {
+    [Fact]
+    public async Task SaveGraphProfileAsyncPersistsProfileSettingsAndSecrets() {
+        var profileStore = new InMemoryProfileStore();
+        var secretStore = new InMemorySecretStore();
+        var service = new MailProfileBootstrapService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore);
+
+        var result = await service.SaveGraphProfileAsync(new GraphProfileBootstrapRequest {
+            ProfileId = "graph-work",
+            DisplayName = "Work Graph",
+            Mailbox = "shared@example.com",
+            ClientId = "client-id",
+            TenantId = "tenant-id",
+            ClientSecret = "client-secret",
+            IsDefault = true
+        });
+
+        var profile = await profileStore.GetByIdAsync("graph-work");
+        var clientSecret = await secretStore.GetSecretAsync("graph-work", MailSecretNames.ClientSecret);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(profile);
+        Assert.Equal(MailProfileKind.Graph, profile!.Kind);
+        Assert.Equal("shared@example.com", profile.DefaultMailbox);
+        Assert.Equal("shared@example.com", profile.DefaultSender);
+        Assert.True(profile.IsDefault);
+        Assert.Equal("shared@example.com", profile.Settings[MailProfileSettingsKeys.Mailbox]);
+        Assert.Equal("client-id", profile.Settings[MailProfileSettingsKeys.ClientId]);
+        Assert.Equal("tenant-id", profile.Settings[MailProfileSettingsKeys.TenantId]);
+        Assert.Equal("client-secret", clientSecret);
+    }
+
+    [Fact]
+    public async Task SaveGraphProfileAsyncRequiresAuthenticationMaterial() {
+        var profileStore = new InMemoryProfileStore();
+        var secretStore = new InMemorySecretStore();
+        var service = new MailProfileBootstrapService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore);
+
+        var result = await service.SaveGraphProfileAsync(new GraphProfileBootstrapRequest {
+            ProfileId = "graph-work",
+            DisplayName = "Work Graph",
+            Mailbox = "shared@example.com"
+        });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("graph_auth_required", result.Code);
+    }
+
+    [Fact]
+    public async Task SaveGmailProfileAsyncPersistsProfileSettingsAndSecrets() {
+        var profileStore = new InMemoryProfileStore();
+        var secretStore = new InMemorySecretStore();
+        var service = new MailProfileBootstrapService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore);
+
+        var result = await service.SaveGmailProfileAsync(new GmailProfileBootstrapRequest {
+            ProfileId = "gmail-work",
+            DisplayName = "Work Gmail",
+            Mailbox = "me@example.com",
+            ClientId = "client-id",
+            ClientSecret = "client-secret",
+            RefreshToken = "refresh-token",
+            IsDefault = true
+        });
+
+        var profile = await profileStore.GetByIdAsync("gmail-work");
+        var clientSecret = await secretStore.GetSecretAsync("gmail-work", MailSecretNames.ClientSecret);
+        var refreshToken = await secretStore.GetSecretAsync("gmail-work", MailSecretNames.RefreshToken);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(profile);
+        Assert.Equal(MailProfileKind.Gmail, profile!.Kind);
+        Assert.Equal("me@example.com", profile.DefaultMailbox);
+        Assert.Equal("me@example.com", profile.DefaultSender);
+        Assert.True(profile.IsDefault);
+        Assert.Equal("me@example.com", profile.Settings[MailProfileSettingsKeys.Mailbox]);
+        Assert.Equal("client-id", profile.Settings[MailProfileSettingsKeys.ClientId]);
+        Assert.Equal("client-secret", clientSecret);
+        Assert.Equal("refresh-token", refreshToken);
+    }
+
+    [Fact]
+    public async Task SaveGmailProfileAsyncRequiresAuthenticationMaterial() {
+        var profileStore = new InMemoryProfileStore();
+        var secretStore = new InMemorySecretStore();
+        var service = new MailProfileBootstrapService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore);
+
+        var result = await service.SaveGmailProfileAsync(new GmailProfileBootstrapRequest {
+            ProfileId = "gmail-work",
+            DisplayName = "Work Gmail"
+        });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("gmail_auth_required", result.Code);
+    }
+
+    [Fact]
+    public async Task DiagnoseAsyncReportsMissingGmailSecrets() {
+        var profileStore = new InMemoryProfileStore();
+        var secretStore = new InMemorySecretStore();
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "gmail-work",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail,
+            DefaultMailbox = "me@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "me@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        var service = new MailProfileService(profileStore, secretStore);
+
+        var result = await service.DiagnoseAsync("gmail-work");
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("profile_not_ready", result.Code);
+        Assert.Contains(result.Errors, error => error.Contains("Gmail profiles need an access token", StringComparison.Ordinal));
+    }
+
+    private sealed class InMemoryProfileStore : IMailProfileStore {
+        private readonly Dictionary<string, MailProfile> _profiles = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<IReadOnlyList<MailProfile>> GetAllAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailProfile>>(_profiles.Values.ToArray());
+
+        public Task<MailProfile?> GetByIdAsync(string profileId, CancellationToken cancellationToken = default) {
+            _profiles.TryGetValue(profileId, out var profile);
+            return Task.FromResult<MailProfile?>(profile);
+        }
+
+        public Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_profiles.Remove(profileId));
+
+        public Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+            _profiles[profile.Id] = profile;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class InMemorySecretStore : IMailSecretStore {
+        private readonly Dictionary<string, string> _values = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            _values.TryGetValue($"{profileId}::{secretName}", out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_values.Remove($"{profileId}::{secretName}"));
+
+        public Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+            _values[$"{profileId}::{secretName}"] = secretValue;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationProfileConnectionServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileConnectionServiceTests.cs
@@ -1,0 +1,161 @@
+using MailKit.Net.Imap;
+using Mailozaurr;
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationProfileConnectionServiceTests {
+    [Fact]
+    public async Task TestAsyncUsesMailboxScopeByDefaultForGmail() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "gmail-work",
+                DisplayName = "Work Gmail",
+                Kind = MailProfileKind.Gmail,
+                DefaultMailbox = "user@gmail.com"
+            }
+        });
+        var authProbeCalls = 0;
+        var mailboxProbeCalls = 0;
+        var service = new MailProfileConnectionService(
+            profileStore,
+            gmailSessionFactory: new FakeGmailSessionFactory(),
+            probeGmailAsync: (_, _) => {
+                authProbeCalls++;
+                return Task.CompletedTask;
+            },
+            probeGmailMailboxAsync: (session, _) => {
+                mailboxProbeCalls++;
+                Assert.Equal("user@gmail.com", session.UserId);
+                return Task.CompletedTask;
+            });
+
+        var result = await service.TestAsync("gmail-work");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(MailProfileConnectionTestScope.Auto, result.RequestedScope);
+        Assert.Equal(MailProfileConnectionTestScope.Mailbox, result.ExecutedScope);
+        Assert.Equal("listFolders", result.Probe);
+        Assert.Equal(0, authProbeCalls);
+        Assert.Equal(1, mailboxProbeCalls);
+    }
+
+    [Fact]
+    public async Task TestAsyncUsesAuthScopeWhenRequestedForGraph() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "graph-work",
+                DisplayName = "Work Graph",
+                Kind = MailProfileKind.Graph,
+                DefaultMailbox = "user@example.com"
+            }
+        });
+        var authProbeCalls = 0;
+        var mailboxProbeCalls = 0;
+        var service = new MailProfileConnectionService(
+            profileStore,
+            graphSessionFactory: new FakeGraphSessionFactory(),
+            probeGraphAsync: (_, _) => {
+                authProbeCalls++;
+                return Task.CompletedTask;
+            },
+            probeGraphMailboxAsync: (_, _) => {
+                mailboxProbeCalls++;
+                return Task.CompletedTask;
+            });
+
+        var result = await service.TestAsync("graph-work", MailProfileConnectionTestScope.Auth);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(MailProfileConnectionTestScope.Auth, result.RequestedScope);
+        Assert.Equal(MailProfileConnectionTestScope.Auth, result.ExecutedScope);
+        Assert.Equal("connect", result.Probe);
+        Assert.Equal(1, authProbeCalls);
+        Assert.Equal(0, mailboxProbeCalls);
+    }
+
+    [Fact]
+    public async Task TestAsyncFallsBackFromSendToAuthForImap() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "imap-work",
+                DisplayName = "Work IMAP",
+                Kind = MailProfileKind.Imap,
+                DefaultMailbox = "user@example.com"
+            }
+        });
+        var service = new MailProfileConnectionService(
+            profileStore,
+            imapSessionFactory: new FakeImapSessionFactory(),
+            probeImapAsync: (_, _) => Task.CompletedTask,
+            probeImapMailboxAsync: (_, _) => Task.CompletedTask);
+
+        var result = await service.TestAsync("imap-work", MailProfileConnectionTestScope.Send);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(MailProfileConnectionTestScope.Send, result.RequestedScope);
+        Assert.Equal(MailProfileConnectionTestScope.Auth, result.ExecutedScope);
+        Assert.Equal("connect", result.Probe);
+    }
+
+    private sealed class InMemoryProfileStore : IMailProfileStore {
+        private readonly Dictionary<string, MailProfile> _profiles;
+
+        public InMemoryProfileStore(IEnumerable<MailProfile> profiles) {
+            _profiles = profiles.ToDictionary(profile => profile.Id, CloneProfile, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public Task<IReadOnlyList<MailProfile>> GetAllAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailProfile>>(_profiles.Values.Select(CloneProfile).ToArray());
+
+        public Task<MailProfile?> GetByIdAsync(string profileId, CancellationToken cancellationToken = default) {
+            _profiles.TryGetValue(profileId, out var profile);
+            return Task.FromResult(profile == null ? null : CloneProfile(profile));
+        }
+
+        public Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_profiles.Remove(profileId));
+
+        public Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+            _profiles[profile.Id] = CloneProfile(profile);
+            return Task.CompletedTask;
+        }
+
+        private static MailProfile CloneProfile(MailProfile profile) => new() {
+            Id = profile.Id,
+            DisplayName = profile.DisplayName,
+            Description = profile.Description,
+            Kind = profile.Kind,
+            DefaultSender = profile.DefaultSender,
+            DefaultMailbox = profile.DefaultMailbox,
+            IsDefault = profile.IsDefault,
+            Settings = new Dictionary<string, string>(profile.Settings, StringComparer.OrdinalIgnoreCase),
+            Capabilities = profile.Capabilities == null
+                ? null
+                : new ProfileCapabilities(profile.Capabilities.Kind, profile.Capabilities.Capabilities)
+        };
+    }
+
+    private sealed class FakeImapSessionFactory : IImapSessionFactory {
+        public Task<ImapClient> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ImapClient());
+    }
+
+    private sealed class FakeGraphSessionFactory : IGraphSessionFactory {
+        public Task<GraphSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GraphSession(new GraphApiClient(new OAuthCredential {
+                UserName = profile.DefaultMailbox ?? "me",
+                AccessToken = "token",
+                ExpiresOn = DateTimeOffset.MaxValue
+            }), profile.DefaultMailbox ?? "me"));
+    }
+
+    private sealed class FakeGmailSessionFactory : IGmailSessionFactory {
+        public Task<GmailSession> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GmailSession(new GmailApiClient(new OAuthCredential {
+                UserName = profile.DefaultMailbox ?? "me",
+                AccessToken = "token",
+                ExpiresOn = DateTimeOffset.MaxValue
+            }), profile.DefaultMailbox ?? "me"));
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationProfileOverviewServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileOverviewServiceTests.cs
@@ -1,0 +1,273 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationProfileOverviewServiceTests {
+    [Fact]
+    public async Task GetOverviewAggregatesCapabilitiesAuthAndReadiness() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "gmail-work",
+                DisplayName = "Work Gmail",
+                Kind = MailProfileKind.Gmail,
+                DefaultSender = "user@example.com",
+                DefaultMailbox = "user@example.com",
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Mailbox] = "user@example.com",
+                    [MailProfileSettingsKeys.ClientId] = "client-id"
+                }
+            }
+        });
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("gmail-work", MailSecretNames.AccessToken, "token");
+        var profiles = new MailProfileService(profileStore, secretStore);
+        var auth = new FakeProfileAuthService();
+        var service = new MailProfileOverviewService(profiles, auth);
+
+        var overview = await service.GetOverviewAsync("gmail-work");
+
+        Assert.NotNull(overview);
+        Assert.Equal("gmail-work", overview!.Profile.Id);
+        Assert.True(overview.SupportsRead);
+        Assert.True(overview.SupportsSend);
+        Assert.True(overview.IsReady);
+        Assert.Equal(0, overview.ErrorCount);
+        Assert.Equal(0, overview.WarningCount);
+        Assert.NotNull(overview.Capabilities);
+        Assert.NotNull(overview.AuthStatus);
+        Assert.Contains("read=yes", overview.Summary, StringComparison.Ordinal);
+        Assert.Contains("send=yes", overview.Summary, StringComparison.Ordinal);
+        Assert.Contains("auth=interactive", overview.Summary, StringComparison.Ordinal);
+        Assert.Contains("readiness=ready", overview.Summary, StringComparison.Ordinal);
+        Assert.Equal("gmail-work", auth.LastProfileId);
+    }
+
+    [Fact]
+    public async Task GetOverviewReturnsNullWhenProfileDoesNotExist() {
+        var profiles = new MailProfileService(new InMemoryProfileStore(Array.Empty<MailProfile>()), new InMemorySecretStore());
+        var service = new MailProfileOverviewService(profiles, new FakeProfileAuthService());
+
+        var overview = await service.GetOverviewAsync("missing");
+
+        Assert.Null(overview);
+    }
+
+    [Fact]
+    public async Task GetOverviewsReturnsAggregatedSummariesForAllProfiles() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "imap-work",
+                DisplayName = "Work IMAP",
+                Kind = MailProfileKind.Imap,
+                IsDefault = true,
+                DefaultMailbox = "work@example.com",
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Server] = "imap.example.com"
+                }
+            },
+            new MailProfile {
+                Id = "smtp-alerts",
+                DisplayName = "Alerts SMTP",
+                Kind = MailProfileKind.Smtp,
+                DefaultSender = "alerts@example.com",
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Server] = "smtp.example.com"
+                }
+            }
+        });
+        var profiles = new MailProfileService(profileStore, new InMemorySecretStore());
+        var auth = new FakeProfileAuthService();
+        var service = new MailProfileOverviewService(profiles, auth);
+
+        var overviews = await service.GetOverviewsAsync();
+
+        Assert.Equal(2, overviews.Count);
+        Assert.Contains(overviews, overview => overview.Profile.Id == "imap-work" && overview.SupportsRead);
+        Assert.Contains(overviews, overview => overview.Profile.Id == "smtp-alerts" && overview.SupportsSend);
+    }
+
+    [Fact]
+    public async Task GetOverviewsAppliesSharedFilters() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "imap-work",
+                DisplayName = "Work IMAP",
+                Kind = MailProfileKind.Imap,
+                IsDefault = true,
+                DefaultMailbox = "work@example.com",
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Server] = "imap.example.com"
+                }
+            },
+            new MailProfile {
+                Id = "smtp-alerts",
+                DisplayName = "Alerts SMTP",
+                Kind = MailProfileKind.Smtp,
+                DefaultSender = "alerts@example.com",
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Server] = "smtp.example.com"
+                }
+            }
+        });
+        var profiles = new MailProfileService(profileStore, new InMemorySecretStore());
+        var service = new MailProfileOverviewService(profiles, new FakeProfileAuthService());
+
+        var overviews = await service.GetOverviewsAsync(new MailProfileOverviewQuery {
+            CanSendOnly = true,
+            DefaultOnly = false,
+            Kind = MailProfileKind.Smtp
+        });
+
+        var overview = Assert.Single(overviews);
+        Assert.Equal("smtp-alerts", overview.Profile.Id);
+        Assert.True(overview.SupportsSend);
+    }
+
+    [Fact]
+    public async Task GetOverviewsSupportsReadinessSorting() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "gmail-broken",
+                DisplayName = "Broken Gmail",
+                Kind = MailProfileKind.Gmail,
+                DefaultMailbox = "broken@example.com",
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Mailbox] = "broken@example.com",
+                    [MailProfileSettingsKeys.ClientId] = "client-id"
+                }
+            },
+            new MailProfile {
+                Id = "smtp-ready",
+                DisplayName = "Ready SMTP",
+                Kind = MailProfileKind.Smtp,
+                DefaultSender = "alerts@example.com",
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Server] = "smtp.example.com"
+                }
+            }
+        });
+        var secretStore = new InMemorySecretStore();
+        var profiles = new MailProfileService(profileStore, secretStore);
+        var service = new MailProfileOverviewService(profiles, new FakeProfileAuthService());
+
+        var overviews = await service.GetOverviewsAsync(new MailProfileOverviewQuery {
+            SortBy = MailProfileOverviewSortBy.Readiness
+        });
+
+        Assert.Equal(2, overviews.Count);
+        Assert.Equal("gmail-broken", overviews[0].Profile.Id);
+        Assert.False(overviews[0].IsReady);
+        Assert.Equal("smtp-ready", overviews[1].Profile.Id);
+        Assert.True(overviews[1].IsReady);
+    }
+
+    [Fact]
+    public async Task GetCompactOverviewsReturnsLightweightProjection() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "imap-work",
+                DisplayName = "Work IMAP",
+                Kind = MailProfileKind.Imap,
+                DefaultMailbox = "work@example.com",
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Server] = "imap.example.com"
+                }
+            }
+        });
+        var profiles = new MailProfileService(profileStore, new InMemorySecretStore());
+        var service = new MailProfileOverviewService(profiles, new FakeProfileAuthService());
+
+        var overviews = await service.GetCompactOverviewsAsync();
+
+        var overview = Assert.Single(overviews);
+        Assert.Equal("imap-work", overview.Id);
+        Assert.Equal("Work IMAP", overview.DisplayName);
+        Assert.Equal(MailProfileKind.Imap, overview.Kind);
+        Assert.True(overview.SupportsRead);
+        Assert.False(overview.SupportsSend);
+    }
+
+    private sealed class FakeProfileAuthService : IMailProfileAuthService {
+        public string? LastProfileId { get; private set; }
+
+        public Task<MailProfileAuthStatus?> GetStatusAsync(string profileId, CancellationToken cancellationToken = default) {
+            LastProfileId = profileId;
+            return Task.FromResult<MailProfileAuthStatus?>(new MailProfileAuthStatus {
+                ProfileId = profileId,
+                ProfileKind = MailProfileKind.Gmail,
+                Mode = "interactive",
+                Mailbox = "user@example.com",
+                HasAccessToken = true,
+                CanRefresh = true,
+                CanLoginInteractively = true,
+                Summary = $"{profileId} auth status available."
+            });
+        }
+
+        public Task<MailProfileAuthenticationResult> LoginGmailAsync(GmailProfileLoginRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<MailProfileAuthenticationResult> LoginGraphAsync(GraphProfileLoginRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<MailProfileAuthenticationResult> RefreshAsync(string profileId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class InMemoryProfileStore : IMailProfileStore {
+        private readonly Dictionary<string, MailProfile> _profiles;
+
+        public InMemoryProfileStore(IEnumerable<MailProfile> profiles) {
+            _profiles = profiles.ToDictionary(profile => profile.Id, CloneProfile, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public Task<IReadOnlyList<MailProfile>> GetAllAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailProfile>>(_profiles.Values.Select(CloneProfile).ToArray());
+
+        public Task<MailProfile?> GetByIdAsync(string profileId, CancellationToken cancellationToken = default) {
+            _profiles.TryGetValue(profileId, out var profile);
+            return Task.FromResult(profile == null ? null : CloneProfile(profile));
+        }
+
+        public Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+            _profiles[profile.Id] = CloneProfile(profile);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_profiles.Remove(profileId));
+
+        private static MailProfile CloneProfile(MailProfile profile) => new() {
+            Id = profile.Id,
+            DisplayName = profile.DisplayName,
+            Description = profile.Description,
+            Kind = profile.Kind,
+            DefaultSender = profile.DefaultSender,
+            DefaultMailbox = profile.DefaultMailbox,
+            IsDefault = profile.IsDefault,
+            Settings = new Dictionary<string, string>(profile.Settings, StringComparer.OrdinalIgnoreCase),
+            Capabilities = profile.Capabilities == null
+                ? null
+                : new ProfileCapabilities(profile.Capabilities.Kind, profile.Capabilities.Capabilities)
+        };
+    }
+
+    private sealed class InMemorySecretStore : IMailSecretStore {
+        private readonly Dictionary<string, string> _secrets = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            _secrets.TryGetValue(CreateKey(profileId, secretName), out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+            _secrets[CreateKey(profileId, secretName)] = secretValue;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_secrets.Remove(CreateKey(profileId, secretName)));
+
+        private static string CreateKey(string profileId, string secretName) => $"{profileId}::{secretName}";
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationProfileSecretServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileSecretServiceTests.cs
@@ -1,0 +1,56 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationProfileSecretServiceTests {
+    [Fact]
+    public async Task SetSecretAsyncRequiresExistingProfile() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var secretStore = new FileMailSecretStore(CreateTemporaryFilePath("secrets.json"), new TestCredentialProtector());
+        var service = new MailProfileSecretService(profileStore, secretStore);
+
+        var result = await service.SetSecretAsync("missing", MailSecretNames.Password, "secret");
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("profile_not_found", result.Code);
+    }
+
+    [Fact]
+    public async Task SetSecretAsyncPersistsSecretForExistingProfile() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var secretStore = new FileMailSecretStore(CreateTemporaryFilePath("secrets.json"), new TestCredentialProtector());
+        var service = new MailProfileSecretService(profileStore, secretStore);
+
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var result = await service.SetSecretAsync("work-imap", MailSecretNames.Password, "secret");
+        var stored = await secretStore.GetSecretAsync("work-imap", MailSecretNames.Password);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("secret", stored);
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+
+    private sealed class TestCredentialProtector : ICredentialProtector {
+        public string Protect(string plainText) => Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"protected::{plainText}"));
+
+        public string Unprotect(string protectedData) {
+            var decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(protectedData));
+            return decoded.StartsWith("protected::", StringComparison.Ordinal)
+                ? decoded.Substring("protected::".Length)
+                : decoded;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationProfileServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileServiceTests.cs
@@ -1,0 +1,82 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationProfileServiceTests {
+    [Fact]
+    public async Task SaveAsyncReturnsValidationErrorForInvalidProfile() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var service = new MailProfileService(store);
+
+        var result = await service.SaveAsync(new MailProfile());
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("profile_invalid", result.Code);
+    }
+
+    [Fact]
+    public async Task SetDefaultAsyncMarksRequestedProfileAsDefault() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var service = new MailProfileService(store);
+
+        await service.SaveAsync(new MailProfile {
+            Id = "imap",
+            DisplayName = "IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+        await service.SaveAsync(new MailProfile {
+            Id = "graph",
+            DisplayName = "Graph",
+            Kind = MailProfileKind.Graph,
+            DefaultMailbox = "user@example.com"
+        });
+
+        var result = await service.SetDefaultAsync("graph");
+        var profiles = await service.GetProfilesAsync();
+
+        Assert.True(result.Succeeded);
+        Assert.False(profiles.Single(p => p.Id == "imap").IsDefault);
+        Assert.True(profiles.Single(p => p.Id == "graph").IsDefault);
+    }
+
+    [Fact]
+    public async Task DeleteAsyncRemovesKnownSecretsWhenSecretStoreIsProvided() {
+        var profilePath = CreateTemporaryFilePath("profiles.json");
+        var secretPath = CreateTemporaryFilePath("secrets.json");
+        var store = new FileMailProfileStore(profilePath);
+        var secretStore = new FileMailSecretStore(secretPath, new TestCredentialProtector());
+        var service = new MailProfileService(store, secretStore);
+
+        await service.SaveAsync(new MailProfile {
+            Id = "smtp",
+            DisplayName = "SMTP",
+            Kind = MailProfileKind.Smtp,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "smtp.example.com" }
+        });
+        await secretStore.SetSecretAsync("smtp", MailSecretNames.Password, "secret");
+
+        var result = await service.DeleteAsync("smtp");
+        var secret = await secretStore.GetSecretAsync("smtp", MailSecretNames.Password);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(secret);
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+
+    private sealed class TestCredentialProtector : ICredentialProtector {
+        public string Protect(string plainText) => Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"protected::{plainText}"));
+
+        public string Unprotect(string protectedData) {
+            var decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(protectedData));
+            return decoded.StartsWith("protected::", StringComparison.Ordinal)
+                ? decoded.Substring("protected::".Length)
+                : decoded;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationProfileStoreTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileStoreTests.cs
@@ -1,0 +1,71 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationProfileStoreTests {
+    [Fact]
+    public async Task FileProfileStoreRoundTripsProfiles() {
+        var filePath = CreateTemporaryFilePath();
+        var store = new FileMailProfileStore(filePath);
+
+        var profile = new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            DefaultMailbox = "user@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                ["server"] = "imap.example.com"
+            }
+        };
+
+        await store.SaveAsync(profile);
+        var loaded = await store.GetByIdAsync(profile.Id);
+        var all = await store.GetAllAsync();
+
+        Assert.NotNull(loaded);
+        Assert.Equal("Work IMAP", loaded!.DisplayName);
+        Assert.Equal("imap.example.com", loaded.Settings["server"]);
+        Assert.Single(all);
+    }
+
+    [Fact]
+    public async Task SavingDefaultProfileClearsPreviousDefault() {
+        var filePath = CreateTemporaryFilePath();
+        var store = new FileMailProfileStore(filePath);
+
+        await store.SaveAsync(new MailProfile {
+            Id = "one",
+            DisplayName = "One",
+            Kind = MailProfileKind.Imap,
+            IsDefault = true
+        });
+        await store.SaveAsync(new MailProfile {
+            Id = "two",
+            DisplayName = "Two",
+            Kind = MailProfileKind.Graph,
+            IsDefault = true
+        });
+
+        var all = await store.GetAllAsync();
+
+        Assert.Equal(2, all.Count);
+        Assert.False(all.Single(p => p.Id == "one").IsDefault);
+        Assert.True(all.Single(p => p.Id == "two").IsDefault);
+    }
+
+    [Fact]
+    public async Task RemoveReturnsFalseWhenProfileDoesNotExist() {
+        var filePath = CreateTemporaryFilePath();
+        var store = new FileMailProfileStore(filePath);
+
+        var removed = await store.RemoveAsync("missing");
+
+        Assert.False(removed);
+    }
+
+    private static string CreateTemporaryFilePath() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, "profiles.json");
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationQueueServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationQueueServiceTests.cs
@@ -1,0 +1,86 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationQueueServiceTests {
+    [Fact]
+    public async Task ListAsyncReturnsQueuedMessagesInScheduleOrder() {
+        var repository = new FilePendingMessageRepository(new PendingMessageRepositoryOptions {
+            DirectoryPath = CreateTemporaryDirectory()
+        });
+        await repository.SaveAsync(new PendingMessageRecord {
+            MessageId = "b",
+            Provider = EmailProvider.Gmail,
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-10),
+            NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(10),
+            AttemptCount = 1,
+            MimeMessage = Convert.ToBase64String(Array.Empty<byte>())
+        });
+        await repository.SaveAsync(new PendingMessageRecord {
+            MessageId = "a",
+            Provider = EmailProvider.None,
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-20),
+            NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            AttemptCount = 0,
+            MimeMessage = Convert.ToBase64String(Array.Empty<byte>())
+        });
+
+        var service = new PendingMailQueueService(repository);
+        var queued = await service.ListAsync();
+
+        Assert.Equal(2, queued.Count);
+        Assert.Equal("a", queued[0].MessageId);
+        Assert.Equal(MailProfileKind.Smtp, queued[0].ProfileKind);
+        Assert.Equal(MailProfileKind.Gmail, queued[1].ProfileKind);
+    }
+
+    [Fact]
+    public async Task RemoveAsyncReturnsFailureWhenMessageDoesNotExist() {
+        var repository = new FilePendingMessageRepository(new PendingMessageRepositoryOptions {
+            DirectoryPath = CreateTemporaryDirectory()
+        });
+
+        var service = new PendingMailQueueService(repository);
+        var result = await service.RemoveAsync("missing");
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("queue_message_not_found", result.Code);
+    }
+
+    [Fact]
+    public async Task ProcessAsyncReturnsObserverCounts() {
+        var repository = new FilePendingMessageRepository(new PendingMessageRepositoryOptions {
+            DirectoryPath = CreateTemporaryDirectory()
+        });
+        var record = new PendingMessageRecord {
+            MessageId = "queued-1",
+            Provider = EmailProvider.Gmail,
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-30),
+            NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            AttemptCount = 0,
+            MimeMessage = Convert.ToBase64String(Array.Empty<byte>())
+        };
+        await repository.SaveAsync(record);
+
+        var service = new PendingMailQueueService(
+            repository,
+            (pendingRepository, observer, cancellationToken) => {
+                observer.MessageAttemptStarted(record, 1);
+                observer.MessageSent(record, 1, TimeSpan.FromSeconds(1));
+                return Task.CompletedTask;
+            });
+
+        var result = await service.ProcessAsync();
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(1, result.AttemptedCount);
+        Assert.Equal(1, result.SentCount);
+        Assert.Equal(0, result.FailedCount);
+    }
+
+    private static string CreateTemporaryDirectory() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationRoutingServicesTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationRoutingServicesTests.cs
@@ -1,0 +1,292 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationRoutingServicesTests {
+    [Fact]
+    public async Task RoutedReadServiceDispatchesToMatchingHandler() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeReadHandler(MailProfileKind.Imap);
+        var service = new RoutedMailReadService(store, new[] { handler });
+
+        var results = await service.SearchAsync(new MailSearchRequest {
+            ProfileId = "work-imap",
+            QueryText = "reports"
+        });
+
+        Assert.Single(results);
+        Assert.Equal("msg-1", results[0].Id);
+        Assert.Equal(1, handler.SearchCalls);
+    }
+
+    [Fact]
+    public async Task RoutedReadServiceBuildsCompactFolderProjection() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeReadHandler(MailProfileKind.Imap);
+        var service = new RoutedMailReadService(store, new[] { handler });
+
+        var results = await service.GetFoldersCompactAsync(new MailFolderQuery {
+            ProfileId = "work-imap"
+        });
+
+        var result = Assert.Single(results);
+        Assert.Equal("inbox", result.Id);
+        Assert.Equal("Inbox", result.DisplayName);
+        Assert.Equal("inbox Inbox", result.Summary);
+    }
+
+    [Fact]
+    public async Task RoutedReadServiceBuildsCompactSearchProjection() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeReadHandler(MailProfileKind.Imap);
+        var service = new RoutedMailReadService(store, new[] { handler });
+
+        var results = await service.SearchCompactAsync(new MailSearchRequest {
+            ProfileId = "work-imap",
+            QueryText = "reports"
+        });
+
+        var result = Assert.Single(results);
+        Assert.Equal("msg-1", result.Id);
+        Assert.Equal("reports", result.Subject);
+        Assert.Equal("sender@example.com", result.From);
+        Assert.Equal("msg-1 reports", result.Summary);
+    }
+
+    [Fact]
+    public async Task RoutedReadServiceListsAttachmentsThroughSharedMessageProjection() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeReadHandler(MailProfileKind.Imap);
+        var service = new RoutedMailReadService(store, new[] { handler });
+
+        var results = await service.GetAttachmentsAsync(new ListAttachmentsRequest {
+            ProfileId = "work-imap",
+            MessageId = "msg-1"
+        });
+
+        var result = Assert.Single(results);
+        Assert.Equal("att-1", result.Id);
+        Assert.Equal("report.pdf", result.FileName);
+    }
+
+    [Fact]
+    public async Task RoutedReadServiceBuildsCompactMessageProjection() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeReadHandler(MailProfileKind.Imap);
+        var service = new RoutedMailReadService(store, new[] { handler });
+
+        var result = await service.GetMessageCompactAsync(new GetMessageRequest {
+            ProfileId = "work-imap",
+            MessageId = "msg-1",
+            IncludeRawContent = true
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("msg-1", result!.Id);
+        Assert.Equal("msg-1 Subject", result.SummaryText);
+        Assert.True(result.HasRawContent);
+        Assert.Single(result.Attachments);
+    }
+
+    [Fact]
+    public async Task RoutedReadServiceSavesFilteredAttachmentsThroughSharedBatchWorkflow() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeReadHandler(MailProfileKind.Imap);
+        var service = new RoutedMailReadService(store, new[] { handler });
+
+        var result = await service.SaveAttachmentsAsync(new SaveAttachmentsRequest {
+            ProfileId = "work-imap",
+            MessageId = "msg-1",
+            DestinationPath = @"C:\Temp",
+            FileNameContains = "report"
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(1, result.MatchedCount);
+        Assert.Equal(1, result.SavedCount);
+        Assert.Equal(0, result.FailedCount);
+    }
+
+    [Fact]
+    public async Task RoutedSendServiceDispatchesToMatchingHandler() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-smtp",
+            DisplayName = "Work SMTP",
+            Kind = MailProfileKind.Smtp,
+            DefaultSender = "sender@example.com",
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Server] = "smtp.example.com"
+            }
+        });
+
+        var handler = new FakeSendHandler(MailProfileKind.Smtp);
+        var service = new RoutedMailSendService(store, new[] { handler });
+
+        var result = await service.SendAsync(new SendMessageRequest {
+            ProfileId = "work-smtp",
+            Message = new DraftMessage {
+                ProfileId = "work-smtp",
+                Subject = "Hello"
+            }
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(1, handler.SendCalls);
+    }
+
+    [Fact]
+    public async Task RoutedReadServiceRejectsUnsupportedCapabilities() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-smtp",
+            DisplayName = "Work SMTP",
+            Kind = MailProfileKind.Smtp,
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Server] = "smtp.example.com"
+            }
+        });
+
+        var handler = new FakeReadHandler(MailProfileKind.Smtp);
+        var service = new RoutedMailReadService(store, new[] { handler });
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => service.SearchAsync(new MailSearchRequest {
+            ProfileId = "work-smtp"
+        }));
+
+        Assert.Contains("SearchMessages", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+
+    private sealed class FakeReadHandler : IMailReadHandler {
+        public FakeReadHandler(MailProfileKind kind) {
+            Kind = kind;
+        }
+
+        public MailProfileKind Kind { get; }
+
+        public int SearchCalls { get; private set; }
+
+        public int SaveAttachmentCalls { get; private set; }
+
+        public Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailProfile profile, MailFolderQuery query, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<FolderRef>>(new[] {
+                new FolderRef {
+                    ProfileId = profile.Id,
+                    MailboxId = query.MailboxId,
+                    Id = "inbox",
+                    DisplayName = "Inbox",
+                    Path = "Inbox"
+                }
+            });
+
+        public Task<MessageDetail?> GetMessageAsync(MailProfile profile, GetMessageRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MessageDetail?>(new MessageDetail {
+                ProfileId = profile.Id,
+                Id = request.MessageId,
+                Summary = new MessageSummary {
+                    ProfileId = profile.Id,
+                    Id = request.MessageId,
+                    Subject = "Subject"
+                },
+                TextBody = "Body",
+                Attachments = {
+                    new AttachmentSummary {
+                        MessageId = request.MessageId,
+                        Id = "att-1",
+                        FileName = "report.pdf",
+                        SizeInBytes = 1024
+                    }
+                },
+                RawContent = request.IncludeRawContent ? "raw" : null
+            });
+
+        public Task<OperationResult> SaveAttachmentAsync(MailProfile profile, SaveAttachmentRequest request, CancellationToken cancellationToken = default) {
+            SaveAttachmentCalls++;
+            return Task.FromResult(OperationResult.Success());
+        }
+
+        public Task<IReadOnlyList<MessageSummary>> SearchAsync(MailProfile profile, MailSearchRequest request, CancellationToken cancellationToken = default) {
+            SearchCalls++;
+            IReadOnlyList<MessageSummary> results = new[] {
+                new MessageSummary {
+                    ProfileId = profile.Id,
+                    Id = "msg-1",
+                    Subject = request.QueryText,
+                    From = {
+                        new MessageRecipient {
+                            Address = "sender@example.com"
+                        }
+                    }
+                }
+            };
+            return Task.FromResult(results);
+        }
+    }
+
+    private sealed class FakeSendHandler : IMailSendHandler {
+        public FakeSendHandler(MailProfileKind kind) {
+            Kind = kind;
+        }
+
+        public MailProfileKind Kind { get; }
+
+        public int SendCalls { get; private set; }
+
+        public Task<SendResult> SendAsync(MailProfile profile, SendMessageRequest request, CancellationToken cancellationToken = default) {
+            SendCalls++;
+            return Task.FromResult(new SendResult {
+                Succeeded = true,
+                ProfileId = profile.Id,
+                ProfileKind = profile.Kind
+            });
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationSecretStoreTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationSecretStoreTests.cs
@@ -1,0 +1,62 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationSecretStoreTests {
+    [Fact]
+    public async Task SecretStoreProtectsAndReturnsValues() {
+        var filePath = CreateTemporaryFilePath();
+        var protector = new TestCredentialProtector();
+        var store = new FileMailSecretStore(filePath, protector);
+
+        await store.SetSecretAsync("work-imap", "password", "super-secret");
+
+        var loaded = await store.GetSecretAsync("work-imap", "password");
+        var fileContent = File.ReadAllText(filePath);
+
+        Assert.Equal("super-secret", loaded);
+        Assert.DoesNotContain("super-secret", fileContent, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RemoveSecretReturnsFalseWhenEntryDoesNotExist() {
+        var filePath = CreateTemporaryFilePath();
+        var protector = new TestCredentialProtector();
+        var store = new FileMailSecretStore(filePath, protector);
+
+        var removed = await store.RemoveSecretAsync("work-imap", "password");
+
+        Assert.False(removed);
+    }
+
+    [Fact]
+    public async Task RemoveSecretDeletesStoredValue() {
+        var filePath = CreateTemporaryFilePath();
+        var protector = new TestCredentialProtector();
+        var store = new FileMailSecretStore(filePath, protector);
+
+        await store.SetSecretAsync("work-imap", "password", "super-secret");
+        var removed = await store.RemoveSecretAsync("work-imap", "password");
+        var loaded = await store.GetSecretAsync("work-imap", "password");
+
+        Assert.True(removed);
+        Assert.Null(loaded);
+    }
+
+    private static string CreateTemporaryFilePath() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, "secrets.json");
+    }
+
+    private sealed class TestCredentialProtector : ICredentialProtector {
+        public string Protect(string plainText) => Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"protected::{plainText}"));
+
+        public string Unprotect(string protectedData) {
+            var decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(protectedData));
+            return decoded.StartsWith("protected::", StringComparison.Ordinal)
+                ? decoded.Substring("protected::".Length)
+                : decoded;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationSmtpMailSendHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationSmtpMailSendHandlerTests.cs
@@ -1,0 +1,109 @@
+using Mailozaurr;
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationSmtpMailSendHandlerTests {
+    [Fact]
+    public async Task HandlerUsesInjectedSendDelegate() {
+        var handler = new SmtpMailSendHandler(
+            new FakeSmtpSessionFactory(),
+            sendAsync: (session, profile, request, message, cancellationToken) => {
+                Assert.Equal("sender@example.com", message.From.Mailboxes.First().Address);
+                Assert.Equal("alice@example.com", message.To.Mailboxes.First().Address);
+                Assert.Equal("Hello SMTP", message.Subject);
+                return Task.FromResult(new SmtpResult(true, EmailAction.Send, "alice@example.com", "sender@example.com", "smtp.example.com", 587, TimeSpan.Zero) {
+                    MessageId = "smtp-msg-123"
+                });
+            });
+
+        var result = await handler.SendAsync(
+            new MailProfile {
+                Id = "work-smtp",
+                DisplayName = "Work SMTP",
+                Kind = MailProfileKind.Smtp,
+                DefaultSender = "sender@example.com",
+                Settings = new Dictionary<string, string> {
+                    [MailProfileSettingsKeys.Server] = "smtp.example.com"
+                }
+            },
+            new SendMessageRequest {
+                ProfileId = "work-smtp",
+                Message = new DraftMessage {
+                    Subject = "Hello SMTP",
+                    TextBody = "hello",
+                    To = {
+                        new MessageRecipient { Address = "alice@example.com" }
+                    }
+                }
+            });
+
+        Assert.True(result.Succeeded);
+        Assert.False(result.Queued);
+        Assert.Equal("work-smtp", result.ProfileId);
+        Assert.Equal(MailProfileKind.Smtp, result.ProfileKind);
+        Assert.Equal("smtp-msg-123", result.ProviderMessageId);
+    }
+
+    [Fact]
+    public async Task HandlerReturnsQueuedResultWhenRepositoryCapturesFailedSend() {
+        var repository = new FilePendingMessageRepository(new PendingMessageRepositoryOptions {
+            DirectoryPath = CreateTemporaryDirectory()
+        });
+
+        var handler = new SmtpMailSendHandler(
+            new FakeSmtpSessionFactory(),
+            pendingMessageRepository: repository,
+            sendAsync: async (session, profile, request, message, cancellationToken) => {
+                await repository.SaveAsync(new PendingMessageRecord {
+                    MessageId = message.MessageId ?? "queued-1",
+                    Timestamp = DateTimeOffset.UtcNow,
+                    NextAttemptAt = DateTimeOffset.UtcNow,
+                    Provider = EmailProvider.None,
+                    MimeMessage = Convert.ToBase64String(Array.Empty<byte>())
+                }, cancellationToken).ConfigureAwait(false);
+
+                return new SmtpResult(false, EmailAction.Send, "alice@example.com", "sender@example.com", "smtp.example.com", 587, TimeSpan.Zero, error: "temporary smtp failure") {
+                    MessageId = message.MessageId ?? "queued-1"
+                };
+            });
+
+        var result = await handler.SendAsync(
+            new MailProfile {
+                Id = "work-smtp",
+                DisplayName = "Work SMTP",
+                Kind = MailProfileKind.Smtp,
+                DefaultSender = "sender@example.com",
+                Settings = new Dictionary<string, string> {
+                    [MailProfileSettingsKeys.Server] = "smtp.example.com"
+                }
+            },
+            new SendMessageRequest {
+                ProfileId = "work-smtp",
+                PreferQueue = true,
+                Message = new DraftMessage {
+                    Subject = "Hello SMTP",
+                    TextBody = "hello",
+                    To = {
+                        new MessageRecipient { Address = "alice@example.com" }
+                    }
+                }
+            });
+
+        Assert.True(result.Succeeded);
+        Assert.True(result.Queued);
+        Assert.NotNull(result.QueueMessageId);
+        Assert.Contains("queued", result.Message ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string CreateTemporaryDirectory() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private sealed class FakeSmtpSessionFactory : ISmtpSessionFactory {
+        public Task<Smtp> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new Smtp());
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationSmtpSessionFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationSmtpSessionFactoryTests.cs
@@ -1,0 +1,86 @@
+using MailKit.Security;
+using Mailozaurr;
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationSmtpSessionFactoryTests {
+    [Fact]
+    public async Task FactoryBuildsBasicAuthSessionRequestFromProfileAndSecrets() {
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("work-smtp", MailSecretNames.Password, "super-secret");
+
+        SmtpSessionRequest? captured = null;
+        var factory = new SmtpSessionFactory(secretStore, (request, _) => {
+            captured = request;
+            return Task.FromResult(new Smtp());
+        });
+
+        await factory.ConnectAsync(new MailProfile {
+            Id = "work-smtp",
+            DisplayName = "Work SMTP",
+            Kind = MailProfileKind.Smtp,
+            DefaultSender = "sender@example.com",
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Server] = "smtp.example.com",
+                [MailProfileSettingsKeys.Port] = "1587",
+                [MailProfileSettingsKeys.SecureSocketOptions] = SecureSocketOptions.StartTls.ToString(),
+                [MailProfileSettingsKeys.UseSsl] = "true"
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal("smtp.example.com", captured!.Server);
+        Assert.Equal(1587, captured.Port);
+        Assert.Equal(SecureSocketOptions.StartTls, captured.SecureSocketOptions);
+        Assert.True(captured.UseSsl);
+        Assert.Equal("sender@example.com", captured.UserName);
+        Assert.Equal("super-secret", captured.Password);
+        Assert.Equal(ProtocolAuthMode.Basic, captured.AuthMode);
+    }
+
+    [Fact]
+    public async Task FactoryUsesOAuthAccessTokenWhenConfigured() {
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("gmail-smtp", MailSecretNames.AccessToken, "oauth-token");
+
+        SmtpSessionRequest? captured = null;
+        var factory = new SmtpSessionFactory(secretStore, (request, _) => {
+            captured = request;
+            return Task.FromResult(new Smtp());
+        });
+
+        await factory.ConnectAsync(new MailProfile {
+            Id = "gmail-smtp",
+            DisplayName = "Gmail SMTP",
+            Kind = MailProfileKind.Smtp,
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Server] = "smtp.gmail.com",
+                [MailProfileSettingsKeys.UserName] = "user@gmail.com",
+                [MailProfileSettingsKeys.AuthMode] = "oauth2"
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal(ProtocolAuthMode.OAuth2, captured!.AuthMode);
+        Assert.Equal("oauth-token", captured.Password);
+        Assert.Equal("user@gmail.com", captured.UserName);
+    }
+
+    private sealed class InMemorySecretStore : IMailSecretStore {
+        private readonly Dictionary<string, string> _values = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            _values.TryGetValue($"{profileId}::{secretName}", out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_values.Remove($"{profileId}::{secretName}"));
+
+        public Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+            _values[$"{profileId}::{secretName}"] = secretValue;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/CliRunnerTests.cs
+++ b/Sources/Mailozaurr.Tests/CliRunnerTests.cs
@@ -1,0 +1,1601 @@
+#if NET8_0_OR_GREATER
+using System.Text.Json;
+using Mailozaurr.Application;
+using Mailozaurr.Cli;
+
+namespace Mailozaurr.Tests;
+
+public sealed class CliRunnerTests {
+    [Fact]
+    public async Task HelpIsShownWhenNoArgumentsAreProvided() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(Array.Empty<string>(), stdout, stderr, _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Mailozaurr CLI", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileListUsesApplicationProfilesService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "list", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("work-imap", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileListSummaryUsesSharedOverviewService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "list", "--summary", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("work-imap", fixture.ProfileAuthService.LastStatusProfileId);
+        Assert.Contains("\"SupportsRead\": true", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Summary\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileListSummaryCompactUsesSharedCompactProjection() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "list", "--summary", "--compact", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"Id\": \"work-imap\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("\"Profile\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileListSummarySupportsSharedFilters() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "list", "--summary", "--kind", "imap", "--can-read", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"Profile\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Kind\": 1", stdout.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("\"SupportsSend\": true", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileListSummarySupportsSharedSorting() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "z-smtp",
+            DisplayName = "SMTP Z",
+            Kind = MailProfileKind.Smtp,
+            DefaultSender = "alerts@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "smtp.example.com"
+            }
+        });
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "list", "--summary", "--sort", "id", "--desc", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"Id\": \"z-smtp\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.True(stdout.ToString().IndexOf("\"Id\": \"z-smtp\"", StringComparison.Ordinal) <
+                    stdout.ToString().IndexOf("\"Id\": \"work-imap\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ProfileCreateSavesProfileThroughApplicationService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "profile", "create",
+                "--profile", "alerts-imap",
+                "--kind", "imap",
+                "--name", "Alerts IMAP",
+                "--default-mailbox", "alerts@example.com",
+                "--setting", "server=imap.alerts.example.com",
+                "--setting", "port=993",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        var created = await fixture.ProfileStore.GetByIdAsync("alerts-imap");
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(created);
+        Assert.Equal(MailProfileKind.Imap, created!.Kind);
+        Assert.Equal("Alerts IMAP", created.DisplayName);
+        Assert.Equal("alerts@example.com", created.DefaultMailbox);
+        Assert.Equal("imap.alerts.example.com", created.Settings[MailProfileSettingsKeys.Server]);
+        Assert.Equal("993", created.Settings[MailProfileSettingsKeys.Port]);
+    }
+
+    [Fact]
+    public async Task ProfileGraphBootstrapSavesProfileAndSecretsThroughApplicationServices() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "profile", "graph-bootstrap",
+                "--profile", "graph-work",
+                "--name", "Work Graph",
+                "--mailbox", "shared@example.com",
+                "--client-id", "client-id",
+                "--tenant-id", "tenant-id",
+                "--client-secret", "client-secret",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        var profile = await fixture.ProfileStore.GetByIdAsync("graph-work");
+        var clientSecret = await fixture.SecretStore.GetSecretAsync("graph-work", MailSecretNames.ClientSecret);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(profile);
+        Assert.Equal(MailProfileKind.Graph, profile!.Kind);
+        Assert.Equal("shared@example.com", profile.DefaultMailbox);
+        Assert.Equal("shared@example.com", profile.Settings[MailProfileSettingsKeys.Mailbox]);
+        Assert.Equal("client-id", profile.Settings[MailProfileSettingsKeys.ClientId]);
+        Assert.Equal("tenant-id", profile.Settings[MailProfileSettingsKeys.TenantId]);
+        Assert.Equal("client-secret", clientSecret);
+    }
+
+    [Fact]
+    public async Task ProfileGmailBootstrapSavesProfileAndSecretsThroughApplicationServices() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "profile", "gmail-bootstrap",
+                "--profile", "gmail-work",
+                "--name", "Work Gmail",
+                "--mailbox", "me@example.com",
+                "--client-id", "client-id",
+                "--client-secret", "client-secret",
+                "--refresh-token", "refresh-token",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        var profile = await fixture.ProfileStore.GetByIdAsync("gmail-work");
+        var clientSecret = await fixture.SecretStore.GetSecretAsync("gmail-work", MailSecretNames.ClientSecret);
+        var refreshToken = await fixture.SecretStore.GetSecretAsync("gmail-work", MailSecretNames.RefreshToken);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(profile);
+        Assert.Equal(MailProfileKind.Gmail, profile!.Kind);
+        Assert.Equal("me@example.com", profile.DefaultMailbox);
+        Assert.Equal("me@example.com", profile.Settings[MailProfileSettingsKeys.Mailbox]);
+        Assert.Equal("client-id", profile.Settings[MailProfileSettingsKeys.ClientId]);
+        Assert.Equal("client-secret", clientSecret);
+        Assert.Equal("refresh-token", refreshToken);
+    }
+
+    [Fact]
+    public async Task ProfileDoctorReportsMissingGmailAuthenticationMaterial() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-broken",
+            DisplayName = "Broken Gmail",
+            Kind = MailProfileKind.Gmail,
+            DefaultMailbox = "me@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "me@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "doctor", "--profile", "gmail-broken", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("profile_not_ready", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Gmail profiles need an access token", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileGmailLoginPersistsTokensThroughApplicationService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-login",
+            DisplayName = "Gmail Login",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "user@gmail.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("gmail-login", MailSecretNames.ClientSecret, "client-secret");
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "gmail-login", "--profile", "gmail-login", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        var accessToken = await fixture.SecretStore.GetSecretAsync("gmail-login", MailSecretNames.AccessToken);
+        var refreshToken = await fixture.SecretStore.GetSecretAsync("gmail-login", MailSecretNames.RefreshToken);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("gmail-access-token", accessToken);
+        Assert.Equal("gmail-refresh-token", refreshToken);
+        Assert.NotNull(fixture.ProfileAuthService.LastGmailRequest);
+        Assert.Equal("user@gmail.com", fixture.ProfileAuthService.LastGmailRequest!.GmailAccount);
+    }
+
+    [Fact]
+    public async Task ProfileGraphLoginPersistsAccessTokenThroughApplicationService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "graph-login",
+            DisplayName = "Graph Login",
+            Kind = MailProfileKind.Graph,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.ClientId] = "client-id",
+                [MailProfileSettingsKeys.TenantId] = "tenant-id"
+            }
+        });
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "graph-login", "--profile", "graph-login", "--login", "user@example.com", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        var accessToken = await fixture.SecretStore.GetSecretAsync("graph-login", MailSecretNames.AccessToken);
+        var profile = await fixture.ProfileStore.GetByIdAsync("graph-login");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("graph-access-token", accessToken);
+        Assert.NotNull(profile);
+        Assert.Equal("user@example.com", profile!.DefaultMailbox);
+        Assert.Equal("user@example.com", profile.Settings[MailProfileSettingsKeys.Mailbox]);
+        Assert.Equal("https://login.microsoftonline.com/common/oauth2/nativeclient", profile.Settings[MailProfileSettingsKeys.RedirectUri]);
+        Assert.NotNull(fixture.ProfileAuthService.LastGraphRequest);
+        Assert.Equal("user@example.com", fixture.ProfileAuthService.LastGraphRequest!.Login);
+    }
+
+    [Fact]
+    public async Task ProfileRefreshAuthDelegatesToSharedAuthService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-refresh",
+            DisplayName = "Gmail Refresh",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "refresh@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("gmail-refresh", MailSecretNames.ClientSecret, "client-secret");
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "refresh-auth", "--profile", "gmail-refresh", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, fixture.ProfileAuthService.RefreshCalls);
+        Assert.Equal("gmail-refresh", fixture.ProfileAuthService.LastRefreshProfileId);
+        Assert.Contains("ProfileId", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileAuthStatusDelegatesToSharedAuthService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "auth-status", "--profile", "work-imap", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("work-imap", fixture.ProfileAuthService.LastStatusProfileId);
+        Assert.Contains("\"Mode\": \"basic\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileSummaryUsesSharedOverviewService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "summary", "--profile", "work-imap", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("work-imap", fixture.ProfileAuthService.LastStatusProfileId);
+        Assert.Contains("\"SupportsRead\": true", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"IsReady\": true", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileSummaryCompactUsesSharedCompactProjection() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "summary", "--profile", "work-imap", "--compact", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"Id\": \"work-imap\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("\"Profile\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileTestDelegatesToSharedConnectionService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "test", "--profile", "work-imap", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("work-imap", fixture.ProfileConnectionService.LastProfileId);
+        Assert.Contains("\"Probe\": \"connect\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileTestParsesRequestedScope() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "test", "--profile", "work-imap", "--scope", "send", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(MailProfileConnectionTestScope.Send, fixture.ProfileConnectionService.LastScope);
+        Assert.Contains("\"RequestedScope\": 3", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileCapabilitiesUsesApplicationProfileService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "capabilities", "--profile", "work-imap", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"Kind\": 1", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Capabilities\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProfileSetSecretPersistsSecretThroughApplicationService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "profile", "set-secret",
+                "--profile", "work-imap",
+                "--name", MailSecretNames.Password,
+                "--value", "super-secret",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        var secretValue = await fixture.SecretStore.GetSecretAsync("work-imap", MailSecretNames.Password);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("super-secret", secretValue);
+    }
+
+    [Fact]
+    public async Task ProfileRemoveSecretDeletesSecretThroughApplicationService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        await fixture.SecretStore.SetSecretAsync("work-imap", MailSecretNames.Password, "super-secret");
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "profile", "remove-secret",
+                "--profile", "work-imap",
+                "--name", MailSecretNames.Password,
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        var secretValue = await fixture.SecretStore.GetSecretAsync("work-imap", MailSecretNames.Password);
+
+        Assert.Equal(0, exitCode);
+        Assert.Null(secretValue);
+    }
+
+    [Fact]
+    public async Task ProfileDeleteRemovesProfileThroughApplicationService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "delete", "--profile", "work-imap", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        var profile = await fixture.ProfileStore.GetByIdAsync("work-imap");
+
+        Assert.Equal(0, exitCode);
+        Assert.Null(profile);
+    }
+
+    [Fact]
+    public async Task ProfileSetDefaultUpdatesProfileThroughApplicationService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "profile", "set-default", "--profile", "work-imap", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        var profile = await fixture.ProfileStore.GetByIdAsync("work-imap");
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(profile);
+        Assert.True(profile!.IsDefault);
+    }
+
+    [Fact]
+    public async Task MailFoldersUsesApplicationReadService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "folders", "--profile", "work-imap", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"Inbox\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailFoldersCompactUsesApplicationReadService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "folders", "--profile", "work-imap", "--compact", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ReadService.LastFolderCompactQuery);
+        Assert.Equal("work-imap", fixture.ReadService.LastFolderCompactQuery!.ProfileId);
+        Assert.Contains("\"Summary\": \"inbox Inbox\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailSearchUsesApplicationReadService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "search", "--profile", "work-imap", "--query", "reports", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"msg-1\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailSearchCompactUsesApplicationReadService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "search", "--profile", "work-imap", "--query", "reports", "--compact", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ReadService.LastSearchCompactRequest);
+        Assert.Equal("work-imap", fixture.ReadService.LastSearchCompactRequest!.ProfileId);
+        Assert.Equal("reports", fixture.ReadService.LastSearchCompactRequest.QueryText);
+        Assert.Contains("\"Summary\": \"msg-1 reports\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailGetPassesMailboxToApplicationReadService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "get",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--message-id", "msg-42",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ReadService.LastGetRequest);
+        Assert.Equal("shared@example.com", fixture.ReadService.LastGetRequest!.MailboxId);
+        Assert.Equal("msg-42", fixture.ReadService.LastGetRequest.MessageId);
+    }
+
+    [Fact]
+    public async Task MailGetCompactUsesApplicationReadService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "get",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--message-id", "msg-42",
+                "--compact",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ReadService.LastGetCompactRequest);
+        Assert.Equal("shared@example.com", fixture.ReadService.LastGetCompactRequest!.MailboxId);
+        Assert.Equal("msg-42", fixture.ReadService.LastGetCompactRequest.MessageId);
+        Assert.Contains("\"SummaryText\": \"msg-42 Subject\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailAttachmentsUsesApplicationReadService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "attachments",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--message-id", "msg-42",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ReadService.LastListAttachmentsRequest);
+        Assert.Equal("shared@example.com", fixture.ReadService.LastListAttachmentsRequest!.MailboxId);
+        Assert.Equal("msg-42", fixture.ReadService.LastListAttachmentsRequest.MessageId);
+        Assert.Contains("\"report.pdf\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailSaveAttachmentPassesMailboxToApplicationReadService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "save-attachment",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--message-id", "msg-42",
+                "--attachment-id", "1",
+                "--path", "C:\\Temp\\report.pdf",
+                "--overwrite",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ReadService.LastSaveAttachmentRequest);
+        Assert.Equal("shared@example.com", fixture.ReadService.LastSaveAttachmentRequest!.MailboxId);
+        Assert.Equal("1", fixture.ReadService.LastSaveAttachmentRequest.AttachmentId);
+        Assert.True(fixture.ReadService.LastSaveAttachmentRequest.Overwrite);
+    }
+
+    [Fact]
+    public async Task MailSaveAttachmentsUsesApplicationReadService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "save-attachments",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--message-id", "msg-42",
+                "--path", "C:\\Temp",
+                "--attachment-id", "att-1",
+                "--name-contains", "report",
+                "--content-type", "pdf",
+                "--overwrite",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ReadService.LastSaveAttachmentsRequest);
+        Assert.Equal("shared@example.com", fixture.ReadService.LastSaveAttachmentsRequest!.MailboxId);
+        Assert.Equal("msg-42", fixture.ReadService.LastSaveAttachmentsRequest.MessageId);
+        Assert.Equal("C:\\Temp", fixture.ReadService.LastSaveAttachmentsRequest.DestinationPath);
+        Assert.Contains("att-1", fixture.ReadService.LastSaveAttachmentsRequest.AttachmentIds);
+        Assert.Equal("report", fixture.ReadService.LastSaveAttachmentsRequest.FileNameContains);
+        Assert.Equal("pdf", fixture.ReadService.LastSaveAttachmentsRequest.ContentTypeContains);
+        Assert.True(fixture.ReadService.LastSaveAttachmentsRequest.Overwrite);
+    }
+
+    [Fact]
+    public async Task QueueListUsesApplicationQueueService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "queue", "list", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"queued-1\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task QueueListCompactUsesApplicationQueueService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "queue", "list", "--compact", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"MessageId\": \"queued-1\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("\"QueuedAt\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task QueueGetUsesApplicationQueueService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "queue", "get", "--message-id", "queued-1", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("queued-1", fixture.QueueService.LastGetMessageId);
+    }
+
+    [Fact]
+    public async Task QueueGetCompactUsesApplicationQueueService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "queue", "get", "--message-id", "queued-1", "--compact", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"MessageId\": \"queued-1\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("\"QueuedAt\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task QueueProcessUsesApplicationQueueService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "queue", "process", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, fixture.QueueService.ProcessCalls);
+    }
+
+    [Fact]
+    public async Task DraftSaveUsesApplicationDraftService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "draft", "save",
+                "--draft", "draft-1",
+                "--name", "Quarterly report",
+                "--profile", "work-imap",
+                "--to", "alice@example.com",
+                "--subject", "Quarterly report",
+                "--text", "Body",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.DraftService.LastSavedDraft);
+        Assert.Equal("draft-1", fixture.DraftService.LastSavedDraft!.Id);
+        Assert.Equal("work-imap", fixture.DraftService.LastSavedDraft.Message.ProfileId);
+    }
+
+    [Fact]
+    public async Task DraftListCompactUsesApplicationDraftService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "draft", "list", "--compact", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"Id\": \"draft-1\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("\"Message\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DraftGetCompactUsesApplicationDraftService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "draft", "get", "--draft", "draft-1", "--compact", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"Id\": \"draft-1\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("\"Message\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DraftSaveFromFileUsesDraftExchangeService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        var importPath = CreateTemporaryFilePath("import-draft.json");
+        await File.WriteAllTextAsync(importPath, JsonSerializer.Serialize(new MailDraft {
+            Id = "imported-draft",
+            Name = "Imported draft",
+            Message = new DraftMessage {
+                ProfileId = "work-imap",
+                Subject = "Imported subject",
+                To = {
+                    new MessageRecipient { Address = "imported@example.com" }
+                }
+            }
+        }));
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "draft", "save",
+                "--file", importPath,
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(importPath, fixture.DraftExchangeService.LastLoadedPath);
+        Assert.NotNull(fixture.DraftService.LastSavedDraft);
+        Assert.Equal("imported-draft", fixture.DraftService.LastSavedDraft!.Id);
+    }
+
+    [Fact]
+    public async Task DraftExportUsesDraftExchangeService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        var exportPath = CreateTemporaryFilePath("export-draft.json");
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "draft", "export",
+                "--draft", "draft-1",
+                "--path", exportPath,
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("draft-1", fixture.DraftService.LastRequestedDraftId);
+        Assert.Equal(exportPath, fixture.DraftExchangeService.LastSavedPath);
+    }
+
+    [Fact]
+    public async Task SendUsingDraftUsesApplicationDraftService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "send",
+                "--draft", "draft-1",
+                "--send-now",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("draft-1", fixture.DraftService.LastRequestedDraftId);
+        Assert.NotNull(fixture.SendService.LastRequest);
+        Assert.Equal("work-imap", fixture.SendService.LastRequest!.ProfileId);
+        Assert.Equal("saved@example.com", fixture.SendService.LastRequest.Message.To[0].Address);
+    }
+
+    [Fact]
+    public async Task SendUsingFileUsesDraftExchangeService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        var importPath = CreateTemporaryFilePath("send-draft.json");
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "send",
+                "--file", importPath,
+                "--send-now",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(importPath, fixture.DraftExchangeService.LastLoadedPath);
+        Assert.NotNull(fixture.SendService.LastRequest);
+        Assert.Equal("work-imap", fixture.SendService.LastRequest!.ProfileId);
+        Assert.True(fixture.SendService.LastRequest.RequireImmediateSend);
+        Assert.False(fixture.SendService.LastRequest.PreferQueue);
+        Assert.Equal("imported@example.com", fixture.SendService.LastRequest.Message.To[0].Address);
+        Assert.Equal("Imported subject", fixture.SendService.LastRequest.Message.Subject);
+    }
+
+    [Fact]
+    public async Task SendUsesApplicationSendService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "send",
+                "--profile", "work-imap",
+                "--from", "sender@example.com",
+                "--to", "alice@example.com",
+                "--to", "bob@example.com",
+                "--cc", "carol@example.com",
+                "--reply-to", "reply@example.com",
+                "--subject", "Quarterly report",
+                "--text", "Plain text body",
+                "--html", "<b>HTML body</b>",
+                "--header", "X-Test=value",
+                "--attachment", "C:\\Temp\\report.pdf",
+                "--send-now",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.SendService.LastRequest);
+        Assert.Equal("work-imap", fixture.SendService.LastRequest!.ProfileId);
+        Assert.True(fixture.SendService.LastRequest.RequireImmediateSend);
+        Assert.False(fixture.SendService.LastRequest.PreferQueue);
+        Assert.Equal("sender@example.com", fixture.SendService.LastRequest.Message.From!.Address);
+        Assert.Equal(2, fixture.SendService.LastRequest.Message.To.Count);
+        Assert.Equal("alice@example.com", fixture.SendService.LastRequest.Message.To[0].Address);
+        Assert.Equal("carol@example.com", fixture.SendService.LastRequest.Message.Cc[0].Address);
+        Assert.Equal("reply@example.com", fixture.SendService.LastRequest.Message.ReplyTo[0].Address);
+        Assert.Equal("Quarterly report", fixture.SendService.LastRequest.Message.Subject);
+        Assert.Equal("Plain text body", fixture.SendService.LastRequest.Message.TextBody);
+        Assert.Equal("<b>HTML body</b>", fixture.SendService.LastRequest.Message.HtmlBody);
+        Assert.Equal("value", fixture.SendService.LastRequest.Message.Headers["X-Test"]);
+        Assert.Equal("C:\\Temp\\report.pdf", fixture.SendService.LastRequest.Message.Attachments[0].Path);
+    }
+
+    private static TestApplicationFixture CreateFixture() => new();
+
+    private sealed class InMemoryProfileStore : IMailProfileStore {
+        private readonly Dictionary<string, MailProfile> _profiles;
+
+        public InMemoryProfileStore(IEnumerable<MailProfile> profiles) {
+            _profiles = profiles.ToDictionary(profile => profile.Id, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public Task<IReadOnlyList<MailProfile>> GetAllAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailProfile>>(_profiles.Values.ToArray());
+
+        public Task<MailProfile?> GetByIdAsync(string profileId, CancellationToken cancellationToken = default) {
+            _profiles.TryGetValue(profileId, out var profile);
+            return Task.FromResult(profile);
+        }
+
+        public Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_profiles.Remove(profileId));
+
+        public Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+            _profiles[profile.Id] = profile;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class InMemorySecretStore : IMailSecretStore {
+        private readonly Dictionary<string, Dictionary<string, string>> _secrets = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            if (_secrets.TryGetValue(profileId, out var profileSecrets) &&
+                profileSecrets.TryGetValue(secretName, out var secretValue)) {
+                return Task.FromResult<string?>(secretValue);
+            }
+
+            return Task.FromResult<string?>(null);
+        }
+
+        public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            var removed = _secrets.TryGetValue(profileId, out var profileSecrets) &&
+                          profileSecrets.Remove(secretName);
+            return Task.FromResult(removed);
+        }
+
+        public Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+            if (!_secrets.TryGetValue(profileId, out var profileSecrets)) {
+                profileSecrets = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                _secrets[profileId] = profileSecrets;
+            }
+
+            profileSecrets[secretName] = secretValue;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeReadService : IMailReadService {
+        public GetMessageRequest? LastGetCompactRequest { get; private set; }
+
+        public SaveAttachmentsRequest? LastSaveAttachmentsRequest { get; private set; }
+
+        public ListAttachmentsRequest? LastListAttachmentsRequest { get; private set; }
+
+        public MailFolderQuery? LastFolderCompactQuery { get; private set; }
+
+        public MailSearchRequest? LastSearchCompactRequest { get; private set; }
+
+        public GetMessageRequest? LastGetRequest { get; private set; }
+
+        public SaveAttachmentRequest? LastSaveAttachmentRequest { get; private set; }
+
+        public Task<MessageDetail?> GetMessageAsync(GetMessageRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MessageDetail?>(CaptureGetRequest(request));
+
+        public Task<MessageDetailCompact?> GetMessageCompactAsync(GetMessageRequest request, CancellationToken cancellationToken = default) {
+            LastGetCompactRequest = request;
+            return Task.FromResult<MessageDetailCompact?>(new MessageDetailCompact {
+                ProfileId = request.ProfileId,
+                Id = request.MessageId,
+                Summary = new MessageSummaryCompact {
+                    ProfileId = request.ProfileId,
+                    Id = request.MessageId,
+                    Subject = "Subject",
+                    Summary = $"{request.MessageId} Subject"
+                },
+                TextBodyPreview = "Body",
+                SummaryText = $"{request.MessageId} Subject"
+            });
+        }
+
+        private MessageDetail CaptureGetRequest(GetMessageRequest request) {
+            LastGetRequest = request;
+            return new MessageDetail {
+                ProfileId = request.ProfileId,
+                Id = request.MessageId,
+                Summary = new MessageSummary {
+                    ProfileId = request.ProfileId,
+                    Id = request.MessageId,
+                    Subject = "Subject"
+                },
+                TextBody = "Body"
+            };
+        }
+
+        public Task<IReadOnlyList<FolderRefCompact>> GetFoldersCompactAsync(MailFolderQuery query, CancellationToken cancellationToken = default) {
+            LastFolderCompactQuery = query;
+            return Task.FromResult<IReadOnlyList<FolderRefCompact>>(new[] {
+                new FolderRefCompact {
+                    ProfileId = query.ProfileId,
+                    MailboxId = query.MailboxId,
+                    Id = "inbox",
+                    DisplayName = "Inbox",
+                    Path = "Inbox",
+                    Summary = "inbox Inbox"
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailFolderQuery query, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<FolderRef>>(new[] {
+                new FolderRef {
+                    ProfileId = query.ProfileId,
+                    MailboxId = query.MailboxId,
+                    Id = "inbox",
+                    DisplayName = "Inbox",
+                    Path = "Inbox"
+                }
+            });
+
+        public Task<OperationResult> SaveAttachmentAsync(SaveAttachmentRequest request, CancellationToken cancellationToken = default) {
+            LastSaveAttachmentRequest = request;
+            return Task.FromResult(OperationResult.Success("Attachment saved."));
+        }
+
+        public Task<SaveAttachmentsResult> SaveAttachmentsAsync(SaveAttachmentsRequest request, CancellationToken cancellationToken = default) {
+            LastSaveAttachmentsRequest = request;
+            return Task.FromResult(new SaveAttachmentsResult {
+                Succeeded = true,
+                ProfileId = request.ProfileId,
+                MessageId = request.MessageId,
+                MatchedCount = 1,
+                AttemptedCount = 1,
+                SavedCount = 1,
+                FailedCount = 0,
+                Message = "Saved 1 attachment(s).",
+                Results = {
+                    new SavedAttachmentResult {
+                        Succeeded = true,
+                        AttachmentId = "att-1",
+                        FileName = "report.pdf",
+                        ContentType = "application/pdf"
+                    }
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<MessageSummaryCompact>> SearchCompactAsync(MailSearchRequest request, CancellationToken cancellationToken = default) {
+            LastSearchCompactRequest = request;
+            return Task.FromResult<IReadOnlyList<MessageSummaryCompact>>(new[] {
+                new MessageSummaryCompact {
+                    ProfileId = request.ProfileId,
+                    Id = "msg-1",
+                    Subject = request.QueryText,
+                    Summary = $"msg-1 {request.QueryText}"
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<AttachmentSummary>> GetAttachmentsAsync(ListAttachmentsRequest request, CancellationToken cancellationToken = default) {
+            LastListAttachmentsRequest = request;
+            return Task.FromResult<IReadOnlyList<AttachmentSummary>>(new[] {
+                new AttachmentSummary {
+                    MessageId = request.MessageId,
+                    Id = "att-1",
+                    FileName = "report.pdf",
+                    SizeInBytes = 2048
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<MessageSummary>> SearchAsync(MailSearchRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MessageSummary>>(new[] {
+                new MessageSummary {
+                    ProfileId = request.ProfileId,
+                    Id = "msg-1",
+                    Subject = request.QueryText
+                }
+            });
+    }
+
+    private sealed class FakeSendService : IMailSendService {
+        public SendMessageRequest? LastRequest { get; private set; }
+
+        public Task<SendResult> SendAsync(SendMessageRequest request, CancellationToken cancellationToken = default) {
+            LastRequest = request;
+            return Task.FromResult(new SendResult {
+                Succeeded = true,
+                ProfileId = request.ProfileId,
+                ProfileKind = MailProfileKind.Imap,
+                ProviderMessageId = "provider-1",
+                Message = "Message sent successfully."
+            });
+        }
+    }
+
+    private sealed class FakeQueueService : IMailQueueService {
+        public string? LastGetMessageId { get; private set; }
+
+        public string? LastRemoveMessageId { get; private set; }
+
+        public int ProcessCalls { get; private set; }
+
+        public Task<QueuedMessageCompact?> GetCompactAsync(string messageId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<QueuedMessageCompact?>(new QueuedMessageCompact {
+                MessageId = messageId,
+                Provider = "Gmail",
+                ProfileKind = MailProfileKind.Gmail,
+                NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(1),
+                AttemptCount = 0,
+                IsDue = false,
+                HasProviderData = false,
+                Summary = $"{messageId} [Gmail] attempts=0"
+            });
+
+        public Task<QueuedMessageSummary?> GetAsync(string messageId, CancellationToken cancellationToken = default) {
+            LastGetMessageId = messageId;
+            return Task.FromResult<QueuedMessageSummary?>(new QueuedMessageSummary {
+                MessageId = messageId,
+                Provider = "Gmail",
+                ProfileKind = MailProfileKind.Gmail,
+                QueuedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+                NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(1)
+            });
+        }
+
+        public Task<IReadOnlyList<QueuedMessageCompact>> ListCompactAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<QueuedMessageCompact>>(new[] {
+                new QueuedMessageCompact {
+                    MessageId = "queued-1",
+                    Provider = "Gmail",
+                    ProfileKind = MailProfileKind.Gmail,
+                    NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(1),
+                    AttemptCount = 1,
+                    IsDue = false,
+                    HasProviderData = true,
+                    Summary = "queued-1 [Gmail] attempts=1"
+                }
+            });
+
+        public Task<IReadOnlyList<QueuedMessageSummary>> ListAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<QueuedMessageSummary>>(new[] {
+                new QueuedMessageSummary {
+                    MessageId = "queued-1",
+                    Provider = "Gmail",
+                    ProfileKind = MailProfileKind.Gmail,
+                    QueuedAt = DateTimeOffset.UtcNow.AddMinutes(-10),
+                    NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(1),
+                    AttemptCount = 1,
+                    HasProviderData = true
+                }
+            });
+
+        public Task<QueueProcessResult> ProcessAsync(CancellationToken cancellationToken = default) {
+            ProcessCalls++;
+            return Task.FromResult(new QueueProcessResult {
+                Succeeded = true,
+                AttemptedCount = 1,
+                SentCount = 1,
+                Message = "Queue processing completed."
+            });
+        }
+
+        public Task<OperationResult> RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+            LastRemoveMessageId = messageId;
+            return Task.FromResult(OperationResult.Success("Queued message removed."));
+        }
+    }
+
+    private sealed class FakeDraftService : IMailDraftService {
+        public string? LastRequestedDraftId { get; private set; }
+
+        public MailDraft? LastSavedDraft { get; private set; }
+
+        public Task<MailDraftCompact?> GetDraftCompactAsync(string draftId, CancellationToken cancellationToken = default) {
+            LastRequestedDraftId = draftId;
+            return Task.FromResult<MailDraftCompact?>(new MailDraftCompact {
+                Id = draftId,
+                Name = "Saved draft",
+                ProfileId = "work-imap",
+                Subject = "Saved subject",
+                ToCount = 1,
+                AttachmentCount = 0,
+                UpdatedAt = DateTimeOffset.UtcNow,
+                Summary = $"{draftId} [work-imap] Saved draft"
+            });
+        }
+
+        public Task<MailDraft?> GetDraftAsync(string draftId, CancellationToken cancellationToken = default) {
+            LastRequestedDraftId = draftId;
+            return Task.FromResult<MailDraft?>(new MailDraft {
+                Id = draftId,
+                Name = "Saved draft",
+                Message = new DraftMessage {
+                    ProfileId = "work-imap",
+                    Subject = "Saved subject",
+                    To = {
+                        new MessageRecipient { Address = "saved@example.com" }
+                    }
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<MailDraftCompact>> GetDraftsCompactAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailDraftCompact>>(new[] {
+                new MailDraftCompact {
+                    Id = "draft-1",
+                    Name = "Saved draft",
+                    ProfileId = "work-imap",
+                    Subject = "Saved subject",
+                    ToCount = 0,
+                    AttachmentCount = 0,
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                    Summary = "draft-1 [work-imap] Saved draft"
+                }
+            });
+
+        public Task<IReadOnlyList<MailDraft>> GetDraftsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailDraft>>(new[] {
+                new MailDraft {
+                    Id = "draft-1",
+                    Name = "Saved draft",
+                    Message = new DraftMessage {
+                        ProfileId = "work-imap",
+                        Subject = "Saved subject"
+                    }
+                }
+            });
+
+        public Task<OperationResult> SaveAsync(MailDraft draft, CancellationToken cancellationToken = default) {
+            LastSavedDraft = draft;
+            return Task.FromResult(OperationResult.Success("Draft saved."));
+        }
+
+        public Task<OperationResult> DeleteAsync(string draftId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success("Draft deleted."));
+    }
+
+    private sealed class FakeDraftExchangeService : IMailDraftExchangeService {
+        public string? LastLoadedPath { get; private set; }
+
+        public string? LastSavedPath { get; private set; }
+
+        public Task<MailDraft> LoadAsync(string path, CancellationToken cancellationToken = default) {
+            LastLoadedPath = path;
+            return Task.FromResult(new MailDraft {
+                Id = "imported-draft",
+                Name = "Imported draft",
+                Message = new DraftMessage {
+                    ProfileId = "work-imap",
+                    Subject = "Imported subject",
+                    To = {
+                        new MessageRecipient { Address = "imported@example.com" }
+                    }
+                }
+            });
+        }
+
+        public Task SaveAsync(string path, MailDraft draft, CancellationToken cancellationToken = default) {
+            LastSavedPath = path;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeProfileAuthService : IMailProfileAuthService {
+        private readonly InMemoryProfileStore _profileStore;
+        private readonly InMemorySecretStore _secretStore;
+
+        public FakeProfileAuthService(InMemoryProfileStore profileStore, InMemorySecretStore secretStore) {
+            _profileStore = profileStore;
+            _secretStore = secretStore;
+        }
+
+        public GmailProfileLoginRequest? LastGmailRequest { get; private set; }
+
+        public GraphProfileLoginRequest? LastGraphRequest { get; private set; }
+
+        public string? LastRefreshProfileId { get; private set; }
+
+        public string? LastStatusProfileId { get; private set; }
+
+        public int RefreshCalls { get; private set; }
+
+        public async Task<MailProfileAuthStatus?> GetStatusAsync(string profileId, CancellationToken cancellationToken = default) {
+            LastStatusProfileId = profileId;
+            var profile = await _profileStore.GetByIdAsync(profileId, cancellationToken);
+            if (profile == null) {
+                return null;
+            }
+
+            var accessToken = await _secretStore.GetSecretAsync(profileId, MailSecretNames.AccessToken, cancellationToken);
+            var refreshToken = await _secretStore.GetSecretAsync(profileId, MailSecretNames.RefreshToken, cancellationToken);
+            var clientSecret = await _secretStore.GetSecretAsync(profileId, MailSecretNames.ClientSecret, cancellationToken);
+            var password = await _secretStore.GetSecretAsync(profileId, MailSecretNames.Password, cancellationToken);
+
+            return new MailProfileAuthStatus {
+                ProfileId = profile.Id,
+                ProfileKind = profile.Kind,
+                AuthFlow = profile.Settings.TryGetValue(MailProfileSettingsKeys.AuthFlow, out var authFlow) ? authFlow : null,
+                Mode = profile.Kind == MailProfileKind.Imap && !string.IsNullOrWhiteSpace(password) ? "basic" : "interactive",
+                Mailbox = profile.DefaultMailbox,
+                HasAccessToken = !string.IsNullOrWhiteSpace(accessToken),
+                HasRefreshToken = !string.IsNullOrWhiteSpace(refreshToken),
+                HasClientSecret = !string.IsNullOrWhiteSpace(clientSecret),
+                HasPassword = !string.IsNullOrWhiteSpace(password),
+                CanRefresh = profile.Kind is MailProfileKind.Gmail or MailProfileKind.Graph,
+                CanLoginInteractively = profile.Kind is MailProfileKind.Gmail or MailProfileKind.Graph,
+                Summary = $"{profile.Id} [{profile.Kind}] auth status available."
+            };
+        }
+
+        public async Task<MailProfileAuthenticationResult> LoginGmailAsync(GmailProfileLoginRequest request, CancellationToken cancellationToken = default) {
+            var profile = await _profileStore.GetByIdAsync(request.ProfileId, cancellationToken);
+            Assert.NotNull(profile);
+            var savedProfile = profile!;
+            var account = request.GmailAccount
+                ?? (savedProfile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) ? mailbox : null)
+                ?? "user@gmail.com";
+            LastGmailRequest = new GmailProfileLoginRequest {
+                ProfileId = request.ProfileId,
+                GmailAccount = account,
+                ClientId = request.ClientId ?? (savedProfile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientId) ? clientId : null),
+                ClientSecret = request.ClientSecret,
+                Scopes = request.Scopes
+            };
+            savedProfile.Settings[MailProfileSettingsKeys.Mailbox] = account;
+            savedProfile.Settings[MailProfileSettingsKeys.ClientId] = request.ClientId ?? savedProfile.Settings[MailProfileSettingsKeys.ClientId];
+            savedProfile.DefaultMailbox = account;
+            await _profileStore.SaveAsync(savedProfile, cancellationToken);
+            await _secretStore.SetSecretAsync(request.ProfileId, MailSecretNames.AccessToken, "gmail-access-token", cancellationToken);
+            await _secretStore.SetSecretAsync(request.ProfileId, MailSecretNames.RefreshToken, "gmail-refresh-token", cancellationToken);
+            return new MailProfileAuthenticationResult {
+                Succeeded = true,
+                Message = "Gmail login completed.",
+                ProfileId = request.ProfileId,
+                ProfileKind = MailProfileKind.Gmail,
+                UserName = account
+            };
+        }
+
+        public async Task<MailProfileAuthenticationResult> LoginGraphAsync(GraphProfileLoginRequest request, CancellationToken cancellationToken = default) {
+            LastGraphRequest = request;
+            var profile = await _profileStore.GetByIdAsync(request.ProfileId, cancellationToken);
+            var mailbox = request.Mailbox ?? request.Login ?? "user@example.com";
+            profile!.Settings[MailProfileSettingsKeys.Mailbox] = mailbox;
+            profile.Settings[MailProfileSettingsKeys.RedirectUri] = request.RedirectUri ?? "https://login.microsoftonline.com/common/oauth2/nativeclient";
+            profile.DefaultMailbox = mailbox;
+            await _profileStore.SaveAsync(profile, cancellationToken);
+            await _secretStore.SetSecretAsync(request.ProfileId, MailSecretNames.AccessToken, "graph-access-token", cancellationToken);
+            return new MailProfileAuthenticationResult {
+                Succeeded = true,
+                Message = "Graph login completed.",
+                ProfileId = request.ProfileId,
+                ProfileKind = MailProfileKind.Graph,
+                UserName = request.Login ?? mailbox
+            };
+        }
+
+        public async Task<MailProfileAuthenticationResult> RefreshAsync(string profileId, CancellationToken cancellationToken = default) {
+            RefreshCalls++;
+            LastRefreshProfileId = profileId;
+            var profile = await _profileStore.GetByIdAsync(profileId, cancellationToken);
+            Assert.NotNull(profile);
+            return profile!.Kind switch {
+                MailProfileKind.Gmail => await LoginGmailAsync(new GmailProfileLoginRequest { ProfileId = profileId }, cancellationToken),
+                MailProfileKind.Graph => await LoginGraphAsync(new GraphProfileLoginRequest { ProfileId = profileId }, cancellationToken),
+                _ => new MailProfileAuthenticationResult {
+                    Succeeded = false,
+                    Code = "refresh_not_supported",
+                    Message = "Refresh not supported.",
+                    ProfileId = profileId,
+                    ProfileKind = profile.Kind
+                }
+            };
+        }
+    }
+
+    private sealed class FakeProfileConnectionService : IMailProfileConnectionService {
+        public string? LastProfileId { get; private set; }
+
+        public MailProfileConnectionTestScope LastScope { get; private set; }
+
+        public Task<MailProfileConnectionTestResult> TestAsync(
+            string profileId,
+            MailProfileConnectionTestScope scope = MailProfileConnectionTestScope.Auto,
+            CancellationToken cancellationToken = default) {
+            LastProfileId = profileId;
+            LastScope = scope;
+            return Task.FromResult(new MailProfileConnectionTestResult {
+                Succeeded = true,
+                Message = "Profile connection succeeded.",
+                ProfileId = profileId,
+                ProfileKind = MailProfileKind.Imap,
+                Probe = "connect",
+                Target = "work@example.com",
+                RequestedScope = scope,
+                ExecutedScope = scope == MailProfileConnectionTestScope.Auto ? MailProfileConnectionTestScope.Auth : scope
+            });
+        }
+    }
+
+    private sealed class TestApplicationFixture {
+        public TestApplicationFixture() {
+            ProfileStore = new InMemoryProfileStore(new[] {
+                new MailProfile {
+                    Id = "work-imap",
+                    DisplayName = "Work IMAP",
+                    Kind = MailProfileKind.Imap,
+                    Settings = new Dictionary<string, string> {
+                        [MailProfileSettingsKeys.Server] = "imap.example.com"
+                    }
+                }
+            });
+            SecretStore = new InMemorySecretStore();
+            SecretStore.SetSecretAsync("work-imap", MailSecretNames.Password, "secret").GetAwaiter().GetResult();
+            ProfileAuthService = new FakeProfileAuthService(ProfileStore, SecretStore);
+        }
+
+        public InMemoryProfileStore ProfileStore { get; }
+
+        public InMemorySecretStore SecretStore { get; }
+
+        public FakeReadService ReadService { get; } = new();
+
+        public FakeQueueService QueueService { get; } = new();
+
+        public FakeSendService SendService { get; } = new();
+
+        public FakeDraftService DraftService { get; } = new();
+
+        public FakeDraftExchangeService DraftExchangeService { get; } = new();
+
+        public FakeProfileAuthService ProfileAuthService { get; }
+
+        public FakeProfileConnectionService ProfileConnectionService { get; } = new();
+
+        public MailApplicationBuilder CreateBuilder() =>
+            new MailApplicationBuilder()
+                .UseProfileStore(ProfileStore)
+                .UseSecretStore(SecretStore)
+                .UseDraftStore(new FileMailDraftStore(CreateTemporaryFilePath("drafts.json")))
+                .UseProfileService(new MailProfileService(ProfileStore, SecretStore))
+                .UseProfileConnectionService(ProfileConnectionService)
+                .UseProfileSecretService(new MailProfileSecretService(ProfileStore, SecretStore))
+                .UseProfileAuthService(ProfileAuthService)
+                .UseDraftService(DraftService)
+                .UseDraftExchangeService(DraftExchangeService)
+                .UseReadService(ReadService)
+                .UseQueueService(QueueService)
+                .UseSendService(SendService);
+
+        private static string CreateTemporaryFilePath(string fileName) {
+            var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            return Path.Combine(directory, fileName);
+        }
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+}
+#endif

--- a/Sources/Mailozaurr.Tests/DraftMimeMessageFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/DraftMimeMessageFactoryTests.cs
@@ -1,0 +1,72 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class DraftMimeMessageFactoryTests {
+    [Fact]
+    public async Task CreateAsyncBuildsMimeMessageFromDraftAndProfileDefaults() {
+        var attachmentPath = CreateTemporaryFilePath("hello.txt");
+        File.WriteAllText(attachmentPath, "hello world");
+
+        var factory = new DraftMimeMessageFactory();
+        var message = await factory.CreateAsync(
+            new MailProfile {
+                Id = "gmail-personal",
+                DisplayName = "Personal Gmail",
+                Kind = MailProfileKind.Gmail,
+                DefaultSender = "Sender Name <sender@example.com>"
+            },
+            new DraftMessage {
+                Subject = "Hello",
+                TextBody = "plain text",
+                HtmlBody = "<b>html</b>",
+                To = {
+                    new MessageRecipient { Name = "Alice", Address = "alice@example.com" }
+                },
+                ReplyTo = {
+                    new MessageRecipient { Address = "reply@example.com" }
+                },
+                Headers = {
+                    ["X-Test"] = "value"
+                },
+                Attachments = {
+                    new DraftAttachment {
+                        Path = attachmentPath
+                    }
+                }
+            });
+
+        Assert.Equal("sender@example.com", message.From.Mailboxes.First().Address);
+        Assert.Equal("alice@example.com", message.To.Mailboxes.First().Address);
+        Assert.Equal("reply@example.com", message.ReplyTo.Mailboxes.First().Address);
+        Assert.Equal("Hello", message.Subject);
+        Assert.Equal("plain text", message.TextBody);
+        Assert.Equal("<b>html</b>", message.HtmlBody);
+        Assert.Equal("value", message.Headers["X-Test"]);
+        Assert.Single(message.Attachments);
+    }
+
+    [Fact]
+    public async Task CreateAsyncRejectsDraftWithoutRecipients() {
+        var factory = new DraftMimeMessageFactory();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => factory.CreateAsync(
+            new MailProfile {
+                Id = "gmail-personal",
+                DisplayName = "Personal Gmail",
+                Kind = MailProfileKind.Gmail,
+                DefaultSender = "sender@example.com"
+            },
+            new DraftMessage {
+                Subject = "Hello"
+            }));
+
+        Assert.Contains("recipient", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+}

--- a/Sources/Mailozaurr.Tests/JsonMailDraftExchangeServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/JsonMailDraftExchangeServiceTests.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class JsonMailDraftExchangeServiceTests {
+    [Fact]
+    public async Task SaveAndLoadRoundTripsDraftJson() {
+        var service = new JsonMailDraftExchangeService();
+        var path = CreateTemporaryFilePath("draft.json");
+        var draft = new MailDraft {
+            Id = "draft-1",
+            Name = "Quarterly report",
+            Message = new DraftMessage {
+                ProfileId = "work-gmail",
+                Subject = "Hello",
+                To = {
+                    new MessageRecipient { Address = "alice@example.com" }
+                }
+            }
+        };
+
+        await service.SaveAsync(path, draft);
+        var loaded = await service.LoadAsync(path);
+
+        Assert.Equal("draft-1", loaded.Id);
+        Assert.Equal("Quarterly report", loaded.Name);
+        Assert.Equal("work-gmail", loaded.Message.ProfileId);
+        Assert.Equal("alice@example.com", loaded.Message.To[0].Address);
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+}

--- a/Sources/Mailozaurr.Tests/MailMcpToolsTests.cs
+++ b/Sources/Mailozaurr.Tests/MailMcpToolsTests.cs
@@ -1,0 +1,1255 @@
+#if NET8_0_OR_GREATER
+using Mailozaurr.Application;
+using Mailozaurr.Cli.Mcp;
+
+namespace Mailozaurr.Tests;
+
+public sealed class MailMcpToolsTests {
+    [Fact]
+    public async Task MailProfilesListReturnsConfiguredProfiles() {
+        using var fixture = new TestFixture();
+
+        var profiles = await fixture.Tools.mail_profiles_list();
+
+        var profile = Assert.Single(profiles);
+        Assert.Equal("gmail-work", profile.Id);
+        Assert.Equal(MailProfileKind.Gmail, profile.Kind);
+    }
+
+    [Fact]
+    public async Task MailProfilesSummaryListReturnsAggregatedOverviews() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-work",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail,
+            DefaultSender = "user@example.com",
+            DefaultMailbox = "user@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "user@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("gmail-work", MailSecretNames.AccessToken, "token");
+
+        var overviews = await fixture.Tools.mail_profiles_summary_list();
+
+        var overview = Assert.Single(overviews);
+        Assert.Equal("gmail-work", overview.Profile.Id);
+        Assert.True(overview.SupportsRead);
+        Assert.True(overview.SupportsSend);
+        Assert.True(overview.IsReady);
+        Assert.Equal("gmail-work", fixture.ProfileAuthService.LastStatusProfileId);
+    }
+
+    [Fact]
+    public async Task MailProfilesSummaryCompactListReturnsLightweightProjection() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-work",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail,
+            DefaultSender = "user@example.com",
+            DefaultMailbox = "user@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "user@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("gmail-work", MailSecretNames.AccessToken, "token");
+
+        var overviews = await fixture.Tools.mail_profiles_summary_compact_list();
+
+        var overview = Assert.Single(overviews);
+        Assert.Equal("gmail-work", overview.Id);
+        Assert.Equal("interactive", overview.AuthMode);
+        Assert.True(overview.IsReady);
+    }
+
+    [Fact]
+    public async Task MailProfilesSummaryListSupportsSharedFilters() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "smtp-alerts",
+            DisplayName = "Alerts SMTP",
+            Kind = MailProfileKind.Smtp,
+            DefaultSender = "alerts@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "smtp.example.com"
+            }
+        });
+
+        var overviews = await fixture.Tools.mail_profiles_summary_list(kind: "smtp", canSendOnly: true);
+
+        var overview = Assert.Single(overviews);
+        Assert.Equal("smtp-alerts", overview.Profile.Id);
+        Assert.True(overview.SupportsSend);
+        Assert.False(overview.SupportsRead);
+    }
+
+    [Fact]
+    public async Task MailProfilesSummaryListSupportsSharedSorting() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "a-smtp",
+            DisplayName = "SMTP A",
+            Kind = MailProfileKind.Smtp,
+            DefaultSender = "alerts@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "smtp.example.com"
+            }
+        });
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "z-gmail",
+            DisplayName = "Gmail Z",
+            Kind = MailProfileKind.Gmail,
+            DefaultSender = "user@example.com",
+            DefaultMailbox = "user@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "user@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("z-gmail", MailSecretNames.AccessToken, "token");
+
+        var overviews = await fixture.Tools.mail_profiles_summary_list(sortBy: "kind", descending: true);
+
+        Assert.Equal(3, overviews.Count);
+        Assert.Equal("a-smtp", overviews[0].Profile.Id);
+    }
+
+    [Fact]
+    public async Task MailCapabilitiesGetReturnsEffectiveCapabilities() {
+        using var fixture = new TestFixture();
+
+        var capabilities = await fixture.Tools.mail_capabilities_get("gmail-work");
+
+        Assert.Equal(MailProfileKind.Gmail, capabilities.Kind);
+        Assert.True(capabilities.Supports(MailCapability.SendMessages));
+        Assert.True(capabilities.Supports(MailCapability.SearchMessages));
+    }
+
+    [Fact]
+    public async Task MailProfileSaveCreatesProfileWithSettings() {
+        using var fixture = new TestFixture();
+
+        var profile = await fixture.Tools.mail_profile_save(
+            profileId: "graph-work",
+            kind: "graph",
+            displayName: "Work Graph",
+            description: "Microsoft 365 profile",
+            defaultSender: "graph@example.com",
+            defaultMailbox: "graph@example.com",
+            settings: new Dictionary<string, string> {
+                ["tenant-id"] = "tenant-1",
+                ["client-id"] = "client-1"
+            });
+
+        Assert.Equal("graph-work", profile.Id);
+        Assert.Equal(MailProfileKind.Graph, profile.Kind);
+        Assert.Equal("Microsoft 365 profile", profile.Description);
+        Assert.Equal("tenant-1", profile.Settings["tenant-id"]);
+        Assert.Equal("client-1", profile.Settings["client-id"]);
+    }
+
+    [Fact]
+    public async Task MailProfileGraphBootstrapCreatesProfileAndStoresSecrets() {
+        using var fixture = new TestFixture();
+
+        var profile = await fixture.Tools.mail_profile_graph_bootstrap(
+            profileId: "graph-work",
+            displayName: "Work Graph",
+            mailbox: "shared@example.com",
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "client-secret");
+        var storedSecret = await fixture.SecretStore.GetSecretAsync("graph-work", MailSecretNames.ClientSecret);
+
+        Assert.Equal("graph-work", profile.Id);
+        Assert.Equal(MailProfileKind.Graph, profile.Kind);
+        Assert.Equal("shared@example.com", profile.DefaultMailbox);
+        Assert.Equal("shared@example.com", profile.Settings[MailProfileSettingsKeys.Mailbox]);
+        Assert.Equal("client-id", profile.Settings[MailProfileSettingsKeys.ClientId]);
+        Assert.Equal("tenant-id", profile.Settings[MailProfileSettingsKeys.TenantId]);
+        Assert.Equal("client-secret", storedSecret);
+    }
+
+    [Fact]
+    public async Task MailProfileGmailBootstrapCreatesProfileAndStoresSecrets() {
+        using var fixture = new TestFixture();
+
+        var profile = await fixture.Tools.mail_profile_gmail_bootstrap(
+            profileId: "gmail-work",
+            displayName: "Work Gmail",
+            mailbox: "me@example.com",
+            clientId: "client-id",
+            clientSecret: "client-secret",
+            refreshToken: "refresh-token");
+        var clientSecret = await fixture.SecretStore.GetSecretAsync("gmail-work", MailSecretNames.ClientSecret);
+        var refreshToken = await fixture.SecretStore.GetSecretAsync("gmail-work", MailSecretNames.RefreshToken);
+
+        Assert.Equal("gmail-work", profile.Id);
+        Assert.Equal(MailProfileKind.Gmail, profile.Kind);
+        Assert.Equal("me@example.com", profile.DefaultMailbox);
+        Assert.Equal("me@example.com", profile.Settings[MailProfileSettingsKeys.Mailbox]);
+        Assert.Equal("client-id", profile.Settings[MailProfileSettingsKeys.ClientId]);
+        Assert.Equal("client-secret", clientSecret);
+        Assert.Equal("refresh-token", refreshToken);
+    }
+
+    [Fact]
+    public async Task MailProfileDoctorReportsMissingGmailAuthenticationMaterial() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-broken",
+            DisplayName = "Broken Gmail",
+            Kind = MailProfileKind.Gmail,
+            DefaultMailbox = "me@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "me@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+
+        var result = await fixture.Tools.mail_profile_doctor("gmail-broken");
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("profile_not_ready", result.Code);
+        Assert.Contains(result.Errors, error => error.Contains("Gmail profiles need an access token", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task MailProfileValidateRunsStructuralValidationOnly() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-structural",
+            DisplayName = "Gmail Structural",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "me@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+
+        var result = await fixture.Tools.mail_profile_validate("gmail-structural");
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.Code);
+    }
+
+    [Fact]
+    public async Task MailProfileGmailLoginPersistsTokens() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-login",
+            DisplayName = "Gmail Login",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "user@gmail.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("gmail-login", MailSecretNames.ClientSecret, "client-secret");
+
+        var result = await fixture.Tools.mail_profile_gmail_login("gmail-login");
+        var accessToken = await fixture.SecretStore.GetSecretAsync("gmail-login", MailSecretNames.AccessToken);
+        var refreshToken = await fixture.SecretStore.GetSecretAsync("gmail-login", MailSecretNames.RefreshToken);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("gmail-login", result.ProfileId);
+        Assert.Equal("gmail-access-token", accessToken);
+        Assert.Equal("gmail-refresh-token", refreshToken);
+        Assert.NotNull(fixture.ProfileAuthService.LastGmailRequest);
+        Assert.Equal("user@gmail.com", fixture.ProfileAuthService.LastGmailRequest!.GmailAccount);
+    }
+
+    [Fact]
+    public async Task MailProfileGraphLoginPersistsAccessToken() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "graph-login",
+            DisplayName = "Graph Login",
+            Kind = MailProfileKind.Graph,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.ClientId] = "client-id",
+                [MailProfileSettingsKeys.TenantId] = "tenant-id"
+            }
+        });
+
+        var result = await fixture.Tools.mail_profile_graph_login("graph-login", login: "user@example.com");
+        var accessToken = await fixture.SecretStore.GetSecretAsync("graph-login", MailSecretNames.AccessToken);
+        var profile = await fixture.ProfileStore.GetByIdAsync("graph-login");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("graph-login", result.ProfileId);
+        Assert.Equal("graph-access-token", accessToken);
+        Assert.NotNull(profile);
+        Assert.Equal("user@example.com", profile!.Settings[MailProfileSettingsKeys.Mailbox]);
+        Assert.NotNull(fixture.ProfileAuthService.LastGraphRequest);
+        Assert.Equal("user@example.com", fixture.ProfileAuthService.LastGraphRequest!.Login);
+    }
+
+    [Fact]
+    public async Task MailProfileRefreshAuthDelegatesToSharedAuthService() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-refresh",
+            DisplayName = "Gmail Refresh",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "refresh@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("gmail-refresh", MailSecretNames.ClientSecret, "client-secret");
+
+        var result = await fixture.Tools.mail_profile_refresh_auth("gmail-refresh");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(1, fixture.ProfileAuthService.RefreshCalls);
+        Assert.Equal("gmail-refresh", fixture.ProfileAuthService.LastRefreshProfileId);
+    }
+
+    [Fact]
+    public async Task MailProfileAuthStatusDelegatesToSharedAuthService() {
+        using var fixture = new TestFixture();
+
+        var status = await fixture.Tools.mail_profile_auth_status("gmail-work");
+
+        Assert.Equal("gmail-work", status.ProfileId);
+        Assert.Equal("gmail-work", fixture.ProfileAuthService.LastStatusProfileId);
+        Assert.Equal("interactive", status.Mode);
+    }
+
+    [Fact]
+    public async Task MailProfileSummaryAggregatesSharedOverview() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-work",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail,
+            DefaultSender = "user@example.com",
+            DefaultMailbox = "user@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "user@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("gmail-work", MailSecretNames.AccessToken, "token");
+
+        var overview = await fixture.Tools.mail_profile_summary("gmail-work");
+
+        Assert.Equal("gmail-work", overview.Profile.Id);
+        Assert.True(overview.SupportsRead);
+        Assert.True(overview.SupportsSend);
+        Assert.True(overview.IsReady);
+        Assert.Equal("gmail-work", fixture.ProfileAuthService.LastStatusProfileId);
+    }
+
+    [Fact]
+    public async Task MailProfileSummaryCompactReturnsLightweightProjection() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-work",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail,
+            DefaultSender = "user@example.com",
+            DefaultMailbox = "user@example.com",
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "user@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("gmail-work", MailSecretNames.AccessToken, "token");
+
+        var overview = await fixture.Tools.mail_profile_summary_compact("gmail-work");
+
+        Assert.Equal("gmail-work", overview.Id);
+        Assert.Equal("Work Gmail", overview.DisplayName);
+        Assert.True(overview.SupportsSend);
+        Assert.True(overview.IsReady);
+    }
+
+    [Fact]
+    public async Task MailProfileTestDelegatesToSharedConnectionService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_profile_test("gmail-work");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("gmail-work", fixture.ProfileConnectionService.LastProfileId);
+        Assert.Equal("getProfile", result.Probe);
+    }
+
+    [Fact]
+    public async Task MailProfileTestParsesRequestedScope() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_profile_test("gmail-work", scope: "send");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(MailProfileConnectionTestScope.Send, fixture.ProfileConnectionService.LastScope);
+        Assert.Equal(MailProfileConnectionTestScope.Send, result.RequestedScope);
+    }
+
+    [Fact]
+    public async Task MailProfileSetDefaultMarksProfileAsDefault() {
+        using var fixture = new TestFixture();
+        await fixture.Tools.mail_profile_save(
+            profileId: "graph-work",
+            kind: "graph",
+            displayName: "Work Graph");
+
+        var result = await fixture.Tools.mail_profile_set_default("graph-work");
+        var profile = await fixture.Tools.mail_profile_get("graph-work");
+
+        Assert.True(result.Succeeded);
+        Assert.True(profile.IsDefault);
+    }
+
+    [Fact]
+    public async Task MailProfileSecretSetAndRemoveUseSharedSecretStore() {
+        using var fixture = new TestFixture();
+
+        var setResult = await fixture.Tools.mail_profile_secret_set("gmail-work", "refresh-token", "secret-value");
+        var storedSecret = await fixture.SecretStore.GetSecretAsync("gmail-work", "refresh-token");
+        var removeResult = await fixture.Tools.mail_profile_secret_remove("gmail-work", "refresh-token");
+        var removedSecret = await fixture.SecretStore.GetSecretAsync("gmail-work", "refresh-token");
+
+        Assert.True(setResult.Succeeded);
+        Assert.Equal("secret-value", storedSecret);
+        Assert.True(removeResult.Succeeded);
+        Assert.Null(removedSecret);
+    }
+
+    [Fact]
+    public async Task MailProfileDeleteRemovesProfile() {
+        using var fixture = new TestFixture();
+        await fixture.Tools.mail_profile_save(
+            profileId: "graph-work",
+            kind: "graph",
+            displayName: "Work Graph");
+
+        var result = await fixture.Tools.mail_profile_delete("graph-work");
+        var profiles = await fixture.Tools.mail_profiles_list();
+
+        Assert.True(result.Succeeded);
+        Assert.DoesNotContain(profiles, profile => profile.Id == "graph-work");
+    }
+
+    [Fact]
+    public async Task MailSearchDelegatesToApplicationReadService() {
+        using var fixture = new TestFixture();
+
+        var results = await fixture.Tools.mail_search(
+            "gmail-work",
+            mailboxId: "primary",
+            folderId: "Inbox",
+            queryText: "invoice",
+            subjectContains: "Quarterly",
+            fromContains: "billing@example.com",
+            toContains: "team@example.com",
+            hasAttachments: true,
+            limit: 5);
+
+        var result = Assert.Single(results);
+        Assert.Equal("message-1", result.Id);
+        Assert.NotNull(fixture.ReadService.LastSearchRequest);
+        Assert.Equal("gmail-work", fixture.ReadService.LastSearchRequest!.ProfileId);
+        Assert.Equal("primary", fixture.ReadService.LastSearchRequest.MailboxId);
+        Assert.Equal("Inbox", fixture.ReadService.LastSearchRequest.FolderId);
+        Assert.Equal("invoice", fixture.ReadService.LastSearchRequest.QueryText);
+        Assert.True(fixture.ReadService.LastSearchRequest.HasAttachments);
+        Assert.Equal(5, fixture.ReadService.LastSearchRequest.Limit);
+    }
+
+    [Fact]
+    public async Task MailFoldersCompactDelegatesToApplicationReadService() {
+        using var fixture = new TestFixture();
+
+        var results = await fixture.Tools.mail_folders_compact_list(
+            "gmail-work",
+            mailboxId: "primary",
+            parentFolderId: "root",
+            rootOnly: true);
+
+        var result = Assert.Single(results);
+        Assert.Equal("Inbox", result.Id);
+        Assert.NotNull(fixture.ReadService.LastFolderCompactQuery);
+        Assert.Equal("gmail-work", fixture.ReadService.LastFolderCompactQuery!.ProfileId);
+        Assert.Equal("primary", fixture.ReadService.LastFolderCompactQuery.MailboxId);
+        Assert.Equal("root", fixture.ReadService.LastFolderCompactQuery.ParentFolderId);
+        Assert.True(fixture.ReadService.LastFolderCompactQuery.RootOnly);
+    }
+
+    [Fact]
+    public async Task MailSearchCompactDelegatesToApplicationReadService() {
+        using var fixture = new TestFixture();
+
+        var results = await fixture.Tools.mail_search_compact(
+            "gmail-work",
+            mailboxId: "primary",
+            folderId: "Inbox",
+            queryText: "invoice",
+            subjectContains: "Quarterly",
+            fromContains: "billing@example.com",
+            toContains: "team@example.com",
+            hasAttachments: true,
+            limit: 5);
+
+        var result = Assert.Single(results);
+        Assert.Equal("message-1", result.Id);
+        Assert.NotNull(fixture.ReadService.LastSearchCompactRequest);
+        Assert.Equal("gmail-work", fixture.ReadService.LastSearchCompactRequest!.ProfileId);
+        Assert.Equal("primary", fixture.ReadService.LastSearchCompactRequest.MailboxId);
+        Assert.Equal("Inbox", fixture.ReadService.LastSearchCompactRequest.FolderId);
+        Assert.Equal("invoice", fixture.ReadService.LastSearchCompactRequest.QueryText);
+        Assert.True(fixture.ReadService.LastSearchCompactRequest.HasAttachments);
+        Assert.Equal(5, fixture.ReadService.LastSearchCompactRequest.Limit);
+    }
+
+    [Fact]
+    public async Task MailAttachmentsListDelegatesToApplicationReadService() {
+        using var fixture = new TestFixture();
+
+        var results = await fixture.Tools.mail_attachments_list(
+            "gmail-work",
+            "message-1",
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        var result = Assert.Single(results);
+        Assert.Equal("attachment-1", result.Id);
+        Assert.NotNull(fixture.ReadService.LastListAttachmentsRequest);
+        Assert.Equal("gmail-work", fixture.ReadService.LastListAttachmentsRequest!.ProfileId);
+        Assert.Equal("primary", fixture.ReadService.LastListAttachmentsRequest.MailboxId);
+        Assert.Equal("Inbox", fixture.ReadService.LastListAttachmentsRequest.FolderId);
+        Assert.Equal("message-1", fixture.ReadService.LastListAttachmentsRequest.MessageId);
+    }
+
+    [Fact]
+    public async Task MailAttachmentsSaveDelegatesToApplicationReadService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_attachments_save(
+            "gmail-work",
+            "message-1",
+            @"C:\Temp",
+            mailboxId: "primary",
+            folderId: "Inbox",
+            attachmentIds: new[] { "attachment-1" },
+            fileNameContains: "invoice",
+            contentTypeContains: "pdf",
+            overwrite: true);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(fixture.ReadService.LastSaveAttachmentsRequest);
+        Assert.Equal("gmail-work", fixture.ReadService.LastSaveAttachmentsRequest!.ProfileId);
+        Assert.Equal("primary", fixture.ReadService.LastSaveAttachmentsRequest.MailboxId);
+        Assert.Equal("Inbox", fixture.ReadService.LastSaveAttachmentsRequest.FolderId);
+        Assert.Equal(@"C:\Temp", fixture.ReadService.LastSaveAttachmentsRequest.DestinationPath);
+        Assert.Contains("attachment-1", fixture.ReadService.LastSaveAttachmentsRequest.AttachmentIds);
+        Assert.Equal("invoice", fixture.ReadService.LastSaveAttachmentsRequest.FileNameContains);
+        Assert.Equal("pdf", fixture.ReadService.LastSaveAttachmentsRequest.ContentTypeContains);
+        Assert.True(fixture.ReadService.LastSaveAttachmentsRequest.Overwrite);
+    }
+
+    [Fact]
+    public async Task MailGetCompactDelegatesToApplicationReadService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_get_compact(
+            "gmail-work",
+            "message-1",
+            mailboxId: "primary",
+            folderId: "Inbox",
+            includeRawContent: true);
+
+        Assert.Equal("message-1", result.Id);
+        Assert.NotNull(fixture.ReadService.LastGetCompactRequest);
+        Assert.Equal("gmail-work", fixture.ReadService.LastGetCompactRequest!.ProfileId);
+        Assert.Equal("primary", fixture.ReadService.LastGetCompactRequest.MailboxId);
+        Assert.Equal("Inbox", fixture.ReadService.LastGetCompactRequest.FolderId);
+        Assert.Equal("message-1", fixture.ReadService.LastGetCompactRequest.MessageId);
+        Assert.True(fixture.ReadService.LastGetCompactRequest.IncludeRawContent);
+    }
+
+    [Fact]
+    public async Task MailSendBuildsQueueFirstSendRequest() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_send(
+            "gmail-work",
+            to: new[] { "alice@example.com" },
+            subject: "Status update",
+            textBody: "Queued body",
+            cc: new[] { "bob@example.com" },
+            attachmentPaths: new[] { "C:\\Temp\\status.txt" });
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(fixture.SendService.LastRequest);
+        Assert.Equal("gmail-work", fixture.SendService.LastRequest!.ProfileId);
+        Assert.True(fixture.SendService.LastRequest.PreferQueue);
+        Assert.False(fixture.SendService.LastRequest.RequireImmediateSend);
+        Assert.Equal("alice@example.com", fixture.SendService.LastRequest.Message.To[0].Address);
+        Assert.Equal("bob@example.com", fixture.SendService.LastRequest.Message.Cc[0].Address);
+        Assert.Equal("C:\\Temp\\status.txt", fixture.SendService.LastRequest.Message.Attachments[0].Path);
+    }
+
+    [Fact]
+    public async Task MailDraftSaveAndListRoundTripsThroughDraftService() {
+        using var fixture = new TestFixture();
+
+        var saveResult = await fixture.Tools.mail_draft_save(
+            draftId: "draft-1",
+            name: "Weekly update",
+            profileId: "gmail-work",
+            to: new[] { "alice@example.com" },
+            subject: "Weekly update",
+            textBody: "Draft body",
+            cc: new[] { "bob@example.com" });
+
+        Assert.True(saveResult.Succeeded);
+
+        var drafts = await fixture.Tools.mail_draft_list();
+
+        var draft = Assert.Single(drafts);
+        Assert.Equal("draft-1", draft.Id);
+        Assert.Equal("Weekly update", draft.Name);
+        Assert.Equal("gmail-work", draft.Message.ProfileId);
+        Assert.Equal("alice@example.com", draft.Message.To[0].Address);
+        Assert.Equal("bob@example.com", draft.Message.Cc[0].Address);
+    }
+
+    [Fact]
+    public async Task MailDraftCompactListReturnsLightweightProjection() {
+        using var fixture = new TestFixture();
+        await fixture.Tools.mail_draft_save(
+            draftId: "draft-1",
+            name: "Weekly update",
+            profileId: "gmail-work",
+            to: new[] { "alice@example.com" },
+            subject: "Weekly update");
+
+        var drafts = await fixture.Tools.mail_draft_compact_list();
+
+        var draft = Assert.Single(drafts);
+        Assert.Equal("draft-1", draft.Id);
+        Assert.Equal("gmail-work", draft.ProfileId);
+        Assert.Equal("Weekly update", draft.Subject);
+    }
+
+    [Fact]
+    public async Task MailDraftGetReturnsStoredDraft() {
+        using var fixture = new TestFixture();
+        await fixture.Tools.mail_draft_save(
+            draftId: "draft-1",
+            name: "Weekly update",
+            profileId: "gmail-work",
+            to: new[] { "alice@example.com" },
+            subject: "Weekly update");
+
+        var draft = await fixture.Tools.mail_draft_get("draft-1");
+
+        Assert.Equal("draft-1", draft.Id);
+        Assert.Equal("Weekly update", draft.Name);
+        Assert.Equal("alice@example.com", draft.Message.To[0].Address);
+    }
+
+    [Fact]
+    public async Task MailDraftCompactGetReturnsLightweightProjection() {
+        using var fixture = new TestFixture();
+        await fixture.Tools.mail_draft_save(
+            draftId: "draft-1",
+            name: "Weekly update",
+            profileId: "gmail-work",
+            to: new[] { "alice@example.com" },
+            subject: "Weekly update");
+
+        var draft = await fixture.Tools.mail_draft_compact_get("draft-1");
+
+        Assert.Equal("draft-1", draft.Id);
+        Assert.Equal("gmail-work", draft.ProfileId);
+        Assert.Equal("Weekly update", draft.Subject);
+    }
+
+    [Fact]
+    public async Task MailDraftSendUsesStoredDraft() {
+        using var fixture = new TestFixture();
+        await fixture.Tools.mail_draft_save(
+            draftId: "draft-1",
+            name: "Weekly update",
+            profileId: "gmail-work",
+            to: new[] { "alice@example.com" },
+            subject: "Weekly update",
+            textBody: "Draft body");
+
+        var result = await fixture.Tools.mail_draft_send("draft-1", sendNow: true);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(fixture.SendService.LastRequest);
+        Assert.Equal("gmail-work", fixture.SendService.LastRequest!.ProfileId);
+        Assert.True(fixture.SendService.LastRequest.RequireImmediateSend);
+        Assert.False(fixture.SendService.LastRequest.PreferQueue);
+        Assert.Equal("alice@example.com", fixture.SendService.LastRequest.Message.To[0].Address);
+        Assert.Equal("Weekly update", fixture.SendService.LastRequest.Message.Subject);
+    }
+
+    [Fact]
+    public async Task MailDraftImportLoadsDraftFileIntoSharedStore() {
+        using var fixture = new TestFixture();
+        var path = fixture.CreatePath("imported-draft.json");
+        await fixture.Application.DraftExchange.SaveAsync(path, new MailDraft {
+            Id = "external-draft",
+            Name = "Imported draft",
+            Message = new DraftMessage {
+                ProfileId = "gmail-work",
+                Subject = "Imported subject",
+                To = {
+                    new MessageRecipient { Address = "imported@example.com" }
+                }
+            }
+        });
+
+        var imported = await fixture.Tools.mail_draft_import(path, draftId: "draft-1", name: "Imported into store");
+        var stored = await fixture.Tools.mail_draft_get("draft-1");
+
+        Assert.Equal("draft-1", imported.Id);
+        Assert.Equal("Imported into store", imported.Name);
+        Assert.Equal("draft-1", stored.Id);
+        Assert.Equal("Imported into store", stored.Name);
+        Assert.Equal("imported@example.com", stored.Message.To[0].Address);
+    }
+
+    [Fact]
+    public async Task MailDraftExportWritesStoredDraftFile() {
+        using var fixture = new TestFixture();
+        var path = fixture.CreatePath("exported-draft.json");
+        await fixture.Tools.mail_draft_save(
+            draftId: "draft-1",
+            name: "Weekly update",
+            profileId: "gmail-work",
+            to: new[] { "alice@example.com" },
+            subject: "Weekly update");
+
+        var result = await fixture.Tools.mail_draft_export("draft-1", path);
+        var exported = await fixture.Application.DraftExchange.LoadAsync(path);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("draft-1", exported.Id);
+        Assert.Equal("Weekly update", exported.Name);
+        Assert.Equal("alice@example.com", exported.Message.To[0].Address);
+    }
+
+    [Fact]
+    public async Task MailDraftDeleteRemovesStoredDraft() {
+        using var fixture = new TestFixture();
+        await fixture.Tools.mail_draft_save(
+            draftId: "draft-1",
+            name: "Weekly update",
+            profileId: "gmail-work",
+            to: new[] { "alice@example.com" },
+            subject: "Weekly update");
+
+        var deleteResult = await fixture.Tools.mail_draft_delete("draft-1");
+        var drafts = await fixture.Tools.mail_draft_list();
+
+        Assert.True(deleteResult.Succeeded);
+        Assert.Empty(drafts);
+    }
+
+    [Fact]
+    public async Task MailQueueProcessDelegatesToQueueService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_queue_process();
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(1, result.AttemptedCount);
+        Assert.Equal(1, result.SentCount);
+        Assert.True(fixture.QueueService.ProcessCalled);
+    }
+
+    [Fact]
+    public async Task MailQueueCompactListReturnsLightweightProjection() {
+        using var fixture = new TestFixture();
+
+        var queued = await fixture.Tools.mail_queue_compact_list();
+
+        var message = Assert.Single(queued);
+        Assert.Equal("queued-1", message.MessageId);
+        Assert.Equal("gmail", message.Provider);
+    }
+
+    [Fact]
+    public async Task MailQueueCompactGetReturnsLightweightProjection() {
+        using var fixture = new TestFixture();
+
+        var message = await fixture.Tools.mail_queue_compact_get("queued-1");
+
+        Assert.Equal("queued-1", message.MessageId);
+        Assert.Equal("gmail", message.Provider);
+    }
+
+    private sealed class TestFixture : IDisposable {
+        private readonly string _tempDirectory;
+
+        public TestFixture() {
+            _tempDirectory = Path.Combine(Path.GetTempPath(), "Mailozaurr.McpTests", Guid.NewGuid().ToString("N"));
+
+            ProfileStore = new InMemoryProfileStore(new[] {
+                new MailProfile {
+                    Id = "gmail-work",
+                    DisplayName = "Work Gmail",
+                    Kind = MailProfileKind.Gmail
+                }
+            });
+            SecretStore = new InMemorySecretStore();
+            ReadService = new FakeReadService();
+            SendService = new FakeSendService();
+            QueueService = new FakeQueueService();
+            ProfileAuthService = new FakeProfileAuthService(ProfileStore, SecretStore);
+            ProfileConnectionService = new FakeProfileConnectionService();
+
+            Application = new MailApplicationBuilder()
+                .UseProfileStore(ProfileStore)
+                .UseSecretStore(SecretStore)
+                .UseDraftStore(new FileMailDraftStore(Path.Combine(_tempDirectory, "drafts.json")))
+                .UseProfileAuthService(ProfileAuthService)
+                .UseProfileConnectionService(ProfileConnectionService)
+                .UseReadService(ReadService)
+                .UseSendService(SendService)
+                .UseQueueService(QueueService)
+                .Build();
+
+            Tools = new MailMcpTools(Application);
+        }
+
+        public MailApplication Application { get; }
+
+        public MailMcpTools Tools { get; }
+
+        public InMemoryProfileStore ProfileStore { get; }
+
+        public InMemorySecretStore SecretStore { get; }
+
+        public FakeReadService ReadService { get; }
+
+        public FakeSendService SendService { get; }
+
+        public FakeQueueService QueueService { get; }
+
+        public FakeProfileAuthService ProfileAuthService { get; }
+
+        public FakeProfileConnectionService ProfileConnectionService { get; }
+
+        public string CreatePath(string fileName) => Path.Combine(_tempDirectory, fileName);
+
+        public void Dispose() {
+            if (Directory.Exists(_tempDirectory)) {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+        }
+    }
+
+    private sealed class InMemoryProfileStore : IMailProfileStore {
+        private readonly Dictionary<string, MailProfile> _profiles;
+
+        public InMemoryProfileStore(IEnumerable<MailProfile> profiles) {
+            _profiles = profiles.ToDictionary(profile => profile.Id, CloneProfile, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public Task<IReadOnlyList<MailProfile>> GetAllAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailProfile>>(_profiles.Values.Select(CloneProfile).ToArray());
+
+        public Task<MailProfile?> GetByIdAsync(string profileId, CancellationToken cancellationToken = default) {
+            _profiles.TryGetValue(profileId, out var profile);
+            return Task.FromResult(profile == null ? null : CloneProfile(profile));
+        }
+
+        public Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+            _profiles[profile.Id] = CloneProfile(profile);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_profiles.Remove(profileId));
+
+        private static MailProfile CloneProfile(MailProfile profile) => new() {
+            Id = profile.Id,
+            DisplayName = profile.DisplayName,
+            Description = profile.Description,
+            Kind = profile.Kind,
+            DefaultSender = profile.DefaultSender,
+            DefaultMailbox = profile.DefaultMailbox,
+            IsDefault = profile.IsDefault,
+            Settings = new Dictionary<string, string>(profile.Settings, StringComparer.OrdinalIgnoreCase),
+            Capabilities = profile.Capabilities == null
+                ? null
+                : new ProfileCapabilities(profile.Capabilities.Kind, profile.Capabilities.Capabilities)
+        };
+    }
+
+    private sealed class InMemorySecretStore : IMailSecretStore {
+        private readonly Dictionary<string, string> _secrets = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            _secrets.TryGetValue(CreateKey(profileId, secretName), out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+            _secrets[CreateKey(profileId, secretName)] = secretValue;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_secrets.Remove(CreateKey(profileId, secretName)));
+
+        private static string CreateKey(string profileId, string secretName) => $"{profileId}::{secretName}";
+    }
+
+    private sealed class FakeReadService : IMailReadService {
+        public GetMessageRequest? LastGetCompactRequest { get; private set; }
+
+        public SaveAttachmentsRequest? LastSaveAttachmentsRequest { get; private set; }
+
+        public ListAttachmentsRequest? LastListAttachmentsRequest { get; private set; }
+
+        public MailFolderQuery? LastFolderCompactQuery { get; private set; }
+
+        public MailSearchRequest? LastSearchCompactRequest { get; private set; }
+
+        public MailSearchRequest? LastSearchRequest { get; private set; }
+
+        public Task<IReadOnlyList<FolderRefCompact>> GetFoldersCompactAsync(MailFolderQuery query, CancellationToken cancellationToken = default) {
+            LastFolderCompactQuery = query;
+            return Task.FromResult<IReadOnlyList<FolderRefCompact>>(new[] {
+                new FolderRefCompact {
+                    ProfileId = query.ProfileId,
+                    MailboxId = query.MailboxId,
+                    Id = "Inbox",
+                    DisplayName = "Inbox",
+                    Path = "Inbox",
+                    Summary = "Inbox Inbox"
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailFolderQuery query, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<FolderRef>>(new[] {
+                new FolderRef {
+                    Id = "Inbox",
+                    DisplayName = "Inbox",
+                    Path = "Inbox"
+                }
+            });
+
+        public Task<IReadOnlyList<MessageSummary>> SearchAsync(MailSearchRequest request, CancellationToken cancellationToken = default) {
+            LastSearchRequest = request;
+            return Task.FromResult<IReadOnlyList<MessageSummary>>(new[] {
+                new MessageSummary {
+                    ProfileId = request.ProfileId,
+                    Id = "message-1",
+                    Subject = "Quarterly invoice"
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<MessageSummaryCompact>> SearchCompactAsync(MailSearchRequest request, CancellationToken cancellationToken = default) {
+            LastSearchCompactRequest = request;
+            return Task.FromResult<IReadOnlyList<MessageSummaryCompact>>(new[] {
+                new MessageSummaryCompact {
+                    ProfileId = request.ProfileId,
+                    Id = "message-1",
+                    Subject = "Quarterly invoice",
+                    Summary = "message-1 Quarterly invoice"
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<AttachmentSummary>> GetAttachmentsAsync(ListAttachmentsRequest request, CancellationToken cancellationToken = default) {
+            LastListAttachmentsRequest = request;
+            return Task.FromResult<IReadOnlyList<AttachmentSummary>>(new[] {
+                new AttachmentSummary {
+                    MessageId = request.MessageId,
+                    Id = "attachment-1",
+                    FileName = "invoice.pdf",
+                    SizeInBytes = 4096
+                }
+            });
+        }
+
+        public Task<SaveAttachmentsResult> SaveAttachmentsAsync(SaveAttachmentsRequest request, CancellationToken cancellationToken = default) {
+            LastSaveAttachmentsRequest = request;
+            return Task.FromResult(new SaveAttachmentsResult {
+                Succeeded = true,
+                ProfileId = request.ProfileId,
+                MessageId = request.MessageId,
+                MatchedCount = 1,
+                AttemptedCount = 1,
+                SavedCount = 1,
+                FailedCount = 0,
+                Message = "Saved 1 attachment(s).",
+                Results = {
+                    new SavedAttachmentResult {
+                        Succeeded = true,
+                        AttachmentId = "attachment-1",
+                        FileName = "invoice.pdf",
+                        ContentType = "application/pdf"
+                    }
+                }
+            });
+        }
+
+        public Task<MessageDetailCompact?> GetMessageCompactAsync(GetMessageRequest request, CancellationToken cancellationToken = default) {
+            LastGetCompactRequest = request;
+            return Task.FromResult<MessageDetailCompact?>(new MessageDetailCompact {
+                ProfileId = request.ProfileId,
+                Id = request.MessageId,
+                Summary = new MessageSummaryCompact {
+                    ProfileId = request.ProfileId,
+                    Id = request.MessageId,
+                    Subject = "Retrieved message",
+                    Summary = $"{request.MessageId} Retrieved message"
+                },
+                TextBodyPreview = "Preview",
+                HtmlBodyPreview = "<p>Preview</p>",
+                HasRawContent = request.IncludeRawContent,
+                SummaryText = $"{request.MessageId} Retrieved message"
+            });
+        }
+
+        public Task<MessageDetail?> GetMessageAsync(GetMessageRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MessageDetail?>(new MessageDetail {
+                ProfileId = request.ProfileId,
+                Id = request.MessageId,
+                Summary = new MessageSummary {
+                    ProfileId = request.ProfileId,
+                    Id = request.MessageId,
+                    Subject = "Retrieved message"
+                }
+            });
+
+        public Task<OperationResult> SaveAttachmentAsync(SaveAttachmentRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success("Attachment saved."));
+    }
+
+    private sealed class FakeSendService : IMailSendService {
+        public SendMessageRequest? LastRequest { get; private set; }
+
+        public Task<SendResult> SendAsync(SendMessageRequest request, CancellationToken cancellationToken = default) {
+            LastRequest = request;
+            return Task.FromResult(new SendResult {
+                Succeeded = true,
+                Queued = request.PreferQueue,
+                QueueMessageId = request.PreferQueue ? "queued-1" : null,
+                ProviderMessageId = request.RequireImmediateSend ? "provider-1" : null,
+                ProfileId = request.ProfileId,
+                ProfileKind = MailProfileKind.Gmail,
+                Message = "Send handled."
+            });
+        }
+    }
+
+    private sealed class FakeQueueService : IMailQueueService {
+        public bool ProcessCalled { get; private set; }
+
+        public Task<IReadOnlyList<QueuedMessageCompact>> ListCompactAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<QueuedMessageCompact>>(new[] {
+                new QueuedMessageCompact {
+                    MessageId = "queued-1",
+                    Provider = "gmail",
+                    ProfileKind = MailProfileKind.Gmail,
+                    NextAttemptAt = DateTimeOffset.UtcNow,
+                    AttemptCount = 0,
+                    IsDue = true,
+                    HasProviderData = false,
+                    Summary = "queued-1 [gmail] attempts=0"
+                }
+            });
+
+        public Task<IReadOnlyList<QueuedMessageSummary>> ListAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<QueuedMessageSummary>>(new[] {
+                new QueuedMessageSummary {
+                    MessageId = "queued-1",
+                    Provider = "gmail",
+                    ProfileKind = MailProfileKind.Gmail,
+                    QueuedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+                    NextAttemptAt = DateTimeOffset.UtcNow,
+                    AttemptCount = 0
+                }
+            });
+
+        public Task<QueuedMessageCompact?> GetCompactAsync(string messageId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<QueuedMessageCompact?>(new QueuedMessageCompact {
+                MessageId = messageId,
+                Provider = "gmail",
+                ProfileKind = MailProfileKind.Gmail,
+                NextAttemptAt = DateTimeOffset.UtcNow,
+                AttemptCount = 0,
+                IsDue = true,
+                HasProviderData = false,
+                Summary = $"{messageId} [gmail] attempts=0"
+            });
+
+        public Task<QueuedMessageSummary?> GetAsync(string messageId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<QueuedMessageSummary?>(new QueuedMessageSummary {
+                MessageId = messageId,
+                Provider = "gmail",
+                ProfileKind = MailProfileKind.Gmail,
+                QueuedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+                NextAttemptAt = DateTimeOffset.UtcNow,
+                AttemptCount = 0
+            });
+
+        public Task<OperationResult> RemoveAsync(string messageId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success("Queued message removed."));
+
+        public Task<QueueProcessResult> ProcessAsync(CancellationToken cancellationToken = default) {
+            ProcessCalled = true;
+            return Task.FromResult(new QueueProcessResult {
+                Succeeded = true,
+                AttemptedCount = 1,
+                SentCount = 1,
+                FailedCount = 0,
+                SkippedCount = 0,
+                DroppedCount = 0,
+                Message = "Queue processed."
+            });
+        }
+    }
+
+    private sealed class FakeProfileAuthService : IMailProfileAuthService {
+        private readonly InMemoryProfileStore _profileStore;
+        private readonly InMemorySecretStore _secretStore;
+
+        public FakeProfileAuthService(InMemoryProfileStore profileStore, InMemorySecretStore secretStore) {
+            _profileStore = profileStore;
+            _secretStore = secretStore;
+        }
+
+        public GmailProfileLoginRequest? LastGmailRequest { get; private set; }
+
+        public GraphProfileLoginRequest? LastGraphRequest { get; private set; }
+
+        public string? LastRefreshProfileId { get; private set; }
+
+        public string? LastStatusProfileId { get; private set; }
+
+        public int RefreshCalls { get; private set; }
+
+        public async Task<MailProfileAuthStatus?> GetStatusAsync(string profileId, CancellationToken cancellationToken = default) {
+            LastStatusProfileId = profileId;
+            var profile = await _profileStore.GetByIdAsync(profileId, cancellationToken);
+            if (profile == null) {
+                return null;
+            }
+
+            var accessToken = await _secretStore.GetSecretAsync(profileId, MailSecretNames.AccessToken, cancellationToken);
+            var refreshToken = await _secretStore.GetSecretAsync(profileId, MailSecretNames.RefreshToken, cancellationToken);
+            var clientSecret = await _secretStore.GetSecretAsync(profileId, MailSecretNames.ClientSecret, cancellationToken);
+            return new MailProfileAuthStatus {
+                ProfileId = profile.Id,
+                ProfileKind = profile.Kind,
+                AuthFlow = profile.Settings.TryGetValue(MailProfileSettingsKeys.AuthFlow, out var authFlow) ? authFlow : MailProfileAuthFlowNames.Interactive,
+                Mode = profile.Kind == MailProfileKind.Graph ? "appOnly" : "interactive",
+                Mailbox = profile.DefaultMailbox,
+                HasAccessToken = !string.IsNullOrWhiteSpace(accessToken),
+                HasRefreshToken = !string.IsNullOrWhiteSpace(refreshToken),
+                HasClientSecret = !string.IsNullOrWhiteSpace(clientSecret),
+                CanRefresh = profile.Kind is MailProfileKind.Gmail or MailProfileKind.Graph,
+                CanLoginInteractively = profile.Kind is MailProfileKind.Gmail or MailProfileKind.Graph,
+                Summary = $"{profile.Id} [{profile.Kind}] auth status available."
+            };
+        }
+
+        public async Task<MailProfileAuthenticationResult> LoginGmailAsync(GmailProfileLoginRequest request, CancellationToken cancellationToken = default) {
+            var profile = await _profileStore.GetByIdAsync(request.ProfileId, cancellationToken);
+            Assert.NotNull(profile);
+            var savedProfile = profile!;
+            var account = request.GmailAccount
+                ?? (savedProfile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) ? mailbox : null)
+                ?? "user@gmail.com";
+            LastGmailRequest = new GmailProfileLoginRequest {
+                ProfileId = request.ProfileId,
+                GmailAccount = account,
+                ClientId = request.ClientId ?? (savedProfile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientId) ? clientId : null),
+                ClientSecret = request.ClientSecret,
+                Scopes = request.Scopes
+            };
+            savedProfile.Settings[MailProfileSettingsKeys.Mailbox] = account;
+            savedProfile.DefaultMailbox = account;
+            await _profileStore.SaveAsync(savedProfile, cancellationToken);
+            await _secretStore.SetSecretAsync(request.ProfileId, MailSecretNames.AccessToken, "gmail-access-token", cancellationToken);
+            await _secretStore.SetSecretAsync(request.ProfileId, MailSecretNames.RefreshToken, "gmail-refresh-token", cancellationToken);
+            return new MailProfileAuthenticationResult {
+                Succeeded = true,
+                Message = "Gmail login completed.",
+                ProfileId = request.ProfileId,
+                ProfileKind = MailProfileKind.Gmail,
+                UserName = account
+            };
+        }
+
+        public async Task<MailProfileAuthenticationResult> LoginGraphAsync(GraphProfileLoginRequest request, CancellationToken cancellationToken = default) {
+            LastGraphRequest = request;
+            var profile = await _profileStore.GetByIdAsync(request.ProfileId, cancellationToken);
+            var mailbox = request.Mailbox ?? request.Login ?? "user@example.com";
+            profile!.Settings[MailProfileSettingsKeys.Mailbox] = mailbox;
+            profile.DefaultMailbox = mailbox;
+            await _profileStore.SaveAsync(profile, cancellationToken);
+            await _secretStore.SetSecretAsync(request.ProfileId, MailSecretNames.AccessToken, "graph-access-token", cancellationToken);
+            return new MailProfileAuthenticationResult {
+                Succeeded = true,
+                Message = "Graph login completed.",
+                ProfileId = request.ProfileId,
+                ProfileKind = MailProfileKind.Graph,
+                UserName = mailbox
+            };
+        }
+
+        public async Task<MailProfileAuthenticationResult> RefreshAsync(string profileId, CancellationToken cancellationToken = default) {
+            RefreshCalls++;
+            LastRefreshProfileId = profileId;
+            var profile = await _profileStore.GetByIdAsync(profileId, cancellationToken);
+            Assert.NotNull(profile);
+            return profile!.Kind switch {
+                MailProfileKind.Gmail => await LoginGmailAsync(new GmailProfileLoginRequest { ProfileId = profileId }, cancellationToken),
+                MailProfileKind.Graph => await LoginGraphAsync(new GraphProfileLoginRequest { ProfileId = profileId }, cancellationToken),
+                _ => new MailProfileAuthenticationResult {
+                    Succeeded = false,
+                    Code = "refresh_not_supported",
+                    Message = "Refresh not supported.",
+                    ProfileId = profileId,
+                    ProfileKind = profile.Kind
+                }
+            };
+        }
+    }
+
+    private sealed class FakeProfileConnectionService : IMailProfileConnectionService {
+        public string? LastProfileId { get; private set; }
+
+        public MailProfileConnectionTestScope LastScope { get; private set; }
+
+        public Task<MailProfileConnectionTestResult> TestAsync(
+            string profileId,
+            MailProfileConnectionTestScope scope = MailProfileConnectionTestScope.Auto,
+            CancellationToken cancellationToken = default) {
+            LastProfileId = profileId;
+            LastScope = scope;
+            return Task.FromResult(new MailProfileConnectionTestResult {
+                Succeeded = true,
+                Message = "Profile connection succeeded.",
+                ProfileId = profileId,
+                ProfileKind = MailProfileKind.Gmail,
+                Probe = "getProfile",
+                Target = "gmail-work",
+                RequestedScope = scope,
+                ExecutedScope = scope == MailProfileConnectionTestScope.Auto ? MailProfileConnectionTestScope.Mailbox : scope
+            });
+        }
+    }
+}
+#endif

--- a/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
+++ b/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
@@ -30,6 +30,8 @@
     </ItemGroup>
 
   <ItemGroup>
+        <ProjectReference Include="..\Mailozaurr.Cli\Mailozaurr.Cli.csproj" Condition=" '$(TargetFramework)' == 'net8.0' " />
+        <ProjectReference Include="..\Mailozaurr.Application\Mailozaurr.Application.csproj" />
         <ProjectReference Include="..\Mailozaurr\Mailozaurr.csproj" />
         <ProjectReference Include="..\Mailozaurr.Msg\Mailozaurr.Msg.csproj" />
         <ProjectReference Include="..\Mailozaurr.PowerShell\Mailozaurr.PowerShell.csproj" />

--- a/Sources/Mailozaurr.Tests/SentMessages/GraphPendingMessageSenderTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/GraphPendingMessageSenderTests.cs
@@ -1,0 +1,129 @@
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using MimeKit;
+
+namespace Mailozaurr.Tests.SentMessages;
+
+public sealed class GraphPendingMessageSenderTests {
+    private sealed class TestHandler : HttpMessageHandler {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        public TestHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) {
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            _handler(request, cancellationToken);
+    }
+
+    [Fact]
+    public async Task SendAsync_UsesStoredAccessTokenAndUserId() {
+        var requests = new List<HttpRequestMessage>();
+        using var client = new HttpClient(new TestHandler((request, cancellationToken) => {
+            requests.Add(request);
+
+            if (request.RequestUri!.AbsoluteUri.EndsWith("/messages", StringComparison.OrdinalIgnoreCase)) {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created) {
+                    Content = new StringContent("{\"id\":\"draft-1\"}", Encoding.UTF8, "application/json")
+                });
+            }
+
+            if (request.RequestUri.AbsoluteUri.EndsWith("/send", StringComparison.OrdinalIgnoreCase)) {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted) {
+                    Content = new StringContent(string.Empty, Encoding.UTF8, "text/plain")
+                });
+            }
+
+            throw new InvalidOperationException("Unexpected Graph request: " + request.RequestUri);
+        })) {
+            BaseAddress = new Uri("https://graph.microsoft.com/v1.0/")
+        };
+
+        var sender = new GraphPendingMessageSender(credential => new GraphApiClient(client, credential: credential));
+        var record = await CreateRecordAsync();
+        record.ProviderData[GraphPendingMessageSender.UserIdKey] = "shared@example.com";
+        record.ProviderData[GraphPendingMessageSender.UserNameKey] = "shared@example.com";
+        record.ProviderData[GraphPendingMessageSender.AccessTokenProtectedKey] = CredentialProtection.Default.Protect("graph-token");
+        record.ProviderData[GraphPendingMessageSender.ExpiresOnKey] = DateTimeOffset.UtcNow.AddHours(1).ToString("o", CultureInfo.InvariantCulture);
+
+        await sender.SendAsync(record, CancellationToken.None);
+
+        Assert.Equal(2, requests.Count);
+        Assert.Equal("Bearer graph-token", requests[0].Headers.Authorization?.ToString());
+        Assert.Contains("/users/shared%40example.com/messages", requests[0].RequestUri!.AbsoluteUri, StringComparison.Ordinal);
+        Assert.Contains("/users/shared%40example.com/messages/draft-1/send", requests[1].RequestUri!.AbsoluteUri, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SendAsync_ReacquiresTokenWhenCredentialMetadataIsPresent() {
+        var requests = new List<HttpRequestMessage>();
+        using var client = new HttpClient(new TestHandler((request, cancellationToken) => {
+            requests.Add(request);
+
+            if (request.RequestUri!.AbsoluteUri.EndsWith("/messages", StringComparison.OrdinalIgnoreCase)) {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created) {
+                    Content = new StringContent("{\"id\":\"draft-2\"}", Encoding.UTF8, "application/json")
+                });
+            }
+
+            if (request.RequestUri.AbsoluteUri.EndsWith("/send", StringComparison.OrdinalIgnoreCase)) {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted) {
+                    Content = new StringContent(string.Empty, Encoding.UTF8, "text/plain")
+                });
+            }
+
+            throw new InvalidOperationException("Unexpected Graph request: " + request.RequestUri);
+        })) {
+            BaseAddress = new Uri("https://graph.microsoft.com/v1.0/")
+        };
+
+        GraphCredential? acquired = null;
+        var sender = new GraphPendingMessageSender(
+            credential => new GraphApiClient(client, credential: credential),
+            (graphCredential, cancellationToken) => {
+                acquired = graphCredential;
+                return Task.FromResult("fresh-token");
+            });
+
+        var record = await CreateRecordAsync();
+        record.ProviderData[GraphPendingMessageSender.UserIdKey] = "shared@example.com";
+        record.ProviderData[GraphPendingMessageSender.UserNameKey] = "shared@example.com";
+        record.ProviderData[GraphPendingMessageSender.AccessTokenProtectedKey] = CredentialProtection.Default.Protect("expired-token");
+        record.ProviderData[GraphPendingMessageSender.ExpiresOnKey] = DateTimeOffset.UtcNow.AddMinutes(-5).ToString("o", CultureInfo.InvariantCulture);
+        record.ProviderData[GraphPendingMessageSender.ClientIdKey] = "client-id";
+        record.ProviderData[GraphPendingMessageSender.TenantIdKey] = "tenant-id";
+        record.ProviderData[GraphPendingMessageSender.ClientSecretProtectedKey] = CredentialProtection.Default.Protect("client-secret");
+
+        await sender.SendAsync(record, CancellationToken.None);
+
+        Assert.NotNull(acquired);
+        Assert.Equal("client-id", acquired!.ClientId);
+        Assert.Equal("tenant-id", acquired.DirectoryId);
+        Assert.Equal("client-secret", acquired.ClientSecret);
+        Assert.Equal("Bearer fresh-token", requests[0].Headers.Authorization?.ToString());
+        var storedToken = CredentialProtection.UnprotectWithFallback(record.ProviderData[GraphPendingMessageSender.AccessTokenProtectedKey]);
+        Assert.Equal("fresh-token", storedToken);
+    }
+
+    private static async Task<PendingMessageRecord> CreateRecordAsync() {
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse("sender@example.com"));
+        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
+        message.Subject = "queued-graph";
+        message.Body = new TextPart("plain") { Text = "body" };
+
+        using var stream = new MemoryStream();
+        await message.WriteToAsync(stream);
+
+        return new PendingMessageRecord {
+            Provider = EmailProvider.Graph,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-10),
+            NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            MimeMessage = Convert.ToBase64String(stream.ToArray())
+        };
+    }
+}

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
@@ -173,7 +173,8 @@ public sealed class PendingMessageProcessorTests {
         EmailProvider.SendGrid,
         EmailProvider.Mailgun,
         EmailProvider.SES,
-        EmailProvider.Gmail
+        EmailProvider.Gmail,
+        EmailProvider.Graph
     };
 
     private static PendingMessageRecord CreateRecord(DateTimeOffset nextAttempt, string? messageId = null) => new() {

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageRecordSerializationTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageRecordSerializationTests.cs
@@ -29,6 +29,13 @@ public sealed class PendingMessageRecordSerializationTests {
             }
         };
         yield return new object[] {
+            EmailProvider.Graph,
+            new Dictionary<string, string> {
+                ["TenantId"] = "tenant-id",
+                ["UserId"] = "shared@example.com"
+            }
+        };
+        yield return new object[] {
             EmailProvider.Mailgun,
             new Dictionary<string, string> {
                 ["Domain"] = "mg.example.com",

--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageSenderFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageSenderFactoryTests.cs
@@ -59,6 +59,7 @@ public sealed class PendingMessageSenderFactoryTests {
     [InlineData(EmailProvider.Mailgun, typeof(MailgunPendingMessageSender))]
     [InlineData(EmailProvider.SES, typeof(SesPendingMessageSender))]
     [InlineData(EmailProvider.Gmail, typeof(GmailPendingMessageSender))]
+    [InlineData(EmailProvider.Graph, typeof(GraphPendingMessageSender))]
     public void Resolve_ReturnsDefaultSenderForKnownProviders(EmailProvider provider, Type expectedType) {
         var factory = new PendingMessageSenderFactory();
 

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -414,6 +414,74 @@ public sealed class ProviderPendingMessageTests {
     }
 
     [Fact]
+    public async Task GraphApplicationHandlerQueuesAndProcessesPendingMessage() {
+        var repository = new InMemoryPendingMessageRepository();
+        var handler = new Application.GraphMailSendHandler(
+            new FakeGraphSessionFactory(),
+            pendingMessageRepository: repository,
+            sendAsync: (session, profile, request, message, cancellationToken) =>
+                Task.FromResult(new GraphMessage { Id = "sent-now" }));
+
+        var queued = await handler.SendAsync(
+            new Application.MailProfile {
+                Id = "graph-profile",
+                DisplayName = "Graph Profile",
+                Kind = Application.MailProfileKind.Graph,
+                DefaultMailbox = "shared@example.com",
+                DefaultSender = "sender@example.com",
+                Settings = new Dictionary<string, string> {
+                    [Application.MailProfileSettingsKeys.TenantId] = "tenant-id"
+                }
+            },
+            new Application.SendMessageRequest {
+                ProfileId = "graph-profile",
+                Message = new Application.DraftMessage {
+                    Subject = "graph-queued",
+                    TextBody = "body",
+                    To = {
+                        new Application.MessageRecipient { Address = "recipient@example.com" }
+                    }
+                }
+            },
+            CancellationToken.None);
+
+        Assert.True(queued.Queued);
+        var record = repository.LastSaved;
+        Assert.NotNull(record);
+        Assert.Equal(EmailProvider.Graph, record!.Provider);
+        Assert.Equal("shared@example.com", record.ProviderData[GraphPendingMessageSender.UserIdKey]);
+
+        var successHandler = new TestHandler((request, _) => {
+            if (request.RequestUri!.AbsoluteUri.EndsWith("/messages", StringComparison.OrdinalIgnoreCase)) {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created) {
+                    Content = new StringContent("{\"id\":\"draft-graph\"}", Encoding.UTF8, "application/json")
+                });
+            }
+
+            if (request.RequestUri.AbsoluteUri.EndsWith("/send", StringComparison.OrdinalIgnoreCase)) {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted) {
+                    Content = new StringContent(string.Empty, Encoding.UTF8, "text/plain")
+                });
+            }
+
+            throw new InvalidOperationException("Unexpected Graph request: " + request.RequestUri);
+        });
+        using var graphHttpClient = new HttpClient(successHandler) {
+            BaseAddress = new Uri("https://graph.microsoft.com/v1.0/")
+        };
+        var sender = new GraphPendingMessageSender(credential => new GraphApiClient(graphHttpClient, credential: credential));
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.Graph, sender }
+        });
+        var processor = new PendingMessageProcessor(repository, factory);
+
+        await processor.ProcessAsync(CancellationToken.None);
+
+        Assert.Equal(2, successHandler.CallCount);
+        Assert.Null(await repository.GetByMessageIdAsync(record.MessageId, CancellationToken.None));
+    }
+
+    [Fact]
     public async Task SesClientQueuesAndProcessesPendingMessage() {
         var repository = new InMemoryPendingMessageRepository();
         using var client = new SesClient {
@@ -489,5 +557,26 @@ public sealed class ProviderPendingMessageTests {
         cts.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
+    }
+
+    private sealed class FakeGraphSessionFactory : Application.IGraphSessionFactory {
+        public Task<Application.GraphSession> ConnectAsync(Application.MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new Application.GraphSession(
+                new GraphApiClient(new OAuthCredential {
+                    UserName = profile.DefaultMailbox ?? "me",
+                    AccessToken = "graph-token",
+                    ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+                }),
+                profile.DefaultMailbox ?? "me",
+                new OAuthCredential {
+                    UserName = profile.DefaultMailbox ?? "me",
+                    AccessToken = "graph-token",
+                    ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+                },
+                new GraphCredential {
+                    ClientId = "client-id",
+                    DirectoryId = "tenant-id",
+                    ClientSecret = "client-secret"
+                }));
     }
 }

--- a/Sources/Mailozaurr.sln
+++ b/Sources/Mailozaurr.sln
@@ -19,6 +19,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mailozaurr.Tests", "Mailoza
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mailozaurr.Msg", "Mailozaurr.Msg\Mailozaurr.Msg.csproj", "{23C45348-807F-462A-866E-9F90E81DBDBB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mailozaurr.Application", "Mailozaurr.Application\Mailozaurr.Application.csproj", "{6844B2F5-759E-461A-9B8B-F6B492B492F7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mailozaurr.Cli", "Mailozaurr.Cli\Mailozaurr.Cli.csproj", "{77665733-679C-492B-8AA4-9793DF741FA5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -89,6 +93,30 @@ Global
 		{23C45348-807F-462A-866E-9F90E81DBDBB}.Release|x64.Build.0 = Release|Any CPU
 		{23C45348-807F-462A-866E-9F90E81DBDBB}.Release|x86.ActiveCfg = Release|Any CPU
 		{23C45348-807F-462A-866E-9F90E81DBDBB}.Release|x86.Build.0 = Release|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Debug|x64.Build.0 = Debug|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Debug|x86.Build.0 = Debug|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Release|x64.ActiveCfg = Release|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Release|x64.Build.0 = Release|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Release|x86.ActiveCfg = Release|Any CPU
+		{6844B2F5-759E-461A-9B8B-F6B492B492F7}.Release|x86.Build.0 = Release|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Debug|x64.Build.0 = Debug|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Debug|x86.Build.0 = Debug|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Release|x64.ActiveCfg = Release|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Release|x64.Build.0 = Release|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Release|x86.ActiveCfg = Release|Any CPU
+		{77665733-679C-492B-8AA4-9793DF741FA5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -246,6 +246,30 @@ public static class OAuthHelpers {
     }
 
     /// <summary>
+    /// Attempts to silently acquire an Office 365 token from the existing token cache without prompting the user.
+    /// </summary>
+    /// <param name="login">Optional login hint for the cached account.</param>
+    /// <param name="clientId">The application (client) identifier.</param>
+    /// <param name="tenantId">The tenant identifier.</param>
+    /// <param name="redirectUri">The redirect URI registered for the application.</param>
+    /// <param name="scopes">The scopes to request for the token.</param>
+    /// <returns>The refreshed credential when available; otherwise <c>null</c>.</returns>
+    public static async Task<OAuthCredential?> TryAcquireO365TokenSilentAsync(
+        string? login,
+        string clientId,
+        string tenantId,
+        string redirectUri,
+        IEnumerable<string> scopes) {
+        var normalizedScopes = NormalizeScopes(scopes);
+        var credential = await AcquireO365TokenSilentAsync(login, clientId, tenantId, redirectUri, normalizedScopes).ConfigureAwait(false);
+        if (credential != null) {
+            await PersistO365CredentialAsync(credential, clientId, tenantId, redirectUri, normalizedScopes).ConfigureAwait(false);
+        }
+
+        return credential;
+    }
+
+    /// <summary>
     /// Attempts to retrieve a cached Google token or acquire a new one if necessary.
     /// </summary>
     public static async Task<OAuthCredential> AcquireGoogleTokenCachedAsync(

--- a/Sources/Mailozaurr/Enums/EmailProvider.cs
+++ b/Sources/Mailozaurr/Enums/EmailProvider.cs
@@ -31,6 +31,11 @@ public enum EmailProvider {
     /// Use the Gmail REST API to deliver mail.
     /// </summary>
     Gmail,
+
+    /// <summary>
+    /// Use Microsoft Graph REST API to deliver mail.
+    /// </summary>
+    Graph,
     //MailChimp,
     //Moosend,
     //Postmark,
@@ -38,4 +43,3 @@ public enum EmailProvider {
     //MessageBird (SparkPost),
     //MailerSend
 }
-

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMimeMessageSender.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMimeMessageSender.cs
@@ -1,0 +1,102 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Sends MIME messages through Microsoft Graph draft and attachment APIs.
+/// </summary>
+public static class GraphMimeMessageSender {
+    /// <summary>
+    /// Sends a MIME message by creating a Graph draft, uploading large attachments, and sending the draft.
+    /// </summary>
+    public static async Task<GraphMessage> SendAsync(
+        GraphApiClient client,
+        string userId,
+        MimeMessage message,
+        CancellationToken cancellationToken = default) {
+        if (client == null) {
+            throw new ArgumentNullException(nameof(client));
+        }
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var prepared = GraphMimePreparation.PrepareMessage(message);
+        try {
+            var created = await client.CreateMessageAsync(
+                prepared.Message,
+                userId: userId,
+                folderIdOrWellKnownName: null,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            await UploadAttachmentsAsync(client, userId, created, prepared.UploadAttachments, cancellationToken).ConfigureAwait(false);
+            await client.SendDraftMessageAsync(created.Id!, userId, cancellationToken).ConfigureAwait(false);
+            return created;
+        } finally {
+            foreach (var uploadAttachment in prepared.UploadAttachments) {
+                uploadAttachment.Dispose();
+            }
+        }
+    }
+
+    private static async Task UploadAttachmentsAsync(
+        GraphApiClient client,
+        string userId,
+        GraphMessage draft,
+        IReadOnlyList<DecodedMimeAttachment> attachments,
+        CancellationToken cancellationToken) {
+        if (attachments.Count == 0 || string.IsNullOrWhiteSpace(draft.Id)) {
+            return;
+        }
+
+        foreach (var attachment in attachments) {
+            var uploadSession = await client.CreateAttachmentUploadSessionAsync(
+                draft.Id!,
+                new GraphAttachmentItem("file", attachment.Name, attachment.Length) {
+                    ContentType = attachment.ContentType,
+                    IsInline = attachment.IsInline,
+                    ContentId = attachment.ContentId
+                },
+                userId: userId,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            await UploadAttachmentAsync(client, uploadSession, attachment, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task UploadAttachmentAsync(
+        GraphApiClient client,
+        GraphUploadSessionResult uploadSession,
+        DecodedMimeAttachment attachment,
+        CancellationToken cancellationToken) {
+        const int chunkSize = Graph.MaxChunkSize;
+        using var stream = attachment.OpenRead();
+        var buffer = new byte[chunkSize];
+        long position = 0;
+
+        while (true) {
+            var read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            if (read <= 0) {
+                break;
+            }
+
+            var chunk = new byte[read];
+            Buffer.BlockCopy(buffer, 0, chunk, 0, read);
+            var startInclusive = position;
+            var endInclusive = position + read - 1L;
+
+            await client.UploadAttachmentChunkAsync(
+                uploadSession.UploadUrl!,
+                chunk,
+                startInclusive,
+                endInclusive,
+                attachment.Length,
+                cancellationToken).ConfigureAwait(false);
+
+            position += read;
+        }
+    }
+}

--- a/Sources/Mailozaurr/SentMessages/PendingMessageSenderFactory.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageSenderFactory.cs
@@ -76,5 +76,6 @@ public sealed class PendingMessageSenderFactory {
         yield return new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.Mailgun, new MailgunPendingMessageSender());
         yield return new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.SES, new SesPendingMessageSender());
         yield return new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.Gmail, new GmailPendingMessageSender());
+        yield return new KeyValuePair<EmailProvider, IPendingMessageSender>(EmailProvider.Graph, new GraphPendingMessageSender());
     }
 }

--- a/Sources/Mailozaurr/SentMessages/Senders/GraphPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/GraphPendingMessageSender.cs
@@ -1,0 +1,201 @@
+using System.Globalization;
+using System.IO;
+using System.Text;
+using MimeKit;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Sends queued Microsoft Graph messages using <see cref="GraphApiClient"/>.
+/// </summary>
+public sealed class GraphPendingMessageSender : IPendingMessageSender {
+    /// <summary>Provider-data key storing the Graph mailbox user id.</summary>
+    public const string UserIdKey = "UserId";
+
+    /// <summary>Provider-data key storing the Graph mailbox user name.</summary>
+    public const string UserNameKey = "UserName";
+
+    /// <summary>Provider-data key storing the access-token expiry timestamp.</summary>
+    public const string ExpiresOnKey = "ExpiresOn";
+
+    /// <summary>Provider-data key storing the raw access token.</summary>
+    public const string AccessTokenKey = "AccessToken";
+
+    /// <summary>Provider-data key storing the base64-encoded access token.</summary>
+    public const string AccessTokenBase64Key = "AccessTokenBase64";
+
+    /// <summary>Provider-data key storing the protected access token.</summary>
+    public const string AccessTokenProtectedKey = "AccessTokenProtected";
+
+    /// <summary>Provider-data key storing the Graph client id.</summary>
+    public const string ClientIdKey = "ClientId";
+
+    /// <summary>Provider-data key storing the Graph tenant id.</summary>
+    public const string TenantIdKey = "TenantId";
+
+    /// <summary>Provider-data key storing the protected Graph client secret.</summary>
+    public const string ClientSecretProtectedKey = "ClientSecretProtected";
+
+    /// <summary>Provider-data key storing the Graph certificate path.</summary>
+    public const string CertificatePathKey = "CertificatePath";
+
+    /// <summary>Provider-data key storing the protected Graph certificate password.</summary>
+    public const string CertificatePasswordProtectedKey = "CertificatePasswordProtected";
+
+    private readonly Func<OAuthCredential, GraphApiClient> clientFactory;
+    private readonly Func<GraphCredential, CancellationToken, Task<string>> acquireAccessTokenAsync;
+
+    /// <summary>
+    /// Creates a new pending-message sender for Graph.
+    /// </summary>
+    public GraphPendingMessageSender(
+        Func<OAuthCredential, GraphApiClient>? clientFactory = null,
+        Func<GraphCredential, CancellationToken, Task<string>>? acquireAccessTokenAsync = null) {
+        this.clientFactory = clientFactory ?? (credential => new GraphApiClient(credential));
+        this.acquireAccessTokenAsync = acquireAccessTokenAsync ?? DefaultAcquireAccessTokenAsync;
+    }
+
+    /// <inheritdoc />
+    public async Task SendAsync(PendingMessageRecord record, CancellationToken ct) {
+        if (record == null) {
+            throw new ArgumentNullException(nameof(record));
+        }
+        if (!record.ProviderData.TryGetValue(UserIdKey, out var userId) || string.IsNullOrWhiteSpace(userId)) {
+            throw new InvalidOperationException("Pending Graph message is missing the user identifier.");
+        }
+
+        var message = await LoadMessageAsync(record, ct).ConfigureAwait(false);
+        var credential = await ResolveCredentialAsync(record.ProviderData, userId, ct).ConfigureAwait(false);
+
+        using var client = clientFactory(credential);
+        await GraphMimeMessageSender.SendAsync(client, userId, message, ct).ConfigureAwait(false);
+    }
+
+    private async Task<OAuthCredential> ResolveCredentialAsync(
+        Dictionary<string, string> providerData,
+        string userId,
+        CancellationToken cancellationToken) {
+        var accessToken = ResolveAccessToken(providerData);
+        var expiresOn = ResolveExpiration(providerData);
+        var graphCredential = BuildGraphCredential(providerData);
+
+        if ((string.IsNullOrEmpty(accessToken) || ShouldRefreshToken(expiresOn)) && graphCredential != null) {
+            accessToken = await acquireAccessTokenAsync(graphCredential, cancellationToken).ConfigureAwait(false);
+            expiresOn = DateTimeOffset.UtcNow.AddMinutes(55);
+            providerData[AccessTokenProtectedKey] = CredentialProtection.Default.Protect(accessToken);
+            providerData.Remove(AccessTokenKey);
+            providerData.Remove(AccessTokenBase64Key);
+            providerData[ExpiresOnKey] = expiresOn.ToString("o", CultureInfo.InvariantCulture);
+        }
+
+        if (string.IsNullOrEmpty(accessToken)) {
+            throw new InvalidOperationException("Pending Graph message is missing an access token and cannot mint a new one.");
+        }
+
+        return new OAuthCredential {
+            UserName = providerData.TryGetValue(UserNameKey, out var userName) && !string.IsNullOrWhiteSpace(userName)
+                ? userName
+                : userId,
+            AccessToken = accessToken!,
+            ExpiresOn = expiresOn,
+            ClientId = providerData.TryGetValue(ClientIdKey, out var clientId) && !string.IsNullOrWhiteSpace(clientId)
+                ? clientId
+                : null,
+            ClientSecret = ResolveProtectedString(providerData, ClientSecretProtectedKey)
+        };
+    }
+
+    private static async Task<MimeMessage> LoadMessageAsync(PendingMessageRecord record, CancellationToken ct) {
+        if (string.IsNullOrWhiteSpace(record.MimeMessage)) {
+            throw new InvalidOperationException("Pending Graph message does not contain MIME content.");
+        }
+
+        var bytes = Convert.FromBase64String(record.MimeMessage);
+        using var stream = new MemoryStream(bytes);
+        return await MimeMessage.LoadAsync(stream, ct).ConfigureAwait(false);
+    }
+
+    private static string? ResolveAccessToken(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(AccessTokenProtectedKey, out var protectedValue) && !string.IsNullOrWhiteSpace(protectedValue)) {
+            var decrypted = CredentialProtection.UnprotectWithFallback(protectedValue);
+            if (!string.IsNullOrEmpty(decrypted)) {
+                return decrypted;
+            }
+        }
+
+        if (providerData.TryGetValue(AccessTokenBase64Key, out var encoded) && !string.IsNullOrWhiteSpace(encoded)) {
+            var bytes = Convert.FromBase64String(encoded);
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        if (providerData.TryGetValue(AccessTokenKey, out var token) && !string.IsNullOrWhiteSpace(token)) {
+            return token;
+        }
+
+        return null;
+    }
+
+    private static DateTimeOffset ResolveExpiration(Dictionary<string, string> providerData) {
+        if (providerData.TryGetValue(ExpiresOnKey, out var value) && !string.IsNullOrWhiteSpace(value) &&
+            DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed)) {
+            return parsed;
+        }
+
+        return DateTimeOffset.MaxValue;
+    }
+
+    private static GraphCredential? BuildGraphCredential(Dictionary<string, string> providerData) {
+        if (!providerData.TryGetValue(ClientIdKey, out var clientId) || string.IsNullOrWhiteSpace(clientId) ||
+            !providerData.TryGetValue(TenantIdKey, out var tenantId) || string.IsNullOrWhiteSpace(tenantId)) {
+            return null;
+        }
+
+        var clientSecret = ResolveProtectedString(providerData, ClientSecretProtectedKey);
+        providerData.TryGetValue(CertificatePathKey, out var certificatePath);
+        var certificatePassword = ResolveProtectedString(providerData, CertificatePasswordProtectedKey);
+
+        if (string.IsNullOrWhiteSpace(clientSecret) && string.IsNullOrWhiteSpace(certificatePath)) {
+            return null;
+        }
+
+        return new GraphCredential {
+            ClientId = clientId.Trim(),
+            DirectoryId = tenantId.Trim(),
+            ClientSecret = string.IsNullOrWhiteSpace(clientSecret) ? null : clientSecret,
+            CertificatePath = string.IsNullOrWhiteSpace(certificatePath) ? null : certificatePath.Trim(),
+            CertificatePassword = string.IsNullOrWhiteSpace(certificatePassword) ? null : certificatePassword
+        };
+    }
+
+    private static string? ResolveProtectedString(Dictionary<string, string> providerData, string key) {
+        if (providerData.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            var decrypted = CredentialProtection.UnprotectWithFallback(value);
+            return string.IsNullOrEmpty(decrypted) ? null : decrypted;
+        }
+
+        return null;
+    }
+
+    private static bool ShouldRefreshToken(DateTimeOffset expiresOn) => expiresOn <= DateTimeOffset.UtcNow.AddMinutes(1);
+
+    private static async Task<string> DefaultAcquireAccessTokenAsync(GraphCredential credential, CancellationToken cancellationToken) {
+        var authorization = await MicrosoftGraphUtils.ConnectO365GraphAsync(
+            credential,
+            credential.DirectoryId,
+            "https://graph.microsoft.com",
+            cancellationToken).ConfigureAwait(false);
+        return NormalizeAccessToken(authorization);
+    }
+
+    private static string NormalizeAccessToken(string authorizationHeaderValue) {
+        if (string.IsNullOrWhiteSpace(authorizationHeaderValue)) {
+            throw new InvalidOperationException("Graph authorization did not return a token.");
+        }
+
+        var trimmed = authorizationHeaderValue.Trim();
+        const string bearerPrefix = "Bearer ";
+        return trimmed.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase)
+            ? trimmed.Substring(bearerPrefix.Length).Trim()
+            : trimmed;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `Mailozaurr.Application` layer for shared profile, auth, mailbox read, send, draft, queue, and capability workflows
- add a cross-platform `Mailozaurr.Cli` host with CLI commands and an MCP server backed by the same application services
- add provider-backed IMAP, Graph, Gmail, and SMTP application handlers plus queue/pending-message Graph support and broad test coverage

## Verification
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Debug --filter "ApplicationRoutingServicesTests|CliRunnerTests|MailMcpToolsTests|ApplicationBuilderTests"`