### PR TITLE
Add reusable action-batch workflows for CLI and MCP

### DIFF
--- a/Docs/Platform-Architecture.md
+++ b/Docs/Platform-Architecture.md
@@ -255,6 +255,58 @@ The recommended shape is:
 
 This avoids duplicating logic and gives one headless contract for the ecosystem.
 
+## Skills
+
+Skills should be treated as reusable agent guidance, not as a replacement for shared Mailozaurr capabilities.
+
+The preferred split is:
+
+- `MCP` exposes executable tools over shared Mailozaurr services
+- `skills` teach agents how to use those tools safely and consistently
+
+Examples of skill responsibilities:
+
+- when to prefer drafts over immediate send
+- when to use queue-first sending
+- how to summarize before delete/move
+- how to select compact versus rich read surfaces
+
+Examples of non-skill responsibilities:
+
+- mailbox search logic
+- message retrieval
+- attachment saving
+- queue processing
+- provider auth/session behavior
+
+Those belong in shared code, not only in prompt guidance.
+
+## HTML Body Projection Roadmap
+
+Mailozaurr should eventually support reusable HTML body projection for non-PowerShell headless surfaces, especially CLI and MCP.
+
+The recommended split is:
+
+- keep raw provider body retrieval in `Mailozaurr`
+- place body projection abstractions and policies in `Mailozaurr.Application`
+- keep PowerShell dependency-light by default
+- document PowerShell recipes for richer HTML handling instead of forcing heavy dependencies into the module
+
+### Recommended integration model
+
+- `CLI` / `MCP`
+  Add optional shared HTML-to-Markdown projection via `OfficeIMO.Markdown.Html`
+- `PowerShell`
+  Keep raw body access in the Mailozaurr module
+  Show examples using `PSWriteOffice` / `OfficeIMO.Markdown.Html` for Markdown projection
+  Show examples using `PSParseHTML` for DOM-style extraction and structured data recovery
+
+### Placement rule
+
+If HTML-to-Markdown projection becomes reusable across CLI, MCP, GUI, or plain C# consumers, the abstraction belongs in shared Mailozaurr layers.
+
+If a PowerShell workflow only demonstrates how to pipe a retrieved HTML body into another module, that belongs in documentation/examples, not in the core Mailozaurr PowerShell adapter by default.
+
 ## Migration Guidance
 
 Not every existing area must be refactored immediately.

--- a/README.MD
+++ b/README.MD
@@ -63,6 +63,19 @@ Additional dependency:
 
 - [Platform Architecture](Docs/Platform-Architecture.md) - layering and reuse rules for future library, PowerShell, CLI, MCP, and GUI work
 
+## Additional surfaces
+
+Mailozaurr is no longer only a library and PowerShell module. The repository now also contains shared application-layer work and headless surfaces for broader automation scenarios:
+
+- `.NET library` for direct application and service integration
+- `PowerShell module` for administrators and automation users
+- `mailozaurr` executable for cross-platform CLI workflows
+- `mailozaurr mcp serve` for MCP-based integrations
+
+CLI and MCP are intended to sit on top of shared Mailozaurr services instead of duplicating mailbox, draft, queue, send, and message-action behavior independently.
+
+If you want the placement rules and longer-term cross-surface direction, see [Platform Architecture](Docs/Platform-Architecture.md).
+
 This started with a single goal to replace `Send-MailMessage` which is deprecated/obsolete with something more modern, but since MailKit and MimeKit have lots of options why not build on that?
 
 ## Support This Project

--- a/Sources/Mailozaurr.Application/CommonMessageActionsPreview.cs
+++ b/Sources/Mailozaurr.Application/CommonMessageActionsPreview.cs
@@ -1,0 +1,45 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Aggregate dry-run result comparing common mailbox actions for the same message selection.
+/// </summary>
+public sealed class CommonMessageActionsPreview : OperationResult {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Owning mailbox identifier when relevant.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional source folder identifier.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Optional custom destination folder value included in the comparison.</summary>
+    public string? RequestedDestinationFolderId { get; set; }
+
+    /// <summary>Total raw message identifiers provided in the request.</summary>
+    public int RequestedCount { get; set; }
+
+    /// <summary>Total unique, non-empty message identifiers after normalization.</summary>
+    public int UniqueMessageCount { get; set; }
+
+    /// <summary>Total duplicate or empty message identifiers removed during normalization.</summary>
+    public int DuplicateOrEmptyCount { get; set; }
+
+    /// <summary>The normalized unique message identifiers that would be acted on.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Total number of action previews included in the bundle.</summary>
+    public int IncludedActionCount { get; set; }
+
+    /// <summary>Total number of action previews that are supported and ready.</summary>
+    public int SucceededActionCount { get; set; }
+
+    /// <summary>Total number of action previews that are unsupported or otherwise blocked.</summary>
+    public int FailedActionCount { get; set; }
+
+    /// <summary>Top-level warnings detected during preview normalization.</summary>
+    public List<string> Warnings { get; set; } = new();
+
+    /// <summary>Included action previews such as read-state, flagged-state, archive, trash, move, and delete.</summary>
+    public List<MessageActionPreviewItem> Actions { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/CommonMessageActionsPreviewRequest.cs
+++ b/Sources/Mailozaurr.Application/CommonMessageActionsPreviewRequest.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for previewing a common bundle of message actions side by side.
+/// </summary>
+public sealed class CommonMessageActionsPreviewRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional source folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifiers to preview.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Optional custom destination folder identifier or alias to include as a generic move preview.</summary>
+    public string? DestinationFolderId { get; set; }
+}

--- a/Sources/Mailozaurr.Application/DeleteMessagesPreview.cs
+++ b/Sources/Mailozaurr.Application/DeleteMessagesPreview.cs
@@ -1,0 +1,33 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Aggregate dry-run result for a planned message delete.
+/// </summary>
+public sealed class DeleteMessagesPreview : OperationResult {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Owning mailbox identifier when relevant.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional source folder identifier.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Total raw message identifiers provided in the request.</summary>
+    public int RequestedCount { get; set; }
+
+    /// <summary>Total unique, non-empty message identifiers after normalization.</summary>
+    public int UniqueMessageCount { get; set; }
+
+    /// <summary>Total duplicate or empty message identifiers removed during normalization.</summary>
+    public int DuplicateOrEmptyCount { get; set; }
+
+    /// <summary>The normalized unique message identifiers that would be acted on.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Optional confirmation token that can be supplied when executing the delete.</summary>
+    public string? ConfirmationToken { get; set; }
+
+    /// <summary>Warnings detected during preview.</summary>
+    public List<string> Warnings { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/DeleteMessagesPreviewRequest.cs
+++ b/Sources/Mailozaurr.Application/DeleteMessagesPreviewRequest.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for previewing a message delete without executing it.
+/// </summary>
+public sealed class DeleteMessagesPreviewRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifiers to preview.</summary>
+    public List<string> MessageIds { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/DeleteMessagesRequest.cs
+++ b/Sources/Mailozaurr.Application/DeleteMessagesRequest.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for deleting one or more messages.
+/// </summary>
+public sealed class DeleteMessagesRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifiers to delete.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Optional confirmation token from a prior preview for this exact action.</summary>
+    public string? ConfirmationToken { get; set; }
+}

--- a/Sources/Mailozaurr.Application/FileMailMessageActionPlanBatchStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailMessageActionPlanBatchStore.cs
@@ -1,0 +1,216 @@
+using System.Text.Json;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Stores reusable message action plan batches in a JSON document on disk.
+/// </summary>
+public sealed class FileMailMessageActionPlanBatchStore : IMailMessageActionPlanBatchStore {
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private static readonly JsonSerializerOptions SerializerOptions = new() {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    /// <summary>
+    /// Creates a new store using the provided options.
+    /// </summary>
+    public FileMailMessageActionPlanBatchStore(MailMessageActionPlanBatchStoreOptions? options = null)
+        : this((options ?? new MailMessageActionPlanBatchStoreOptions()).GetFilePath()) {
+    }
+
+    /// <summary>
+    /// Creates a new store using the specified file path.
+    /// </summary>
+    public FileMailMessageActionPlanBatchStore(string filePath) {
+        _filePath = Path.GetFullPath(filePath ?? throw new ArgumentNullException(nameof(filePath)));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailMessageActionPlanBatch>> GetAllAsync(CancellationToken cancellationToken = default) {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            return document.Batches
+                .Select(CloneBatch)
+                .OrderBy(batch => batch.Name, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(batch => batch.Id, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<MailMessageActionPlanBatch?> GetByIdAsync(string batchId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(batchId)) {
+            throw new ArgumentException("Batch id is required.", nameof(batchId));
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var batch = document.Batches.FirstOrDefault(existing => string.Equals(existing.Id, batchId, StringComparison.OrdinalIgnoreCase));
+            return batch == null ? null : CloneBatch(batch);
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(MailMessageActionPlanBatch batch, CancellationToken cancellationToken = default) {
+        ValidateBatch(batch);
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var index = document.Batches.FindIndex(existing => string.Equals(existing.Id, batch.Id, StringComparison.OrdinalIgnoreCase));
+            var batchToStore = CloneBatch(batch);
+            if (batchToStore.CreatedAt == default) {
+                batchToStore.CreatedAt = DateTimeOffset.UtcNow;
+            }
+            batchToStore.UpdatedAt = DateTimeOffset.UtcNow;
+
+            if (index >= 0) {
+                batchToStore.CreatedAt = document.Batches[index].CreatedAt == default
+                    ? batchToStore.CreatedAt
+                    : document.Batches[index].CreatedAt;
+                document.Batches[index] = batchToStore;
+            } else {
+                document.Batches.Add(batchToStore);
+            }
+
+            await SaveDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveAsync(string batchId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(batchId)) {
+            throw new ArgumentException("Batch id is required.", nameof(batchId));
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var removed = document.Batches.RemoveAll(existing => string.Equals(existing.Id, batchId, StringComparison.OrdinalIgnoreCase)) > 0;
+            if (!removed) {
+                return false;
+            }
+
+            await SaveDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+            return true;
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    private async Task<MailMessageActionPlanBatchStoreDocument> LoadDocumentAsync(CancellationToken cancellationToken) {
+        if (!File.Exists(_filePath)) {
+            return new MailMessageActionPlanBatchStoreDocument();
+        }
+
+        using (var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+            var document = await JsonSerializer.DeserializeAsync<MailMessageActionPlanBatchStoreDocument>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            return document ?? new MailMessageActionPlanBatchStoreDocument();
+        }
+    }
+
+    private async Task SaveDocumentAsync(MailMessageActionPlanBatchStoreDocument document, CancellationToken cancellationToken) {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (string.IsNullOrWhiteSpace(directory)) {
+            throw new InvalidOperationException("Action plan batch store path is invalid.");
+        }
+
+        Directory.CreateDirectory(directory);
+
+        var tempPath = Path.Combine(directory, Path.GetRandomFileName());
+        try {
+            using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
+                await JsonSerializer.SerializeAsync(stream, document, SerializerOptions, cancellationToken).ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (File.Exists(_filePath)) {
+                File.Delete(_filePath);
+            }
+
+            File.Move(tempPath, _filePath);
+            tempPath = string.Empty;
+        } finally {
+            if (!string.IsNullOrEmpty(tempPath) && File.Exists(tempPath)) {
+                File.Delete(tempPath);
+            }
+        }
+    }
+
+    private static void ValidateBatch(MailMessageActionPlanBatch? batch) {
+        if (batch == null) {
+            throw new ArgumentNullException(nameof(batch));
+        }
+        if (string.IsNullOrWhiteSpace(batch.Id)) {
+            throw new InvalidOperationException("Action plan batch id is required.");
+        }
+        if (string.IsNullOrWhiteSpace(batch.Name)) {
+            throw new InvalidOperationException("Action plan batch name is required.");
+        }
+        if (batch.Plans == null) {
+            throw new InvalidOperationException("Action plan batch plans are required.");
+        }
+    }
+
+    private static MailMessageActionPlanBatch CloneBatch(MailMessageActionPlanBatch batch) => new() {
+        Id = batch.Id,
+        Name = batch.Name,
+        Description = batch.Description,
+        CreatedAt = batch.CreatedAt,
+        UpdatedAt = batch.UpdatedAt,
+        Plans = batch.Plans.Select(ClonePlan).ToList()
+    };
+
+    private static MessageActionExecutionPlan ClonePlan(MessageActionExecutionPlan plan) => new() {
+        Succeeded = plan.Succeeded,
+        Code = plan.Code,
+        Message = plan.Message,
+        Name = plan.Name,
+        Summary = plan.Summary,
+        Action = plan.Action,
+        ExecutionKind = plan.ExecutionKind,
+        ProfileId = plan.ProfileId,
+        MailboxId = plan.MailboxId,
+        FolderId = plan.FolderId,
+        RequestedCount = plan.RequestedCount,
+        UniqueMessageCount = plan.UniqueMessageCount,
+        MessageIds = plan.MessageIds.ToList(),
+        RequestedDestinationFolderId = plan.RequestedDestinationFolderId,
+        Destination = plan.Destination == null
+            ? null
+            : new MailFolderTargetResolution {
+                ProfileId = plan.Destination.ProfileId,
+                MailboxId = plan.Destination.MailboxId,
+                RequestedValue = plan.Destination.RequestedValue,
+                IsAlias = plan.Destination.IsAlias,
+                Alias = plan.Destination.Alias,
+                IsSupported = plan.Destination.IsSupported,
+                IsResolved = plan.Destination.IsResolved,
+                EffectiveFolderId = plan.Destination.EffectiveFolderId,
+                FolderDisplayName = plan.Destination.FolderDisplayName,
+                FolderPath = plan.Destination.FolderPath,
+                Summary = plan.Destination.Summary
+            },
+        DesiredState = plan.DesiredState,
+        ConfirmationToken = plan.ConfirmationToken,
+        ConfirmationProvided = plan.ConfirmationProvided,
+        ConfirmationValidated = plan.ConfirmationValidated,
+        Warnings = plan.Warnings.ToList()
+    };
+
+    private sealed class MailMessageActionPlanBatchStoreDocument {
+        public int Version { get; set; } = 1;
+
+        public List<MailMessageActionPlanBatch> Batches { get; set; } = new();
+    }
+}

--- a/Sources/Mailozaurr.Application/GetMessagesRequest.cs
+++ b/Sources/Mailozaurr.Application/GetMessagesRequest.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for retrieving multiple messages.
+/// </summary>
+public sealed class GetMessagesRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifiers.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Whether raw content should be included when available.</summary>
+    public bool IncludeRawContent { get; set; }
+}

--- a/Sources/Mailozaurr.Application/GmailMailMessageActionHandler.cs
+++ b/Sources/Mailozaurr.Application/GmailMailMessageActionHandler.cs
@@ -1,0 +1,106 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Normalized Gmail mailbox action handler backed by Mailozaurr Gmail helpers.
+/// </summary>
+public sealed class GmailMailMessageActionHandler : IMailMessageActionHandler {
+    private readonly IGmailSessionFactory _sessionFactory;
+    private readonly Func<GmailSession, MailProfile, SetReadStateRequest, CancellationToken, Task<MessageActionResult>> _setReadStateAsync;
+    private readonly Func<GmailSession, MailProfile, MoveMessagesRequest, CancellationToken, Task<MessageActionResult>> _moveAsync;
+    private readonly Func<GmailSession, MailProfile, DeleteMessagesRequest, CancellationToken, Task<MessageActionResult>> _deleteAsync;
+
+    /// <summary>
+    /// Creates a new Gmail message-action handler.
+    /// </summary>
+    public GmailMailMessageActionHandler(
+        IGmailSessionFactory sessionFactory,
+        Func<GmailSession, MailProfile, SetReadStateRequest, CancellationToken, Task<MessageActionResult>>? setReadStateAsync = null,
+        Func<GmailSession, MailProfile, MoveMessagesRequest, CancellationToken, Task<MessageActionResult>>? moveAsync = null,
+        Func<GmailSession, MailProfile, DeleteMessagesRequest, CancellationToken, Task<MessageActionResult>>? deleteAsync = null) {
+        _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
+        _setReadStateAsync = setReadStateAsync ?? DefaultSetReadStateAsync;
+        _moveAsync = moveAsync ?? DefaultMoveAsync;
+        _deleteAsync = deleteAsync ?? DefaultDeleteAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Gmail;
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> SetReadStateAsync(MailProfile profile, SetReadStateRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _setReadStateAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> SetFlaggedStateAsync(MailProfile profile, SetFlaggedStateRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        var results = await session.Browser.SetMessagesFlaggedAsync(
+            request.MessageIds.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToArray(),
+            request.IsFlagged,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        return MapResult(profile.Id, results, request.IsFlagged ? "Flagged messages." : "Unflagged messages.");
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> MoveAsync(MailProfile profile, MoveMessagesRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _moveAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> DeleteAsync(MailProfile profile, DeleteMessagesRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _deleteAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<MessageActionResult> DefaultSetReadStateAsync(GmailSession session, MailProfile profile, SetReadStateRequest request, CancellationToken cancellationToken) {
+        var results = await session.Browser.SetMessagesSeenAsync(NormalizeIds(request.MessageIds), request.IsRead, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return MapResult(profile.Id, results, request.IsRead ? "Marked messages as read." : "Marked messages as unread.");
+    }
+
+    private static async Task<MessageActionResult> DefaultMoveAsync(GmailSession session, MailProfile profile, MoveMessagesRequest request, CancellationToken cancellationToken) {
+        var results = await session.Browser.MoveMessagesAsync(
+            NormalizeIds(request.MessageIds),
+            request.FolderId,
+            request.DestinationFolderId,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        return MapResult(profile.Id, results, $"Moved messages to '{request.DestinationFolderId}'.");
+    }
+
+    private static async Task<MessageActionResult> DefaultDeleteAsync(GmailSession session, MailProfile profile, DeleteMessagesRequest request, CancellationToken cancellationToken) {
+        var results = await session.Browser.DeleteMessagesAsync(NormalizeIds(request.MessageIds), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return MapResult(profile.Id, results, "Deleted messages.");
+    }
+
+    private static IReadOnlyList<string> NormalizeIds(IEnumerable<string> messageIds) =>
+        messageIds.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToArray();
+
+    private static MessageActionResult MapResult(string profileId, IReadOnlyList<MailboxBulkOperationResult> items, string successMessage) {
+        var result = new MessageActionResult {
+            ProfileId = profileId,
+            RequestedCount = items.Count
+        };
+
+        foreach (var item in items) {
+            result.Results.Add(new MessageActionItemResult {
+                MessageId = item.Id,
+                Succeeded = item.Ok,
+                Code = item.Ok ? null : "message_action_failed",
+                Message = item.Ok ? null : item.Error
+            });
+            if (item.Ok) {
+                result.SucceededCount++;
+            } else {
+                result.FailedCount++;
+            }
+        }
+
+        result.Succeeded = result.FailedCount == 0 && result.SucceededCount > 0;
+        result.Code = result.Succeeded ? null : "message_action_failed";
+        result.Message = result.Succeeded
+            ? successMessage
+            : $"{result.SucceededCount} message action(s) succeeded; {result.FailedCount} failed.";
+        return result;
+    }
+}

--- a/Sources/Mailozaurr.Application/GraphMailMessageActionHandler.cs
+++ b/Sources/Mailozaurr.Application/GraphMailMessageActionHandler.cs
@@ -1,0 +1,106 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Normalized Graph mailbox action handler backed by Mailozaurr Graph helpers.
+/// </summary>
+public sealed class GraphMailMessageActionHandler : IMailMessageActionHandler {
+    private readonly IGraphSessionFactory _sessionFactory;
+    private readonly Func<GraphSession, MailProfile, SetReadStateRequest, CancellationToken, Task<MessageActionResult>> _setReadStateAsync;
+    private readonly Func<GraphSession, MailProfile, MoveMessagesRequest, CancellationToken, Task<MessageActionResult>> _moveAsync;
+    private readonly Func<GraphSession, MailProfile, DeleteMessagesRequest, CancellationToken, Task<MessageActionResult>> _deleteAsync;
+
+    /// <summary>
+    /// Creates a new Graph message-action handler.
+    /// </summary>
+    public GraphMailMessageActionHandler(
+        IGraphSessionFactory sessionFactory,
+        Func<GraphSession, MailProfile, SetReadStateRequest, CancellationToken, Task<MessageActionResult>>? setReadStateAsync = null,
+        Func<GraphSession, MailProfile, MoveMessagesRequest, CancellationToken, Task<MessageActionResult>>? moveAsync = null,
+        Func<GraphSession, MailProfile, DeleteMessagesRequest, CancellationToken, Task<MessageActionResult>>? deleteAsync = null) {
+        _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
+        _setReadStateAsync = setReadStateAsync ?? DefaultSetReadStateAsync;
+        _moveAsync = moveAsync ?? DefaultMoveAsync;
+        _deleteAsync = deleteAsync ?? DefaultDeleteAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Graph;
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> SetReadStateAsync(MailProfile profile, SetReadStateRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _setReadStateAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> SetFlaggedStateAsync(MailProfile profile, SetFlaggedStateRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        var browser = new GraphMailboxBrowser(session.Client);
+        var results = await browser.SetMessagesFlaggedAsync(
+            request.MessageIds.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToArray(),
+            request.IsFlagged,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        return MapResult(profile.Id, results, request.IsFlagged ? "Flagged messages." : "Unflagged messages.");
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> MoveAsync(MailProfile profile, MoveMessagesRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _moveAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> DeleteAsync(MailProfile profile, DeleteMessagesRequest request, CancellationToken cancellationToken = default) {
+        using var session = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _deleteAsync(session, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<MessageActionResult> DefaultSetReadStateAsync(GraphSession session, MailProfile profile, SetReadStateRequest request, CancellationToken cancellationToken) {
+        var browser = new GraphMailboxBrowser(session.Client);
+        var results = await browser.SetMessagesSeenAsync(NormalizeIds(request.MessageIds), request.IsRead, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return MapResult(profile.Id, results, request.IsRead ? "Marked messages as read." : "Marked messages as unread.");
+    }
+
+    private static async Task<MessageActionResult> DefaultMoveAsync(GraphSession session, MailProfile profile, MoveMessagesRequest request, CancellationToken cancellationToken) {
+        var browser = new GraphMailboxBrowser(session.Client);
+        var results = await browser.MoveMessagesAsync(NormalizeIds(request.MessageIds), request.DestinationFolderId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return MapResult(profile.Id, results, $"Moved messages to '{request.DestinationFolderId}'.");
+    }
+
+    private static async Task<MessageActionResult> DefaultDeleteAsync(GraphSession session, MailProfile profile, DeleteMessagesRequest request, CancellationToken cancellationToken) {
+        var browser = new GraphMailboxBrowser(session.Client);
+        var results = await browser.DeleteMessagesAsync(NormalizeIds(request.MessageIds), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return MapResult(profile.Id, results, "Deleted messages.");
+    }
+
+    private static IReadOnlyList<string> NormalizeIds(IEnumerable<string> messageIds) =>
+        messageIds.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToArray();
+
+    private static MessageActionResult MapResult(string profileId, IReadOnlyList<MailboxBulkOperationResult> items, string successMessage) {
+        var result = new MessageActionResult {
+            ProfileId = profileId,
+            RequestedCount = items.Count
+        };
+
+        foreach (var item in items) {
+            result.Results.Add(new MessageActionItemResult {
+                MessageId = item.Id,
+                Succeeded = item.Ok,
+                Code = item.Ok ? null : "message_action_failed",
+                Message = item.Ok ? null : item.Error
+            });
+            if (item.Ok) {
+                result.SucceededCount++;
+            } else {
+                result.FailedCount++;
+            }
+        }
+
+        result.Succeeded = result.FailedCount == 0 && result.SucceededCount > 0;
+        result.Code = result.Succeeded ? null : "message_action_failed";
+        result.Message = result.Succeeded
+            ? successMessage
+            : $"{result.SucceededCount} message action(s) succeeded; {result.FailedCount} failed.";
+        return result;
+    }
+}

--- a/Sources/Mailozaurr.Application/IMailFolderAliasService.cs
+++ b/Sources/Mailozaurr.Application/IMailFolderAliasService.cs
@@ -1,0 +1,19 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Provides provider-neutral folder alias discovery for reusable adapters.
+/// </summary>
+public interface IMailFolderAliasService {
+    /// <summary>Lists supported folder aliases for a profile.</summary>
+    Task<IReadOnlyList<MailFolderAliasSummary>> GetAliasesAsync(
+        string profileId,
+        string? mailboxId = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Resolves a requested folder target to an alias or provider-specific destination.</summary>
+    Task<MailFolderTargetResolution> ResolveAsync(
+        string profileId,
+        string targetFolderId,
+        string? mailboxId = null,
+        CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailMessageActionBatchService.cs
+++ b/Sources/Mailozaurr.Application/IMailMessageActionBatchService.cs
@@ -1,0 +1,12 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Executes one or more normalized message action plans and returns a shared summary.
+/// </summary>
+public interface IMailMessageActionBatchService {
+    /// <summary>Executes a batch of normalized message action plans.</summary>
+    Task<MessageActionBatchExecutionResult> ExecuteAsync(
+        IReadOnlyList<MessageActionExecutionPlan> plans,
+        bool continueOnError = true,
+        CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailMessageActionHandler.cs
+++ b/Sources/Mailozaurr.Application/IMailMessageActionHandler.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Handles normalized mailbox message actions for a specific profile kind.
+/// </summary>
+public interface IMailMessageActionHandler {
+    /// <summary>Profile kind handled by this instance.</summary>
+    MailProfileKind Kind { get; }
+
+    /// <summary>Sets read/unread state for messages.</summary>
+    Task<MessageActionResult> SetReadStateAsync(MailProfile profile, SetReadStateRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Sets flagged/starred state for messages.</summary>
+    Task<MessageActionResult> SetFlaggedStateAsync(MailProfile profile, SetFlaggedStateRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Moves messages to a destination folder.</summary>
+    Task<MessageActionResult> MoveAsync(MailProfile profile, MoveMessagesRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes messages.</summary>
+    Task<MessageActionResult> DeleteAsync(MailProfile profile, DeleteMessagesRequest request, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailMessageActionPlanBatchStore.cs
+++ b/Sources/Mailozaurr.Application/IMailMessageActionPlanBatchStore.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Persists reusable message action plan batches.
+/// </summary>
+public interface IMailMessageActionPlanBatchStore {
+    /// <summary>Lists all saved plan batches.</summary>
+    Task<IReadOnlyList<MailMessageActionPlanBatch>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Gets a saved plan batch by id.</summary>
+    Task<MailMessageActionPlanBatch?> GetByIdAsync(string batchId, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves or updates a plan batch.</summary>
+    Task SaveAsync(MailMessageActionPlanBatch batch, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a saved plan batch by id.</summary>
+    Task<bool> RemoveAsync(string batchId, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailMessageActionPlanExchangeService.cs
+++ b/Sources/Mailozaurr.Application/IMailMessageActionPlanExchangeService.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Imports and exports normalized message action plans to stable external files.
+/// </summary>
+public interface IMailMessageActionPlanExchangeService {
+    /// <summary>Loads one normalized action plan from an external file.</summary>
+    Task<MessageActionExecutionPlan> LoadAsync(string path, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves one normalized action plan to an external file.</summary>
+    Task SaveAsync(string path, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default);
+
+    /// <summary>Loads a batch of normalized action plans from an external file.</summary>
+    Task<IReadOnlyList<MessageActionExecutionPlan>> LoadBatchAsync(string path, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves a batch of normalized action plans to an external file.</summary>
+    Task SaveBatchAsync(string path, IReadOnlyList<MessageActionExecutionPlan> plans, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailMessageActionPlanRegistryService.cs
+++ b/Sources/Mailozaurr.Application/IMailMessageActionPlanRegistryService.cs
@@ -1,0 +1,90 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Provides reusable lifecycle operations for persisted message action plan batches.
+/// </summary>
+public interface IMailMessageActionPlanRegistryService {
+    /// <summary>Lists all saved plan batches.</summary>
+    Task<IReadOnlyList<MailMessageActionPlanBatch>> GetBatchesAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Lists all saved plan batches using a lightweight projection.</summary>
+    Task<IReadOnlyList<MailMessageActionPlanBatchCompact>> GetBatchesCompactAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Lists all saved plan batches using a richer summary projection.</summary>
+    Task<IReadOnlyList<MailMessageActionPlanBatchSummary>> GetBatchesSummaryAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets a batch by id.</summary>
+    Task<MailMessageActionPlanBatch?> GetBatchAsync(string batchId, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets a batch by id using a lightweight projection.</summary>
+    Task<MailMessageActionPlanBatchCompact?> GetBatchCompactAsync(string batchId, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets a batch by id using a richer summary projection.</summary>
+    Task<MailMessageActionPlanBatchSummary?> GetBatchSummaryAsync(string batchId, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves or updates a persisted plan batch.</summary>
+    Task<OperationResult> SaveAsync(MailMessageActionPlanBatch batch, CancellationToken cancellationToken = default);
+
+    /// <summary>Builds and saves a persisted plan batch from a common mailbox action selection.</summary>
+    Task<OperationResult> CreateCommonBatchAsync(
+        string batchId,
+        string name,
+        CommonMessageActionsPreviewRequest request,
+        IReadOnlyList<string>? actions = null,
+        string? description = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Builds and saves a persisted plan batch from an existing common mailbox action preview bundle.</summary>
+    Task<OperationResult> CreateCommonBatchFromPreviewAsync(
+        string batchId,
+        string name,
+        CommonMessageActionsPreview preview,
+        IReadOnlyList<string>? actions = null,
+        string? description = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Clones an existing persisted batch to a new identifier and name.</summary>
+    Task<OperationResult> CloneAsync(string sourceBatchId, string targetBatchId, string name, string? description = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Clones an existing persisted batch while applying shared profile/mailbox/folder/destination transforms.</summary>
+    Task<OperationResult> TransformCloneAsync(
+        string sourceBatchId,
+        string targetBatchId,
+        string name,
+        MessageActionPlanBatchTransformRequest transform,
+        string? description = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Previews a stored batch transform and reports what would change before cloning and saving it.</summary>
+    Task<MailMessageActionPlanBatchTransformPreview> PreviewTransformCloneAsync(
+        string sourceBatchId,
+        MessageActionPlanBatchTransformRequest transform,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Appends one normalized plan to an existing persisted batch.</summary>
+    Task<OperationResult> AppendPlanAsync(string batchId, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default);
+
+    /// <summary>Loads one normalized plan from a file and appends it to an existing persisted batch.</summary>
+    Task<OperationResult> AppendImportedPlanAsync(string batchId, string path, CancellationToken cancellationToken = default);
+
+    /// <summary>Replaces one plan inside an existing persisted batch by zero-based index.</summary>
+    Task<OperationResult> ReplacePlanAtAsync(string batchId, int index, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default);
+
+    /// <summary>Loads one normalized plan from a file and replaces a stored plan by zero-based index.</summary>
+    Task<OperationResult> ReplaceImportedPlanAtAsync(string batchId, int index, string path, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes one plan from an existing persisted batch by zero-based index.</summary>
+    Task<OperationResult> RemovePlanAtAsync(string batchId, int index, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes a persisted plan batch by id.</summary>
+    Task<OperationResult> DeleteAsync(string batchId, CancellationToken cancellationToken = default);
+
+    /// <summary>Imports a persisted plan batch from an external batch file.</summary>
+    Task<OperationResult> ImportAsync(string batchId, string name, string path, string? description = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Exports a persisted plan batch to an external batch file.</summary>
+    Task<OperationResult> ExportAsync(string batchId, string path, CancellationToken cancellationToken = default);
+
+    /// <summary>Executes a persisted plan batch through the shared batch executor.</summary>
+    Task<MessageActionBatchExecutionResult> ExecuteAsync(string batchId, bool continueOnError = true, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailMessageActionPlanService.cs
+++ b/Sources/Mailozaurr.Application/IMailMessageActionPlanService.cs
@@ -1,0 +1,12 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Creates reusable execution plans from previewable message actions and can execute those plans.
+/// </summary>
+public interface IMailMessageActionPlanService {
+    /// <summary>Creates a normalized execution plan for a requested message action.</summary>
+    Task<MessageActionExecutionPlan> CreatePlanAsync(MessageActionExecutionPlanRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Executes a previously created normalized execution plan.</summary>
+    Task<MessageActionResult> ExecuteAsync(MessageActionExecutionPlan plan, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailMessageActionPreviewService.cs
+++ b/Sources/Mailozaurr.Application/IMailMessageActionPreviewService.cs
@@ -1,0 +1,24 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Provides reusable dry-run previews for mailbox message actions.
+/// </summary>
+public interface IMailMessageActionPreviewService {
+    /// <summary>Previews a read/unread state change without executing it.</summary>
+    Task<MessageStateChangePreview> PreviewReadStateAsync(SetReadStateRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Previews a flagged/unflagged state change without executing it.</summary>
+    Task<MessageStateChangePreview> PreviewFlaggedStateAsync(SetFlaggedStateRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Previews a common bundle of state-change and mailbox actions side by side without executing them.</summary>
+    Task<CommonMessageActionsPreview> PreviewCommonActionsAsync(CommonMessageActionsPreviewRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Previews a message move without executing it.</summary>
+    Task<MoveMessagesPreview> PreviewMoveAsync(MoveMessagesPreviewRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Previews a message delete without executing it.</summary>
+    Task<DeleteMessagesPreview> PreviewDeleteAsync(DeleteMessagesPreviewRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Previews the standard set of mailbox actions side by side without executing them.</summary>
+    Task<StandardMessageActionsPreview> PreviewStandardActionsAsync(StandardMessageActionsPreviewRequest request, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailMessageActionService.cs
+++ b/Sources/Mailozaurr.Application/IMailMessageActionService.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Provides normalized mailbox message actions such as read-state changes, move, and delete.
+/// </summary>
+public interface IMailMessageActionService {
+    /// <summary>Sets read/unread state for messages.</summary>
+    Task<MessageActionResult> SetReadStateAsync(SetReadStateRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Sets flagged/starred state for messages.</summary>
+    Task<MessageActionResult> SetFlaggedStateAsync(SetFlaggedStateRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Moves messages to a destination folder.</summary>
+    Task<MessageActionResult> MoveAsync(MoveMessagesRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes messages.</summary>
+    Task<MessageActionResult> DeleteAsync(DeleteMessagesRequest request, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailReadService.cs
+++ b/Sources/Mailozaurr.Application/IMailReadService.cs
@@ -22,11 +22,20 @@ public interface IMailReadService {
     /// <summary>Retrieves a detailed message view.</summary>
     Task<MessageDetail?> GetMessageAsync(GetMessageRequest request, CancellationToken cancellationToken = default);
 
+    /// <summary>Retrieves detailed message views for multiple message identifiers.</summary>
+    Task<IReadOnlyList<MessageDetail>> GetMessagesAsync(GetMessagesRequest request, CancellationToken cancellationToken = default);
+
     /// <summary>Retrieves a lightweight detailed message view.</summary>
     Task<MessageDetailCompact?> GetMessageCompactAsync(GetMessageRequest request, CancellationToken cancellationToken = default);
 
+    /// <summary>Retrieves lightweight detailed message views for multiple message identifiers.</summary>
+    Task<IReadOnlyList<MessageDetailCompact>> GetMessagesCompactAsync(GetMessagesRequest request, CancellationToken cancellationToken = default);
+
     /// <summary>Saves one or more attachments associated with a specific message.</summary>
     Task<SaveAttachmentsResult> SaveAttachmentsAsync(SaveAttachmentsRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves one or more attachments across multiple messages.</summary>
+    Task<SaveAttachmentsManyResult> SaveAttachmentsManyAsync(SaveAttachmentsManyRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>Saves an attachment to the requested destination.</summary>
     Task<OperationResult> SaveAttachmentAsync(SaveAttachmentRequest request, CancellationToken cancellationToken = default);

--- a/Sources/Mailozaurr.Application/ImapMailMessageActionHandler.cs
+++ b/Sources/Mailozaurr.Application/ImapMailMessageActionHandler.cs
@@ -1,0 +1,182 @@
+using MailKit;
+using MailKit.Net.Imap;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Normalized IMAP mailbox action handler backed by Mailozaurr IMAP helpers.
+/// </summary>
+public sealed class ImapMailMessageActionHandler : IMailMessageActionHandler {
+    private readonly IImapSessionFactory _sessionFactory;
+    private readonly Func<ImapClient, MailProfile, SetReadStateRequest, CancellationToken, Task<MessageActionResult>> _setReadStateAsync;
+    private readonly Func<ImapClient, MailProfile, MoveMessagesRequest, CancellationToken, Task<MessageActionResult>> _moveAsync;
+    private readonly Func<ImapClient, MailProfile, DeleteMessagesRequest, CancellationToken, Task<MessageActionResult>> _deleteAsync;
+
+    /// <summary>
+    /// Creates a new IMAP message-action handler.
+    /// </summary>
+    public ImapMailMessageActionHandler(
+        IImapSessionFactory sessionFactory,
+        Func<ImapClient, MailProfile, SetReadStateRequest, CancellationToken, Task<MessageActionResult>>? setReadStateAsync = null,
+        Func<ImapClient, MailProfile, MoveMessagesRequest, CancellationToken, Task<MessageActionResult>>? moveAsync = null,
+        Func<ImapClient, MailProfile, DeleteMessagesRequest, CancellationToken, Task<MessageActionResult>>? deleteAsync = null) {
+        _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
+        _setReadStateAsync = setReadStateAsync ?? DefaultSetReadStateAsync;
+        _moveAsync = moveAsync ?? DefaultMoveAsync;
+        _deleteAsync = deleteAsync ?? DefaultDeleteAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Imap;
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> SetReadStateAsync(MailProfile profile, SetReadStateRequest request, CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _setReadStateAsync(client, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> SetFlaggedStateAsync(MailProfile profile, SetFlaggedStateRequest request, CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        var folder = client.GetCachedFolder(ResolveFolder(request.FolderId, profile), FolderAccess.ReadWrite);
+        var operation = await ImapBulkFlagOperations.SetFlagsAsync(
+            folder,
+            ParseUids(request.MessageIds),
+            MessageFlags.Flagged,
+            add: request.IsFlagged,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new MessageActionResult {
+            Succeeded = operation.Results.All(item => item.Ok) && operation.Updated > 0,
+            Code = operation.Results.All(item => item.Ok) && operation.Updated > 0 ? null : "message_action_failed",
+            Message = operation.Results.All(item => item.Ok) && operation.Updated > 0
+                ? (request.IsFlagged ? "Flagged messages." : "Unflagged messages.")
+                : $"{operation.Updated} message action(s) succeeded; {operation.Results.Count(item => !item.Ok)} failed.",
+            ProfileId = profile.Id,
+            RequestedCount = operation.Requested,
+            SucceededCount = operation.Updated,
+            FailedCount = operation.Results.Count(item => !item.Ok),
+            Results = operation.Results.Select(item => new MessageActionItemResult {
+                MessageId = item.Uid.Id.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                Succeeded = item.Ok,
+                Code = item.Ok ? null : "message_action_failed",
+                Message = item.Error
+            }).ToList()
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> MoveAsync(MailProfile profile, MoveMessagesRequest request, CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _moveAsync(client, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> DeleteAsync(MailProfile profile, DeleteMessagesRequest request, CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _deleteAsync(client, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<MessageActionResult> DefaultSetReadStateAsync(ImapClient client, MailProfile profile, SetReadStateRequest request, CancellationToken cancellationToken) {
+        var folder = client.GetCachedFolder(ResolveFolder(request.FolderId, profile), FolderAccess.ReadWrite);
+        var operation = await ImapBulkFlagOperations.SetFlagsAsync(
+            folder,
+            ParseUids(request.MessageIds),
+            MessageFlags.Seen,
+            add: request.IsRead,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new MessageActionResult {
+            Succeeded = operation.Results.All(item => item.Ok) && operation.Updated > 0,
+            Code = operation.Results.All(item => item.Ok) && operation.Updated > 0 ? null : "message_action_failed",
+            Message = operation.Results.All(item => item.Ok) && operation.Updated > 0
+                ? (request.IsRead ? "Marked messages as read." : "Marked messages as unread.")
+                : $"{operation.Updated} message action(s) succeeded; {operation.Results.Count(item => !item.Ok)} failed.",
+            ProfileId = profile.Id,
+            RequestedCount = operation.Requested,
+            SucceededCount = operation.Updated,
+            FailedCount = operation.Results.Count(item => !item.Ok),
+            Results = operation.Results.Select(item => new MessageActionItemResult {
+                MessageId = item.Uid.Id.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                Succeeded = item.Ok,
+                Code = item.Ok ? null : "message_action_failed",
+                Message = item.Error
+            }).ToList()
+        };
+    }
+
+    private static async Task<MessageActionResult> DefaultMoveAsync(ImapClient client, MailProfile profile, MoveMessagesRequest request, CancellationToken cancellationToken) {
+        var operation = await ImapMoveOperations.MoveAsync(
+            client,
+            ResolveFolder(request.FolderId, profile),
+            request.DestinationFolderId,
+            ParseUids(request.MessageIds),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new MessageActionResult {
+            Succeeded = operation.Results.All(item => item.Ok) && operation.Moved > 0,
+            Code = operation.Results.All(item => item.Ok) && operation.Moved > 0 ? null : "message_action_failed",
+            Message = operation.Results.All(item => item.Ok) && operation.Moved > 0
+                ? $"Moved messages to '{request.DestinationFolderId}'."
+                : $"{operation.Moved} message action(s) succeeded; {operation.Results.Count(item => !item.Ok)} failed.",
+            ProfileId = profile.Id,
+            RequestedCount = operation.Requested,
+            SucceededCount = operation.Moved,
+            FailedCount = operation.Results.Count(item => !item.Ok),
+            Results = operation.Results.Select(item => new MessageActionItemResult {
+                MessageId = item.Uid.Id.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                Succeeded = item.Ok,
+                Code = item.Ok ? null : "message_action_failed",
+                Message = item.Error
+            }).ToList()
+        };
+    }
+
+    private static async Task<MessageActionResult> DefaultDeleteAsync(ImapClient client, MailProfile profile, DeleteMessagesRequest request, CancellationToken cancellationToken) {
+        var folder = client.GetCachedFolder(ResolveFolder(request.FolderId, profile), FolderAccess.ReadWrite);
+        var operation = await ImapDeleteOperations.DeleteAsync(
+            folder,
+            ParseUids(request.MessageIds),
+            expunge: true,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new MessageActionResult {
+            Succeeded = operation.Results.All(item => item.Ok) && operation.Deleted > 0,
+            Code = operation.Results.All(item => item.Ok) && operation.Deleted > 0 ? null : "message_action_failed",
+            Message = operation.Results.All(item => item.Ok) && operation.Deleted > 0
+                ? "Deleted messages."
+                : $"{operation.Deleted} message action(s) succeeded; {operation.Results.Count(item => !item.Ok)} failed.",
+            ProfileId = profile.Id,
+            RequestedCount = operation.Requested,
+            SucceededCount = operation.Deleted,
+            FailedCount = operation.Results.Count(item => !item.Ok),
+            Results = operation.Results.Select(item => new MessageActionItemResult {
+                MessageId = item.Uid.Id.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                Succeeded = item.Ok,
+                Code = item.Ok ? null : "message_action_failed",
+                Message = item.Error
+            }).ToList()
+        };
+    }
+
+    private static IReadOnlyList<UniqueId> ParseUids(IEnumerable<string> messageIds) =>
+        messageIds.Where(id => !string.IsNullOrWhiteSpace(id)).Select(ParseUid).ToArray();
+
+    private static UniqueId ParseUid(string value) {
+        if (uint.TryParse(value.Trim(), out var uid)) {
+            return new UniqueId(uid);
+        }
+
+        throw new InvalidOperationException($"Message id '{value}' is not a valid IMAP UID.");
+    }
+
+    private static string ResolveFolder(string? folderId, MailProfile profile) {
+        if (!string.IsNullOrWhiteSpace(folderId)) {
+            return folderId!.Trim();
+        }
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Folder, out var folder) && !string.IsNullOrWhiteSpace(folder)) {
+            return folder!.Trim();
+        }
+        return "INBOX";
+    }
+}

--- a/Sources/Mailozaurr.Application/JsonMailMessageActionPlanExchangeService.cs
+++ b/Sources/Mailozaurr.Application/JsonMailMessageActionPlanExchangeService.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Imports and exports normalized message action plans as JSON documents.
+/// </summary>
+public sealed class JsonMailMessageActionPlanExchangeService : IMailMessageActionPlanExchangeService {
+    private static readonly JsonSerializerOptions SerializerOptions = new() {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    /// <inheritdoc />
+    public async Task<MessageActionExecutionPlan> LoadAsync(string path, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            throw new ArgumentException("Action plan path is required.", nameof(path));
+        }
+
+        var fullPath = Path.GetFullPath(path);
+        using var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var plan = await JsonSerializer.DeserializeAsync<MessageActionExecutionPlan>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        if (plan == null) {
+            throw new InvalidDataException($"Action plan file '{fullPath}' did not contain a valid action plan document.");
+        }
+
+        return plan;
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(string path, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            throw new ArgumentException("Action plan path is required.", nameof(path));
+        }
+        if (plan == null) {
+            throw new ArgumentNullException(nameof(plan));
+        }
+
+        var fullPath = Path.GetFullPath(path);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrWhiteSpace(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var stream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        await JsonSerializer.SerializeAsync(stream, plan, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MessageActionExecutionPlan>> LoadBatchAsync(string path, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            throw new ArgumentException("Action plan batch path is required.", nameof(path));
+        }
+
+        var fullPath = Path.GetFullPath(path);
+        using var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var plans = await JsonSerializer.DeserializeAsync<List<MessageActionExecutionPlan>>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        if (plans == null) {
+            throw new InvalidDataException($"Action plan batch file '{fullPath}' did not contain a valid action plan array.");
+        }
+
+        return plans;
+    }
+
+    /// <inheritdoc />
+    public async Task SaveBatchAsync(string path, IReadOnlyList<MessageActionExecutionPlan> plans, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            throw new ArgumentException("Action plan batch path is required.", nameof(path));
+        }
+        if (plans == null) {
+            throw new ArgumentNullException(nameof(plans));
+        }
+
+        var fullPath = Path.GetFullPath(path);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrWhiteSpace(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var stream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        await JsonSerializer.SerializeAsync(stream, plans, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/Sources/Mailozaurr.Application/MailApplication.cs
+++ b/Sources/Mailozaurr.Application/MailApplication.cs
@@ -14,12 +14,20 @@ public sealed class MailApplication {
         IMailProfileSecretService profileSecrets,
         IMailProfileBootstrapService profileBootstrap,
         IMailProfileAuthService profileAuth,
+        IMailFolderAliasService folderAliases,
         IMailDraftService drafts,
         IMailDraftExchangeService draftExchange,
         IMailReadService read,
+        IMailMessageActionPreviewService messageActionPreview,
+        IMailMessageActionPlanService messageActionPlans,
+        IMailMessageActionPlanExchangeService messageActionPlanExchange,
+        IMailMessageActionPlanRegistryService messageActionPlanRegistry,
+        IMailMessageActionBatchService messageActionBatch,
+        IMailMessageActionService messageActions,
         IMailSendService send,
         IMailQueueService queue,
         IReadOnlyList<IMailReadHandler> readHandlers,
+        IReadOnlyList<IMailMessageActionHandler> messageActionHandlers,
         IReadOnlyList<IMailSendHandler> sendHandlers) {
         ProfileStore = profileStore;
         SecretStore = secretStore;
@@ -30,12 +38,20 @@ public sealed class MailApplication {
         ProfileSecrets = profileSecrets;
         ProfileBootstrap = profileBootstrap;
         ProfileAuth = profileAuth;
+        FolderAliases = folderAliases;
         Drafts = drafts;
         DraftExchange = draftExchange;
         Read = read;
+        MessageActionPreview = messageActionPreview;
+        MessageActionPlans = messageActionPlans;
+        MessageActionPlanExchange = messageActionPlanExchange;
+        MessageActionPlanRegistry = messageActionPlanRegistry;
+        MessageActionBatch = messageActionBatch;
+        MessageActions = messageActions;
         Send = send;
         Queue = queue;
         ReadHandlers = readHandlers;
+        MessageActionHandlers = messageActionHandlers;
         SendHandlers = sendHandlers;
     }
 
@@ -66,6 +82,9 @@ public sealed class MailApplication {
     /// <summary>Higher-level profile authentication workflows.</summary>
     public IMailProfileAuthService ProfileAuth { get; }
 
+    /// <summary>Provider-neutral folder alias discovery service.</summary>
+    public IMailFolderAliasService FolderAliases { get; }
+
     /// <summary>Draft lifecycle service.</summary>
     public IMailDraftService Drafts { get; }
 
@@ -75,6 +94,24 @@ public sealed class MailApplication {
     /// <summary>Normalized read service.</summary>
     public IMailReadService Read { get; }
 
+    /// <summary>Normalized dry-run mailbox action preview service.</summary>
+    public IMailMessageActionPreviewService MessageActionPreview { get; }
+
+    /// <summary>Normalized mailbox action planning service.</summary>
+    public IMailMessageActionPlanService MessageActionPlans { get; }
+
+    /// <summary>Normalized mailbox action plan import/export service.</summary>
+    public IMailMessageActionPlanExchangeService MessageActionPlanExchange { get; }
+
+    /// <summary>Normalized persisted mailbox action plan batch registry service.</summary>
+    public IMailMessageActionPlanRegistryService MessageActionPlanRegistry { get; }
+
+    /// <summary>Normalized mailbox action batch execution service.</summary>
+    public IMailMessageActionBatchService MessageActionBatch { get; }
+
+    /// <summary>Normalized mailbox message action service.</summary>
+    public IMailMessageActionService MessageActions { get; }
+
     /// <summary>Normalized send service.</summary>
     public IMailSendService Send { get; }
 
@@ -83,6 +120,9 @@ public sealed class MailApplication {
 
     /// <summary>Registered read handlers.</summary>
     public IReadOnlyList<IMailReadHandler> ReadHandlers { get; }
+
+    /// <summary>Registered message-action handlers.</summary>
+    public IReadOnlyList<IMailMessageActionHandler> MessageActionHandlers { get; }
 
     /// <summary>Registered send handlers.</summary>
     public IReadOnlyList<IMailSendHandler> SendHandlers { get; }

--- a/Sources/Mailozaurr.Application/MailApplicationBuilder.cs
+++ b/Sources/Mailozaurr.Application/MailApplicationBuilder.cs
@@ -5,20 +5,29 @@ namespace Mailozaurr.Application;
 /// </summary>
 public sealed class MailApplicationBuilder {
     private readonly List<IMailReadHandler> _readHandlers = new();
+    private readonly List<IMailMessageActionHandler> _messageActionHandlers = new();
     private readonly List<IMailSendHandler> _sendHandlers = new();
     private MailApplicationOptions _options = new();
     private IMailProfileStore? _profileStore;
     private IMailSecretStore? _secretStore;
     private IMailDraftStore? _draftStore;
+    private IMailMessageActionPlanBatchStore? _messageActionPlanBatchStore;
     private IMailProfileService? _profileService;
     private IMailProfileOverviewService? _profileOverviewService;
     private IMailProfileConnectionService? _profileConnectionService;
     private IMailProfileSecretService? _profileSecretService;
     private IMailProfileBootstrapService? _profileBootstrapService;
     private IMailProfileAuthService? _profileAuthService;
+    private IMailFolderAliasService? _folderAliasService;
     private IMailDraftService? _draftService;
     private IMailDraftExchangeService? _draftExchangeService;
     private IMailReadService? _readService;
+    private IMailMessageActionPreviewService? _messageActionPreviewService;
+    private IMailMessageActionPlanService? _messageActionPlanService;
+    private IMailMessageActionPlanExchangeService? _messageActionPlanExchangeService;
+    private IMailMessageActionPlanRegistryService? _messageActionPlanRegistryService;
+    private IMailMessageActionBatchService? _messageActionBatchService;
+    private IMailMessageActionService? _messageActionService;
     private IMailSendService? _sendService;
     private IMailQueueService? _queueService;
     private IDraftMimeMessageFactory? _draftMimeMessageFactory;
@@ -65,6 +74,12 @@ public sealed class MailApplicationBuilder {
         return this;
     }
 
+    /// <summary>Uses an explicit message-action plan batch store.</summary>
+    public MailApplicationBuilder UseMessageActionPlanBatchStore(IMailMessageActionPlanBatchStore messageActionPlanBatchStore) {
+        _messageActionPlanBatchStore = messageActionPlanBatchStore ?? throw new ArgumentNullException(nameof(messageActionPlanBatchStore));
+        return this;
+    }
+
     /// <summary>Uses an explicit profile service.</summary>
     public MailApplicationBuilder UseProfileService(IMailProfileService profileService) {
         _profileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
@@ -101,6 +116,12 @@ public sealed class MailApplicationBuilder {
         return this;
     }
 
+    /// <summary>Uses an explicit folder alias discovery service.</summary>
+    public MailApplicationBuilder UseFolderAliasService(IMailFolderAliasService folderAliasService) {
+        _folderAliasService = folderAliasService ?? throw new ArgumentNullException(nameof(folderAliasService));
+        return this;
+    }
+
     /// <summary>Uses an explicit draft service.</summary>
     public MailApplicationBuilder UseDraftService(IMailDraftService draftService) {
         _draftService = draftService ?? throw new ArgumentNullException(nameof(draftService));
@@ -116,6 +137,42 @@ public sealed class MailApplicationBuilder {
     /// <summary>Uses an explicit read service.</summary>
     public MailApplicationBuilder UseReadService(IMailReadService readService) {
         _readService = readService ?? throw new ArgumentNullException(nameof(readService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit message-action preview service.</summary>
+    public MailApplicationBuilder UseMessageActionPreviewService(IMailMessageActionPreviewService messageActionPreviewService) {
+        _messageActionPreviewService = messageActionPreviewService ?? throw new ArgumentNullException(nameof(messageActionPreviewService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit message-action planning service.</summary>
+    public MailApplicationBuilder UseMessageActionPlanService(IMailMessageActionPlanService messageActionPlanService) {
+        _messageActionPlanService = messageActionPlanService ?? throw new ArgumentNullException(nameof(messageActionPlanService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit message-action plan exchange service.</summary>
+    public MailApplicationBuilder UseMessageActionPlanExchangeService(IMailMessageActionPlanExchangeService messageActionPlanExchangeService) {
+        _messageActionPlanExchangeService = messageActionPlanExchangeService ?? throw new ArgumentNullException(nameof(messageActionPlanExchangeService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit message-action plan registry service.</summary>
+    public MailApplicationBuilder UseMessageActionPlanRegistryService(IMailMessageActionPlanRegistryService messageActionPlanRegistryService) {
+        _messageActionPlanRegistryService = messageActionPlanRegistryService ?? throw new ArgumentNullException(nameof(messageActionPlanRegistryService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit message-action batch execution service.</summary>
+    public MailApplicationBuilder UseMessageActionBatchService(IMailMessageActionBatchService messageActionBatchService) {
+        _messageActionBatchService = messageActionBatchService ?? throw new ArgumentNullException(nameof(messageActionBatchService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit message-action service.</summary>
+    public MailApplicationBuilder UseMessageActionService(IMailMessageActionService messageActionService) {
+        _messageActionService = messageActionService ?? throw new ArgumentNullException(nameof(messageActionService));
         return this;
     }
 
@@ -173,6 +230,12 @@ public sealed class MailApplicationBuilder {
         return this;
     }
 
+    /// <summary>Adds a message-action handler.</summary>
+    public MailApplicationBuilder AddMessageActionHandler(IMailMessageActionHandler handler) {
+        _messageActionHandlers.Add(handler ?? throw new ArgumentNullException(nameof(handler)));
+        return this;
+    }
+
     /// <summary>Adds a send handler.</summary>
     public MailApplicationBuilder AddSendHandler(IMailSendHandler handler) {
         _sendHandlers.Add(handler ?? throw new ArgumentNullException(nameof(handler)));
@@ -186,6 +249,7 @@ public sealed class MailApplicationBuilder {
         var profileStore = _profileStore ?? new FileMailProfileStore(_options.ProfileStore);
         var secretStore = _secretStore ?? new FileMailSecretStore(_options.SecretStore);
         var draftStore = _draftStore ?? new FileMailDraftStore(_options.DraftStore);
+        var messageActionPlanBatchStore = _messageActionPlanBatchStore ?? new FileMailMessageActionPlanBatchStore(_options.ActionPlanBatchStore);
         var profileService = _profileService ?? new MailProfileService(profileStore, secretStore);
         var imapSessionFactory = _imapSessionFactory ?? new ImapSessionFactory(secretStore);
         var graphSessionFactory = _graphSessionFactory ?? new GraphSessionFactory(secretStore);
@@ -212,6 +276,17 @@ public sealed class MailApplicationBuilder {
             readHandlers.Add(new GmailMailReadHandler(gmailSessionFactory));
         }
 
+        var messageActionHandlers = new List<IMailMessageActionHandler>(_messageActionHandlers);
+        if (!messageActionHandlers.Any(handler => handler.Kind == MailProfileKind.Imap)) {
+            messageActionHandlers.Add(new ImapMailMessageActionHandler(imapSessionFactory));
+        }
+        if (!messageActionHandlers.Any(handler => handler.Kind == MailProfileKind.Graph)) {
+            messageActionHandlers.Add(new GraphMailMessageActionHandler(graphSessionFactory));
+        }
+        if (!messageActionHandlers.Any(handler => handler.Kind == MailProfileKind.Gmail)) {
+            messageActionHandlers.Add(new GmailMailMessageActionHandler(gmailSessionFactory));
+        }
+
         var sendHandlers = new List<IMailSendHandler>(_sendHandlers);
         if (_options.EnableGraphSendHandler && !sendHandlers.Any(handler => handler.Kind == MailProfileKind.Graph)) {
             sendHandlers.Add(new GraphMailSendHandler(graphSessionFactory, draftMimeMessageFactory, pendingMessageRepository));
@@ -224,6 +299,13 @@ public sealed class MailApplicationBuilder {
         }
 
         var readService = _readService ?? new RoutedMailReadService(profileStore, readHandlers);
+        var folderAliasService = _folderAliasService ?? new MailFolderAliasService(profileStore, readService);
+        var messageActionPreviewService = _messageActionPreviewService ?? new MailMessageActionPreviewService(profileStore, folderAliasService);
+        var messageActionService = _messageActionService ?? new RoutedMailMessageActionService(profileStore, messageActionHandlers, folderAliasService);
+        var messageActionPlanService = _messageActionPlanService ?? new MailMessageActionPlanService(messageActionPreviewService, messageActionService);
+        var messageActionPlanExchangeService = _messageActionPlanExchangeService ?? new JsonMailMessageActionPlanExchangeService();
+        var messageActionBatchService = _messageActionBatchService ?? new MailMessageActionBatchService(messageActionPlanService);
+        var messageActionPlanRegistryService = _messageActionPlanRegistryService ?? new MailMessageActionPlanRegistryService(messageActionPlanBatchStore, messageActionPlanExchangeService, messageActionPreviewService, messageActionPlanService, messageActionBatchService, profileStore);
         var sendService = _sendService ?? new RoutedMailSendService(profileStore, sendHandlers);
         var queueService = _queueService ?? new PendingMailQueueService(pendingMessageRepository);
 
@@ -237,12 +319,20 @@ public sealed class MailApplicationBuilder {
             profileSecretService,
             profileBootstrapService,
             profileAuthService,
+            folderAliasService,
             draftService,
             draftExchangeService,
             readService,
+            messageActionPreviewService,
+            messageActionPlanService,
+            messageActionPlanExchangeService,
+            messageActionPlanRegistryService,
+            messageActionBatchService,
+            messageActionService,
             sendService,
             queueService,
             readHandlers.AsReadOnly(),
+            messageActionHandlers.AsReadOnly(),
             sendHandlers.AsReadOnly());
     }
 }

--- a/Sources/Mailozaurr.Application/MailApplicationOptions.cs
+++ b/Sources/Mailozaurr.Application/MailApplicationOptions.cs
@@ -13,6 +13,9 @@ public sealed class MailApplicationOptions {
     /// <summary>Options used for the default draft store.</summary>
     public MailDraftStoreOptions DraftStore { get; set; } = new();
 
+    /// <summary>Options used for the default reusable action plan batch store.</summary>
+    public MailMessageActionPlanBatchStoreOptions ActionPlanBatchStore { get; set; } = new();
+
     /// <summary>Options used for the default pending-message repository.</summary>
     public PendingMessageRepositoryOptions PendingMessageStore { get; set; } = new();
 

--- a/Sources/Mailozaurr.Application/MailApplicationPaths.cs
+++ b/Sources/Mailozaurr.Application/MailApplicationPaths.cs
@@ -8,9 +8,11 @@ public static class MailApplicationPaths {
     private const string ProfilesSubDirectoryName = "Profiles";
     private const string SecretsSubDirectoryName = "Secrets";
     private const string DraftsSubDirectoryName = "Drafts";
+    private const string ActionPlanBatchesSubDirectoryName = "ActionPlanBatches";
     private const string ProfilesOverrideDirectoryVariable = "MAILOZAURR_PROFILE_DIRECTORY";
     private const string SecretsOverrideDirectoryVariable = "MAILOZAURR_SECRET_DIRECTORY";
     private const string DraftsOverrideDirectoryVariable = "MAILOZAURR_DRAFT_DIRECTORY";
+    private const string ActionPlanBatchesOverrideDirectoryVariable = "MAILOZAURR_ACTION_PLAN_DIRECTORY";
 
     /// <summary>
     /// Resolves the default directory used to store profile configuration.
@@ -32,6 +34,13 @@ public static class MailApplicationPaths {
     public static string ResolveDraftsDirectory() => ResolveDirectory(
         DraftsOverrideDirectoryVariable,
         DraftsSubDirectoryName);
+
+    /// <summary>
+    /// Resolves the default directory used to store reusable action plan batches.
+    /// </summary>
+    public static string ResolveActionPlanBatchesDirectory() => ResolveDirectory(
+        ActionPlanBatchesOverrideDirectoryVariable,
+        ActionPlanBatchesSubDirectoryName);
 
     private static string ResolveDirectory(string overrideVariableName, string subDirectoryName) {
         var overrideDirectory = Environment.GetEnvironmentVariable(overrideVariableName);

--- a/Sources/Mailozaurr.Application/MailCapabilityCatalog.cs
+++ b/Sources/Mailozaurr.Application/MailCapabilityCatalog.cs
@@ -38,6 +38,8 @@ public static class MailCapabilityCatalog {
                 | MailCapability.SearchMessages
                 | MailCapability.ReadMessages
                 | MailCapability.SaveAttachments
+                | MailCapability.MarkMessages
+                | MailCapability.MoveMessages
                 | MailCapability.DeleteMessages
                 | MailCapability.SendMessages
                 | MailCapability.UseThreads

--- a/Sources/Mailozaurr.Application/MailFolderAliasService.cs
+++ b/Sources/Mailozaurr.Application/MailFolderAliasService.cs
@@ -1,0 +1,236 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Default implementation of provider-neutral folder alias discovery.
+/// </summary>
+public sealed class MailFolderAliasService : IMailFolderAliasService {
+    private static readonly AliasDefinition[] KnownAliases = {
+        new(MailFolderAliases.Inbox, "Inbox", MatchMode.ReadOrList, new[] { "inbox" }, new[] { "inbox" }),
+        new(MailFolderAliases.Archive, "Archive", MatchMode.Move, new[] { "archive", "allmail" }, new[] { "archive", "allmail" }),
+        new(MailFolderAliases.Trash, "Trash", MatchMode.Move, new[] { "trash", "deleteditems", "bin" }, new[] { "trash", "deleteditems", "deleteditem", "bin" }),
+        new(MailFolderAliases.Sent, "Sent", MatchMode.ListOnly, new[] { "sent", "sentitems" }, new[] { "sent", "sentitems", "sentmail" }),
+        new(MailFolderAliases.Drafts, "Drafts", MatchMode.ListOnly, new[] { "drafts", "draft" }, new[] { "drafts", "draft" }),
+        new(MailFolderAliases.Junk, "Junk", MatchMode.MoveOrList, new[] { "junk", "junkemail", "spam" }, new[] { "junk", "junkemail", "spam" })
+    };
+
+    private readonly IMailProfileStore _profileStore;
+    private readonly IMailReadService _read;
+
+    /// <summary>
+    /// Creates a new folder alias service.
+    /// </summary>
+    public MailFolderAliasService(IMailProfileStore profileStore, IMailReadService read) {
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        _read = read ?? throw new ArgumentNullException(nameof(read));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailFolderAliasSummary>> GetAliasesAsync(
+        string profileId,
+        string? mailboxId = null,
+        CancellationToken cancellationToken = default) {
+        var profile = await GetProfileAsync(profileId, cancellationToken).ConfigureAwait(false);
+        var capabilities = profile.GetCapabilities();
+        var folders = await TryGetFoldersAsync(profile, mailboxId, capabilities, cancellationToken).ConfigureAwait(false);
+        var results = new List<MailFolderAliasSummary>();
+        foreach (var alias in KnownAliases) {
+            if (!IsSupported(alias.Mode, capabilities)) {
+                continue;
+            }
+
+            var resolved = TryResolveAlias(alias, folders);
+            results.Add(new MailFolderAliasSummary {
+                ProfileId = profile.Id,
+                MailboxId = mailboxId,
+                Alias = alias.Alias,
+                DisplayName = alias.DisplayName,
+                IsSupported = true,
+                IsResolved = resolved != null,
+                FolderId = resolved?.Id,
+                FolderDisplayName = resolved?.DisplayName,
+                FolderPath = resolved?.Path,
+                SpecialUse = resolved?.SpecialUse,
+                Summary = resolved == null
+                    ? $"{alias.Alias} [alias-only]"
+                    : $"{alias.Alias} -> {resolved.Path ?? resolved.DisplayName ?? resolved.Id}"
+            });
+        }
+
+        return results;
+    }
+
+    /// <inheritdoc />
+    public async Task<MailFolderTargetResolution> ResolveAsync(
+        string profileId,
+        string targetFolderId,
+        string? mailboxId = null,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(targetFolderId)) {
+            throw new ArgumentException("Target folder id is required.", nameof(targetFolderId));
+        }
+
+        var normalizedTarget = targetFolderId.Trim();
+        var canonicalAlias = MailFolderAliases.Canonicalize(normalizedTarget);
+        if (canonicalAlias == null) {
+            return new MailFolderTargetResolution {
+                ProfileId = profileId,
+                MailboxId = mailboxId,
+                RequestedValue = normalizedTarget,
+                IsAlias = false,
+                IsSupported = true,
+                IsResolved = true,
+                EffectiveFolderId = normalizedTarget,
+                Summary = $"{normalizedTarget} [explicit]"
+            };
+        }
+
+        var alias = (await GetAliasesAsync(profileId, mailboxId, cancellationToken).ConfigureAwait(false))
+            .FirstOrDefault(item => string.Equals(item.Alias, canonicalAlias, StringComparison.OrdinalIgnoreCase));
+
+        if (alias == null) {
+            return new MailFolderTargetResolution {
+                ProfileId = profileId,
+                MailboxId = mailboxId,
+                RequestedValue = normalizedTarget,
+                IsAlias = true,
+                Alias = canonicalAlias,
+                IsSupported = false,
+                IsResolved = false,
+                EffectiveFolderId = canonicalAlias,
+                Summary = $"{canonicalAlias} [unsupported]"
+            };
+        }
+
+        return new MailFolderTargetResolution {
+            ProfileId = alias.ProfileId,
+            MailboxId = alias.MailboxId,
+            RequestedValue = normalizedTarget,
+            IsAlias = true,
+            Alias = alias.Alias,
+            IsSupported = alias.IsSupported,
+            IsResolved = alias.IsResolved,
+            EffectiveFolderId = !string.IsNullOrWhiteSpace(alias.FolderId) ? alias.FolderId! : alias.Alias,
+            FolderDisplayName = alias.FolderDisplayName,
+            FolderPath = alias.FolderPath,
+            SpecialUse = alias.SpecialUse,
+            Summary = alias.IsResolved
+                ? $"{alias.Alias} -> {alias.FolderPath ?? alias.FolderDisplayName ?? alias.FolderId}"
+                : $"{alias.Alias} [alias-only]"
+        };
+    }
+
+    private async Task<MailProfile> GetProfileAsync(string profileId, CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            throw new ArgumentException("Profile id is required.", nameof(profileId));
+        }
+
+        var profile = await _profileStore.GetByIdAsync(profileId.Trim(), cancellationToken).ConfigureAwait(false);
+        return profile ?? throw new InvalidOperationException($"Profile '{profileId}' was not found.");
+    }
+
+    private async Task<IReadOnlyList<FolderRef>> TryGetFoldersAsync(
+        MailProfile profile,
+        string? mailboxId,
+        ProfileCapabilities capabilities,
+        CancellationToken cancellationToken) {
+        if (!capabilities.Supports(MailCapability.ListFolders)) {
+            return Array.Empty<FolderRef>();
+        }
+
+        try {
+            return await _read.GetFoldersAsync(new MailFolderQuery {
+                ProfileId = profile.Id,
+                MailboxId = mailboxId
+            }, cancellationToken).ConfigureAwait(false);
+        } catch {
+            return Array.Empty<FolderRef>();
+        }
+    }
+
+    private static bool IsSupported(MatchMode mode, ProfileCapabilities capabilities) => mode switch {
+        MatchMode.Move => capabilities.Supports(MailCapability.MoveMessages),
+        MatchMode.ListOnly => capabilities.Supports(MailCapability.ListFolders),
+        MatchMode.MoveOrList => capabilities.Supports(MailCapability.MoveMessages) || capabilities.Supports(MailCapability.ListFolders),
+        MatchMode.ReadOrList => capabilities.Supports(MailCapability.ListFolders) || capabilities.Supports(MailCapability.ReadMessages) || capabilities.Supports(MailCapability.SearchMessages),
+        _ => false
+    };
+
+    private static FolderRef? TryResolveAlias(AliasDefinition alias, IReadOnlyList<FolderRef> folders) {
+        if (folders.Count == 0) {
+            return null;
+        }
+
+        foreach (var folder in folders) {
+            if (Matches(folder.SpecialUse, alias.SpecialUseMatches)) {
+                return folder;
+            }
+        }
+
+        foreach (var folder in folders) {
+            if (Matches(folder.Path, alias.NameMatches) || Matches(folder.DisplayName, alias.NameMatches)) {
+                return folder;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool Matches(string? value, IReadOnlyList<string> candidates) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        var normalizedValue = Normalize(value!);
+        foreach (var candidate in candidates) {
+            if (!string.IsNullOrWhiteSpace(candidate) && normalizedValue == Normalize(candidate!)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string Normalize(string value) {
+        var buffer = new char[value.Length];
+        var index = 0;
+        foreach (var character in value) {
+            if (char.IsLetterOrDigit(character)) {
+                buffer[index++] = char.ToLowerInvariant(character);
+            }
+        }
+
+        return new string(buffer, 0, index);
+    }
+
+    private sealed class AliasDefinition {
+        public AliasDefinition(
+            string alias,
+            string displayName,
+            MatchMode mode,
+            IReadOnlyList<string> specialUseMatches,
+            IReadOnlyList<string> nameMatches) {
+            Alias = alias;
+            DisplayName = displayName;
+            Mode = mode;
+            SpecialUseMatches = specialUseMatches;
+            NameMatches = nameMatches;
+        }
+
+        public string Alias { get; }
+
+        public string DisplayName { get; }
+
+        public MatchMode Mode { get; }
+
+        public IReadOnlyList<string> SpecialUseMatches { get; }
+
+        public IReadOnlyList<string> NameMatches { get; }
+    }
+
+    private enum MatchMode {
+        Move,
+        ListOnly,
+        MoveOrList,
+        ReadOrList
+    }
+}

--- a/Sources/Mailozaurr.Application/MailFolderAliasSummary.cs
+++ b/Sources/Mailozaurr.Application/MailFolderAliasSummary.cs
@@ -1,0 +1,39 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Describes a provider-neutral folder alias and its resolved provider target when known.
+/// </summary>
+public sealed class MailFolderAliasSummary {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Owning mailbox identifier when relevant.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Provider-neutral alias such as Inbox, Archive, or Trash.</summary>
+    public string Alias { get; set; } = string.Empty;
+
+    /// <summary>User-facing alias display name.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Indicates whether the alias can be used by the selected profile.</summary>
+    public bool IsSupported { get; set; }
+
+    /// <summary>Indicates whether the alias was resolved to a provider folder.</summary>
+    public bool IsResolved { get; set; }
+
+    /// <summary>Resolved provider folder identifier when known.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Resolved provider folder display name when known.</summary>
+    public string? FolderDisplayName { get; set; }
+
+    /// <summary>Resolved provider folder path when known.</summary>
+    public string? FolderPath { get; set; }
+
+    /// <summary>Resolved provider special-use marker when known.</summary>
+    public string? SpecialUse { get; set; }
+
+    /// <summary>Human-readable summary for lightweight CLI and MCP output.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MailFolderAliases.cs
+++ b/Sources/Mailozaurr.Application/MailFolderAliases.cs
@@ -1,0 +1,52 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Shared well-known folder aliases used across providers.
+/// </summary>
+public static class MailFolderAliases {
+    private static readonly string[] KnownAliases = {
+        Inbox,
+        Archive,
+        Trash,
+        Sent,
+        Drafts,
+        Junk
+    };
+
+    /// <summary>Inbox folder alias.</summary>
+    public const string Inbox = "Inbox";
+
+    /// <summary>Archive folder alias.</summary>
+    public const string Archive = "Archive";
+
+    /// <summary>Trash/deleted-items folder alias.</summary>
+    public const string Trash = "Trash";
+
+    /// <summary>Sent items folder alias.</summary>
+    public const string Sent = "Sent";
+
+    /// <summary>Drafts folder alias.</summary>
+    public const string Drafts = "Drafts";
+
+    /// <summary>Junk or spam folder alias.</summary>
+    public const string Junk = "Junk";
+
+    /// <summary>Returns all known provider-neutral folder aliases.</summary>
+    public static IReadOnlyList<string> All => KnownAliases;
+
+    /// <summary>Returns the canonical alias value when the input matches a known alias.</summary>
+    public static string? Canonicalize(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        var normalizedValue = value!.Trim();
+        foreach (var alias in KnownAliases) {
+            if (string.Equals(alias, normalizedValue, StringComparison.OrdinalIgnoreCase)) {
+                return alias;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Sources/Mailozaurr.Application/MailFolderTargetResolution.cs
+++ b/Sources/Mailozaurr.Application/MailFolderTargetResolution.cs
@@ -1,0 +1,42 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Describes how a requested folder target resolves for a specific profile and mailbox.
+/// </summary>
+public sealed class MailFolderTargetResolution {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Owning mailbox identifier when relevant.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>The original requested destination folder value.</summary>
+    public string RequestedValue { get; set; } = string.Empty;
+
+    /// <summary>True when the requested value matched a known provider-neutral alias.</summary>
+    public bool IsAlias { get; set; }
+
+    /// <summary>The canonical provider-neutral alias when <see cref="IsAlias" /> is true.</summary>
+    public string? Alias { get; set; }
+
+    /// <summary>True when the target is supported for the selected profile.</summary>
+    public bool IsSupported { get; set; }
+
+    /// <summary>True when a provider-specific folder target was resolved.</summary>
+    public bool IsResolved { get; set; }
+
+    /// <summary>The effective folder identifier that should be used for actions.</summary>
+    public string EffectiveFolderId { get; set; } = string.Empty;
+
+    /// <summary>The resolved provider folder display name when known.</summary>
+    public string? FolderDisplayName { get; set; }
+
+    /// <summary>The resolved provider folder path when known.</summary>
+    public string? FolderPath { get; set; }
+
+    /// <summary>The resolved provider special-use marker when known.</summary>
+    public string? SpecialUse { get; set; }
+
+    /// <summary>Human-readable summary for lightweight CLI and MCP output.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MailMessageActionBatchService.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionBatchService.cs
@@ -1,0 +1,100 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Executes batches of normalized message action plans through the shared planning service.
+/// </summary>
+public sealed class MailMessageActionBatchService : IMailMessageActionBatchService {
+    private readonly IMailMessageActionPlanService _planService;
+
+    /// <summary>
+    /// Creates a new message action batch execution service.
+    /// </summary>
+    public MailMessageActionBatchService(IMailMessageActionPlanService planService) {
+        _planService = planService ?? throw new ArgumentNullException(nameof(planService));
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionBatchExecutionResult> ExecuteAsync(
+        IReadOnlyList<MessageActionExecutionPlan> plans,
+        bool continueOnError = true,
+        CancellationToken cancellationToken = default) {
+        if (plans == null) {
+            throw new ArgumentNullException(nameof(plans));
+        }
+
+        var result = new MessageActionBatchExecutionResult {
+            RequestedPlanCount = plans.Count
+        };
+
+        for (var index = 0; index < plans.Count; index++) {
+            var plan = plans[index];
+            if (plan == null) {
+                result.FailedPlanCount++;
+                result.AttemptedPlanCount++;
+                result.Results.Add(new MessageActionBatchExecutionItemResult {
+                    Index = index,
+                    Succeeded = false,
+                    Code = "plan_required",
+                    Message = "A plan entry was null.",
+                    FailedCount = 1
+                });
+                if (!continueOnError) {
+                    AddSkippedItems(result, plans, index + 1);
+                    break;
+                }
+
+                continue;
+            }
+
+            var execution = await _planService.ExecuteAsync(plan, cancellationToken).ConfigureAwait(false);
+            result.AttemptedPlanCount++;
+            if (execution.Succeeded) {
+                result.SucceededPlanCount++;
+            } else {
+                result.FailedPlanCount++;
+            }
+
+            result.Results.Add(new MessageActionBatchExecutionItemResult {
+                Index = index,
+                Action = plan.Action,
+                ExecutionKind = plan.ExecutionKind,
+                ProfileId = plan.ProfileId,
+                RequestedCount = plan.RequestedCount,
+                Succeeded = execution.Succeeded,
+                Code = execution.Code,
+                Message = execution.Message,
+                SucceededCount = execution.SucceededCount,
+                FailedCount = execution.FailedCount
+            });
+
+            if (!execution.Succeeded && !continueOnError) {
+                AddSkippedItems(result, plans, index + 1);
+                break;
+            }
+        }
+
+        result.Succeeded = result.FailedPlanCount == 0;
+        result.Code = result.Succeeded ? null : "batch_execution_failed";
+        result.Message = result.Succeeded
+            ? $"Executed {result.AttemptedPlanCount} action plan(s) successfully."
+            : $"Executed {result.AttemptedPlanCount} action plan(s): {result.SucceededPlanCount} succeeded, {result.FailedPlanCount} failed, {result.SkippedPlanCount} skipped.";
+        return result;
+    }
+
+    private static void AddSkippedItems(MessageActionBatchExecutionResult result, IReadOnlyList<MessageActionExecutionPlan> plans, int startIndex) {
+        for (var index = startIndex; index < plans.Count; index++) {
+            var plan = plans[index];
+            result.SkippedPlanCount++;
+            result.Results.Add(new MessageActionBatchExecutionItemResult {
+                Index = index,
+                Action = plan?.Action ?? string.Empty,
+                ExecutionKind = plan?.ExecutionKind ?? string.Empty,
+                ProfileId = plan?.ProfileId ?? string.Empty,
+                RequestedCount = plan?.RequestedCount ?? 0,
+                Succeeded = false,
+                Code = "skipped_after_failure",
+                Message = "Skipped because an earlier plan failed and continueOnError was false."
+            });
+        }
+    }
+}

--- a/Sources/Mailozaurr.Application/MailMessageActionPlanBatch.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionPlanBatch.cs
@@ -1,0 +1,24 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents a persisted reusable batch of normalized message action plans.
+/// </summary>
+public sealed class MailMessageActionPlanBatch {
+    /// <summary>Stable batch identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>User-facing batch name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Optional operator-facing description.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>When the batch was first created.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>When the batch was last updated.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>The normalized plans contained in this reusable batch.</summary>
+    public List<MessageActionExecutionPlan> Plans { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/MailMessageActionPlanBatchCompact.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionPlanBatchCompact.cs
@@ -1,0 +1,30 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Lightweight projection of a persisted reusable message action plan batch.
+/// </summary>
+public sealed class MailMessageActionPlanBatchCompact {
+    /// <summary>Stable batch identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>User-facing batch name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Total plans in the batch.</summary>
+    public int PlanCount { get; set; }
+
+    /// <summary>Total plans currently ready for execution.</summary>
+    public int ReadyPlanCount { get; set; }
+
+    /// <summary>Total distinct profiles referenced by the stored plans.</summary>
+    public int ProfileCount { get; set; }
+
+    /// <summary>Lightweight human-readable plan names available in the batch.</summary>
+    public List<string> PlanNames { get; set; } = new();
+
+    /// <summary>Last updated timestamp for the batch.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>Human-readable summary.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MailMessageActionPlanBatchQuery.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionPlanBatchQuery.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Optional filters for persisted action-plan batch queries.
+/// </summary>
+public sealed class MailMessageActionPlanBatchQuery {
+    /// <summary>Optional human-readable plan names that must exist in the returned batch.</summary>
+    public List<string> PlanNames { get; set; } = new();
+
+    /// <summary>Optional profile identifiers that must be referenced by the returned batch.</summary>
+    public List<string> ProfileIds { get; set; } = new();
+
+    /// <summary>Optional normalized action names that must be referenced by the returned batch.</summary>
+    public List<string> Actions { get; set; } = new();
+
+    /// <summary>Optional sort order for the returned batches.</summary>
+    public MailMessageActionPlanBatchSortBy SortBy { get; set; } = MailMessageActionPlanBatchSortBy.Id;
+
+    /// <summary>When true, reverses the selected sort order.</summary>
+    public bool Descending { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MailMessageActionPlanBatchSortBy.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionPlanBatchSortBy.cs
@@ -1,0 +1,24 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Supported sort orders for stored action-plan batch queries.
+/// </summary>
+public enum MailMessageActionPlanBatchSortBy {
+    /// <summary>Sort by stable batch identifier.</summary>
+    Id,
+
+    /// <summary>Sort by user-facing batch name.</summary>
+    Name,
+
+    /// <summary>Sort by total plan count.</summary>
+    PlanCount,
+
+    /// <summary>Sort by ready plan count.</summary>
+    ReadyPlanCount,
+
+    /// <summary>Sort by last updated timestamp.</summary>
+    UpdatedAt,
+
+    /// <summary>Sort by the number of distinct action types referenced by the batch.</summary>
+    ActionTypeCount
+}

--- a/Sources/Mailozaurr.Application/MailMessageActionPlanBatchStoreOptions.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionPlanBatchStoreOptions.cs
@@ -1,0 +1,22 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Configures where persisted reusable message action plan batches are stored.
+/// </summary>
+public sealed class MailMessageActionPlanBatchStoreOptions {
+    /// <summary>Directory containing the batch store file.</summary>
+    public string? DirectoryPath { get; set; }
+
+    /// <summary>File name used to persist batches.</summary>
+    public string FileName { get; set; } = "action-plan-batches.json";
+
+    /// <summary>
+    /// Resolves the file path that should be used by the batch store.
+    /// </summary>
+    public string GetFilePath() {
+        var directory = string.IsNullOrWhiteSpace(DirectoryPath)
+            ? MailApplicationPaths.ResolveActionPlanBatchesDirectory()
+            : Path.GetFullPath(DirectoryPath);
+        return Path.Combine(directory, FileName);
+    }
+}

--- a/Sources/Mailozaurr.Application/MailMessageActionPlanBatchSummary.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionPlanBatchSummary.cs
@@ -1,0 +1,33 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Rich lightweight summary of a persisted reusable message action plan batch.
+/// </summary>
+public sealed class MailMessageActionPlanBatchSummary {
+    /// <summary>Stable batch identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>User-facing batch name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Total plans in the batch.</summary>
+    public int PlanCount { get; set; }
+
+    /// <summary>Total plans currently ready for execution.</summary>
+    public int ReadyPlanCount { get; set; }
+
+    /// <summary>Distinct profile identifiers referenced by the stored plans.</summary>
+    public List<string> ProfileIds { get; set; } = new();
+
+    /// <summary>Per-action plan counts keyed by normalized action name.</summary>
+    public Dictionary<string, int> ActionCounts { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Lightweight human-readable plan names available in the batch.</summary>
+    public List<string> PlanNames { get; set; } = new();
+
+    /// <summary>Last updated timestamp for the batch.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>Human-readable summary.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MailMessageActionPlanBatchTransformPreview.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionPlanBatchTransformPreview.cs
@@ -1,0 +1,36 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Dry-run preview for cloning and transforming a stored message-action plan batch.
+/// </summary>
+public sealed class MailMessageActionPlanBatchTransformPreview : OperationResult {
+    /// <summary>Source batch identifier.</summary>
+    public string SourceBatchId { get; set; } = string.Empty;
+
+    /// <summary>Source batch name when available.</summary>
+    public string? SourceBatchName { get; set; }
+
+    /// <summary>Total plans contained in the source batch.</summary>
+    public int PlanCount { get; set; }
+
+    /// <summary>Total transformed plans whose effective values would change.</summary>
+    public int ChangedPlanCount { get; set; }
+
+    /// <summary>Total transformed plans whose confirmation token would be regenerated.</summary>
+    public int ConfirmationTokenChangedCount { get; set; }
+
+    /// <summary>Whether the requested target profile exists when a profile remap was requested.</summary>
+    public bool? TargetProfileExists { get; set; }
+
+    /// <summary>Target profile kind when a profile remap was requested and resolved.</summary>
+    public MailProfileKind? TargetProfileKind { get; set; }
+
+    /// <summary>Validation or transform warnings.</summary>
+    public List<string> Warnings { get; set; } = new();
+
+    /// <summary>Validation errors that would block saving the transformed clone.</summary>
+    public List<string> Errors { get; set; } = new();
+
+    /// <summary>Per-plan transform preview items.</summary>
+    public List<MessageActionPlanBatchTransformPreviewItem> Plans { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/MailMessageActionPlanRegistryService.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionPlanRegistryService.cs
@@ -1,0 +1,787 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Implements reusable lifecycle operations for persisted message action plan batches.
+/// </summary>
+public sealed class MailMessageActionPlanRegistryService : IMailMessageActionPlanRegistryService {
+    private readonly IMailMessageActionPlanBatchStore _store;
+    private readonly IMailMessageActionPlanExchangeService _exchangeService;
+    private readonly IMailMessageActionPreviewService _previewService;
+    private readonly IMailMessageActionPlanService _planService;
+    private readonly IMailMessageActionBatchService _batchService;
+    private readonly IMailProfileStore _profileStore;
+
+    /// <summary>
+    /// Creates a new persisted action plan registry service.
+    /// </summary>
+    public MailMessageActionPlanRegistryService(
+        IMailMessageActionPlanBatchStore store,
+        IMailMessageActionPlanExchangeService exchangeService,
+        IMailMessageActionPreviewService previewService,
+        IMailMessageActionPlanService planService,
+        IMailMessageActionBatchService batchService,
+        IMailProfileStore profileStore) {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _exchangeService = exchangeService ?? throw new ArgumentNullException(nameof(exchangeService));
+        _previewService = previewService ?? throw new ArgumentNullException(nameof(previewService));
+        _planService = planService ?? throw new ArgumentNullException(nameof(planService));
+        _batchService = batchService ?? throw new ArgumentNullException(nameof(batchService));
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailMessageActionPlanBatch>> GetBatchesAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default) =>
+        ApplyBatchQuery(await _store.GetAllAsync(cancellationToken).ConfigureAwait(false), query);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailMessageActionPlanBatchCompact>> GetBatchesCompactAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default) =>
+        ApplyBatchQuery(await _store.GetAllAsync(cancellationToken).ConfigureAwait(false), query)
+        .Select(ToCompact)
+        .ToArray();
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailMessageActionPlanBatchSummary>> GetBatchesSummaryAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default) =>
+        ApplyBatchQuery(await _store.GetAllAsync(cancellationToken).ConfigureAwait(false), query)
+        .Select(ToSummary)
+        .ToArray();
+
+    /// <inheritdoc />
+    public Task<MailMessageActionPlanBatch?> GetBatchAsync(string batchId, CancellationToken cancellationToken = default) =>
+        _store.GetByIdAsync(batchId, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<MailMessageActionPlanBatchCompact?> GetBatchCompactAsync(string batchId, CancellationToken cancellationToken = default) {
+        var batch = await _store.GetByIdAsync(batchId, cancellationToken).ConfigureAwait(false);
+        return batch == null ? null : ToCompact(batch);
+    }
+
+    /// <inheritdoc />
+    public async Task<MailMessageActionPlanBatchSummary?> GetBatchSummaryAsync(string batchId, CancellationToken cancellationToken = default) {
+        var batch = await _store.GetByIdAsync(batchId, cancellationToken).ConfigureAwait(false);
+        return batch == null ? null : ToSummary(batch);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SaveAsync(MailMessageActionPlanBatch batch, CancellationToken cancellationToken = default) {
+        var validation = await ValidateAsync(batch, cancellationToken).ConfigureAwait(false);
+        if (!validation.Succeeded) {
+            return validation;
+        }
+
+        await _store.SaveAsync(batch, cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success($"Action plan batch '{batch.Id}' saved.");
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> CreateCommonBatchAsync(
+        string batchId,
+        string name,
+        CommonMessageActionsPreviewRequest request,
+        IReadOnlyList<string>? actions = null,
+        string? description = null,
+        CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var preview = await _previewService.PreviewCommonActionsAsync(request, cancellationToken).ConfigureAwait(false);
+        return await CreateCommonBatchFromPreviewAsync(batchId, name, preview, actions, description, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> CreateCommonBatchFromPreviewAsync(
+        string batchId,
+        string name,
+        CommonMessageActionsPreview preview,
+        IReadOnlyList<string>? actions = null,
+        string? description = null,
+        CancellationToken cancellationToken = default) {
+        if (preview == null) {
+            throw new ArgumentNullException(nameof(preview));
+        }
+
+        var selectedActions = SelectCommonActions(preview, actions);
+        var plans = new List<MessageActionExecutionPlan>();
+        foreach (var action in selectedActions) {
+            var plan = await _planService.CreatePlanAsync(new MessageActionExecutionPlanRequest {
+                Action = action.Action,
+                ProfileId = preview.ProfileId,
+                MailboxId = preview.MailboxId,
+                FolderId = preview.FolderId,
+                MessageIds = preview.MessageIds.ToList(),
+                DestinationFolderId = ResolveDestinationFolderId(action, preview.RequestedDestinationFolderId),
+                ConfirmationToken = action.ConfirmationToken
+            }, cancellationToken).ConfigureAwait(false);
+
+            if (plan.Succeeded) {
+                plans.Add(plan);
+            }
+        }
+
+        if (plans.Count == 0) {
+            return OperationResult.Failure("no_supported_actions", "No supported action plans could be created for this message selection.");
+        }
+
+        return await SaveAsync(new MailMessageActionPlanBatch {
+            Id = batchId,
+            Name = name,
+            Description = description,
+            Plans = plans
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> CloneAsync(string sourceBatchId, string targetBatchId, string name, string? description = null, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(sourceBatchId)) {
+            throw new ArgumentException("Source batch id is required.", nameof(sourceBatchId));
+        }
+        if (string.IsNullOrWhiteSpace(targetBatchId)) {
+            throw new ArgumentException("Target batch id is required.", nameof(targetBatchId));
+        }
+        if (string.IsNullOrWhiteSpace(name)) {
+            throw new ArgumentException("Batch name is required.", nameof(name));
+        }
+
+        var source = await _store.GetByIdAsync(sourceBatchId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (source == null) {
+            return OperationResult.Failure("action_plan_batch_not_found", $"Action plan batch '{sourceBatchId.Trim()}' was not found.");
+        }
+
+        return await SaveAsync(new MailMessageActionPlanBatch {
+            Id = targetBatchId.Trim(),
+            Name = name.Trim(),
+            Description = description ?? source.Description,
+            Plans = source.Plans.Select(ClonePlan).ToList()
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> TransformCloneAsync(
+        string sourceBatchId,
+        string targetBatchId,
+        string name,
+        MessageActionPlanBatchTransformRequest transform,
+        string? description = null,
+        CancellationToken cancellationToken = default) {
+        if (transform == null) {
+            throw new ArgumentNullException(nameof(transform));
+        }
+        if (string.IsNullOrWhiteSpace(sourceBatchId)) {
+            throw new ArgumentException("Source batch id is required.", nameof(sourceBatchId));
+        }
+        if (string.IsNullOrWhiteSpace(targetBatchId)) {
+            throw new ArgumentException("Target batch id is required.", nameof(targetBatchId));
+        }
+        if (string.IsNullOrWhiteSpace(name)) {
+            throw new ArgumentException("Batch name is required.", nameof(name));
+        }
+
+        var source = await _store.GetByIdAsync(sourceBatchId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (source == null) {
+            return OperationResult.Failure("action_plan_batch_not_found", $"Action plan batch '{sourceBatchId.Trim()}' was not found.");
+        }
+
+        var selectedPlans = SelectPlans(source, transform, out var selectionError);
+        if (selectionError != null) {
+            return selectionError;
+        }
+
+        return await SaveAsync(new MailMessageActionPlanBatch {
+            Id = targetBatchId.Trim(),
+            Name = name.Trim(),
+            Description = description ?? source.Description,
+            Plans = selectedPlans.Select(selection => TransformPlan(selection.Plan, transform)).ToList()
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MailMessageActionPlanBatchTransformPreview> PreviewTransformCloneAsync(
+        string sourceBatchId,
+        MessageActionPlanBatchTransformRequest transform,
+        CancellationToken cancellationToken = default) {
+        if (transform == null) {
+            throw new ArgumentNullException(nameof(transform));
+        }
+        if (string.IsNullOrWhiteSpace(sourceBatchId)) {
+            throw new ArgumentException("Source batch id is required.", nameof(sourceBatchId));
+        }
+
+        var normalizedSourceBatchId = sourceBatchId.Trim();
+        var source = await _store.GetByIdAsync(normalizedSourceBatchId, cancellationToken).ConfigureAwait(false);
+        if (source == null) {
+            return new MailMessageActionPlanBatchTransformPreview {
+                Succeeded = false,
+                Code = "action_plan_batch_not_found",
+                Message = $"Action plan batch '{normalizedSourceBatchId}' was not found.",
+                SourceBatchId = normalizedSourceBatchId
+            };
+        }
+
+        var selectedPlans = SelectPlans(source, transform, out var selectionError);
+
+        var preview = new MailMessageActionPlanBatchTransformPreview {
+            Succeeded = selectionError == null,
+            Code = selectionError?.Code,
+            SourceBatchId = source.Id,
+            SourceBatchName = source.Name,
+            PlanCount = selectedPlans.Count,
+            Message = selectionError?.Message
+        };
+
+        if (selectionError != null && !string.IsNullOrWhiteSpace(selectionError.Message)) {
+            preview.Errors.Add(selectionError.Message!);
+        }
+
+        if (!string.IsNullOrWhiteSpace(transform.ProfileId)) {
+            var targetProfileId = transform.ProfileId!.Trim();
+            var targetProfile = await _profileStore.GetByIdAsync(targetProfileId, cancellationToken).ConfigureAwait(false);
+            preview.TargetProfileExists = targetProfile != null;
+            preview.TargetProfileKind = targetProfile?.Kind;
+            if (targetProfile == null) {
+                preview.Succeeded = false;
+                preview.Code = "action_plan_profile_not_found";
+                preview.Errors.Add($"Profile '{targetProfileId}' was not found.");
+            }
+        }
+
+        foreach (var selection in selectedPlans) {
+            var sourcePlan = selection.Plan;
+            var transformedPlan = TransformPlan(sourcePlan, transform);
+            var willChange =
+                !string.Equals(sourcePlan.ProfileId, transformedPlan.ProfileId, StringComparison.Ordinal) ||
+                !string.Equals(sourcePlan.MailboxId, transformedPlan.MailboxId, StringComparison.Ordinal) ||
+                !string.Equals(sourcePlan.FolderId, transformedPlan.FolderId, StringComparison.Ordinal) ||
+                !string.Equals(sourcePlan.RequestedDestinationFolderId, transformedPlan.RequestedDestinationFolderId, StringComparison.Ordinal);
+            var tokenChanged = !string.Equals(sourcePlan.ConfirmationToken, transformedPlan.ConfirmationToken, StringComparison.Ordinal);
+
+            if (willChange) {
+                preview.ChangedPlanCount++;
+            }
+            if (tokenChanged) {
+                preview.ConfirmationTokenChangedCount++;
+            }
+
+            preview.Plans.Add(new MessageActionPlanBatchTransformPreviewItem {
+                Index = selection.Index,
+                Action = sourcePlan.Action,
+                ExecutionKind = sourcePlan.ExecutionKind,
+                SourceProfileId = sourcePlan.ProfileId,
+                TargetProfileId = transformedPlan.ProfileId,
+                SourceMailboxId = sourcePlan.MailboxId,
+                TargetMailboxId = transformedPlan.MailboxId,
+                SourceFolderId = sourcePlan.FolderId,
+                TargetFolderId = transformedPlan.FolderId,
+                SourceDestinationFolderId = sourcePlan.RequestedDestinationFolderId,
+                TargetDestinationFolderId = transformedPlan.RequestedDestinationFolderId,
+                WillChange = willChange,
+                ConfirmationTokenWillChange = tokenChanged,
+                Summary = BuildTransformSummary(sourcePlan, transformedPlan, willChange, tokenChanged)
+            });
+        }
+
+        if (preview.ChangedPlanCount == 0) {
+            preview.Warnings.Add("The requested transform would not change any stored plan values.");
+        }
+
+        preview.Message = preview.Succeeded
+            ? $"Previewed transform for {preview.PlanCount} plan(s); {preview.ChangedPlanCount} would change and {preview.ConfirmationTokenChangedCount} confirmation token(s) would be regenerated."
+            : preview.Message ?? $"Transform preview for batch '{source.Id}' found validation issues.";
+        return preview;
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> AppendPlanAsync(string batchId, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(batchId)) {
+            throw new ArgumentException("Batch id is required.", nameof(batchId));
+        }
+        if (plan == null) {
+            throw new ArgumentNullException(nameof(plan));
+        }
+
+        var batch = await _store.GetByIdAsync(batchId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (batch == null) {
+            return OperationResult.Failure("action_plan_batch_not_found", $"Action plan batch '{batchId.Trim()}' was not found.");
+        }
+
+        batch.Plans.Add(ClonePlan(plan));
+        return await SaveAsync(batch, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> AppendImportedPlanAsync(string batchId, string path, CancellationToken cancellationToken = default) {
+        var plan = await _exchangeService.LoadAsync(path, cancellationToken).ConfigureAwait(false);
+        return await AppendPlanAsync(batchId, plan, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> ReplacePlanAtAsync(string batchId, int index, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(batchId)) {
+            throw new ArgumentException("Batch id is required.", nameof(batchId));
+        }
+        if (plan == null) {
+            throw new ArgumentNullException(nameof(plan));
+        }
+
+        var batch = await _store.GetByIdAsync(batchId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (batch == null) {
+            return OperationResult.Failure("action_plan_batch_not_found", $"Action plan batch '{batchId.Trim()}' was not found.");
+        }
+        if (index < 0 || index >= batch.Plans.Count) {
+            return OperationResult.Failure("action_plan_batch_index_invalid", $"Action plan batch '{batch.Id}' does not contain a plan at index {index}.");
+        }
+
+        batch.Plans[index] = ClonePlan(plan);
+        return await SaveAsync(batch, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> ReplaceImportedPlanAtAsync(string batchId, int index, string path, CancellationToken cancellationToken = default) {
+        var plan = await _exchangeService.LoadAsync(path, cancellationToken).ConfigureAwait(false);
+        return await ReplacePlanAtAsync(batchId, index, plan, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> RemovePlanAtAsync(string batchId, int index, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(batchId)) {
+            throw new ArgumentException("Batch id is required.", nameof(batchId));
+        }
+
+        var batch = await _store.GetByIdAsync(batchId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (batch == null) {
+            return OperationResult.Failure("action_plan_batch_not_found", $"Action plan batch '{batchId.Trim()}' was not found.");
+        }
+        if (index < 0 || index >= batch.Plans.Count) {
+            return OperationResult.Failure("action_plan_batch_index_invalid", $"Action plan batch '{batch.Id}' does not contain a plan at index {index}.");
+        }
+        if (batch.Plans.Count == 1) {
+            return OperationResult.Failure("action_plan_batch_invalid", "Cannot remove the last plan from a batch. Delete the batch instead.");
+        }
+
+        batch.Plans.RemoveAt(index);
+        return await SaveAsync(batch, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> DeleteAsync(string batchId, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(batchId)) {
+            throw new ArgumentException("Batch id is required.", nameof(batchId));
+        }
+
+        var normalizedId = batchId.Trim();
+        var removed = await _store.RemoveAsync(normalizedId, cancellationToken).ConfigureAwait(false);
+        return removed
+            ? OperationResult.Success($"Action plan batch '{normalizedId}' deleted.")
+            : OperationResult.Failure("action_plan_batch_not_found", $"Action plan batch '{normalizedId}' was not found.");
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> ImportAsync(string batchId, string name, string path, string? description = null, CancellationToken cancellationToken = default) {
+        var plans = await _exchangeService.LoadBatchAsync(path, cancellationToken).ConfigureAwait(false);
+        return await SaveAsync(new MailMessageActionPlanBatch {
+            Id = batchId,
+            Name = name,
+            Description = description,
+            Plans = plans.ToList()
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> ExportAsync(string batchId, string path, CancellationToken cancellationToken = default) {
+        var batch = await _store.GetByIdAsync(batchId, cancellationToken).ConfigureAwait(false);
+        if (batch == null) {
+            return OperationResult.Failure("action_plan_batch_not_found", $"Action plan batch '{batchId}' was not found.");
+        }
+
+        await _exchangeService.SaveBatchAsync(path, batch.Plans, cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success($"Action plan batch '{batch.Id}' exported.");
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionBatchExecutionResult> ExecuteAsync(string batchId, bool continueOnError = true, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(batchId)) {
+            throw new ArgumentException("Batch id is required.", nameof(batchId));
+        }
+
+        var batch = await _store.GetByIdAsync(batchId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (batch == null) {
+            return new MessageActionBatchExecutionResult {
+                Succeeded = false,
+                Code = "action_plan_batch_not_found",
+                Message = $"Action plan batch '{batchId.Trim()}' was not found."
+            };
+        }
+
+        return await _batchService.ExecuteAsync(batch.Plans, continueOnError, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<OperationResult> ValidateAsync(MailMessageActionPlanBatch? batch, CancellationToken cancellationToken) {
+        if (batch == null) {
+            return OperationResult.Failure("action_plan_batch_invalid", "Action plan batch is required.");
+        }
+        if (string.IsNullOrWhiteSpace(batch.Id)) {
+            return OperationResult.Failure("action_plan_batch_invalid", "Action plan batch id is required.");
+        }
+        if (string.IsNullOrWhiteSpace(batch.Name)) {
+            return OperationResult.Failure("action_plan_batch_invalid", "Action plan batch name is required.");
+        }
+        if (batch.Plans == null || batch.Plans.Count == 0) {
+            return OperationResult.Failure("action_plan_batch_invalid", "Action plan batch must contain at least one plan.");
+        }
+
+        foreach (var plan in batch.Plans) {
+            if (plan == null) {
+                return OperationResult.Failure("action_plan_batch_invalid", "Action plan batch cannot contain null plans.");
+            }
+            if (string.IsNullOrWhiteSpace(plan.ProfileId)) {
+                return OperationResult.Failure("action_plan_batch_invalid", "Each stored plan must include a profile id.");
+            }
+
+            var profile = await _profileStore.GetByIdAsync(plan.ProfileId, cancellationToken).ConfigureAwait(false);
+            if (profile == null) {
+                return OperationResult.Failure("action_plan_profile_not_found", $"Profile '{plan.ProfileId}' was not found.");
+            }
+        }
+
+        return OperationResult.Success();
+    }
+
+    private static MessageActionExecutionPlan ClonePlan(MessageActionExecutionPlan plan) => new() {
+        Succeeded = plan.Succeeded,
+        Code = plan.Code,
+        Message = plan.Message,
+        Name = plan.Name,
+        Summary = plan.Summary,
+        Action = plan.Action,
+        ExecutionKind = plan.ExecutionKind,
+        ProfileId = plan.ProfileId,
+        MailboxId = plan.MailboxId,
+        FolderId = plan.FolderId,
+        RequestedCount = plan.RequestedCount,
+        UniqueMessageCount = plan.UniqueMessageCount,
+        MessageIds = plan.MessageIds.ToList(),
+        RequestedDestinationFolderId = plan.RequestedDestinationFolderId,
+        Destination = plan.Destination == null
+            ? null
+            : new MailFolderTargetResolution {
+                ProfileId = plan.Destination.ProfileId,
+                MailboxId = plan.Destination.MailboxId,
+                RequestedValue = plan.Destination.RequestedValue,
+                IsAlias = plan.Destination.IsAlias,
+                Alias = plan.Destination.Alias,
+                IsSupported = plan.Destination.IsSupported,
+                IsResolved = plan.Destination.IsResolved,
+                EffectiveFolderId = plan.Destination.EffectiveFolderId,
+                FolderDisplayName = plan.Destination.FolderDisplayName,
+                FolderPath = plan.Destination.FolderPath,
+                Summary = plan.Destination.Summary
+            },
+        DesiredState = plan.DesiredState,
+        ConfirmationToken = plan.ConfirmationToken,
+        ConfirmationProvided = plan.ConfirmationProvided,
+        ConfirmationValidated = plan.ConfirmationValidated,
+        Warnings = plan.Warnings.ToList()
+    };
+
+    private static MessageActionExecutionPlan TransformPlan(MessageActionExecutionPlan plan, MessageActionPlanBatchTransformRequest transform) {
+        var cloned = ClonePlan(plan);
+        var transformedProfileId = string.IsNullOrWhiteSpace(transform.ProfileId) ? cloned.ProfileId : transform.ProfileId!.Trim();
+        var transformedMailboxId = string.IsNullOrWhiteSpace(transform.MailboxId) ? cloned.MailboxId : transform.MailboxId!.Trim();
+        var transformedFolderId = string.IsNullOrWhiteSpace(transform.FolderId) ? cloned.FolderId : transform.FolderId!.Trim();
+
+        cloned.ProfileId = transformedProfileId;
+        cloned.MailboxId = transformedMailboxId;
+        cloned.FolderId = transformedFolderId;
+
+        if (cloned.Destination != null) {
+            cloned.Destination.ProfileId = transformedProfileId;
+            cloned.Destination.MailboxId = transformedMailboxId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(transform.DestinationFolderId) && string.Equals(cloned.ExecutionKind, "Move", StringComparison.OrdinalIgnoreCase)) {
+            var transformedDestination = transform.DestinationFolderId!.Trim();
+            cloned.RequestedDestinationFolderId = transformedDestination;
+            cloned.Destination = null;
+        }
+
+        cloned.ConfirmationProvided = false;
+        cloned.ConfirmationValidated = true;
+        cloned.ConfirmationToken = CreateConfirmationToken(cloned);
+        cloned.Summary = BuildStoredPlanSummary(cloned);
+        return cloned;
+    }
+
+    private static IReadOnlyList<MessageActionPreviewItem> SelectCommonActions(CommonMessageActionsPreview preview, IReadOnlyList<string>? actions) {
+        if (actions == null || actions.Count == 0) {
+            return preview.Actions
+                .Where(action => action.Succeeded)
+                .ToArray();
+        }
+
+        var selected = new List<MessageActionPreviewItem>();
+        foreach (var actionName in actions
+                     .Where(action => !string.IsNullOrWhiteSpace(action))
+                     .Select(action => action.Trim())
+                     .Distinct(StringComparer.OrdinalIgnoreCase)) {
+            var match = preview.Actions.FirstOrDefault(action =>
+                string.Equals(action.Action, actionName, StringComparison.OrdinalIgnoreCase) &&
+                action.Succeeded);
+            if (match != null) {
+                selected.Add(match);
+            }
+        }
+
+        return selected;
+    }
+
+    private static string? ResolveDestinationFolderId(MessageActionPreviewItem action, string? fallbackDestinationFolderId) =>
+        string.Equals(action.Action, "move", StringComparison.OrdinalIgnoreCase)
+            ? action.Destination?.EffectiveFolderId ?? action.RequestedDestinationFolderId ?? fallbackDestinationFolderId
+            : null;
+
+    private static string? CreateConfirmationToken(MessageActionExecutionPlan plan) =>
+        plan.ExecutionKind switch {
+            "Move" => !string.IsNullOrWhiteSpace(plan.Destination?.EffectiveFolderId ?? plan.RequestedDestinationFolderId)
+                ? MessageActionConfirmationTokens.CreateMoveToken(
+                    plan.ProfileId,
+                    plan.MailboxId,
+                    plan.FolderId,
+                    plan.MessageIds,
+                    plan.Destination?.EffectiveFolderId ?? plan.RequestedDestinationFolderId!)
+                : null,
+            "Delete" => MessageActionConfirmationTokens.CreateDeleteToken(
+                plan.ProfileId,
+                plan.MailboxId,
+                plan.FolderId,
+                plan.MessageIds),
+            "SetReadState" when plan.DesiredState.HasValue => MessageActionConfirmationTokens.CreateReadStateToken(
+                plan.ProfileId,
+                plan.MailboxId,
+                plan.FolderId,
+                plan.MessageIds,
+                plan.DesiredState.Value),
+            "SetFlaggedState" when plan.DesiredState.HasValue => MessageActionConfirmationTokens.CreateFlaggedStateToken(
+                plan.ProfileId,
+                plan.MailboxId,
+                plan.FolderId,
+                plan.MessageIds,
+                plan.DesiredState.Value),
+            _ => plan.ConfirmationToken
+        };
+
+    private static string BuildTransformSummary(MessageActionExecutionPlan sourcePlan, MessageActionExecutionPlan transformedPlan, bool willChange, bool tokenChanged) {
+        var changes = new List<string>();
+        if (!string.Equals(sourcePlan.ProfileId, transformedPlan.ProfileId, StringComparison.Ordinal)) {
+            changes.Add($"profile {sourcePlan.ProfileId}->{transformedPlan.ProfileId}");
+        }
+        if (!string.Equals(sourcePlan.MailboxId, transformedPlan.MailboxId, StringComparison.Ordinal)) {
+            changes.Add($"mailbox {(sourcePlan.MailboxId ?? "<none>")}->{(transformedPlan.MailboxId ?? "<none>")}");
+        }
+        if (!string.Equals(sourcePlan.FolderId, transformedPlan.FolderId, StringComparison.Ordinal)) {
+            changes.Add($"folder {(sourcePlan.FolderId ?? "<none>")}->{(transformedPlan.FolderId ?? "<none>")}");
+        }
+        if (!string.Equals(sourcePlan.RequestedDestinationFolderId, transformedPlan.RequestedDestinationFolderId, StringComparison.Ordinal)) {
+            changes.Add($"destination {(sourcePlan.RequestedDestinationFolderId ?? "<none>")}->{(transformedPlan.RequestedDestinationFolderId ?? "<none>")}");
+        }
+        if (tokenChanged) {
+            changes.Add("confirmation token regenerated");
+        }
+
+        return willChange || tokenChanged
+            ? $"{sourcePlan.Action}: {string.Join(", ", changes)}"
+            : $"{sourcePlan.Action}: unchanged";
+    }
+
+    private static IReadOnlyList<SelectedPlan> SelectPlans(
+        MailMessageActionPlanBatch source,
+        MessageActionPlanBatchTransformRequest transform,
+        out OperationResult? error) {
+        error = null;
+
+        var selected = new Dictionary<int, SelectedPlan>();
+        var hasIndexes = transform.PlanIndexes != null && transform.PlanIndexes.Count > 0;
+        var hasNames = transform.PlanNames != null && transform.PlanNames.Count > 0;
+        IEnumerable<int> requestedIndexes = hasIndexes ? transform.PlanIndexes! : Array.Empty<int>();
+        IEnumerable<string> requestedNames = hasNames ? transform.PlanNames! : Array.Empty<string>();
+
+        if (!hasIndexes && !hasNames) {
+            return source.Plans
+                .Select((plan, index) => new SelectedPlan(index, plan))
+                .ToArray();
+        }
+
+        if (hasIndexes) {
+            foreach (var index in requestedIndexes.Distinct()) {
+                if (index < 0 || index >= source.Plans.Count) {
+                    error = OperationResult.Failure("action_plan_batch_index_invalid", $"Action plan batch '{source.Id}' does not contain a plan at index {index}.");
+                    return Array.Empty<SelectedPlan>();
+                }
+
+                selected[index] = new SelectedPlan(index, source.Plans[index]);
+            }
+        }
+
+        if (hasNames) {
+            foreach (var requestedName in requestedNames
+                         .Where(name => !string.IsNullOrWhiteSpace(name))
+                         .Select(name => name.Trim())
+                         .Distinct(StringComparer.OrdinalIgnoreCase)) {
+                var matches = source.Plans
+                    .Select((plan, index) => new SelectedPlan(index, plan))
+                    .Where(selection => PlanMatchesName(selection.Plan, requestedName))
+                    .ToArray();
+                if (matches.Length == 0) {
+                    error = OperationResult.Failure("action_plan_batch_name_invalid", $"Action plan batch '{source.Id}' does not contain a plan named '{requestedName}'.");
+                    return Array.Empty<SelectedPlan>();
+                }
+
+                foreach (var match in matches) {
+                    selected[match.Index] = match;
+                }
+            }
+        }
+
+        if (selected.Count == 0) {
+            error = OperationResult.Failure("action_plan_batch_invalid", "Action plan batch transform must include at least one plan.");
+            return Array.Empty<SelectedPlan>();
+        }
+
+        return selected
+            .OrderBy(item => item.Key)
+            .Select(item => item.Value)
+            .ToArray();
+    }
+
+    private static MailMessageActionPlanBatchCompact ToCompact(MailMessageActionPlanBatch batch) {
+        var profileCount = batch.Plans
+            .Select(plan => plan.ProfileId)
+            .Where(profileId => !string.IsNullOrWhiteSpace(profileId))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+        var readyPlanCount = batch.Plans.Count(plan => plan.Succeeded);
+
+        return new MailMessageActionPlanBatchCompact {
+            Id = batch.Id,
+            Name = batch.Name,
+            PlanCount = batch.Plans.Count,
+            ReadyPlanCount = readyPlanCount,
+            ProfileCount = profileCount,
+            PlanNames = batch.Plans
+                .Select(plan => !string.IsNullOrWhiteSpace(plan.Name) ? plan.Name : BuildStoredPlanSummary(plan))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            UpdatedAt = batch.UpdatedAt,
+            Summary = $"{batch.Id} ({batch.Plans.Count} plan(s), {readyPlanCount} ready)"
+        };
+    }
+
+    private static MailMessageActionPlanBatchSummary ToSummary(MailMessageActionPlanBatch batch) {
+        var profileIds = batch.Plans
+            .Select(plan => plan.ProfileId)
+            .Where(profileId => !string.IsNullOrWhiteSpace(profileId))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(profileId => profileId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var readyPlanCount = batch.Plans.Count(plan => plan.Succeeded);
+        var actionCounts = batch.Plans
+            .Where(plan => !string.IsNullOrWhiteSpace(plan.Action))
+            .GroupBy(plan => plan.Action, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+
+        return new MailMessageActionPlanBatchSummary {
+            Id = batch.Id,
+            Name = batch.Name,
+            PlanCount = batch.Plans.Count,
+            ReadyPlanCount = readyPlanCount,
+            ProfileIds = profileIds,
+            ActionCounts = actionCounts,
+            PlanNames = batch.Plans
+                .Select(plan => !string.IsNullOrWhiteSpace(plan.Name) ? plan.Name : BuildStoredPlanSummary(plan))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            UpdatedAt = batch.UpdatedAt,
+            Summary = $"{batch.Id} ({batch.Plans.Count} plan(s), {readyPlanCount} ready, {actionCounts.Count} action type(s))"
+        };
+    }
+
+    private static IReadOnlyList<MailMessageActionPlanBatch> ApplyBatchQuery(
+        IReadOnlyList<MailMessageActionPlanBatch> batches,
+        MailMessageActionPlanBatchQuery? query) {
+        if (query == null) {
+            return batches;
+        }
+
+        var requestedPlanNames = query.PlanNames
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var requestedProfileIds = query.ProfileIds
+            .Where(profileId => !string.IsNullOrWhiteSpace(profileId))
+            .Select(profileId => profileId.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var requestedActions = query.Actions
+            .Where(action => !string.IsNullOrWhiteSpace(action))
+            .Select(action => action.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        IEnumerable<MailMessageActionPlanBatch> filtered = batches;
+        if (requestedPlanNames.Length > 0 || requestedProfileIds.Length > 0 || requestedActions.Length > 0) {
+            filtered = filtered.Where(batch =>
+                (requestedPlanNames.Length == 0 || batch.Plans.Any(plan => requestedPlanNames.Any(requestedName => PlanMatchesName(plan, requestedName)))) &&
+                (requestedProfileIds.Length == 0 || batch.Plans.Any(plan => requestedProfileIds.Any(requestedProfileId => string.Equals(plan.ProfileId, requestedProfileId, StringComparison.OrdinalIgnoreCase)))) &&
+                (requestedActions.Length == 0 || batch.Plans.Any(plan => requestedActions.Any(requestedAction => string.Equals(plan.Action, requestedAction, StringComparison.OrdinalIgnoreCase)))));
+        }
+
+        var ordered = ApplyBatchQuerySort(filtered, query.SortBy, query.Descending);
+        return ordered.ToArray();
+    }
+
+    private static IEnumerable<MailMessageActionPlanBatch> ApplyBatchQuerySort(
+        IEnumerable<MailMessageActionPlanBatch> batches,
+        MailMessageActionPlanBatchSortBy sortBy,
+        bool descending) {
+        Func<MailMessageActionPlanBatch, object> keySelector = sortBy switch {
+            MailMessageActionPlanBatchSortBy.Name => batch => batch.Name,
+            MailMessageActionPlanBatchSortBy.PlanCount => batch => batch.Plans.Count,
+            MailMessageActionPlanBatchSortBy.ReadyPlanCount => batch => batch.Plans.Count(plan => plan.Succeeded),
+            MailMessageActionPlanBatchSortBy.UpdatedAt => batch => batch.UpdatedAt,
+            MailMessageActionPlanBatchSortBy.ActionTypeCount => batch => batch.Plans
+                .Select(plan => plan.Action)
+                .Where(action => !string.IsNullOrWhiteSpace(action))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count(),
+            _ => batch => batch.Id
+        };
+
+        var ordered = descending
+            ? batches.OrderByDescending(keySelector)
+            : batches.OrderBy(keySelector);
+
+        return ordered.ThenBy(batch => batch.Id, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool PlanMatchesName(MessageActionExecutionPlan plan, string requestedName) =>
+        (!string.IsNullOrWhiteSpace(plan.Name) && string.Equals(plan.Name, requestedName, StringComparison.OrdinalIgnoreCase)) ||
+        (!string.IsNullOrWhiteSpace(plan.Summary) && string.Equals(plan.Summary, requestedName, StringComparison.OrdinalIgnoreCase));
+
+    private static string BuildStoredPlanSummary(MessageActionExecutionPlan plan) {
+        var messageCount = plan.UniqueMessageCount == 1 ? "1 message" : $"{plan.UniqueMessageCount} messages";
+        return !string.IsNullOrWhiteSpace(plan.Name)
+            ? $"{plan.Name} ({messageCount})"
+            : $"{plan.Action} ({messageCount})";
+    }
+
+    private sealed class SelectedPlan {
+        public SelectedPlan(int index, MessageActionExecutionPlan plan) {
+            Index = index;
+            Plan = plan;
+        }
+
+        public int Index { get; }
+
+        public MessageActionExecutionPlan Plan { get; }
+    }
+}

--- a/Sources/Mailozaurr.Application/MailMessageActionPlanService.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionPlanService.cs
@@ -1,0 +1,282 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Creates normalized execution plans from previewable message actions and can execute those plans.
+/// </summary>
+public sealed class MailMessageActionPlanService : IMailMessageActionPlanService {
+    private readonly IMailMessageActionPreviewService _previewService;
+    private readonly IMailMessageActionService _messageActionService;
+
+    /// <summary>
+    /// Creates a new message action planning service.
+    /// </summary>
+    public MailMessageActionPlanService(IMailMessageActionPreviewService previewService, IMailMessageActionService messageActionService) {
+        _previewService = previewService ?? throw new ArgumentNullException(nameof(previewService));
+        _messageActionService = messageActionService ?? throw new ArgumentNullException(nameof(messageActionService));
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionExecutionPlan> CreatePlanAsync(MessageActionExecutionPlanRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+        if (string.IsNullOrWhiteSpace(request.Action)) {
+            throw new ArgumentException("Action is required.", nameof(request));
+        }
+
+        var action = request.Action.Trim().ToLowerInvariant();
+        return action switch {
+            "mark-read" => CreateStatePlan(
+                action,
+                "SetReadState",
+                request,
+                await _previewService.PreviewReadStateAsync(new SetReadStateRequest {
+                    ProfileId = request.ProfileId,
+                    MailboxId = request.MailboxId,
+                    FolderId = request.FolderId,
+                    MessageIds = request.MessageIds,
+                    IsRead = true
+                }, cancellationToken).ConfigureAwait(false)),
+            "mark-unread" => CreateStatePlan(
+                action,
+                "SetReadState",
+                request,
+                await _previewService.PreviewReadStateAsync(new SetReadStateRequest {
+                    ProfileId = request.ProfileId,
+                    MailboxId = request.MailboxId,
+                    FolderId = request.FolderId,
+                    MessageIds = request.MessageIds,
+                    IsRead = false
+                }, cancellationToken).ConfigureAwait(false)),
+            "flag" => CreateStatePlan(
+                action,
+                "SetFlaggedState",
+                request,
+                await _previewService.PreviewFlaggedStateAsync(new SetFlaggedStateRequest {
+                    ProfileId = request.ProfileId,
+                    MailboxId = request.MailboxId,
+                    FolderId = request.FolderId,
+                    MessageIds = request.MessageIds,
+                    IsFlagged = true
+                }, cancellationToken).ConfigureAwait(false)),
+            "unflag" => CreateStatePlan(
+                action,
+                "SetFlaggedState",
+                request,
+                await _previewService.PreviewFlaggedStateAsync(new SetFlaggedStateRequest {
+                    ProfileId = request.ProfileId,
+                    MailboxId = request.MailboxId,
+                    FolderId = request.FolderId,
+                    MessageIds = request.MessageIds,
+                    IsFlagged = false
+                }, cancellationToken).ConfigureAwait(false)),
+            "archive" => CreateMovePlan(
+                action,
+                request,
+                await _previewService.PreviewMoveAsync(new MoveMessagesPreviewRequest {
+                    ProfileId = request.ProfileId,
+                    MailboxId = request.MailboxId,
+                    FolderId = request.FolderId,
+                    MessageIds = request.MessageIds,
+                    DestinationFolderId = MailFolderAliases.Archive
+                }, cancellationToken).ConfigureAwait(false)),
+            "trash" => CreateMovePlan(
+                action,
+                request,
+                await _previewService.PreviewMoveAsync(new MoveMessagesPreviewRequest {
+                    ProfileId = request.ProfileId,
+                    MailboxId = request.MailboxId,
+                    FolderId = request.FolderId,
+                    MessageIds = request.MessageIds,
+                    DestinationFolderId = MailFolderAliases.Trash
+                }, cancellationToken).ConfigureAwait(false)),
+            "move" => CreateMovePlan(
+                action,
+                request,
+                await _previewService.PreviewMoveAsync(new MoveMessagesPreviewRequest {
+                    ProfileId = request.ProfileId,
+                    MailboxId = request.MailboxId,
+                    FolderId = request.FolderId,
+                    MessageIds = request.MessageIds,
+                    DestinationFolderId = request.DestinationFolderId ?? string.Empty
+                }, cancellationToken).ConfigureAwait(false)),
+            "delete" => CreateDeletePlan(
+                action,
+                request,
+                await _previewService.PreviewDeleteAsync(new DeleteMessagesPreviewRequest {
+                    ProfileId = request.ProfileId,
+                    MailboxId = request.MailboxId,
+                    FolderId = request.FolderId,
+                    MessageIds = request.MessageIds
+                }, cancellationToken).ConfigureAwait(false)),
+            _ => throw new InvalidOperationException($"Unsupported action '{request.Action}'.")
+        };
+    }
+
+    /// <inheritdoc />
+    public Task<MessageActionResult> ExecuteAsync(MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) {
+        if (plan == null) {
+            throw new ArgumentNullException(nameof(plan));
+        }
+        if (!plan.Succeeded) {
+            return Task.FromResult(new MessageActionResult {
+                Succeeded = false,
+                Code = plan.Code ?? "plan_not_ready",
+                Message = plan.Message ?? "The action plan is not ready for execution.",
+                ProfileId = plan.ProfileId,
+                RequestedCount = plan.RequestedCount,
+                FailedCount = plan.UniqueMessageCount
+            });
+        }
+
+        return plan.ExecutionKind switch {
+            "SetReadState" => _messageActionService.SetReadStateAsync(new SetReadStateRequest {
+                ProfileId = plan.ProfileId,
+                MailboxId = plan.MailboxId,
+                FolderId = plan.FolderId,
+                MessageIds = plan.MessageIds.ToList(),
+                IsRead = plan.DesiredState == true,
+                ConfirmationToken = plan.ConfirmationToken
+            }, cancellationToken),
+            "SetFlaggedState" => _messageActionService.SetFlaggedStateAsync(new SetFlaggedStateRequest {
+                ProfileId = plan.ProfileId,
+                MailboxId = plan.MailboxId,
+                FolderId = plan.FolderId,
+                MessageIds = plan.MessageIds.ToList(),
+                IsFlagged = plan.DesiredState == true,
+                ConfirmationToken = plan.ConfirmationToken
+            }, cancellationToken),
+            "Move" => _messageActionService.MoveAsync(new MoveMessagesRequest {
+                ProfileId = plan.ProfileId,
+                MailboxId = plan.MailboxId,
+                FolderId = plan.FolderId,
+                MessageIds = plan.MessageIds.ToList(),
+                DestinationFolderId = plan.Destination?.EffectiveFolderId ?? plan.RequestedDestinationFolderId ?? string.Empty,
+                ConfirmationToken = plan.ConfirmationToken
+            }, cancellationToken),
+            "Delete" => _messageActionService.DeleteAsync(new DeleteMessagesRequest {
+                ProfileId = plan.ProfileId,
+                MailboxId = plan.MailboxId,
+                FolderId = plan.FolderId,
+                MessageIds = plan.MessageIds.ToList(),
+                ConfirmationToken = plan.ConfirmationToken
+            }, cancellationToken),
+            _ => throw new InvalidOperationException($"Unsupported execution kind '{plan.ExecutionKind}'.")
+        };
+    }
+
+    private static MessageActionExecutionPlan CreateStatePlan(
+        string action,
+        string executionKind,
+        MessageActionExecutionPlanRequest request,
+        MessageStateChangePreview preview) {
+        var plan = CreateBasePlan(action, executionKind, request, preview.ProfileId, preview.RequestedCount, preview.UniqueMessageCount, preview.MessageIds);
+        plan.DesiredState = preview.DesiredState;
+        plan.ConfirmationToken = preview.ConfirmationToken;
+        plan.Warnings.AddRange(preview.Warnings);
+        return FinalizePlan(plan, request.ConfirmationToken, preview.Succeeded, preview.Code, preview.Message);
+    }
+
+    private static MessageActionExecutionPlan CreateMovePlan(
+        string action,
+        MessageActionExecutionPlanRequest request,
+        MoveMessagesPreview preview) {
+        var plan = CreateBasePlan(action, "Move", request, preview.ProfileId, preview.RequestedCount, preview.UniqueMessageCount, preview.MessageIds);
+        plan.RequestedDestinationFolderId = preview.RequestedDestinationFolderId;
+        plan.Destination = preview.Destination;
+        plan.ConfirmationToken = preview.ConfirmationToken;
+        plan.Warnings.AddRange(preview.Warnings);
+        return FinalizePlan(plan, request.ConfirmationToken, preview.Succeeded, preview.Code, preview.Message);
+    }
+
+    private static MessageActionExecutionPlan CreateDeletePlan(
+        string action,
+        MessageActionExecutionPlanRequest request,
+        DeleteMessagesPreview preview) {
+        var plan = CreateBasePlan(action, "Delete", request, preview.ProfileId, preview.RequestedCount, preview.UniqueMessageCount, preview.MessageIds);
+        plan.ConfirmationToken = preview.ConfirmationToken;
+        plan.Warnings.AddRange(preview.Warnings);
+        return FinalizePlan(plan, request.ConfirmationToken, preview.Succeeded, preview.Code, preview.Message);
+    }
+
+    private static MessageActionExecutionPlan CreateBasePlan(
+        string action,
+        string executionKind,
+        MessageActionExecutionPlanRequest request,
+        string profileId,
+        int requestedCount,
+        int uniqueMessageCount,
+        List<string> messageIds) =>
+        new() {
+            Action = action,
+            ExecutionKind = executionKind,
+            ProfileId = profileId,
+            MailboxId = request.MailboxId,
+            FolderId = request.FolderId,
+            RequestedCount = requestedCount,
+            UniqueMessageCount = uniqueMessageCount,
+            MessageIds = messageIds
+        };
+
+    private static MessageActionExecutionPlan FinalizePlan(
+        MessageActionExecutionPlan plan,
+        string? providedConfirmationToken,
+        bool previewSucceeded,
+        string? previewCode,
+        string? previewMessage) {
+        plan.Name = BuildPlanName(plan);
+        plan.ConfirmationProvided = !string.IsNullOrWhiteSpace(providedConfirmationToken);
+
+        if (!previewSucceeded) {
+            plan.Succeeded = false;
+            plan.Code = previewCode;
+            plan.Message = previewMessage;
+            plan.ConfirmationValidated = !plan.ConfirmationProvided;
+            plan.Summary = BuildPlanSummary(plan);
+            return plan;
+        }
+
+        if (plan.ConfirmationProvided) {
+            var providedToken = providedConfirmationToken!;
+            providedToken = providedToken.Trim();
+            if (!string.Equals(providedToken, plan.ConfirmationToken, StringComparison.Ordinal)) {
+                plan.Succeeded = false;
+                plan.Code = "confirmation_token_mismatch";
+                plan.Message = "The supplied confirmation token does not match this normalized action plan.";
+                plan.ConfirmationValidated = false;
+                plan.Summary = BuildPlanSummary(plan);
+                return plan;
+            }
+        }
+
+        plan.Succeeded = true;
+        plan.Code = null;
+        plan.ConfirmationValidated = !plan.ConfirmationProvided || string.Equals(providedConfirmationToken, plan.ConfirmationToken, StringComparison.Ordinal);
+        plan.Message = $"Execution plan ready for '{plan.Action}' on {plan.UniqueMessageCount} message(s).";
+        plan.Summary = BuildPlanSummary(plan);
+        return plan;
+    }
+
+    private static string BuildPlanName(MessageActionExecutionPlan plan) =>
+        plan.Action switch {
+            "mark-read" => "Mark as read",
+            "mark-unread" => "Mark as unread",
+            "flag" => "Flag",
+            "unflag" => "Unflag",
+            "archive" => "Archive",
+            "trash" => "Trash",
+            "move" => !string.IsNullOrWhiteSpace(plan.RequestedDestinationFolderId)
+                ? $"Move to {plan.RequestedDestinationFolderId}"
+                : "Move",
+            "delete" => "Delete",
+            _ => plan.Action
+        };
+
+    private static string BuildPlanSummary(MessageActionExecutionPlan plan) {
+        var messageCount = plan.UniqueMessageCount == 1 ? "1 message" : $"{plan.UniqueMessageCount} messages";
+        return plan.Action switch {
+            "move" when !string.IsNullOrWhiteSpace(plan.RequestedDestinationFolderId) => $"{BuildPlanName(plan)} ({messageCount})",
+            _ => $"{BuildPlanName(plan)} ({messageCount})"
+        };
+    }
+}

--- a/Sources/Mailozaurr.Application/MailMessageActionPreviewService.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionPreviewService.cs
@@ -1,0 +1,523 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Default implementation of reusable dry-run mailbox action previews.
+/// </summary>
+public sealed class MailMessageActionPreviewService : IMailMessageActionPreviewService {
+    private readonly IMailProfileStore _profileStore;
+    private readonly IMailFolderAliasService _folderAliases;
+
+    /// <summary>
+    /// Creates a new message action preview service.
+    /// </summary>
+    public MailMessageActionPreviewService(IMailProfileStore profileStore, IMailFolderAliasService folderAliases) {
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        _folderAliases = folderAliases ?? throw new ArgumentNullException(nameof(folderAliases));
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageStateChangePreview> PreviewReadStateAsync(SetReadStateRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var context = await CreateContextAsync(request.ProfileId, request.MessageIds, cancellationToken).ConfigureAwait(false);
+        return CreateReadStatePreview(request, context);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageStateChangePreview> PreviewFlaggedStateAsync(SetFlaggedStateRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var context = await CreateContextAsync(request.ProfileId, request.MessageIds, cancellationToken).ConfigureAwait(false);
+        return CreateFlaggedStatePreview(request, context);
+    }
+
+    /// <inheritdoc />
+    public async Task<CommonMessageActionsPreview> PreviewCommonActionsAsync(CommonMessageActionsPreviewRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var context = await CreateContextAsync(request.ProfileId, request.MessageIds, cancellationToken).ConfigureAwait(false);
+        var preview = CreateCommonPreview(request, context);
+
+        preview.Actions.Add(ToActionItem(
+            "mark-read",
+            "Mark as read",
+            CreateReadStatePreview(new SetReadStateRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                MessageIds = request.MessageIds,
+                IsRead = true
+            }, context)));
+
+        preview.Actions.Add(ToActionItem(
+            "mark-unread",
+            "Mark as unread",
+            CreateReadStatePreview(new SetReadStateRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                MessageIds = request.MessageIds,
+                IsRead = false
+            }, context)));
+
+        preview.Actions.Add(ToActionItem(
+            "flag",
+            "Flag",
+            CreateFlaggedStatePreview(new SetFlaggedStateRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                MessageIds = request.MessageIds,
+                IsFlagged = true
+            }, context)));
+
+        preview.Actions.Add(ToActionItem(
+            "unflag",
+            "Unflag",
+            CreateFlaggedStatePreview(new SetFlaggedStateRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                MessageIds = request.MessageIds,
+                IsFlagged = false
+            }, context)));
+
+        var standardPreview = await PreviewStandardActionsAsync(new StandardMessageActionsPreviewRequest {
+            ProfileId = request.ProfileId,
+            MailboxId = request.MailboxId,
+            FolderId = request.FolderId,
+            MessageIds = request.MessageIds,
+            DestinationFolderId = request.DestinationFolderId
+        }, cancellationToken).ConfigureAwait(false);
+
+        preview.Actions.AddRange(standardPreview.Actions);
+        preview.IncludedActionCount = preview.Actions.Count;
+        preview.SucceededActionCount = preview.Actions.Count(action => action.Succeeded);
+        preview.FailedActionCount = preview.IncludedActionCount - preview.SucceededActionCount;
+        preview.Succeeded = preview.SucceededActionCount > 0;
+        preview.Code = preview.Succeeded ? null : "no_supported_actions";
+        preview.Message = preview.Succeeded
+            ? $"Prepared {preview.IncludedActionCount} action preview(s) for {preview.UniqueMessageCount} message(s); {preview.SucceededActionCount} supported."
+            : $"No previewed actions are currently supported for profile '{preview.ProfileId}'.";
+        return preview;
+    }
+
+    /// <inheritdoc />
+    public async Task<MoveMessagesPreview> PreviewMoveAsync(MoveMessagesPreviewRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var context = await CreateContextAsync(request.ProfileId, request.MessageIds, cancellationToken).ConfigureAwait(false);
+        return await CreateMovePreviewAsync(request, context, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<DeleteMessagesPreview> PreviewDeleteAsync(DeleteMessagesPreviewRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var context = await CreateContextAsync(request.ProfileId, request.MessageIds, cancellationToken).ConfigureAwait(false);
+        return CreateDeletePreview(request, context);
+    }
+
+    /// <inheritdoc />
+    public async Task<StandardMessageActionsPreview> PreviewStandardActionsAsync(StandardMessageActionsPreviewRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var context = await CreateContextAsync(request.ProfileId, request.MessageIds, cancellationToken).ConfigureAwait(false);
+        var preview = CreateStandardPreview(request, context);
+
+        preview.Actions.Add(ToActionItem(
+            "archive",
+            "Archive",
+            await CreateMovePreviewAsync(new MoveMessagesPreviewRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                MessageIds = request.MessageIds,
+                DestinationFolderId = MailFolderAliases.Archive
+            }, context, cancellationToken).ConfigureAwait(false)));
+
+        preview.Actions.Add(ToActionItem(
+            "trash",
+            "Trash",
+            await CreateMovePreviewAsync(new MoveMessagesPreviewRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                MessageIds = request.MessageIds,
+                DestinationFolderId = MailFolderAliases.Trash
+            }, context, cancellationToken).ConfigureAwait(false)));
+
+        if (!string.IsNullOrWhiteSpace(request.DestinationFolderId)) {
+            var trimmedDestination = request.DestinationFolderId!;
+            trimmedDestination = trimmedDestination.Trim();
+            preview.Actions.Add(ToActionItem(
+                "move",
+                $"Move to '{trimmedDestination}'",
+                await CreateMovePreviewAsync(new MoveMessagesPreviewRequest {
+                    ProfileId = request.ProfileId,
+                    MailboxId = request.MailboxId,
+                    FolderId = request.FolderId,
+                    MessageIds = request.MessageIds,
+                    DestinationFolderId = trimmedDestination
+                }, context, cancellationToken).ConfigureAwait(false)));
+        }
+
+        preview.Actions.Add(ToActionItem(
+            "delete",
+            "Delete",
+            CreateDeletePreview(new DeleteMessagesPreviewRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                MessageIds = request.MessageIds
+            }, context)));
+
+        preview.IncludedActionCount = preview.Actions.Count;
+        preview.SucceededActionCount = preview.Actions.Count(action => action.Succeeded);
+        preview.FailedActionCount = preview.IncludedActionCount - preview.SucceededActionCount;
+        preview.Succeeded = preview.SucceededActionCount > 0;
+        preview.Code = preview.Succeeded ? null : "no_supported_actions";
+        preview.Message = preview.Succeeded
+            ? $"Prepared {preview.IncludedActionCount} action preview(s) for {preview.UniqueMessageCount} message(s); {preview.SucceededActionCount} supported."
+            : $"No previewed actions are currently supported for profile '{preview.ProfileId}'.";
+        return preview;
+    }
+
+    private async Task<PreviewContext> CreateContextAsync(string profileId, IReadOnlyList<string> messageIds, CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            throw new ArgumentException("Profile id is required.", nameof(profileId));
+        }
+
+        var profile = await _profileStore.GetByIdAsync(profileId.Trim(), cancellationToken).ConfigureAwait(false);
+        if (profile == null) {
+            throw new InvalidOperationException($"Profile '{profileId}' was not found.");
+        }
+
+        var normalizedMessageIds = NormalizeMessageIds(messageIds);
+        return new PreviewContext(profile, messageIds.Count, normalizedMessageIds);
+    }
+
+    private async Task<MoveMessagesPreview> CreateMovePreviewAsync(
+        MoveMessagesPreviewRequest request,
+        PreviewContext context,
+        CancellationToken cancellationToken) {
+        var preview = CreateMovePreview(request, context.Profile.Id, context.NormalizedMessageIds, context.RequestedCount);
+
+        if (!context.Profile.GetCapabilities().Supports(MailCapability.MoveMessages)) {
+            preview.Succeeded = false;
+            preview.Code = "move_not_supported";
+            preview.Message = $"Profile '{context.Profile.Id}' does not support '{MailCapability.MoveMessages}'.";
+            return preview;
+        }
+
+        if (context.NormalizedMessageIds.Count == 0) {
+            preview.Succeeded = false;
+            preview.Code = "messages_required";
+            preview.Message = "At least one non-empty message id is required.";
+            return preview;
+        }
+
+        var resolution = await _folderAliases.ResolveAsync(context.Profile.Id, request.DestinationFolderId, request.MailboxId, cancellationToken).ConfigureAwait(false);
+        preview.Destination = resolution;
+        if (!resolution.IsSupported) {
+            preview.Succeeded = false;
+            preview.Code = "destination_not_supported";
+            preview.Message = resolution.Summary;
+            return preview;
+        }
+
+        if (!resolution.IsResolved && resolution.IsAlias) {
+            preview.Warnings.Add($"Destination alias '{resolution.Alias}' could not be resolved to a concrete folder and will be used as-is.");
+        }
+
+        preview.ConfirmationToken = MessageActionConfirmationTokens.CreateMoveToken(
+            context.Profile.Id,
+            request.MailboxId,
+            request.FolderId,
+            context.NormalizedMessageIds,
+            resolution.EffectiveFolderId);
+        preview.Succeeded = true;
+        preview.Code = null;
+        preview.Message = $"Move preview ready for {preview.UniqueMessageCount} message(s) to '{resolution.EffectiveFolderId}'.";
+        return preview;
+    }
+
+    private DeleteMessagesPreview CreateDeletePreview(DeleteMessagesPreviewRequest request, PreviewContext context) {
+        var preview = CreateDeletePreview(request, context.Profile.Id, context.NormalizedMessageIds, context.RequestedCount);
+
+        if (!context.Profile.GetCapabilities().Supports(MailCapability.DeleteMessages)) {
+            preview.Succeeded = false;
+            preview.Code = "delete_not_supported";
+            preview.Message = $"Profile '{context.Profile.Id}' does not support '{MailCapability.DeleteMessages}'.";
+            return preview;
+        }
+
+        if (context.NormalizedMessageIds.Count == 0) {
+            preview.Succeeded = false;
+            preview.Code = "messages_required";
+            preview.Message = "At least one non-empty message id is required.";
+            return preview;
+        }
+
+        preview.ConfirmationToken = MessageActionConfirmationTokens.CreateDeleteToken(
+            context.Profile.Id,
+            request.MailboxId,
+            request.FolderId,
+            context.NormalizedMessageIds);
+        preview.Succeeded = true;
+        preview.Code = null;
+        preview.Message = $"Delete preview ready for {preview.UniqueMessageCount} message(s).";
+        return preview;
+    }
+
+    private MessageStateChangePreview CreateReadStatePreview(SetReadStateRequest request, PreviewContext context) {
+        var preview = CreateStatePreview(
+            context,
+            request.MailboxId,
+            request.FolderId,
+            "read-state",
+            request.IsRead);
+        if (!context.Profile.GetCapabilities().Supports(MailCapability.MarkMessages)) {
+            preview.Succeeded = false;
+            preview.Code = "mark_not_supported";
+            preview.Message = $"Profile '{context.Profile.Id}' does not support '{MailCapability.MarkMessages}'.";
+            return preview;
+        }
+
+        if (context.NormalizedMessageIds.Count == 0) {
+            preview.Succeeded = false;
+            preview.Code = "messages_required";
+            preview.Message = "At least one non-empty message id is required.";
+            return preview;
+        }
+
+        preview.ConfirmationToken = MessageActionConfirmationTokens.CreateReadStateToken(
+            context.Profile.Id,
+            request.MailboxId,
+            request.FolderId,
+            context.NormalizedMessageIds,
+            request.IsRead);
+        preview.Succeeded = true;
+        preview.Message = request.IsRead
+            ? $"Read-state preview ready for {preview.UniqueMessageCount} message(s)."
+            : $"Unread-state preview ready for {preview.UniqueMessageCount} message(s).";
+        return preview;
+    }
+
+    private MessageStateChangePreview CreateFlaggedStatePreview(SetFlaggedStateRequest request, PreviewContext context) {
+        var preview = CreateStatePreview(
+            context,
+            request.MailboxId,
+            request.FolderId,
+            "flagged-state",
+            request.IsFlagged);
+        if (!context.Profile.GetCapabilities().Supports(MailCapability.MarkMessages)) {
+            preview.Succeeded = false;
+            preview.Code = "mark_not_supported";
+            preview.Message = $"Profile '{context.Profile.Id}' does not support '{MailCapability.MarkMessages}'.";
+            return preview;
+        }
+
+        if (context.NormalizedMessageIds.Count == 0) {
+            preview.Succeeded = false;
+            preview.Code = "messages_required";
+            preview.Message = "At least one non-empty message id is required.";
+            return preview;
+        }
+
+        preview.ConfirmationToken = MessageActionConfirmationTokens.CreateFlaggedStateToken(
+            context.Profile.Id,
+            request.MailboxId,
+            request.FolderId,
+            context.NormalizedMessageIds,
+            request.IsFlagged);
+        preview.Succeeded = true;
+        preview.Message = request.IsFlagged
+            ? $"Flag preview ready for {preview.UniqueMessageCount} message(s)."
+            : $"Unflag preview ready for {preview.UniqueMessageCount} message(s).";
+        return preview;
+    }
+
+    private static List<string> NormalizeMessageIds(IReadOnlyList<string> messageIds) =>
+        messageIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static MoveMessagesPreview CreateMovePreview(
+        MoveMessagesPreviewRequest request,
+        string profileId,
+        List<string> normalizedMessageIds,
+        int requestedCount) {
+        var preview = new MoveMessagesPreview {
+            ProfileId = profileId,
+            MailboxId = request.MailboxId,
+            FolderId = request.FolderId,
+            RequestedDestinationFolderId = request.DestinationFolderId,
+            RequestedCount = requestedCount,
+            MessageIds = normalizedMessageIds,
+            UniqueMessageCount = normalizedMessageIds.Count,
+            DuplicateOrEmptyCount = requestedCount - normalizedMessageIds.Count
+        };
+
+        if (preview.DuplicateOrEmptyCount > 0) {
+            preview.Warnings.Add($"Ignored {preview.DuplicateOrEmptyCount} duplicate or empty message id value(s).");
+        }
+
+        return preview;
+    }
+
+    private static DeleteMessagesPreview CreateDeletePreview(
+        DeleteMessagesPreviewRequest request,
+        string profileId,
+        List<string> normalizedMessageIds,
+        int requestedCount) {
+        var preview = new DeleteMessagesPreview {
+            ProfileId = profileId,
+            MailboxId = request.MailboxId,
+            FolderId = request.FolderId,
+            RequestedCount = requestedCount,
+            MessageIds = normalizedMessageIds,
+            UniqueMessageCount = normalizedMessageIds.Count,
+            DuplicateOrEmptyCount = requestedCount - normalizedMessageIds.Count
+        };
+
+        if (preview.DuplicateOrEmptyCount > 0) {
+            preview.Warnings.Add($"Ignored {preview.DuplicateOrEmptyCount} duplicate or empty message id value(s).");
+        }
+
+        return preview;
+    }
+
+    private static StandardMessageActionsPreview CreateStandardPreview(StandardMessageActionsPreviewRequest request, PreviewContext context) {
+        var requestedDestinationFolderId = string.IsNullOrWhiteSpace(request.DestinationFolderId)
+            ? null
+            : request.DestinationFolderId!.Trim();
+        var preview = new StandardMessageActionsPreview {
+            ProfileId = context.Profile.Id,
+            MailboxId = request.MailboxId,
+            FolderId = request.FolderId,
+            RequestedDestinationFolderId = requestedDestinationFolderId,
+            RequestedCount = context.RequestedCount,
+            MessageIds = context.NormalizedMessageIds,
+            UniqueMessageCount = context.NormalizedMessageIds.Count,
+            DuplicateOrEmptyCount = context.RequestedCount - context.NormalizedMessageIds.Count
+        };
+
+        if (preview.DuplicateOrEmptyCount > 0) {
+            preview.Warnings.Add($"Ignored {preview.DuplicateOrEmptyCount} duplicate or empty message id value(s).");
+        }
+
+        return preview;
+    }
+
+    private static MessageStateChangePreview CreateStatePreview(
+        PreviewContext context,
+        string? mailboxId,
+        string? folderId,
+        string action,
+        bool desiredState) {
+        var preview = new MessageStateChangePreview {
+            ProfileId = context.Profile.Id,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            Action = action,
+            DesiredState = desiredState,
+            RequestedCount = context.RequestedCount,
+            MessageIds = context.NormalizedMessageIds,
+            UniqueMessageCount = context.NormalizedMessageIds.Count,
+            DuplicateOrEmptyCount = context.RequestedCount - context.NormalizedMessageIds.Count
+        };
+
+        if (preview.DuplicateOrEmptyCount > 0) {
+            preview.Warnings.Add($"Ignored {preview.DuplicateOrEmptyCount} duplicate or empty message id value(s).");
+        }
+
+        return preview;
+    }
+
+    private static MessageActionPreviewItem ToActionItem(string action, string displayName, MoveMessagesPreview preview) =>
+        new() {
+            Action = action,
+            DisplayName = displayName,
+            Succeeded = preview.Succeeded,
+            Code = preview.Code,
+            Message = preview.Message,
+            RequestedDestinationFolderId = preview.RequestedDestinationFolderId,
+            Destination = preview.Destination,
+            ConfirmationToken = preview.ConfirmationToken,
+            Warnings = new List<string>(preview.Warnings)
+        };
+
+    private static MessageActionPreviewItem ToActionItem(string action, string displayName, DeleteMessagesPreview preview) =>
+        new() {
+            Action = action,
+            DisplayName = displayName,
+            Succeeded = preview.Succeeded,
+            Code = preview.Code,
+            Message = preview.Message,
+            ConfirmationToken = preview.ConfirmationToken,
+            Warnings = new List<string>(preview.Warnings)
+        };
+
+    private static MessageActionPreviewItem ToActionItem(string action, string displayName, MessageStateChangePreview preview) =>
+        new() {
+            Action = action,
+            DisplayName = displayName,
+            Succeeded = preview.Succeeded,
+            Code = preview.Code,
+            Message = preview.Message,
+            DesiredState = preview.DesiredState,
+            ConfirmationToken = preview.ConfirmationToken,
+            Warnings = new List<string>(preview.Warnings)
+        };
+
+    private static CommonMessageActionsPreview CreateCommonPreview(CommonMessageActionsPreviewRequest request, PreviewContext context) {
+        var requestedDestinationFolderId = string.IsNullOrWhiteSpace(request.DestinationFolderId)
+            ? null
+            : request.DestinationFolderId!.Trim();
+        var preview = new CommonMessageActionsPreview {
+            ProfileId = context.Profile.Id,
+            MailboxId = request.MailboxId,
+            FolderId = request.FolderId,
+            RequestedDestinationFolderId = requestedDestinationFolderId,
+            RequestedCount = context.RequestedCount,
+            MessageIds = context.NormalizedMessageIds,
+            UniqueMessageCount = context.NormalizedMessageIds.Count,
+            DuplicateOrEmptyCount = context.RequestedCount - context.NormalizedMessageIds.Count
+        };
+
+        if (preview.DuplicateOrEmptyCount > 0) {
+            preview.Warnings.Add($"Ignored {preview.DuplicateOrEmptyCount} duplicate or empty message id value(s).");
+        }
+
+        return preview;
+    }
+
+    private sealed class PreviewContext {
+        public PreviewContext(MailProfile profile, int requestedCount, List<string> normalizedMessageIds) {
+            Profile = profile;
+            RequestedCount = requestedCount;
+            NormalizedMessageIds = normalizedMessageIds;
+        }
+
+        public MailProfile Profile { get; }
+
+        public int RequestedCount { get; }
+
+        public List<string> NormalizedMessageIds { get; }
+    }
+}

--- a/Sources/Mailozaurr.Application/MessageActionBatchExecutionItemResult.cs
+++ b/Sources/Mailozaurr.Application/MessageActionBatchExecutionItemResult.cs
@@ -1,0 +1,27 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Execution outcome for one normalized message action plan inside a batch.
+/// </summary>
+public sealed class MessageActionBatchExecutionItemResult : OperationResult {
+    /// <summary>Zero-based plan index inside the batch request.</summary>
+    public int Index { get; set; }
+
+    /// <summary>Stable action name such as mark-read, archive, move, or delete.</summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>Normalized execution kind such as SetReadState, Move, or Delete.</summary>
+    public string ExecutionKind { get; set; } = string.Empty;
+
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Total message identifiers covered by this plan.</summary>
+    public int RequestedCount { get; set; }
+
+    /// <summary>Total message identifiers that succeeded for this plan.</summary>
+    public int SucceededCount { get; set; }
+
+    /// <summary>Total message identifiers that failed for this plan.</summary>
+    public int FailedCount { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MessageActionBatchExecutionResult.cs
+++ b/Sources/Mailozaurr.Application/MessageActionBatchExecutionResult.cs
@@ -1,0 +1,24 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Aggregate outcome for executing a batch of normalized message action plans.
+/// </summary>
+public sealed class MessageActionBatchExecutionResult : OperationResult {
+    /// <summary>Total number of plans submitted for execution.</summary>
+    public int RequestedPlanCount { get; set; }
+
+    /// <summary>Total number of plans that were actually attempted.</summary>
+    public int AttemptedPlanCount { get; set; }
+
+    /// <summary>Total number of plans that completed successfully.</summary>
+    public int SucceededPlanCount { get; set; }
+
+    /// <summary>Total number of plans that failed.</summary>
+    public int FailedPlanCount { get; set; }
+
+    /// <summary>Total number of plans skipped after an earlier failure.</summary>
+    public int SkippedPlanCount { get; set; }
+
+    /// <summary>Per-plan execution outcomes in request order.</summary>
+    public List<MessageActionBatchExecutionItemResult> Results { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/MessageActionConfirmationTokens.cs
+++ b/Sources/Mailozaurr.Application/MessageActionConfirmationTokens.cs
@@ -1,0 +1,87 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Generates stable confirmation tokens that tie previews to destructive mailbox actions.
+/// </summary>
+public static class MessageActionConfirmationTokens {
+    /// <summary>Creates a confirmation token for a move-like action.</summary>
+    public static string CreateMoveToken(
+        string profileId,
+        string? mailboxId,
+        string? folderId,
+        IEnumerable<string> messageIds,
+        string destinationFolderId) =>
+        CreateToken("move", profileId, mailboxId, folderId, messageIds, destinationFolderId);
+
+    /// <summary>Creates a confirmation token for a delete action.</summary>
+    public static string CreateDeleteToken(
+        string profileId,
+        string? mailboxId,
+        string? folderId,
+        IEnumerable<string> messageIds) =>
+        CreateToken("delete", profileId, mailboxId, folderId, messageIds, destinationFolderId: null);
+
+    /// <summary>Creates a confirmation token for a read/unread state change.</summary>
+    public static string CreateReadStateToken(
+        string profileId,
+        string? mailboxId,
+        string? folderId,
+        IEnumerable<string> messageIds,
+        bool isRead) =>
+        CreateToken(isRead ? "read-state-read" : "read-state-unread", profileId, mailboxId, folderId, messageIds, destinationFolderId: null);
+
+    /// <summary>Creates a confirmation token for a flagged/unflagged state change.</summary>
+    public static string CreateFlaggedStateToken(
+        string profileId,
+        string? mailboxId,
+        string? folderId,
+        IEnumerable<string> messageIds,
+        bool isFlagged) =>
+        CreateToken(isFlagged ? "flagged-state-flagged" : "flagged-state-unflagged", profileId, mailboxId, folderId, messageIds, destinationFolderId: null);
+
+    private static string CreateToken(
+        string action,
+        string profileId,
+        string? mailboxId,
+        string? folderId,
+        IEnumerable<string> messageIds,
+        string? destinationFolderId) {
+        if (string.IsNullOrWhiteSpace(action)) {
+            throw new ArgumentException("Action is required.", nameof(action));
+        }
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            throw new ArgumentException("Profile id is required.", nameof(profileId));
+        }
+        if (messageIds == null) {
+            throw new ArgumentNullException(nameof(messageIds));
+        }
+
+        var normalizedMessageIds = messageIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var payload = string.Join("|", new[] {
+            "mail-action-confirmation-v1",
+            action.Trim().ToLowerInvariant(),
+            profileId.Trim(),
+            mailboxId?.Trim() ?? string.Empty,
+            folderId?.Trim() ?? string.Empty,
+            destinationFolderId?.Trim() ?? string.Empty,
+            string.Join(",", normalizedMessageIds)
+        });
+
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(payload));
+        var token = Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+        return $"mact_v1_{token}";
+    }
+}

--- a/Sources/Mailozaurr.Application/MessageActionExecutionPlan.cs
+++ b/Sources/Mailozaurr.Application/MessageActionExecutionPlan.cs
@@ -1,0 +1,57 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Normalized execution plan for a selected message action.
+/// </summary>
+public sealed class MessageActionExecutionPlan : OperationResult {
+    /// <summary>Human-readable plan name suitable for selection in stored batches.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Human-readable plan summary suitable for list-style displays.</summary>
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>Stable action name such as mark-read, mark-unread, flag, unflag, archive, trash, move, or delete.</summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>Normalized execution kind such as SetReadState, SetFlaggedState, Move, or Delete.</summary>
+    public string ExecutionKind { get; set; } = string.Empty;
+
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Owning mailbox identifier when relevant.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional source folder identifier.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Total raw message identifiers provided in the request.</summary>
+    public int RequestedCount { get; set; }
+
+    /// <summary>Total unique, non-empty message identifiers after normalization.</summary>
+    public int UniqueMessageCount { get; set; }
+
+    /// <summary>The normalized unique message identifiers that would be acted on.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Requested destination folder identifier or alias when relevant.</summary>
+    public string? RequestedDestinationFolderId { get; set; }
+
+    /// <summary>Resolved destination details when the action uses a destination.</summary>
+    public MailFolderTargetResolution? Destination { get; set; }
+
+    /// <summary>Desired state value when the action is a state change.</summary>
+    public bool? DesiredState { get; set; }
+
+    /// <summary>Expected confirmation token for executing this exact action plan.</summary>
+    public string? ConfirmationToken { get; set; }
+
+    /// <summary>Whether a confirmation token was provided while creating the plan.</summary>
+    public bool ConfirmationProvided { get; set; }
+
+    /// <summary>Whether the provided confirmation token matched the normalized plan.</summary>
+    public bool ConfirmationValidated { get; set; }
+
+    /// <summary>Warnings detected while building the plan.</summary>
+    public List<string> Warnings { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/MessageActionExecutionPlanRequest.cs
+++ b/Sources/Mailozaurr.Application/MessageActionExecutionPlanRequest.cs
@@ -1,0 +1,27 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for creating a normalized execution plan from a selected message action.
+/// </summary>
+public sealed class MessageActionExecutionPlanRequest {
+    /// <summary>Stable action name such as mark-read, mark-unread, flag, unflag, archive, trash, move, or delete.</summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional source folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifiers to normalize for execution.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Optional destination folder identifier or alias when the action requires one.</summary>
+    public string? DestinationFolderId { get; set; }
+
+    /// <summary>Optional confirmation token returned by a matching preview call.</summary>
+    public string? ConfirmationToken { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MessageActionItemResult.cs
+++ b/Sources/Mailozaurr.Application/MessageActionItemResult.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Per-message outcome for a bulk message action.
+/// </summary>
+public sealed class MessageActionItemResult {
+    /// <summary>Provider-specific message identifier.</summary>
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>Whether the action succeeded for this message.</summary>
+    public bool Succeeded { get; set; }
+
+    /// <summary>Optional normalized status/error code.</summary>
+    public string? Code { get; set; }
+
+    /// <summary>Optional human-readable action outcome.</summary>
+    public string? Message { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MessageActionPlanBatchTransformPreviewItem.cs
+++ b/Sources/Mailozaurr.Application/MessageActionPlanBatchTransformPreviewItem.cs
@@ -1,0 +1,48 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Per-plan dry-run preview entry for a transformed stored action plan.
+/// </summary>
+public sealed class MessageActionPlanBatchTransformPreviewItem {
+    /// <summary>Zero-based plan index in the source batch.</summary>
+    public int Index { get; set; }
+
+    /// <summary>Action name such as move, delete, or mark-read.</summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>Normalized execution kind.</summary>
+    public string ExecutionKind { get; set; } = string.Empty;
+
+    /// <summary>Original profile identifier.</summary>
+    public string SourceProfileId { get; set; } = string.Empty;
+
+    /// <summary>Transformed profile identifier.</summary>
+    public string TargetProfileId { get; set; } = string.Empty;
+
+    /// <summary>Original mailbox identifier.</summary>
+    public string? SourceMailboxId { get; set; }
+
+    /// <summary>Transformed mailbox identifier.</summary>
+    public string? TargetMailboxId { get; set; }
+
+    /// <summary>Original source folder identifier.</summary>
+    public string? SourceFolderId { get; set; }
+
+    /// <summary>Transformed source folder identifier.</summary>
+    public string? TargetFolderId { get; set; }
+
+    /// <summary>Original requested destination folder for move-like plans.</summary>
+    public string? SourceDestinationFolderId { get; set; }
+
+    /// <summary>Transformed requested destination folder for move-like plans.</summary>
+    public string? TargetDestinationFolderId { get; set; }
+
+    /// <summary>Whether any effective plan values would change.</summary>
+    public bool WillChange { get; set; }
+
+    /// <summary>Whether the confirmation token would be regenerated.</summary>
+    public bool ConfirmationTokenWillChange { get; set; }
+
+    /// <summary>Human-readable summary of the effective transform.</summary>
+    public string Summary { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MessageActionPlanBatchTransformRequest.cs
+++ b/Sources/Mailozaurr.Application/MessageActionPlanBatchTransformRequest.cs
@@ -1,0 +1,24 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Reusable transform request for cloning a stored action-plan batch into a new environment or mailbox scope.
+/// </summary>
+public sealed class MessageActionPlanBatchTransformRequest {
+    /// <summary>Optional zero-based plan indexes to include from the source batch. When omitted, all plans are included.</summary>
+    public List<int> PlanIndexes { get; set; } = new();
+
+    /// <summary>Optional plan names to include from the source batch. When omitted, all names are included.</summary>
+    public List<string> PlanNames { get; set; } = new();
+
+    /// <summary>Optional replacement profile identifier for every transformed plan.</summary>
+    public string? ProfileId { get; set; }
+
+    /// <summary>Optional replacement mailbox identifier for every transformed plan.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional replacement source folder identifier for every transformed plan.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Optional replacement destination folder identifier for move-like plans.</summary>
+    public string? DestinationFolderId { get; set; }
+}

--- a/Sources/Mailozaurr.Application/MessageActionPreviewItem.cs
+++ b/Sources/Mailozaurr.Application/MessageActionPreviewItem.cs
@@ -1,0 +1,27 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Reusable dry-run preview entry for a single mailbox action.
+/// </summary>
+public sealed class MessageActionPreviewItem : OperationResult {
+    /// <summary>Stable action name such as archive, trash, move, or delete.</summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>Human-readable label for the action preview.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>The requested destination folder or alias when relevant.</summary>
+    public string? RequestedDestinationFolderId { get; set; }
+
+    /// <summary>The resolved folder target when the action uses a destination.</summary>
+    public MailFolderTargetResolution? Destination { get; set; }
+
+    /// <summary>Desired state value when the action is a state change.</summary>
+    public bool? DesiredState { get; set; }
+
+    /// <summary>Optional confirmation token for executing this exact action preview.</summary>
+    public string? ConfirmationToken { get; set; }
+
+    /// <summary>Warnings detected while building this action preview.</summary>
+    public List<string> Warnings { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/MessageActionResult.cs
+++ b/Sources/Mailozaurr.Application/MessageActionResult.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Aggregate outcome for a bulk message action.
+/// </summary>
+public sealed class MessageActionResult : OperationResult {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Total unique message ids requested.</summary>
+    public int RequestedCount { get; set; }
+
+    /// <summary>Total messages whose action succeeded.</summary>
+    public int SucceededCount { get; set; }
+
+    /// <summary>Total messages whose action failed.</summary>
+    public int FailedCount { get; set; }
+
+    /// <summary>Per-message outcomes in request order.</summary>
+    public List<MessageActionItemResult> Results { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/MessageStateChangePreview.cs
+++ b/Sources/Mailozaurr.Application/MessageStateChangePreview.cs
@@ -1,0 +1,39 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Aggregate dry-run result for a planned message state change such as read/unread or flag/unflag.
+/// </summary>
+public sealed class MessageStateChangePreview : OperationResult {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Owning mailbox identifier when relevant.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional source folder identifier.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Stable action name such as read-state or flagged-state.</summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>The desired state value for the action.</summary>
+    public bool DesiredState { get; set; }
+
+    /// <summary>Total raw message identifiers provided in the request.</summary>
+    public int RequestedCount { get; set; }
+
+    /// <summary>Total unique, non-empty message identifiers after normalization.</summary>
+    public int UniqueMessageCount { get; set; }
+
+    /// <summary>Total duplicate or empty message identifiers removed during normalization.</summary>
+    public int DuplicateOrEmptyCount { get; set; }
+
+    /// <summary>The normalized unique message identifiers that would be acted on.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Optional confirmation token that can be supplied when executing the action.</summary>
+    public string? ConfirmationToken { get; set; }
+
+    /// <summary>Warnings detected during preview.</summary>
+    public List<string> Warnings { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/MoveMessagesPreview.cs
+++ b/Sources/Mailozaurr.Application/MoveMessagesPreview.cs
@@ -1,0 +1,39 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Aggregate dry-run result for a planned message move.
+/// </summary>
+public sealed class MoveMessagesPreview : OperationResult {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Owning mailbox identifier when relevant.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional source folder identifier.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>The originally requested destination folder value.</summary>
+    public string RequestedDestinationFolderId { get; set; } = string.Empty;
+
+    /// <summary>Total raw message identifiers provided in the request.</summary>
+    public int RequestedCount { get; set; }
+
+    /// <summary>Total unique, non-empty message identifiers after normalization.</summary>
+    public int UniqueMessageCount { get; set; }
+
+    /// <summary>Total duplicate or empty message identifiers removed during normalization.</summary>
+    public int DuplicateOrEmptyCount { get; set; }
+
+    /// <summary>The normalized unique message identifiers that would be acted on.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>The resolved destination details.</summary>
+    public MailFolderTargetResolution? Destination { get; set; }
+
+    /// <summary>Optional confirmation token that can be supplied when executing the move.</summary>
+    public string? ConfirmationToken { get; set; }
+
+    /// <summary>Warnings detected during preview.</summary>
+    public List<string> Warnings { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/MoveMessagesPreviewRequest.cs
+++ b/Sources/Mailozaurr.Application/MoveMessagesPreviewRequest.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for previewing a message move without executing it.
+/// </summary>
+public sealed class MoveMessagesPreviewRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional source folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifiers to preview.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Requested destination folder identifier or provider alias.</summary>
+    public string DestinationFolderId { get; set; } = string.Empty;
+}

--- a/Sources/Mailozaurr.Application/MoveMessagesRequest.cs
+++ b/Sources/Mailozaurr.Application/MoveMessagesRequest.cs
@@ -1,0 +1,24 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for moving one or more messages.
+/// </summary>
+public sealed class MoveMessagesRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional source folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifiers to move.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Destination folder identifier or provider alias.</summary>
+    public string DestinationFolderId { get; set; } = string.Empty;
+
+    /// <summary>Optional confirmation token from a prior preview for this exact action.</summary>
+    public string? ConfirmationToken { get; set; }
+}

--- a/Sources/Mailozaurr.Application/RoutedMailMessageActionService.cs
+++ b/Sources/Mailozaurr.Application/RoutedMailMessageActionService.cs
@@ -1,0 +1,254 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Resolves a profile and routes message actions to the matching provider handler.
+/// </summary>
+public sealed class RoutedMailMessageActionService : IMailMessageActionService {
+    private readonly IMailProfileStore _profileStore;
+    private readonly IMailFolderAliasService? _folderAliases;
+    private readonly IReadOnlyDictionary<MailProfileKind, IMailMessageActionHandler> _handlers;
+
+    /// <summary>
+    /// Creates a new routed message-action service.
+    /// </summary>
+    public RoutedMailMessageActionService(
+        IMailProfileStore profileStore,
+        IEnumerable<IMailMessageActionHandler> handlers,
+        IMailFolderAliasService? folderAliases = null) {
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        _folderAliases = folderAliases;
+        if (handlers == null) {
+            throw new ArgumentNullException(nameof(handlers));
+        }
+
+        _handlers = handlers.ToDictionary(handler => handler.Kind);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> SetReadStateAsync(SetReadStateRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var profile = await GetProfileAsync(request.ProfileId, cancellationToken).ConfigureAwait(false);
+        EnsureCapability(profile, MailCapability.MarkMessages);
+        var confirmationFailure = ValidateReadStateConfirmation(request);
+        if (confirmationFailure != null) {
+            confirmationFailure.ProfileId = profile.Id;
+            confirmationFailure.RequestedCount = request.MessageIds.Count;
+            confirmationFailure.FailedCount = request.MessageIds.Count;
+            return confirmationFailure;
+        }
+        return await GetHandler(profile.Kind).SetReadStateAsync(profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> SetFlaggedStateAsync(SetFlaggedStateRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var profile = await GetProfileAsync(request.ProfileId, cancellationToken).ConfigureAwait(false);
+        EnsureCapability(profile, MailCapability.MarkMessages);
+        var confirmationFailure = ValidateFlaggedStateConfirmation(request);
+        if (confirmationFailure != null) {
+            confirmationFailure.ProfileId = profile.Id;
+            confirmationFailure.RequestedCount = request.MessageIds.Count;
+            confirmationFailure.FailedCount = request.MessageIds.Count;
+            return confirmationFailure;
+        }
+        return await GetHandler(profile.Kind).SetFlaggedStateAsync(profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> MoveAsync(MoveMessagesRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var profile = await GetProfileAsync(request.ProfileId, cancellationToken).ConfigureAwait(false);
+        EnsureCapability(profile, MailCapability.MoveMessages);
+        var normalizedRequest = await NormalizeMoveRequestAsync(profile, request, cancellationToken).ConfigureAwait(false);
+        var confirmationFailure = ValidateMoveConfirmation(normalizedRequest);
+        if (confirmationFailure != null) {
+            confirmationFailure.ProfileId = profile.Id;
+            confirmationFailure.RequestedCount = request.MessageIds.Count;
+            confirmationFailure.FailedCount = request.MessageIds.Count;
+            return confirmationFailure;
+        }
+        return await GetHandler(profile.Kind).MoveAsync(profile, normalizedRequest, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageActionResult> DeleteAsync(DeleteMessagesRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var profile = await GetProfileAsync(request.ProfileId, cancellationToken).ConfigureAwait(false);
+        EnsureCapability(profile, MailCapability.DeleteMessages);
+        var confirmationFailure = ValidateDeleteConfirmation(request);
+        if (confirmationFailure != null) {
+            confirmationFailure.ProfileId = profile.Id;
+            confirmationFailure.RequestedCount = request.MessageIds.Count;
+            confirmationFailure.FailedCount = request.MessageIds.Count;
+            return confirmationFailure;
+        }
+        return await GetHandler(profile.Kind).DeleteAsync(profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<MailProfile> GetProfileAsync(string profileId, CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            throw new ArgumentException("Profile id is required.", nameof(profileId));
+        }
+
+        var profile = await _profileStore.GetByIdAsync(profileId, cancellationToken).ConfigureAwait(false);
+        return profile ?? throw new InvalidOperationException($"Profile '{profileId}' was not found.");
+    }
+
+    private IMailMessageActionHandler GetHandler(MailProfileKind kind) =>
+        _handlers.TryGetValue(kind, out var handler)
+            ? handler
+            : throw new NotSupportedException($"No message-action handler is registered for profile kind '{kind}'.");
+
+    private async Task<MoveMessagesRequest> NormalizeMoveRequestAsync(
+        MailProfile profile,
+        MoveMessagesRequest request,
+        CancellationToken cancellationToken) {
+        var canonicalAlias = MailFolderAliases.Canonicalize(request.DestinationFolderId);
+        if (canonicalAlias == null) {
+            return request;
+        }
+
+        if (_folderAliases == null) {
+            if (string.Equals(request.DestinationFolderId, canonicalAlias, StringComparison.Ordinal)) {
+                return request;
+            }
+
+            return CloneMoveRequest(request, canonicalAlias);
+        }
+
+        var resolution = await _folderAliases.ResolveAsync(profile.Id, request.DestinationFolderId, request.MailboxId, cancellationToken).ConfigureAwait(false);
+        if (!resolution.IsSupported) {
+            throw new NotSupportedException($"Profile '{profile.Id}' does not support folder alias '{resolution.Alias ?? request.DestinationFolderId}'.");
+        }
+
+        var destinationFolderId = resolution.EffectiveFolderId;
+        if (string.Equals(request.DestinationFolderId, destinationFolderId, StringComparison.Ordinal)) {
+            return request;
+        }
+
+        return CloneMoveRequest(request, destinationFolderId);
+    }
+
+    private static MoveMessagesRequest CloneMoveRequest(MoveMessagesRequest request, string destinationFolderId) =>
+        new() {
+            ProfileId = request.ProfileId,
+            MailboxId = request.MailboxId,
+            FolderId = request.FolderId,
+            MessageIds = request.MessageIds.ToList(),
+            DestinationFolderId = destinationFolderId,
+            ConfirmationToken = request.ConfirmationToken
+        };
+
+    private static MessageActionResult? ValidateMoveConfirmation(MoveMessagesRequest request) {
+        if (string.IsNullOrWhiteSpace(request.ConfirmationToken)) {
+            return null;
+        }
+
+        var expectedToken = MessageActionConfirmationTokens.CreateMoveToken(
+            request.ProfileId,
+            request.MailboxId,
+            request.FolderId,
+            request.MessageIds,
+            request.DestinationFolderId);
+        var providedToken = request.ConfirmationToken!;
+        providedToken = providedToken.Trim();
+        if (string.Equals(expectedToken, providedToken, StringComparison.Ordinal)) {
+            return null;
+        }
+
+        return new MessageActionResult {
+            Succeeded = false,
+            Code = "confirmation_token_mismatch",
+            Message = "The supplied confirmation token does not match this move action."
+        };
+    }
+
+    private static MessageActionResult? ValidateDeleteConfirmation(DeleteMessagesRequest request) {
+        if (string.IsNullOrWhiteSpace(request.ConfirmationToken)) {
+            return null;
+        }
+
+        var expectedToken = MessageActionConfirmationTokens.CreateDeleteToken(
+            request.ProfileId,
+            request.MailboxId,
+            request.FolderId,
+            request.MessageIds);
+        var providedToken = request.ConfirmationToken!;
+        providedToken = providedToken.Trim();
+        if (string.Equals(expectedToken, providedToken, StringComparison.Ordinal)) {
+            return null;
+        }
+
+        return new MessageActionResult {
+            Succeeded = false,
+            Code = "confirmation_token_mismatch",
+            Message = "The supplied confirmation token does not match this delete action."
+        };
+    }
+
+    private static MessageActionResult? ValidateReadStateConfirmation(SetReadStateRequest request) {
+        if (string.IsNullOrWhiteSpace(request.ConfirmationToken)) {
+            return null;
+        }
+
+        var expectedToken = MessageActionConfirmationTokens.CreateReadStateToken(
+            request.ProfileId,
+            request.MailboxId,
+            request.FolderId,
+            request.MessageIds,
+            request.IsRead);
+        var providedToken = request.ConfirmationToken!;
+        providedToken = providedToken.Trim();
+        if (string.Equals(expectedToken, providedToken, StringComparison.Ordinal)) {
+            return null;
+        }
+
+        return new MessageActionResult {
+            Succeeded = false,
+            Code = "confirmation_token_mismatch",
+            Message = "The supplied confirmation token does not match this read-state action."
+        };
+    }
+
+    private static MessageActionResult? ValidateFlaggedStateConfirmation(SetFlaggedStateRequest request) {
+        if (string.IsNullOrWhiteSpace(request.ConfirmationToken)) {
+            return null;
+        }
+
+        var expectedToken = MessageActionConfirmationTokens.CreateFlaggedStateToken(
+            request.ProfileId,
+            request.MailboxId,
+            request.FolderId,
+            request.MessageIds,
+            request.IsFlagged);
+        var providedToken = request.ConfirmationToken!;
+        providedToken = providedToken.Trim();
+        if (string.Equals(expectedToken, providedToken, StringComparison.Ordinal)) {
+            return null;
+        }
+
+        return new MessageActionResult {
+            Succeeded = false,
+            Code = "confirmation_token_mismatch",
+            Message = "The supplied confirmation token does not match this flagged-state action."
+        };
+    }
+
+    private static void EnsureCapability(MailProfile profile, MailCapability capability) {
+        if (!profile.GetCapabilities().Supports(capability)) {
+            throw new NotSupportedException($"Profile '{profile.Id}' does not support '{capability}'.");
+        }
+    }
+}

--- a/Sources/Mailozaurr.Application/RoutedMailReadService.cs
+++ b/Sources/Mailozaurr.Application/RoutedMailReadService.cs
@@ -128,6 +128,69 @@ public sealed class RoutedMailReadService : IMailReadService {
     }
 
     /// <inheritdoc />
+    public async Task<SaveAttachmentsManyResult> SaveAttachmentsManyAsync(SaveAttachmentsManyRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var messageIds = request.MessageIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (messageIds.Length == 0) {
+            return new SaveAttachmentsManyResult {
+                Succeeded = false,
+                Code = "messages_not_found",
+                Message = "No messages were provided for attachment export.",
+                ProfileId = request.ProfileId,
+                RequestedMessageCount = 0
+            };
+        }
+
+        var result = new SaveAttachmentsManyResult {
+            ProfileId = request.ProfileId,
+            RequestedMessageCount = messageIds.Length
+        };
+
+        foreach (var messageId in messageIds) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var messageResult = await SaveAttachmentsAsync(new SaveAttachmentsRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                MessageId = messageId,
+                DestinationPath = request.DestinationPath,
+                AttachmentIds = request.AttachmentIds.ToList(),
+                FileNameContains = request.FileNameContains,
+                ContentTypeContains = request.ContentTypeContains,
+                Overwrite = request.Overwrite
+            }, cancellationToken).ConfigureAwait(false);
+
+            result.AttemptedMessageCount++;
+            if (messageResult.Succeeded) {
+                result.SucceededMessageCount++;
+            } else {
+                result.FailedMessageCount++;
+            }
+
+            result.MatchedCount += messageResult.MatchedCount;
+            result.AttemptedCount += messageResult.AttemptedCount;
+            result.SavedCount += messageResult.SavedCount;
+            result.FailedCount += messageResult.FailedCount;
+            result.MessageResults.Add(messageResult);
+        }
+
+        result.Succeeded = result.FailedMessageCount == 0 && result.SavedCount > 0;
+        result.Code = result.Succeeded ? null : "attachment_save_failed";
+        result.Message = result.Succeeded
+            ? $"Saved {result.SavedCount} attachment(s) across {result.SucceededMessageCount} message(s)."
+            : $"Saved {result.SavedCount} attachment(s) across {result.AttemptedMessageCount} message(s); {result.FailedMessageCount} message(s) failed.";
+        return result;
+    }
+
+    /// <inheritdoc />
     public async Task<MessageDetail?> GetMessageAsync(GetMessageRequest request, CancellationToken cancellationToken = default) {
         var profile = await GetProfileAsync(request.ProfileId, cancellationToken).ConfigureAwait(false);
         EnsureCapability(profile, MailCapability.ReadMessages);
@@ -135,9 +198,41 @@ public sealed class RoutedMailReadService : IMailReadService {
     }
 
     /// <inheritdoc />
+    public async Task<IReadOnlyList<MessageDetail>> GetMessagesAsync(GetMessagesRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var results = new List<MessageDetail>();
+        foreach (var messageId in request.MessageIds.Where(id => !string.IsNullOrWhiteSpace(id))) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var detail = await GetMessageAsync(new GetMessageRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                MessageId = messageId.Trim(),
+                IncludeRawContent = request.IncludeRawContent
+            }, cancellationToken).ConfigureAwait(false);
+
+            if (detail != null) {
+                results.Add(detail);
+            }
+        }
+
+        return results;
+    }
+
+    /// <inheritdoc />
     public async Task<MessageDetailCompact?> GetMessageCompactAsync(GetMessageRequest request, CancellationToken cancellationToken = default) {
         var detail = await GetMessageAsync(request, cancellationToken).ConfigureAwait(false);
         return detail == null ? null : ToCompact(detail);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MessageDetailCompact>> GetMessagesCompactAsync(GetMessagesRequest request, CancellationToken cancellationToken = default) {
+        var details = await GetMessagesAsync(request, cancellationToken).ConfigureAwait(false);
+        return details.Select(ToCompact).ToArray();
     }
 
     /// <inheritdoc />

--- a/Sources/Mailozaurr.Application/SaveAttachmentsManyRequest.cs
+++ b/Sources/Mailozaurr.Application/SaveAttachmentsManyRequest.cs
@@ -1,0 +1,33 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for saving one or more attachments across multiple messages.
+/// </summary>
+public sealed class SaveAttachmentsManyRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifiers to inspect.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Destination path or directory.</summary>
+    public string DestinationPath { get; set; } = string.Empty;
+
+    /// <summary>Optional explicit attachment identifiers to include.</summary>
+    public List<string> AttachmentIds { get; set; } = new();
+
+    /// <summary>Optional case-insensitive file-name filter.</summary>
+    public string? FileNameContains { get; set; }
+
+    /// <summary>Optional case-insensitive content-type filter.</summary>
+    public string? ContentTypeContains { get; set; }
+
+    /// <summary>Whether existing files may be overwritten.</summary>
+    public bool Overwrite { get; set; }
+}

--- a/Sources/Mailozaurr.Application/SaveAttachmentsManyResult.cs
+++ b/Sources/Mailozaurr.Application/SaveAttachmentsManyResult.cs
@@ -1,0 +1,36 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Represents the outcome of saving attachments across multiple messages.
+/// </summary>
+public sealed class SaveAttachmentsManyResult : OperationResult {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Total messages requested for inspection.</summary>
+    public int RequestedMessageCount { get; set; }
+
+    /// <summary>Total message-level save operations attempted.</summary>
+    public int AttemptedMessageCount { get; set; }
+
+    /// <summary>Total messages that completed without attachment-save failures.</summary>
+    public int SucceededMessageCount { get; set; }
+
+    /// <summary>Total messages whose attachment-save operation failed.</summary>
+    public int FailedMessageCount { get; set; }
+
+    /// <summary>Total attachments matched for processing across all messages.</summary>
+    public int MatchedCount { get; set; }
+
+    /// <summary>Total attachment save attempts across all messages.</summary>
+    public int AttemptedCount { get; set; }
+
+    /// <summary>Total attachments saved successfully across all messages.</summary>
+    public int SavedCount { get; set; }
+
+    /// <summary>Total attachments whose save attempt failed across all messages.</summary>
+    public int FailedCount { get; set; }
+
+    /// <summary>Per-message outcomes.</summary>
+    public List<SaveAttachmentsResult> MessageResults { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/SetFlaggedStateRequest.cs
+++ b/Sources/Mailozaurr.Application/SetFlaggedStateRequest.cs
@@ -1,0 +1,24 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for setting flagged/starred state on one or more messages.
+/// </summary>
+public sealed class SetFlaggedStateRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifiers to update.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Desired flagged/starred state.</summary>
+    public bool IsFlagged { get; set; }
+
+    /// <summary>Optional confirmation token from a prior preview for this exact action.</summary>
+    public string? ConfirmationToken { get; set; }
+}

--- a/Sources/Mailozaurr.Application/SetReadStateRequest.cs
+++ b/Sources/Mailozaurr.Application/SetReadStateRequest.cs
@@ -1,0 +1,24 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for setting read/unread state on one or more messages.
+/// </summary>
+public sealed class SetReadStateRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifiers to update.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Desired read state.</summary>
+    public bool IsRead { get; set; }
+
+    /// <summary>Optional confirmation token from a prior preview for this exact action.</summary>
+    public string? ConfirmationToken { get; set; }
+}

--- a/Sources/Mailozaurr.Application/StandardMessageActionsPreview.cs
+++ b/Sources/Mailozaurr.Application/StandardMessageActionsPreview.cs
@@ -1,0 +1,45 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Aggregate dry-run result comparing standard mailbox actions for the same message selection.
+/// </summary>
+public sealed class StandardMessageActionsPreview : OperationResult {
+    /// <summary>Owning profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Owning mailbox identifier when relevant.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional source folder identifier.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Optional custom destination folder value included in the comparison.</summary>
+    public string? RequestedDestinationFolderId { get; set; }
+
+    /// <summary>Total raw message identifiers provided in the request.</summary>
+    public int RequestedCount { get; set; }
+
+    /// <summary>Total unique, non-empty message identifiers after normalization.</summary>
+    public int UniqueMessageCount { get; set; }
+
+    /// <summary>Total duplicate or empty message identifiers removed during normalization.</summary>
+    public int DuplicateOrEmptyCount { get; set; }
+
+    /// <summary>The normalized unique message identifiers that would be acted on.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>Total number of action previews included in the comparison.</summary>
+    public int IncludedActionCount { get; set; }
+
+    /// <summary>Total number of action previews that are supported and ready.</summary>
+    public int SucceededActionCount { get; set; }
+
+    /// <summary>Total number of action previews that are unsupported or otherwise blocked.</summary>
+    public int FailedActionCount { get; set; }
+
+    /// <summary>Top-level warnings detected during preview normalization.</summary>
+    public List<string> Warnings { get; set; } = new();
+
+    /// <summary>Included action previews such as archive, trash, move, and delete.</summary>
+    public List<MessageActionPreviewItem> Actions { get; set; } = new();
+}

--- a/Sources/Mailozaurr.Application/StandardMessageActionsPreviewRequest.cs
+++ b/Sources/Mailozaurr.Application/StandardMessageActionsPreviewRequest.cs
@@ -1,0 +1,23 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Request for previewing a standard set of mailbox actions side by side.
+/// </summary>
+public sealed class StandardMessageActionsPreviewRequest {
+    /// <summary>Profile identifier.</summary>
+    public string ProfileId { get; set; } = string.Empty;
+
+    /// <summary>Optional mailbox identifier for multi-mailbox providers.</summary>
+    public string? MailboxId { get; set; }
+
+    /// <summary>Optional source folder identifier or folder path.</summary>
+    public string? FolderId { get; set; }
+
+    /// <summary>Provider-specific message identifiers to preview.</summary>
+    public List<string> MessageIds { get; set; } = new();
+
+    /// <summary>
+    /// Optional custom destination folder identifier or alias to include as a generic move preview.
+    /// </summary>
+    public string? DestinationFolderId { get; set; }
+}

--- a/Sources/Mailozaurr.Cli/CliArguments.cs
+++ b/Sources/Mailozaurr.Cli/CliArguments.cs
@@ -34,6 +34,28 @@ internal sealed class CliArguments {
         throw new InvalidOperationException($"Option '--{name}' must be an integer.");
     }
 
+    public IReadOnlyList<int> GetIntOptionValues(string name) {
+        var values = GetOptionValues(name);
+        if (values.Count == 0) {
+            return Array.Empty<int>();
+        }
+
+        var parsed = new List<int>(values.Count);
+        foreach (var value in values) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                continue;
+            }
+            if (int.TryParse(value, out var item)) {
+                parsed.Add(item);
+                continue;
+            }
+
+            throw new InvalidOperationException($"Option '--{name}' must be an integer.");
+        }
+
+        return parsed;
+    }
+
     public static CliArguments Parse(IReadOnlyList<string> args) {
         var result = new CliArguments();
         for (var i = 0; i < args.Count; i++) {

--- a/Sources/Mailozaurr.Cli/CliRunner.cs
+++ b/Sources/Mailozaurr.Cli/CliRunner.cs
@@ -43,6 +43,10 @@ public static class CliRunner {
         if (!string.IsNullOrWhiteSpace(draftsDir)) {
             options.DraftStore.DirectoryPath = draftsDir;
         }
+        var planBatchesDir = parseResult.GetOption("plan-batches-dir");
+        if (!string.IsNullOrWhiteSpace(planBatchesDir)) {
+            options.ActionPlanBatchStore.DirectoryPath = planBatchesDir;
+        }
 
         var application = (builderFactory ?? (appOptions => new MailApplicationBuilder(appOptions)))
             .Invoke(options)
@@ -267,7 +271,7 @@ public static class CliRunner {
         TextWriter output,
         TextWriter error) {
         if (parseResult.Positionals.Count < 2) {
-            await error.WriteLineAsync("Missing mail command. Use 'mail folders', 'mail search', 'mail attachments', 'mail get', 'mail save-attachment', or 'mail save-attachments'.").ConfigureAwait(false);
+            await error.WriteLineAsync("Missing mail command. Use 'mail folders', 'mail folder-aliases', 'mail resolve-folder', 'mail list-plan-batches', 'mail show-plan-batch', 'mail import-plan-batch', 'mail export-plan-batch', 'mail create-common-plan-batch', 'mail clone-plan-batch', 'mail preview-transform-plan-batch', 'mail transform-plan-batch', 'mail add-plan-to-batch', 'mail add-plan-file-to-batch', 'mail replace-plan-in-batch', 'mail replace-plan-file-in-batch', 'mail remove-plan-from-batch', 'mail delete-plan-batch', 'mail execute-plan-batch-stored', 'mail plan-action', 'mail export-plan', 'mail show-plan', 'mail execute-plan', 'mail execute-plan-file', 'mail execute-plan-batch', 'mail preview-all', 'mail preview-mark-read', 'mail preview-flag', 'mail preview-actions', 'mail preview-move', 'mail preview-delete', 'mail search', 'mail attachments', 'mail get', 'mail get-many', 'mail mark-read', 'mail flag', 'mail archive', 'mail trash', 'mail move', 'mail delete', 'mail save-attachment', 'mail save-attachments', or 'mail save-attachments-many'.").ConfigureAwait(false);
             return 1;
         }
 
@@ -291,6 +295,274 @@ public static class CliRunner {
                 await WriteSequenceAsync(output, folders, json, folder =>
                     $"{folder.Id} {folder.Path ?? folder.DisplayName}").ConfigureAwait(false);
                 return 0;
+            case "folder-aliases":
+                var aliases = await application.FolderAliases.GetAliasesAsync(
+                    RequireOption(parseResult, "profile"),
+                    parseResult.GetOption("mailbox")).ConfigureAwait(false);
+                await WriteSequenceAsync(output, aliases, json, value => value.Summary).ConfigureAwait(false);
+                return 0;
+            case "resolve-folder":
+                var resolution = await application.FolderAliases.ResolveAsync(
+                    RequireOption(parseResult, "profile"),
+                    RequireOption(parseResult, "target-folder"),
+                    parseResult.GetOption("mailbox")).ConfigureAwait(false);
+                await WriteItemAsync(output, resolution, json, value => value.Summary).ConfigureAwait(false);
+                return resolution.IsSupported ? 0 : 1;
+            case "list-plan-batches":
+                var batchQuery = BuildMessageActionPlanBatchQuery(parseResult);
+                if (parseResult.HasFlag("summary")) {
+                    var summaryBatches = await application.MessageActionPlanRegistry.GetBatchesSummaryAsync(batchQuery).ConfigureAwait(false);
+                    await WriteSequenceAsync(output, summaryBatches, json, value => value.Summary).ConfigureAwait(false);
+                    return 0;
+                }
+                if (parseResult.HasFlag("compact")) {
+                    var compactBatches = await application.MessageActionPlanRegistry.GetBatchesCompactAsync(batchQuery).ConfigureAwait(false);
+                    await WriteSequenceAsync(output, compactBatches, json, value => value.Summary).ConfigureAwait(false);
+                    return 0;
+                }
+                var batches = await application.MessageActionPlanRegistry.GetBatchesAsync(batchQuery).ConfigureAwait(false);
+                await WriteSequenceAsync(output, batches, json, value => $"{value.Id} [{value.Plans.Count} plan(s)] {value.Name}").ConfigureAwait(false);
+                return 0;
+            case "show-plan-batch":
+                var batchId = RequireOption(parseResult, "batch");
+                if (parseResult.HasFlag("summary")) {
+                    var summaryBatch = await application.MessageActionPlanRegistry.GetBatchSummaryAsync(batchId).ConfigureAwait(false);
+                    if (summaryBatch == null) {
+                        await error.WriteLineAsync($"Action plan batch '{batchId}' was not found.").ConfigureAwait(false);
+                        return 1;
+                    }
+                    await WriteItemAsync(output, summaryBatch, json, value => value.Summary).ConfigureAwait(false);
+                    return 0;
+                }
+                if (parseResult.HasFlag("compact")) {
+                    var compactBatch = await application.MessageActionPlanRegistry.GetBatchCompactAsync(batchId).ConfigureAwait(false);
+                    if (compactBatch == null) {
+                        await error.WriteLineAsync($"Action plan batch '{batchId}' was not found.").ConfigureAwait(false);
+                        return 1;
+                    }
+                    await WriteItemAsync(output, compactBatch, json, value => value.Summary).ConfigureAwait(false);
+                    return 0;
+                }
+                var batch = await application.MessageActionPlanRegistry.GetBatchAsync(batchId).ConfigureAwait(false);
+                if (batch == null) {
+                    await error.WriteLineAsync($"Action plan batch '{batchId}' was not found.").ConfigureAwait(false);
+                    return 1;
+                }
+                await WriteItemAsync(output, batch, json, value => $"{value.Id} [{value.Plans.Count} plan(s)] {value.Name}").ConfigureAwait(false);
+                return 0;
+            case "import-plan-batch":
+                var importBatchResult = await application.MessageActionPlanRegistry.ImportAsync(
+                    RequireOption(parseResult, "batch"),
+                    RequireOption(parseResult, "name"),
+                    RequireOption(parseResult, "path"),
+                    parseResult.GetOption("description")).ConfigureAwait(false);
+                await WriteItemAsync(output, importBatchResult, json, value => value.Message ?? "Action plan batch imported.").ConfigureAwait(false);
+                return importBatchResult.Succeeded ? 0 : 1;
+            case "export-plan-batch":
+                var exportBatchResult = await application.MessageActionPlanRegistry.ExportAsync(
+                    RequireOption(parseResult, "batch"),
+                    RequireOption(parseResult, "path")).ConfigureAwait(false);
+                await WriteItemAsync(output, exportBatchResult, json, value => value.Message ?? "Action plan batch exported.").ConfigureAwait(false);
+                return exportBatchResult.Succeeded ? 0 : 1;
+            case "create-common-plan-batch":
+                var createCommonBatchResult = await application.MessageActionPlanRegistry.CreateCommonBatchAsync(
+                    RequireOption(parseResult, "batch"),
+                    RequireOption(parseResult, "name"),
+                    BuildCommonActionsPreviewRequest(parseResult),
+                    parseResult.GetOptionValues("action")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToArray(),
+                    parseResult.GetOption("description")).ConfigureAwait(false);
+                await WriteItemAsync(output, createCommonBatchResult, json, value => value.Message ?? "Action plan batch created.").ConfigureAwait(false);
+                return createCommonBatchResult.Succeeded ? 0 : 1;
+            case "clone-plan-batch":
+                var cloneBatchResult = await application.MessageActionPlanRegistry.CloneAsync(
+                    RequireOption(parseResult, "source-batch"),
+                    RequireOption(parseResult, "target-batch"),
+                    RequireOption(parseResult, "name"),
+                    parseResult.GetOption("description")).ConfigureAwait(false);
+                await WriteItemAsync(output, cloneBatchResult, json, value => value.Message ?? "Action plan batch cloned.").ConfigureAwait(false);
+                return cloneBatchResult.Succeeded ? 0 : 1;
+            case "preview-transform-plan-batch":
+                var previewTransformBatchResult = await application.MessageActionPlanRegistry.PreviewTransformCloneAsync(
+                    RequireOption(parseResult, "source-batch"),
+                    BuildMessageActionPlanBatchTransformRequest(parseResult)).ConfigureAwait(false);
+                await WriteItemAsync(output, previewTransformBatchResult, json, value => value.Message ?? "Action plan batch transform preview generated.").ConfigureAwait(false);
+                return previewTransformBatchResult.Succeeded ? 0 : 1;
+            case "transform-plan-batch":
+                var transformBatchResult = await application.MessageActionPlanRegistry.TransformCloneAsync(
+                    RequireOption(parseResult, "source-batch"),
+                    RequireOption(parseResult, "target-batch"),
+                    RequireOption(parseResult, "name"),
+                    BuildMessageActionPlanBatchTransformRequest(parseResult),
+                    parseResult.GetOption("description")).ConfigureAwait(false);
+                await WriteItemAsync(output, transformBatchResult, json, value => value.Message ?? "Action plan batch transformed and cloned.").ConfigureAwait(false);
+                return transformBatchResult.Succeeded ? 0 : 1;
+            case "add-plan-to-batch":
+                var planToAppend = await application.MessageActionPlans.CreatePlanAsync(BuildMessageActionExecutionPlanRequest(parseResult)).ConfigureAwait(false);
+                var appendPlanResult = await application.MessageActionPlanRegistry.AppendPlanAsync(
+                    RequireOption(parseResult, "batch"),
+                    planToAppend).ConfigureAwait(false);
+                await WriteItemAsync(output, appendPlanResult, json, value => value.Message ?? "Action plan appended.").ConfigureAwait(false);
+                return appendPlanResult.Succeeded ? 0 : 1;
+            case "add-plan-file-to-batch":
+                var appendImportedPlanResult = await application.MessageActionPlanRegistry.AppendImportedPlanAsync(
+                    RequireOption(parseResult, "batch"),
+                    RequireOption(parseResult, "path")).ConfigureAwait(false);
+                await WriteItemAsync(output, appendImportedPlanResult, json, value => value.Message ?? "Imported action plan appended.").ConfigureAwait(false);
+                return appendImportedPlanResult.Succeeded ? 0 : 1;
+            case "replace-plan-in-batch":
+                var replaceIndex = parseResult.GetIntOption("index");
+                if (!replaceIndex.HasValue) {
+                    throw new InvalidOperationException("Missing required option '--index'.");
+                }
+                var replacementPlan = await application.MessageActionPlans.CreatePlanAsync(BuildMessageActionExecutionPlanRequest(parseResult)).ConfigureAwait(false);
+                var replacePlanResult = await application.MessageActionPlanRegistry.ReplacePlanAtAsync(
+                    RequireOption(parseResult, "batch"),
+                    replaceIndex.Value,
+                    replacementPlan).ConfigureAwait(false);
+                await WriteItemAsync(output, replacePlanResult, json, value => value.Message ?? "Action plan replaced.").ConfigureAwait(false);
+                return replacePlanResult.Succeeded ? 0 : 1;
+            case "replace-plan-file-in-batch":
+                var replaceImportedIndex = parseResult.GetIntOption("index");
+                if (!replaceImportedIndex.HasValue) {
+                    throw new InvalidOperationException("Missing required option '--index'.");
+                }
+                var replaceImportedPlanResult = await application.MessageActionPlanRegistry.ReplaceImportedPlanAtAsync(
+                    RequireOption(parseResult, "batch"),
+                    replaceImportedIndex.Value,
+                    RequireOption(parseResult, "path")).ConfigureAwait(false);
+                await WriteItemAsync(output, replaceImportedPlanResult, json, value => value.Message ?? "Imported action plan replaced.").ConfigureAwait(false);
+                return replaceImportedPlanResult.Succeeded ? 0 : 1;
+            case "remove-plan-from-batch":
+                var index = parseResult.GetIntOption("index");
+                if (!index.HasValue) {
+                    throw new InvalidOperationException("Missing required option '--index'.");
+                }
+                var removePlanResult = await application.MessageActionPlanRegistry.RemovePlanAtAsync(
+                    RequireOption(parseResult, "batch"),
+                    index.Value).ConfigureAwait(false);
+                await WriteItemAsync(output, removePlanResult, json, value => value.Message ?? "Action plan removed from batch.").ConfigureAwait(false);
+                return removePlanResult.Succeeded ? 0 : 1;
+            case "delete-plan-batch":
+                var deleteBatchResult = await application.MessageActionPlanRegistry.DeleteAsync(RequireOption(parseResult, "batch")).ConfigureAwait(false);
+                await WriteItemAsync(output, deleteBatchResult, json, value => value.Message ?? "Action plan batch deleted.").ConfigureAwait(false);
+                return deleteBatchResult.Succeeded ? 0 : 1;
+            case "execute-plan-batch-stored":
+                var storedBatchExecutionResult = await application.MessageActionPlanRegistry.ExecuteAsync(
+                    RequireOption(parseResult, "batch"),
+                    continueOnError: !parseResult.HasFlag("stop-on-error")).ConfigureAwait(false);
+                await WriteItemAsync(output, storedBatchExecutionResult, json, value => value.Message ?? "Stored action plan batch executed.").ConfigureAwait(false);
+                return storedBatchExecutionResult.Succeeded ? 0 : 1;
+            case "preview-move":
+                var preview = await application.MessageActionPreview.PreviewMoveAsync(new MoveMessagesPreviewRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    DestinationFolderId = RequireOption(parseResult, "target-folder")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, preview, json, value => value.Message ?? "Move preview ready.").ConfigureAwait(false);
+                return preview.Succeeded ? 0 : 1;
+            case "preview-actions":
+                var standardPreview = await application.MessageActionPreview.PreviewStandardActionsAsync(new StandardMessageActionsPreviewRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    DestinationFolderId = parseResult.GetOption("target-folder")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, standardPreview, json, value => value.Message ?? "Action previews ready.").ConfigureAwait(false);
+                return standardPreview.Succeeded ? 0 : 1;
+            case "preview-all":
+                var commonPreview = await application.MessageActionPreview.PreviewCommonActionsAsync(new CommonMessageActionsPreviewRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    DestinationFolderId = parseResult.GetOption("target-folder")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, commonPreview, json, value => value.Message ?? "Common action previews ready.").ConfigureAwait(false);
+                return commonPreview.Succeeded ? 0 : 1;
+            case "plan-action":
+                var actionPlan = await application.MessageActionPlans.CreatePlanAsync(BuildMessageActionExecutionPlanRequest(parseResult)).ConfigureAwait(false);
+                await WriteItemAsync(output, actionPlan, json, value => value.Message ?? "Action plan ready.").ConfigureAwait(false);
+                return actionPlan.Succeeded ? 0 : 1;
+            case "export-plan":
+                var exportPlan = await application.MessageActionPlans.CreatePlanAsync(BuildMessageActionExecutionPlanRequest(parseResult)).ConfigureAwait(false);
+                await application.MessageActionPlanExchange.SaveAsync(RequireOption(parseResult, "path"), exportPlan).ConfigureAwait(false);
+                var exportPlanResult = OperationResult.Success("Action plan exported.");
+                await WriteItemAsync(output, exportPlanResult, json, value => value.Message ?? "Action plan exported.").ConfigureAwait(false);
+                return exportPlan.Succeeded ? 0 : 1;
+            case "show-plan":
+                var loadedPlan = await application.MessageActionPlanExchange.LoadAsync(RequireOption(parseResult, "path")).ConfigureAwait(false);
+                await WriteItemAsync(output, loadedPlan, json, value => value.Message ?? "Action plan loaded.").ConfigureAwait(false);
+                return loadedPlan.Succeeded ? 0 : 1;
+            case "execute-plan":
+                var executionPlan = await application.MessageActionPlans.CreatePlanAsync(BuildMessageActionExecutionPlanRequest(parseResult)).ConfigureAwait(false);
+                var executePlanResult = await application.MessageActionBatch.ExecuteAsync(new[] { executionPlan }).ConfigureAwait(false);
+                await WriteItemAsync(output, executePlanResult, json, value => value.Message ?? "Action plan executed.").ConfigureAwait(false);
+                return executePlanResult.Succeeded ? 0 : 1;
+            case "execute-plan-file":
+                var storedPlan = await application.MessageActionPlanExchange.LoadAsync(RequireOption(parseResult, "path")).ConfigureAwait(false);
+                var executePlanFileResult = await application.MessageActionBatch.ExecuteAsync(new[] { storedPlan }).ConfigureAwait(false);
+                await WriteItemAsync(output, executePlanFileResult, json, value => value.Message ?? "Stored action plan executed.").ConfigureAwait(false);
+                return executePlanFileResult.Succeeded ? 0 : 1;
+            case "execute-plan-batch":
+                var plans = await application.MessageActionPlanExchange.LoadBatchAsync(RequireOption(parseResult, "path")).ConfigureAwait(false);
+                var batchExecutionResult = await application.MessageActionBatch.ExecuteAsync(
+                    plans,
+                    continueOnError: !parseResult.HasFlag("stop-on-error")).ConfigureAwait(false);
+                await WriteItemAsync(output, batchExecutionResult, json, value => value.Message ?? "Action batch executed.").ConfigureAwait(false);
+                return batchExecutionResult.Succeeded ? 0 : 1;
+            case "preview-delete":
+                var deletePreview = await application.MessageActionPreview.PreviewDeleteAsync(new DeleteMessagesPreviewRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList()
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, deletePreview, json, value => value.Message ?? "Delete preview ready.").ConfigureAwait(false);
+                return deletePreview.Succeeded ? 0 : 1;
+            case "preview-mark-read":
+                var readPreview = await application.MessageActionPreview.PreviewReadStateAsync(new SetReadStateRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    IsRead = !parseResult.HasFlag("unread")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, readPreview, json, value => value.Message ?? "Read-state preview ready.").ConfigureAwait(false);
+                return readPreview.Succeeded ? 0 : 1;
+            case "preview-flag":
+                var flagPreview = await application.MessageActionPreview.PreviewFlaggedStateAsync(new SetFlaggedStateRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    IsFlagged = !parseResult.HasFlag("unflag")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, flagPreview, json, value => value.Message ?? "Flag preview ready.").ConfigureAwait(false);
+                return flagPreview.Succeeded ? 0 : 1;
             case "search":
                 var searchRequest = new MailSearchRequest {
                     ProfileId = RequireOption(parseResult, "profile"),
@@ -337,6 +609,117 @@ public static class CliRunner {
                 }
                 await WriteItemAsync(output, detail, json, value => value.Summary?.Subject ?? value.Id).ConfigureAwait(false);
                 return 0;
+            case "get-many":
+                var getMessagesRequest = new GetMessagesRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    IncludeRawContent = parseResult.HasFlag("include-raw")
+                };
+                if (getMessagesRequest.MessageIds.Count == 0) {
+                    throw new InvalidOperationException("Missing required option '--message-id'.");
+                }
+                if (parseResult.HasFlag("compact")) {
+                    var compactDetails = await application.Read.GetMessagesCompactAsync(getMessagesRequest).ConfigureAwait(false);
+                    await WriteSequenceAsync(output, compactDetails, json, value => value.SummaryText).ConfigureAwait(false);
+                    return 0;
+                }
+                var details = await application.Read.GetMessagesAsync(getMessagesRequest).ConfigureAwait(false);
+                await WriteSequenceAsync(output, details, json, value => value.Summary?.Subject ?? value.Id).ConfigureAwait(false);
+                return 0;
+            case "mark-read":
+                var markReadResult = await application.MessageActions.SetReadStateAsync(new SetReadStateRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    IsRead = !parseResult.HasFlag("unread"),
+                    ConfirmationToken = parseResult.GetOption("confirm-token")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, markReadResult, json, value =>
+                    value.Message ?? $"Updated {value.SucceededCount} message(s).").ConfigureAwait(false);
+                return markReadResult.Succeeded ? 0 : 1;
+            case "flag":
+                var flagResult = await application.MessageActions.SetFlaggedStateAsync(new SetFlaggedStateRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    IsFlagged = !parseResult.HasFlag("unflag"),
+                    ConfirmationToken = parseResult.GetOption("confirm-token")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, flagResult, json, value =>
+                    value.Message ?? $"Updated {value.SucceededCount} message(s).").ConfigureAwait(false);
+                return flagResult.Succeeded ? 0 : 1;
+            case "move":
+                var moveResult = await application.MessageActions.MoveAsync(new MoveMessagesRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    DestinationFolderId = RequireOption(parseResult, "target-folder"),
+                    ConfirmationToken = parseResult.GetOption("confirm-token")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, moveResult, json, value =>
+                    value.Message ?? $"Moved {value.SucceededCount} message(s).").ConfigureAwait(false);
+                return moveResult.Succeeded ? 0 : 1;
+            case "archive":
+                var archiveResult = await application.MessageActions.MoveAsync(new MoveMessagesRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    DestinationFolderId = MailFolderAliases.Archive,
+                    ConfirmationToken = parseResult.GetOption("confirm-token")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, archiveResult, json, value =>
+                    value.Message ?? $"Archived {value.SucceededCount} message(s).").ConfigureAwait(false);
+                return archiveResult.Succeeded ? 0 : 1;
+            case "trash":
+                var trashResult = await application.MessageActions.MoveAsync(new MoveMessagesRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    DestinationFolderId = MailFolderAliases.Trash,
+                    ConfirmationToken = parseResult.GetOption("confirm-token")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, trashResult, json, value =>
+                    value.Message ?? $"Moved {value.SucceededCount} message(s) to trash.").ConfigureAwait(false);
+                return trashResult.Succeeded ? 0 : 1;
+            case "delete":
+                var deleteResult = await application.MessageActions.DeleteAsync(new DeleteMessagesRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    ConfirmationToken = parseResult.GetOption("confirm-token")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, deleteResult, json, value =>
+                    value.Message ?? $"Deleted {value.SucceededCount} message(s).").ConfigureAwait(false);
+                return deleteResult.Succeeded ? 0 : 1;
             case "attachments":
                 var attachments = await application.Read.GetAttachmentsAsync(new ListAttachmentsRequest {
                     ProfileId = RequireOption(parseResult, "profile"),
@@ -378,6 +761,27 @@ public static class CliRunner {
                 await WriteItemAsync(output, saveAttachmentsResult, json, value =>
                     value.Message ?? $"Saved {value.SavedCount} attachment(s).").ConfigureAwait(false);
                 return saveAttachmentsResult.Succeeded ? 0 : 1;
+            case "save-attachments-many":
+                var saveAttachmentsManyResult = await application.Read.SaveAttachmentsManyAsync(new SaveAttachmentsManyRequest {
+                    ProfileId = RequireOption(parseResult, "profile"),
+                    MailboxId = parseResult.GetOption("mailbox"),
+                    FolderId = parseResult.GetOption("folder"),
+                    MessageIds = parseResult.GetOptionValues("message-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    DestinationPath = RequireOption(parseResult, "path"),
+                    AttachmentIds = parseResult.GetOptionValues("attachment-id")
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim())
+                        .ToList(),
+                    FileNameContains = parseResult.GetOption("name-contains"),
+                    ContentTypeContains = parseResult.GetOption("content-type"),
+                    Overwrite = parseResult.HasFlag("overwrite")
+                }).ConfigureAwait(false);
+                await WriteItemAsync(output, saveAttachmentsManyResult, json, value =>
+                    value.Message ?? $"Saved {value.SavedCount} attachment(s) across {value.AttemptedMessageCount} message(s).").ConfigureAwait(false);
+                return saveAttachmentsManyResult.Succeeded ? 0 : 1;
             default:
                 await error.WriteLineAsync($"Unknown mail command '{subCommand}'.").ConfigureAwait(false);
                 return 1;
@@ -583,6 +987,90 @@ public static class CliRunner {
         }
 
         return profile;
+    }
+
+    private static MessageActionExecutionPlanRequest BuildMessageActionExecutionPlanRequest(CliArguments parseResult) => new() {
+        Action = RequireOption(parseResult, "action"),
+        ProfileId = RequireOption(parseResult, "profile"),
+        MailboxId = parseResult.GetOption("mailbox"),
+        FolderId = parseResult.GetOption("folder"),
+        MessageIds = parseResult.GetOptionValues("message-id")
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!.Trim())
+            .ToList(),
+        DestinationFolderId = parseResult.GetOption("target-folder"),
+        ConfirmationToken = parseResult.GetOption("confirm-token")
+    };
+
+    private static CommonMessageActionsPreviewRequest BuildCommonActionsPreviewRequest(CliArguments parseResult) => new() {
+        ProfileId = RequireOption(parseResult, "profile"),
+        MailboxId = parseResult.GetOption("mailbox"),
+        FolderId = parseResult.GetOption("folder"),
+        MessageIds = parseResult.GetOptionValues("message-id")
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!.Trim())
+            .ToList(),
+        DestinationFolderId = parseResult.GetOption("target-folder")
+    };
+
+    private static MessageActionPlanBatchTransformRequest BuildMessageActionPlanBatchTransformRequest(CliArguments parseResult) => new() {
+        PlanIndexes = parseResult.GetIntOptionValues("index").ToList(),
+        PlanNames = parseResult.GetOptionValues("plan-name")
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!.Trim())
+            .ToList(),
+        ProfileId = parseResult.GetOption("target-profile"),
+        MailboxId = parseResult.GetOption("mailbox"),
+        FolderId = parseResult.GetOption("folder"),
+        DestinationFolderId = parseResult.GetOption("target-folder")
+    };
+
+    private static MailMessageActionPlanBatchQuery? BuildMessageActionPlanBatchQuery(CliArguments parseResult) {
+        var planNames = parseResult.GetOptionValues("plan-name")
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var profileIds = parseResult.GetOptionValues("profile")
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var actions = parseResult.GetOptionValues("action")
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var sortBy = ParseBatchSortBy(parseResult.GetOption("sort"));
+        var descending = parseResult.HasFlag("desc");
+
+        if (planNames.Count == 0 && profileIds.Count == 0 && actions.Count == 0 && sortBy == MailMessageActionPlanBatchSortBy.Id && !descending) {
+            return null;
+        }
+
+        return new MailMessageActionPlanBatchQuery {
+            PlanNames = planNames,
+            ProfileIds = profileIds,
+            Actions = actions,
+            SortBy = sortBy,
+            Descending = descending
+        };
+    }
+
+    private static MailMessageActionPlanBatchSortBy ParseBatchSortBy(string? rawSortBy) {
+        if (string.IsNullOrWhiteSpace(rawSortBy)) {
+            return MailMessageActionPlanBatchSortBy.Id;
+        }
+
+        return rawSortBy.Trim().ToLowerInvariant() switch {
+            "id" => MailMessageActionPlanBatchSortBy.Id,
+            "name" => MailMessageActionPlanBatchSortBy.Name,
+            "plans" or "plan-count" => MailMessageActionPlanBatchSortBy.PlanCount,
+            "ready" or "ready-count" => MailMessageActionPlanBatchSortBy.ReadyPlanCount,
+            "updated" or "updated-at" => MailMessageActionPlanBatchSortBy.UpdatedAt,
+            "actions" or "action-types" => MailMessageActionPlanBatchSortBy.ActionTypeCount,
+            _ => throw new InvalidOperationException($"Unsupported batch sort '{rawSortBy}'.")
+        };
     }
 
     private static async Task<SendMessageRequest> BuildSendRequestAsync(MailApplication application, CliArguments parseResult) {
@@ -793,11 +1281,48 @@ public static class CliRunner {
         output.WriteLine("  draft delete --draft <id> [--json]");
         output.WriteLine("  draft export --draft <id> --path <file> [--json]");
         output.WriteLine("  mail folders --profile <id> [--mailbox <id>] [--parent-folder <id>] [--root-only] [--compact] [--json]");
+        output.WriteLine("  mail folder-aliases --profile <id> [--mailbox <id>] [--json]");
+        output.WriteLine("  mail resolve-folder --profile <id> --target-folder <id> [--mailbox <id>] [--json]");
+        output.WriteLine("  mail list-plan-batches [--summary|--compact] [--plan-name <name>] [--plan-name <name>] [--profile <id>] [--profile <id>] [--action <name>] [--action <name>] [--sort <id|name|plans|ready|updated|actions>] [--desc] [--json]");
+        output.WriteLine("  mail show-plan-batch --batch <id> [--summary|--compact] [--json]");
+        output.WriteLine("  mail import-plan-batch --batch <id> --name <display-name> --path <file> [--description <text>] [--json]");
+        output.WriteLine("  mail export-plan-batch --batch <id> --path <file> [--json]");
+        output.WriteLine("  mail create-common-plan-batch --batch <id> --name <display-name> --profile <id> --message-id <id> [--message-id <id>] [--action <name>] [--action <name>] [--target-folder <id>] [--mailbox <id>] [--folder <name>] [--description <text>] [--json]");
+        output.WriteLine("  mail clone-plan-batch --source-batch <id> --target-batch <id> --name <display-name> [--description <text>] [--json]");
+        output.WriteLine("  mail preview-transform-plan-batch --source-batch <id> [--index <n>] [--index <n>] [--plan-name <name>] [--plan-name <name>] [--target-profile <id>] [--mailbox <id>] [--folder <name>] [--target-folder <id>] [--json]");
+        output.WriteLine("  mail transform-plan-batch --source-batch <id> --target-batch <id> --name <display-name> [--index <n>] [--index <n>] [--plan-name <name>] [--plan-name <name>] [--target-profile <id>] [--mailbox <id>] [--folder <name>] [--target-folder <id>] [--description <text>] [--json]");
+        output.WriteLine("  mail add-plan-to-batch --batch <id> --action <mark-read|mark-unread|flag|unflag|archive|trash|move|delete> --profile <id> --message-id <id> [--message-id <id>] [--target-folder <id>] [--mailbox <id>] [--folder <name>] [--confirm-token <token>] [--json]");
+        output.WriteLine("  mail add-plan-file-to-batch --batch <id> --path <file> [--json]");
+        output.WriteLine("  mail replace-plan-in-batch --batch <id> --index <n> --action <mark-read|mark-unread|flag|unflag|archive|trash|move|delete> --profile <id> --message-id <id> [--message-id <id>] [--target-folder <id>] [--mailbox <id>] [--folder <name>] [--confirm-token <token>] [--json]");
+        output.WriteLine("  mail replace-plan-file-in-batch --batch <id> --index <n> --path <file> [--json]");
+        output.WriteLine("  mail remove-plan-from-batch --batch <id> --index <n> [--json]");
+        output.WriteLine("  mail delete-plan-batch --batch <id> [--json]");
+        output.WriteLine("  mail execute-plan-batch-stored --batch <id> [--stop-on-error] [--json]");
+        output.WriteLine("  mail plan-action --action <mark-read|mark-unread|flag|unflag|archive|trash|move|delete> --profile <id> --message-id <id> [--message-id <id>] [--target-folder <id>] [--mailbox <id>] [--folder <name>] [--confirm-token <token>] [--json]");
+        output.WriteLine("  mail export-plan --action <mark-read|mark-unread|flag|unflag|archive|trash|move|delete> --profile <id> --message-id <id> [--message-id <id>] --path <file> [--target-folder <id>] [--mailbox <id>] [--folder <name>] [--confirm-token <token>] [--json]");
+        output.WriteLine("  mail show-plan --path <file> [--json]");
+        output.WriteLine("  mail execute-plan --action <mark-read|mark-unread|flag|unflag|archive|trash|move|delete> --profile <id> --message-id <id> [--message-id <id>] [--target-folder <id>] [--mailbox <id>] [--folder <name>] [--confirm-token <token>] [--json]");
+        output.WriteLine("  mail execute-plan-file --path <file> [--json]");
+        output.WriteLine("  mail execute-plan-batch --path <file> [--stop-on-error] [--json]");
+        output.WriteLine("  mail preview-all --profile <id> --message-id <id> [--message-id <id>] [--target-folder <id>] [--mailbox <id>] [--folder <name>] [--json]");
+        output.WriteLine("  mail preview-mark-read --profile <id> --message-id <id> [--message-id <id>] [--mailbox <id>] [--folder <name>] [--unread] [--json]");
+        output.WriteLine("  mail preview-flag --profile <id> --message-id <id> [--message-id <id>] [--mailbox <id>] [--folder <name>] [--unflag] [--json]");
+        output.WriteLine("  mail preview-actions --profile <id> --message-id <id> [--message-id <id>] [--target-folder <id>] [--mailbox <id>] [--folder <name>] [--json]");
+        output.WriteLine("  mail preview-move --profile <id> --message-id <id> [--message-id <id>] --target-folder <id> [--mailbox <id>] [--folder <name>] [--json]");
+        output.WriteLine("  mail preview-delete --profile <id> --message-id <id> [--message-id <id>] [--mailbox <id>] [--folder <name>] [--json]");
         output.WriteLine("  mail search --profile <id> [--mailbox <id>] [--folder <name>] [--query <text>] [--subject <text>] [--from <text>] [--to <text>] [--limit <n>] [--compact] [--json]");
         output.WriteLine("  mail get --profile <id> --message-id <id> [--mailbox <id>] [--folder <name>] [--include-raw] [--compact] [--json]");
+        output.WriteLine("  mail get-many --profile <id> --message-id <id> [--message-id <id>] [--mailbox <id>] [--folder <name>] [--include-raw] [--compact] [--json]");
+        output.WriteLine("  mail mark-read --profile <id> --message-id <id> [--message-id <id>] [--mailbox <id>] [--folder <name>] [--unread] [--confirm-token <token>] [--json]");
+        output.WriteLine("  mail flag --profile <id> --message-id <id> [--message-id <id>] [--mailbox <id>] [--folder <name>] [--unflag] [--confirm-token <token>] [--json]");
+        output.WriteLine("  mail archive --profile <id> --message-id <id> [--message-id <id>] [--mailbox <id>] [--folder <name>] [--confirm-token <token>] [--json]");
+        output.WriteLine("  mail trash --profile <id> --message-id <id> [--message-id <id>] [--mailbox <id>] [--folder <name>] [--confirm-token <token>] [--json]");
+        output.WriteLine("  mail move --profile <id> --message-id <id> [--message-id <id>] --target-folder <id> [--mailbox <id>] [--folder <name>] [--confirm-token <token>] [--json]");
+        output.WriteLine("  mail delete --profile <id> --message-id <id> [--message-id <id>] [--mailbox <id>] [--folder <name>] [--confirm-token <token>] [--json]");
         output.WriteLine("  mail attachments --profile <id> --message-id <id> [--mailbox <id>] [--folder <name>] [--json]");
         output.WriteLine("  mail save-attachment --profile <id> --message-id <id> --attachment-id <id> --path <destination> [--mailbox <id>] [--folder <name>] [--overwrite] [--json]");
         output.WriteLine("  mail save-attachments --profile <id> --message-id <id> --path <destination> [--mailbox <id>] [--folder <name>] [--attachment-id <id>] [--attachment-id <id>] [--name-contains <text>] [--content-type <text>] [--overwrite] [--json]");
+        output.WriteLine("  mail save-attachments-many --profile <id> --message-id <id> [--message-id <id>] --path <destination> [--mailbox <id>] [--folder <name>] [--attachment-id <id>] [--attachment-id <id>] [--name-contains <text>] [--content-type <text>] [--overwrite] [--json]");
         output.WriteLine("  mcp serve");
         output.WriteLine("  send --draft <id> [--send-now] [--json]");
         output.WriteLine("  send --file <path> [--send-now] [--json]");
@@ -811,6 +1336,7 @@ public static class CliRunner {
         output.WriteLine("  --profiles-dir <path>");
         output.WriteLine("  --secrets-dir <path>");
         output.WriteLine("  --drafts-dir <path>");
+        output.WriteLine("  --plan-batches-dir <path>");
         output.WriteLine("  --help");
     }
 

--- a/Sources/Mailozaurr.Cli/CliRunner.cs
+++ b/Sources/Mailozaurr.Cli/CliRunner.cs
@@ -1041,10 +1041,11 @@ public static class CliRunner {
             .Select(value => value!.Trim())
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
+        var hasExplicitSort = parseResult.GetOptionValues("sort").Count > 0;
         var sortBy = ParseBatchSortBy(parseResult.GetOption("sort"));
         var descending = parseResult.HasFlag("desc");
 
-        if (planNames.Count == 0 && profileIds.Count == 0 && actions.Count == 0 && sortBy == MailMessageActionPlanBatchSortBy.Id && !descending) {
+        if (planNames.Count == 0 && profileIds.Count == 0 && actions.Count == 0 && !hasExplicitSort && sortBy == MailMessageActionPlanBatchSortBy.Id && !descending) {
             return null;
         }
 

--- a/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.cs
+++ b/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.cs
@@ -1438,9 +1438,10 @@ public sealed class MailMcpTools {
             .Select(value => value.Trim())
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
+        var hasExplicitSort = !string.IsNullOrWhiteSpace(sortBy);
         var parsedSortBy = ParseBatchSortBy(sortBy);
 
-        if (normalizedPlanNames.Count == 0 && normalizedProfileIds.Count == 0 && normalizedActions.Count == 0 && parsedSortBy == MailMessageActionPlanBatchSortBy.Id && !descending) {
+        if (normalizedPlanNames.Count == 0 && normalizedProfileIds.Count == 0 && normalizedActions.Count == 0 && !hasExplicitSort && parsedSortBy == MailMessageActionPlanBatchSortBy.Id && !descending) {
             return null;
         }
 

--- a/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.cs
+++ b/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.cs
@@ -346,6 +346,473 @@ public sealed class MailMcpTools {
         }, cancellationToken);
 
     [McpServerTool]
+    [Description("Lists provider-neutral folder aliases for a profile, resolving them to provider folders when possible.")]
+    public Task<IReadOnlyList<MailFolderAliasSummary>> mail_folder_aliases_list(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        CancellationToken cancellationToken = default) =>
+        _application.FolderAliases.GetAliasesAsync(profileId, mailboxId, cancellationToken);
+
+    [McpServerTool]
+    [Description("Resolves a requested folder target to a provider-neutral alias or an effective provider folder destination.")]
+    public Task<MailFolderTargetResolution> mail_folder_resolve(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The requested target folder identifier or alias.")] string targetFolderId,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        CancellationToken cancellationToken = default) =>
+        _application.FolderAliases.ResolveAsync(profileId, targetFolderId, mailboxId, cancellationToken);
+
+    [McpServerTool]
+    [Description("Creates a normalized execution plan for a selected message action, with optional preview-token validation and resolved destinations.")]
+    public Task<MessageActionExecutionPlan> mail_action_plan(
+        [Description("The selected action, such as mark-read, mark-unread, flag, unflag, archive, trash, move, or delete.")] string action,
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to normalize.")] string[] messageIds,
+        [Description("Optional custom destination folder identifier or alias when the action is move.")] string? destinationFolderId = null,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional confirmation token returned by a matching preview call.")] string? confirmationToken = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlans.CreatePlanAsync(new MessageActionExecutionPlanRequest {
+            Action = action,
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            DestinationFolderId = destinationFolderId,
+            ConfirmationToken = confirmationToken
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Lists persisted reusable message action plan batches.")]
+    public Task<IReadOnlyList<MailMessageActionPlanBatch>> mail_action_batch_store_list(
+        [Description("Optional human-readable plan names that must exist in the returned batch.")] IReadOnlyList<string>? planNames = null,
+        [Description("Optional profile identifiers that must be referenced by the returned batch.")] IReadOnlyList<string>? profileIds = null,
+        [Description("Optional normalized action names that must be referenced by the returned batch.")] IReadOnlyList<string>? actions = null,
+        [Description("Optional sort key: id, name, plans, ready, updated, or actions.")] string? sortBy = null,
+        [Description("When true, reverses the selected sort order.")] bool descending = false,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.GetBatchesAsync(BuildBatchQuery(planNames, profileIds, actions, sortBy, descending), cancellationToken);
+
+    [McpServerTool]
+    [Description("Lists persisted reusable message action plan batches using a lightweight projection.")]
+    public Task<IReadOnlyList<MailMessageActionPlanBatchCompact>> mail_action_batch_store_compact_list(
+        [Description("Optional human-readable plan names that must exist in the returned batch.")] IReadOnlyList<string>? planNames = null,
+        [Description("Optional profile identifiers that must be referenced by the returned batch.")] IReadOnlyList<string>? profileIds = null,
+        [Description("Optional normalized action names that must be referenced by the returned batch.")] IReadOnlyList<string>? actions = null,
+        [Description("Optional sort key: id, name, plans, ready, updated, or actions.")] string? sortBy = null,
+        [Description("When true, reverses the selected sort order.")] bool descending = false,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.GetBatchesCompactAsync(BuildBatchQuery(planNames, profileIds, actions, sortBy, descending), cancellationToken);
+
+    [McpServerTool]
+    [Description("Lists persisted reusable message action plan batches using a richer summary projection.")]
+    public Task<IReadOnlyList<MailMessageActionPlanBatchSummary>> mail_action_batch_store_summary_list(
+        [Description("Optional human-readable plan names that must exist in the returned batch.")] IReadOnlyList<string>? planNames = null,
+        [Description("Optional profile identifiers that must be referenced by the returned batch.")] IReadOnlyList<string>? profileIds = null,
+        [Description("Optional normalized action names that must be referenced by the returned batch.")] IReadOnlyList<string>? actions = null,
+        [Description("Optional sort key: id, name, plans, ready, updated, or actions.")] string? sortBy = null,
+        [Description("When true, reverses the selected sort order.")] bool descending = false,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.GetBatchesSummaryAsync(BuildBatchQuery(planNames, profileIds, actions, sortBy, descending), cancellationToken);
+
+    [McpServerTool]
+    [Description("Gets one persisted reusable message action plan batch by identifier.")]
+    public async Task<MailMessageActionPlanBatch> mail_action_batch_store_get(
+        [Description("The persisted batch identifier to retrieve.")] string batchId,
+        CancellationToken cancellationToken = default) {
+        var batch = await _application.MessageActionPlanRegistry.GetBatchAsync(batchId, cancellationToken).ConfigureAwait(false);
+        return batch ?? throw new InvalidOperationException($"Action plan batch '{batchId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Gets one persisted reusable message action plan batch by identifier using a lightweight projection.")]
+    public async Task<MailMessageActionPlanBatchCompact> mail_action_batch_store_compact_get(
+        [Description("The persisted batch identifier to retrieve.")] string batchId,
+        CancellationToken cancellationToken = default) {
+        var batch = await _application.MessageActionPlanRegistry.GetBatchCompactAsync(batchId, cancellationToken).ConfigureAwait(false);
+        return batch ?? throw new InvalidOperationException($"Action plan batch '{batchId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Gets one persisted reusable message action plan batch by identifier using a richer summary projection.")]
+    public async Task<MailMessageActionPlanBatchSummary> mail_action_batch_store_summary_get(
+        [Description("The persisted batch identifier to retrieve.")] string batchId,
+        CancellationToken cancellationToken = default) {
+        var batch = await _application.MessageActionPlanRegistry.GetBatchSummaryAsync(batchId, cancellationToken).ConfigureAwait(false);
+        return batch ?? throw new InvalidOperationException($"Action plan batch '{batchId}' was not found.");
+    }
+
+    [McpServerTool]
+    [Description("Imports a persisted reusable message action plan batch from an external batch file.")]
+    public Task<OperationResult> mail_action_batch_store_import(
+        [Description("The persisted batch identifier to create or update.")] string batchId,
+        [Description("The human-readable batch name.")] string name,
+        [Description("The source batch file path on the server filesystem.")] string path,
+        [Description("Optional operator-facing description.")] string? description = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.ImportAsync(batchId, name, path, description, cancellationToken);
+
+    [McpServerTool]
+    [Description("Exports a persisted reusable message action plan batch to an external batch file.")]
+    public Task<OperationResult> mail_action_batch_store_export(
+        [Description("The persisted batch identifier to export.")] string batchId,
+        [Description("The destination batch file path on the server filesystem.")] string path,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.ExportAsync(batchId, path, cancellationToken);
+
+    [McpServerTool]
+    [Description("Builds and stores a reusable action plan batch from a common message selection and selected common actions.")]
+    public Task<OperationResult> mail_action_batch_store_create_common(
+        [Description("The persisted batch identifier to create or update.")] string batchId,
+        [Description("The human-readable batch name.")] string name,
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to include.")] string[] messageIds,
+        [Description("Optional subset of common actions to include, such as mark-read, archive, delete, or move. When omitted, all supported common actions are considered.")] string[]? actions = null,
+        [Description("Optional custom destination folder identifier or alias when a generic move action should be included.")] string? destinationFolderId = null,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional operator-facing description.")] string? description = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.CreateCommonBatchAsync(
+            batchId,
+            name,
+            new CommonMessageActionsPreviewRequest {
+                ProfileId = profileId,
+                MailboxId = mailboxId,
+                FolderId = folderId,
+                MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+                DestinationFolderId = destinationFolderId
+            },
+            actions?.Where(action => !string.IsNullOrWhiteSpace(action)).Select(action => action.Trim()).ToArray(),
+            description,
+            cancellationToken);
+
+    [McpServerTool]
+    [Description("Builds and stores a reusable action plan batch from an existing common action preview bundle and optional selected previewed actions.")]
+    public Task<OperationResult> mail_action_batch_store_create_from_preview(
+        [Description("The persisted batch identifier to create or update.")] string batchId,
+        [Description("The human-readable batch name.")] string name,
+        [Description("The previously generated common action preview bundle.")] CommonMessageActionsPreview preview,
+        [Description("Optional subset of previewed actions to persist. When omitted, all supported previewed actions are used.")] string[]? actions = null,
+        [Description("Optional operator-facing description.")] string? description = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.CreateCommonBatchFromPreviewAsync(
+            batchId,
+            name,
+            preview,
+            actions?.Where(action => !string.IsNullOrWhiteSpace(action)).Select(action => action.Trim()).ToArray(),
+            description,
+            cancellationToken);
+
+    [McpServerTool]
+    [Description("Clones an existing persisted reusable message action plan batch to a new identifier and name.")]
+    public Task<OperationResult> mail_action_batch_store_clone(
+        [Description("The persisted source batch identifier to clone.")] string sourceBatchId,
+        [Description("The persisted target batch identifier to create.")] string targetBatchId,
+        [Description("The human-readable name for the cloned batch.")] string name,
+        [Description("Optional operator-facing description.")] string? description = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.CloneAsync(sourceBatchId, targetBatchId, name, description, cancellationToken);
+
+    [McpServerTool]
+    [Description("Clones an existing persisted reusable message action plan batch while applying shared profile, mailbox, folder, or destination transforms.")]
+    public Task<OperationResult> mail_action_batch_store_transform_clone(
+        [Description("The persisted source batch identifier to clone.")] string sourceBatchId,
+        [Description("The persisted target batch identifier to create.")] string targetBatchId,
+        [Description("The human-readable name for the transformed clone.")] string name,
+        [Description("Optional zero-based plan indexes to include from the source batch. When omitted, all plans are included.")] int[]? indexes = null,
+        [Description("Optional stored plan names to include from the source batch. When omitted, all names are included.")] string[]? planNames = null,
+        [Description("Optional replacement profile identifier for every transformed plan.")] string? profileId = null,
+        [Description("Optional replacement mailbox identifier for every transformed plan.")] string? mailboxId = null,
+        [Description("Optional replacement source folder identifier for every transformed plan.")] string? folderId = null,
+        [Description("Optional replacement destination folder identifier for move-like plans.")] string? destinationFolderId = null,
+        [Description("Optional operator-facing description.")] string? description = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.TransformCloneAsync(
+            sourceBatchId,
+            targetBatchId,
+            name,
+            new MessageActionPlanBatchTransformRequest {
+                PlanIndexes = indexes?.Distinct().ToList() ?? new List<int>(),
+                PlanNames = planNames?.Where(nameValue => !string.IsNullOrWhiteSpace(nameValue)).Select(nameValue => nameValue.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToList() ?? new List<string>(),
+                ProfileId = profileId,
+                MailboxId = mailboxId,
+                FolderId = folderId,
+                DestinationFolderId = destinationFolderId
+            },
+            description,
+            cancellationToken);
+
+    [McpServerTool]
+    [Description("Previews a stored action plan batch transform before cloning and saving it.")]
+    public Task<MailMessageActionPlanBatchTransformPreview> mail_action_batch_store_transform_preview(
+        [Description("The persisted source batch identifier to preview.")] string sourceBatchId,
+        [Description("Optional zero-based plan indexes to include from the source batch. When omitted, all plans are included.")] int[]? indexes = null,
+        [Description("Optional stored plan names to include from the source batch. When omitted, all names are included.")] string[]? planNames = null,
+        [Description("Optional replacement profile identifier for every transformed plan.")] string? profileId = null,
+        [Description("Optional replacement mailbox identifier for every transformed plan.")] string? mailboxId = null,
+        [Description("Optional replacement source folder identifier for every transformed plan.")] string? folderId = null,
+        [Description("Optional replacement destination folder identifier for move-like plans.")] string? destinationFolderId = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.PreviewTransformCloneAsync(
+            sourceBatchId,
+            new MessageActionPlanBatchTransformRequest {
+                PlanIndexes = indexes?.Distinct().ToList() ?? new List<int>(),
+                PlanNames = planNames?.Where(nameValue => !string.IsNullOrWhiteSpace(nameValue)).Select(nameValue => nameValue.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToList() ?? new List<string>(),
+                ProfileId = profileId,
+                MailboxId = mailboxId,
+                FolderId = folderId,
+                DestinationFolderId = destinationFolderId
+            },
+            cancellationToken);
+
+    [McpServerTool]
+    [Description("Appends one newly planned normalized action to an existing persisted batch.")]
+    public async Task<OperationResult> mail_action_batch_store_append_plan(
+        [Description("The persisted batch identifier to update.")] string batchId,
+        [Description("The selected action, such as mark-read, mark-unread, flag, unflag, archive, trash, move, or delete.")] string action,
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to normalize.")] string[] messageIds,
+        [Description("Optional custom destination folder identifier or alias when the action is move.")] string? destinationFolderId = null,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional confirmation token returned by a matching preview call.")] string? confirmationToken = null,
+        CancellationToken cancellationToken = default) {
+        var plan = await mail_action_plan(
+            action,
+            profileId,
+            messageIds,
+            destinationFolderId,
+            mailboxId,
+            folderId,
+            confirmationToken,
+            cancellationToken).ConfigureAwait(false);
+
+        return await _application.MessageActionPlanRegistry.AppendPlanAsync(batchId, plan, cancellationToken).ConfigureAwait(false);
+    }
+
+    [McpServerTool]
+    [Description("Loads one normalized action plan from a file and appends it to an existing persisted batch.")]
+    public Task<OperationResult> mail_action_batch_store_append_imported_plan(
+        [Description("The persisted batch identifier to update.")] string batchId,
+        [Description("The source plan file path on the server filesystem.")] string path,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.AppendImportedPlanAsync(batchId, path, cancellationToken);
+
+    [McpServerTool]
+    [Description("Replaces one stored plan in an existing persisted batch using a newly planned normalized action.")]
+    public async Task<OperationResult> mail_action_batch_store_replace_plan(
+        [Description("The persisted batch identifier to update.")] string batchId,
+        [Description("The zero-based plan index to replace.")] int index,
+        [Description("The selected action, such as mark-read, mark-unread, flag, unflag, archive, trash, move, or delete.")] string action,
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to normalize.")] string[] messageIds,
+        [Description("Optional custom destination folder identifier or alias when the action is move.")] string? destinationFolderId = null,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional confirmation token returned by a matching preview call.")] string? confirmationToken = null,
+        CancellationToken cancellationToken = default) {
+        var plan = await mail_action_plan(
+            action,
+            profileId,
+            messageIds,
+            destinationFolderId,
+            mailboxId,
+            folderId,
+            confirmationToken,
+            cancellationToken).ConfigureAwait(false);
+
+        return await _application.MessageActionPlanRegistry.ReplacePlanAtAsync(batchId, index, plan, cancellationToken).ConfigureAwait(false);
+    }
+
+    [McpServerTool]
+    [Description("Loads one normalized action plan from a file and replaces a stored plan by zero-based index.")]
+    public Task<OperationResult> mail_action_batch_store_replace_imported_plan(
+        [Description("The persisted batch identifier to update.")] string batchId,
+        [Description("The zero-based plan index to replace.")] int index,
+        [Description("The source plan file path on the server filesystem.")] string path,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.ReplaceImportedPlanAtAsync(batchId, index, path, cancellationToken);
+
+    [McpServerTool]
+    [Description("Removes one plan from an existing persisted batch by zero-based index.")]
+    public Task<OperationResult> mail_action_batch_store_remove_plan(
+        [Description("The persisted batch identifier to update.")] string batchId,
+        [Description("The zero-based plan index to remove.")] int index,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.RemovePlanAtAsync(batchId, index, cancellationToken);
+
+    [McpServerTool]
+    [Description("Deletes a persisted reusable message action plan batch.")]
+    public Task<OperationResult> mail_action_batch_store_delete(
+        [Description("The persisted batch identifier to delete.")] string batchId,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.DeleteAsync(batchId, cancellationToken);
+
+    [McpServerTool]
+    [Description("Executes a persisted reusable message action plan batch through the shared batch-execution service.")]
+    public Task<MessageActionBatchExecutionResult> mail_action_batch_store_execute(
+        [Description("The persisted batch identifier to execute.")] string batchId,
+        [Description("When true, continues after failures. When false, later plans are skipped after the first failure.")] bool continueOnError = true,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanRegistry.ExecuteAsync(batchId, continueOnError, cancellationToken);
+
+    [McpServerTool]
+    [Description("Creates a normalized action plan and exports it to a file through the shared Mailozaurr plan-exchange service.")]
+    public async Task<OperationResult> mail_action_plan_export(
+        [Description("The selected action, such as mark-read, mark-unread, flag, unflag, archive, trash, move, or delete.")] string action,
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to normalize.")] string[] messageIds,
+        [Description("The destination file path on the server filesystem.")] string path,
+        [Description("Optional custom destination folder identifier or alias when the action is move.")] string? destinationFolderId = null,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional confirmation token returned by a matching preview call.")] string? confirmationToken = null,
+        CancellationToken cancellationToken = default) {
+        var plan = await mail_action_plan(
+            action,
+            profileId,
+            messageIds,
+            destinationFolderId,
+            mailboxId,
+            folderId,
+            confirmationToken,
+            cancellationToken).ConfigureAwait(false);
+
+        await _application.MessageActionPlanExchange.SaveAsync(path, plan, cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success("Action plan exported.");
+    }
+
+    [McpServerTool]
+    [Description("Loads one normalized action plan from a file through the shared Mailozaurr plan-exchange service.")]
+    public Task<MessageActionExecutionPlan> mail_action_plan_import(
+        [Description("The source file path on the server filesystem.")] string path,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanExchange.LoadAsync(path, cancellationToken);
+
+    [McpServerTool]
+    [Description("Exports a batch of normalized action plans to a file through the shared Mailozaurr plan-exchange service.")]
+    public async Task<OperationResult> mail_action_batch_export(
+        [Description("The destination file path on the server filesystem.")] string path,
+        [Description("The normalized action plans to export.")] MessageActionExecutionPlan[] plans,
+        CancellationToken cancellationToken = default) {
+        await _application.MessageActionPlanExchange.SaveBatchAsync(
+            path,
+            plans?.ToList() ?? new List<MessageActionExecutionPlan>(),
+            cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success("Action plan batch exported.");
+    }
+
+    [McpServerTool]
+    [Description("Loads a batch of normalized action plans from a file through the shared Mailozaurr plan-exchange service.")]
+    public Task<IReadOnlyList<MessageActionExecutionPlan>> mail_action_batch_import(
+        [Description("The source file path on the server filesystem.")] string path,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPlanExchange.LoadBatchAsync(path, cancellationToken);
+
+    [McpServerTool]
+    [Description("Creates and executes one normalized message action plan through the shared Mailozaurr planning and batch-execution services.")]
+    public async Task<MessageActionBatchExecutionResult> mail_action_execute(
+        [Description("The selected action, such as mark-read, mark-unread, flag, unflag, archive, trash, move, or delete.")] string action,
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to normalize and execute.")] string[] messageIds,
+        [Description("Optional custom destination folder identifier or alias when the action is move.")] string? destinationFolderId = null,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional confirmation token returned by a matching preview call.")] string? confirmationToken = null,
+        CancellationToken cancellationToken = default) {
+        var plan = await _application.MessageActionPlans.CreatePlanAsync(new MessageActionExecutionPlanRequest {
+            Action = action,
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            DestinationFolderId = destinationFolderId,
+            ConfirmationToken = confirmationToken
+        }, cancellationToken).ConfigureAwait(false);
+
+        return await _application.MessageActionBatch.ExecuteAsync(new[] { plan }, cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    [McpServerTool]
+    [Description("Executes a batch of prebuilt normalized message action plans through the shared Mailozaurr batch-execution service.")]
+    public Task<MessageActionBatchExecutionResult> mail_action_batch_execute(
+        [Description("The normalized action plans to execute.")] MessageActionExecutionPlan[] plans,
+        [Description("When true, continues after failures. When false, later plans are skipped after the first failure.")] bool continueOnError = true,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionBatch.ExecuteAsync(
+            plans?.ToList() ?? new List<MessageActionExecutionPlan>(),
+            continueOnError,
+            cancellationToken);
+
+    [McpServerTool]
+    [Description("Builds a dry-run bundle of common message actions, including read/unread, flag/unflag, archive, trash, delete, and an optional custom move target.")]
+    public Task<CommonMessageActionsPreview> mail_actions_bundle_preview(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to preview.")] string[] messageIds,
+        [Description("Optional custom destination folder identifier or alias to include as a generic move preview.")] string? destinationFolderId = null,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPreview.PreviewCommonActionsAsync(new CommonMessageActionsPreviewRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            DestinationFolderId = destinationFolderId
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Builds a dry-run comparison for standard message actions such as archive, trash, delete, and an optional custom move target.")]
+    public Task<StandardMessageActionsPreview> mail_actions_preview(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to preview.")] string[] messageIds,
+        [Description("Optional custom destination folder identifier or alias to include as a generic move preview.")] string? destinationFolderId = null,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPreview.PreviewStandardActionsAsync(new StandardMessageActionsPreviewRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            DestinationFolderId = destinationFolderId
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Builds a dry-run preview for moving messages, including normalized message ids and the effective destination folder target.")]
+    public Task<MoveMessagesPreview> mail_move_preview(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to preview.")] string[] messageIds,
+        [Description("The requested destination folder identifier or alias.")] string destinationFolderId,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPreview.PreviewMoveAsync(new MoveMessagesPreviewRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            DestinationFolderId = destinationFolderId
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Builds a dry-run preview for deleting messages, including normalized message ids before execution.")]
+    public Task<DeleteMessagesPreview> mail_delete_preview(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to preview.")] string[] messageIds,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPreview.PreviewDeleteAsync(new DeleteMessagesPreviewRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>()
+        }, cancellationToken);
+
+    [McpServerTool]
     [Description("Searches messages in a mailbox using normalized Mailozaurr filters.")]
     public Task<IReadOnlyList<MessageSummary>> mail_search(
         [Description("The profile identifier to query.")] string profileId,
@@ -436,6 +903,184 @@ public sealed class MailMcpTools {
     }
 
     [McpServerTool]
+    [Description("Gets detailed message views for multiple specific message identifiers.")]
+    public Task<IReadOnlyList<MessageDetail>> mail_get_many(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to retrieve.")] string[] messageIds,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("When true, includes raw provider content where supported.")] bool includeRawContent = false,
+        CancellationToken cancellationToken = default) =>
+        _application.Read.GetMessagesAsync(new GetMessagesRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            IncludeRawContent = includeRawContent
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Gets lightweight detailed message views for multiple specific message identifiers.")]
+    public Task<IReadOnlyList<MessageDetailCompact>> mail_get_many_compact(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to retrieve.")] string[] messageIds,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("When true, includes raw-content presence where supported.")] bool includeRawContent = false,
+        CancellationToken cancellationToken = default) =>
+        _application.Read.GetMessagesCompactAsync(new GetMessagesRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            IncludeRawContent = includeRawContent
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Builds a dry-run preview for changing messages to read or unread, including normalized message ids and a reusable confirmation token.")]
+    public Task<MessageStateChangePreview> mail_mark_read_preview(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to preview.")] string[] messageIds,
+        [Description("Desired read state. True marks as read; false marks as unread.")] bool isRead = true,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPreview.PreviewReadStateAsync(new SetReadStateRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            IsRead = isRead
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Marks one or more messages as read or unread using the shared Mailozaurr message-action service.")]
+    public Task<MessageActionResult> mail_mark_read(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to update.")] string[] messageIds,
+        [Description("Desired read state. True marks as read; false marks as unread.")] bool isRead = true,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional confirmation token returned by a matching preview call.")] string? confirmationToken = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActions.SetReadStateAsync(new SetReadStateRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            IsRead = isRead,
+            ConfirmationToken = confirmationToken
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Builds a dry-run preview for flagging or unflagging messages, including normalized message ids and a reusable confirmation token.")]
+    public Task<MessageStateChangePreview> mail_flag_preview(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to preview.")] string[] messageIds,
+        [Description("Desired flagged state. True flags/star-marks; false unflags.")] bool isFlagged = true,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActionPreview.PreviewFlaggedStateAsync(new SetFlaggedStateRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            IsFlagged = isFlagged
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Flags or unflags one or more messages using the shared Mailozaurr message-action service.")]
+    public Task<MessageActionResult> mail_flag(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to update.")] string[] messageIds,
+        [Description("Desired flagged state. True flags/star-marks; false unflags.")] bool isFlagged = true,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional confirmation token returned by a matching preview call.")] string? confirmationToken = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActions.SetFlaggedStateAsync(new SetFlaggedStateRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            IsFlagged = isFlagged,
+            ConfirmationToken = confirmationToken
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Archives one or more messages using the shared Mailozaurr message-action service and a provider-neutral Archive alias.")]
+    public Task<MessageActionResult> mail_archive(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to archive.")] string[] messageIds,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional confirmation token returned by a matching preview call.")] string? confirmationToken = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActions.MoveAsync(new MoveMessagesRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            DestinationFolderId = MailFolderAliases.Archive,
+            ConfirmationToken = confirmationToken
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Moves one or more messages to trash using the shared Mailozaurr message-action service and a provider-neutral Trash alias.")]
+    public Task<MessageActionResult> mail_trash(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to trash.")] string[] messageIds,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional confirmation token returned by a matching preview call.")] string? confirmationToken = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActions.MoveAsync(new MoveMessagesRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            DestinationFolderId = MailFolderAliases.Trash,
+            ConfirmationToken = confirmationToken
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Moves one or more messages to a destination folder using the shared Mailozaurr message-action service.")]
+    public Task<MessageActionResult> mail_move(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to move.")] string[] messageIds,
+        [Description("Destination folder identifier or provider alias.")] string destinationFolderId,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional source folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional confirmation token returned by a matching preview call.")] string? confirmationToken = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActions.MoveAsync(new MoveMessagesRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            DestinationFolderId = destinationFolderId,
+            ConfirmationToken = confirmationToken
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Deletes one or more messages using the shared Mailozaurr message-action service.")]
+    public Task<MessageActionResult> mail_delete(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers to delete.")] string[] messageIds,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional confirmation token returned by a matching preview call.")] string? confirmationToken = null,
+        CancellationToken cancellationToken = default) =>
+        _application.MessageActions.DeleteAsync(new DeleteMessagesRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            ConfirmationToken = confirmationToken
+        }, cancellationToken);
+
+    [McpServerTool]
     [Description("Lists attachment metadata for a specific message without returning the full message body.")]
     public Task<IReadOnlyList<AttachmentSummary>> mail_attachments_list(
         [Description("The profile identifier to query.")] string profileId,
@@ -489,6 +1134,31 @@ public sealed class MailMcpTools {
             MailboxId = mailboxId,
             FolderId = folderId,
             MessageId = messageId,
+            DestinationPath = destinationPath,
+            AttachmentIds = attachmentIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
+            FileNameContains = fileNameContains,
+            ContentTypeContains = contentTypeContains,
+            Overwrite = overwrite
+        }, cancellationToken);
+
+    [McpServerTool]
+    [Description("Saves attachments from multiple messages using shared Mailozaurr filtering and batching logic.")]
+    public Task<SaveAttachmentsManyResult> mail_attachments_save_many(
+        [Description("The profile identifier to query.")] string profileId,
+        [Description("The provider-specific message identifiers that own the attachments.")] string[] messageIds,
+        [Description("The destination path or directory on the server filesystem.")] string destinationPath,
+        [Description("Optional mailbox identifier for providers that support multiple mailboxes.")] string? mailboxId = null,
+        [Description("Optional folder identifier when the provider requires folder scoping.")] string? folderId = null,
+        [Description("Optional explicit attachment identifiers to save.")] string[]? attachmentIds = null,
+        [Description("Optional case-insensitive file-name filter.")] string? fileNameContains = null,
+        [Description("Optional case-insensitive content-type filter.")] string? contentTypeContains = null,
+        [Description("When true, allows existing destination files to be overwritten.")] bool overwrite = false,
+        CancellationToken cancellationToken = default) =>
+        _application.Read.SaveAttachmentsManyAsync(new SaveAttachmentsManyRequest {
+            ProfileId = profileId,
+            MailboxId = mailboxId,
+            FolderId = folderId,
+            MessageIds = messageIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
             DestinationPath = destinationPath,
             AttachmentIds = attachmentIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()).ToList() ?? new List<string>(),
             FileNameContains = fileNameContains,
@@ -751,6 +1421,53 @@ public sealed class MailMcpTools {
         Name = recipient.Name,
         Address = recipient.Address
     };
+
+    private static MailMessageActionPlanBatchQuery? BuildBatchQuery(IReadOnlyList<string>? planNames, IReadOnlyList<string>? profileIds, IReadOnlyList<string>? actions, string? sortBy, bool descending) {
+        var normalizedPlanNames = (planNames ?? Array.Empty<string>())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var normalizedProfileIds = (profileIds ?? Array.Empty<string>())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var normalizedActions = (actions ?? Array.Empty<string>())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var parsedSortBy = ParseBatchSortBy(sortBy);
+
+        if (normalizedPlanNames.Count == 0 && normalizedProfileIds.Count == 0 && normalizedActions.Count == 0 && parsedSortBy == MailMessageActionPlanBatchSortBy.Id && !descending) {
+            return null;
+        }
+
+        return new MailMessageActionPlanBatchQuery {
+            PlanNames = normalizedPlanNames,
+            ProfileIds = normalizedProfileIds,
+            Actions = normalizedActions,
+            SortBy = parsedSortBy,
+            Descending = descending
+        };
+    }
+
+    private static MailMessageActionPlanBatchSortBy ParseBatchSortBy(string? rawSortBy) {
+        if (string.IsNullOrWhiteSpace(rawSortBy)) {
+            return MailMessageActionPlanBatchSortBy.Id;
+        }
+
+        return rawSortBy.Trim().ToLowerInvariant() switch {
+            "id" => MailMessageActionPlanBatchSortBy.Id,
+            "name" => MailMessageActionPlanBatchSortBy.Name,
+            "plans" or "plan-count" => MailMessageActionPlanBatchSortBy.PlanCount,
+            "ready" or "ready-count" => MailMessageActionPlanBatchSortBy.ReadyPlanCount,
+            "updated" or "updated-at" => MailMessageActionPlanBatchSortBy.UpdatedAt,
+            "actions" or "action-types" => MailMessageActionPlanBatchSortBy.ActionTypeCount,
+            _ => throw new InvalidOperationException($"Unsupported batch sort '{rawSortBy}'.")
+        };
+    }
 
     private static MailProfileConnectionTestScope ParseConnectionTestScope(string? rawScope) {
         if (string.IsNullOrWhiteSpace(rawScope)) {

--- a/Sources/Mailozaurr.Tests/ApplicationBuilderTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationBuilderTests.cs
@@ -25,12 +25,22 @@ public sealed class ApplicationBuilderTests {
         Assert.NotNull(app.DraftExchange);
         Assert.NotNull(app.ProfileBootstrap);
         Assert.NotNull(app.ProfileAuth);
+        Assert.NotNull(app.FolderAliases);
         Assert.NotNull(app.Read);
+        Assert.NotNull(app.MessageActionPreview);
+        Assert.NotNull(app.MessageActionPlans);
+        Assert.NotNull(app.MessageActionPlanExchange);
+        Assert.NotNull(app.MessageActionPlanRegistry);
+        Assert.NotNull(app.MessageActionBatch);
+        Assert.NotNull(app.MessageActions);
         Assert.NotNull(app.Send);
         Assert.NotNull(app.Queue);
         Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Imap);
         Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Graph);
         Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Gmail);
+        Assert.Contains(app.MessageActionHandlers, handler => handler.Kind == MailProfileKind.Imap);
+        Assert.Contains(app.MessageActionHandlers, handler => handler.Kind == MailProfileKind.Graph);
+        Assert.Contains(app.MessageActionHandlers, handler => handler.Kind == MailProfileKind.Gmail);
         Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Graph);
         Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Gmail);
         Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Smtp);
@@ -76,11 +86,13 @@ public sealed class ApplicationBuilderTests {
         builder.UseGmailSessionFactory(new FakeGmailSessionFactory());
         builder.UseSmtpSessionFactory(new FakeSmtpSessionFactory());
         builder.AddReadHandler(new FakeReadHandler(MailProfileKind.Graph));
+        builder.AddMessageActionHandler(new FakeMessageActionHandler(MailProfileKind.Graph));
         builder.AddSendHandler(new FakeSendHandler(MailProfileKind.Graph));
 
         var app = builder.Build();
 
         Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Graph);
+        Assert.Contains(app.MessageActionHandlers, handler => handler.Kind == MailProfileKind.Graph);
         Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Graph);
     }
 
@@ -147,5 +159,25 @@ public sealed class ApplicationBuilderTests {
 
         public Task<SendResult> SendAsync(MailProfile profile, SendMessageRequest request, CancellationToken cancellationToken = default) =>
             Task.FromResult(new SendResult { Succeeded = true, ProfileKind = Kind });
+    }
+
+    private sealed class FakeMessageActionHandler : IMailMessageActionHandler {
+        public FakeMessageActionHandler(MailProfileKind kind) {
+            Kind = kind;
+        }
+
+        public MailProfileKind Kind { get; }
+
+        public Task<MessageActionResult> SetReadStateAsync(MailProfile profile, SetReadStateRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MessageActionResult { Succeeded = true, ProfileId = profile.Id });
+
+        public Task<MessageActionResult> SetFlaggedStateAsync(MailProfile profile, SetFlaggedStateRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MessageActionResult { Succeeded = true, ProfileId = profile.Id });
+
+        public Task<MessageActionResult> MoveAsync(MailProfile profile, MoveMessagesRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MessageActionResult { Succeeded = true, ProfileId = profile.Id });
+
+        public Task<MessageActionResult> DeleteAsync(MailProfile profile, DeleteMessagesRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MessageActionResult { Succeeded = true, ProfileId = profile.Id });
     }
 }

--- a/Sources/Mailozaurr.Tests/ApplicationCapabilitiesTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationCapabilitiesTests.cs
@@ -7,7 +7,7 @@ public sealed class ApplicationCapabilitiesTests {
     [InlineData(MailProfileKind.Imap, MailCapability.ListFolders | MailCapability.SearchMessages | MailCapability.ReadMessages | MailCapability.MoveMessages | MailCapability.WaitForMessages)]
     [InlineData(MailProfileKind.Pop3, MailCapability.SearchMessages | MailCapability.ReadMessages | MailCapability.DeleteMessages)]
     [InlineData(MailProfileKind.Graph, MailCapability.ListFolders | MailCapability.SendMessages | MailCapability.ManageRules | MailCapability.ManageEvents | MailCapability.ManagePermissions)]
-    [InlineData(MailProfileKind.Gmail, MailCapability.SearchMessages | MailCapability.SendMessages | MailCapability.UseThreads | MailCapability.UseLabels)]
+    [InlineData(MailProfileKind.Gmail, MailCapability.SearchMessages | MailCapability.MarkMessages | MailCapability.MoveMessages | MailCapability.SendMessages | MailCapability.UseThreads | MailCapability.UseLabels)]
     [InlineData(MailProfileKind.Smtp, MailCapability.SendMessages)]
     [InlineData(MailProfileKind.SendGrid, MailCapability.SendMessages)]
     public void CatalogExposesExpectedCapabilities(MailProfileKind kind, MailCapability required) {

--- a/Sources/Mailozaurr.Tests/ApplicationFolderAliasServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationFolderAliasServiceTests.cs
@@ -1,0 +1,202 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationFolderAliasServiceTests {
+    [Fact]
+    public async Task FolderAliasServiceResolvesKnownAliasesFromFolderMetadata() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "graph-work",
+            DisplayName = "Graph Work",
+            Kind = MailProfileKind.Graph,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.ClientId] = "client-id",
+                [MailProfileSettingsKeys.TenantId] = "tenant-id",
+                [MailProfileSettingsKeys.Mailbox] = "shared@example.com"
+            }
+        });
+
+        var aliases = await new MailFolderAliasService(store, new FakeReadService()).GetAliasesAsync("graph-work", "shared@example.com");
+
+        var archive = Assert.Single(aliases, alias => alias.Alias == MailFolderAliases.Archive);
+        Assert.True(archive.IsSupported);
+        Assert.True(archive.IsResolved);
+        Assert.Equal("archive", archive.FolderId);
+        Assert.Equal("Archive", archive.FolderDisplayName);
+        Assert.Equal("Archive -> Archive", archive.Summary);
+    }
+
+    [Fact]
+    public async Task FolderAliasServiceFallsBackToAliasOnlyWhenFolderLookupFails() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "imap-work",
+            DisplayName = "IMAP Work",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var aliases = await new MailFolderAliasService(store, new ThrowingReadService()).GetAliasesAsync("imap-work");
+
+        var archive = Assert.Single(aliases, alias => alias.Alias == MailFolderAliases.Archive);
+        Assert.True(archive.IsSupported);
+        Assert.False(archive.IsResolved);
+        Assert.Null(archive.FolderId);
+        Assert.Equal("Archive [alias-only]", archive.Summary);
+    }
+
+    [Fact]
+    public async Task FolderAliasServiceResolvesExplicitFolderTargetsWithoutAliasLookup() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "imap-work",
+            DisplayName = "IMAP Work",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var resolution = await new MailFolderAliasService(store, new FakeReadService()).ResolveAsync("imap-work", "Projects/2026");
+
+        Assert.False(resolution.IsAlias);
+        Assert.True(resolution.IsSupported);
+        Assert.True(resolution.IsResolved);
+        Assert.Equal("Projects/2026", resolution.EffectiveFolderId);
+        Assert.Equal("Projects/2026 [explicit]", resolution.Summary);
+    }
+
+    [Fact]
+    public async Task FolderAliasServiceResolvesKnownAliasesToEffectiveFolderTargets() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "graph-work",
+            DisplayName = "Graph Work",
+            Kind = MailProfileKind.Graph,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.ClientId] = "client-id",
+                [MailProfileSettingsKeys.TenantId] = "tenant-id",
+                [MailProfileSettingsKeys.Mailbox] = "shared@example.com"
+            }
+        });
+
+        var resolution = await new MailFolderAliasService(store, new FakeReadService()).ResolveAsync("graph-work", "archive", "shared@example.com");
+
+        Assert.True(resolution.IsAlias);
+        Assert.True(resolution.IsSupported);
+        Assert.True(resolution.IsResolved);
+        Assert.Equal(MailFolderAliases.Archive, resolution.Alias);
+        Assert.Equal("archive", resolution.EffectiveFolderId);
+        Assert.Equal("Archive -> Archive", resolution.Summary);
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+
+    private sealed class FakeReadService : IMailReadService {
+        public Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailFolderQuery query, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<FolderRef>>(new[] {
+                new FolderRef {
+                    ProfileId = query.ProfileId,
+                    MailboxId = query.MailboxId,
+                    Id = "inbox",
+                    DisplayName = "Inbox",
+                    Path = "Inbox",
+                    SpecialUse = "inbox"
+                },
+                new FolderRef {
+                    ProfileId = query.ProfileId,
+                    MailboxId = query.MailboxId,
+                    Id = "archive",
+                    DisplayName = "Archive",
+                    Path = "Archive",
+                    SpecialUse = "archive"
+                },
+                new FolderRef {
+                    ProfileId = query.ProfileId,
+                    MailboxId = query.MailboxId,
+                    Id = "trash",
+                    DisplayName = "Trash",
+                    Path = "Trash",
+                    SpecialUse = "trash"
+                }
+            });
+
+        public Task<IReadOnlyList<FolderRefCompact>> GetFoldersCompactAsync(MailFolderQuery query, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<FolderRefCompact>>(Array.Empty<FolderRefCompact>());
+
+        public Task<IReadOnlyList<MessageSummary>> SearchAsync(MailSearchRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MessageSummary>>(Array.Empty<MessageSummary>());
+
+        public Task<IReadOnlyList<MessageSummaryCompact>> SearchCompactAsync(MailSearchRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MessageSummaryCompact>>(Array.Empty<MessageSummaryCompact>());
+
+        public Task<IReadOnlyList<AttachmentSummary>> GetAttachmentsAsync(ListAttachmentsRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<AttachmentSummary>>(Array.Empty<AttachmentSummary>());
+
+        public Task<MessageDetail?> GetMessageAsync(GetMessageRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MessageDetail?>(null);
+
+        public Task<IReadOnlyList<MessageDetail>> GetMessagesAsync(GetMessagesRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MessageDetail>>(Array.Empty<MessageDetail>());
+
+        public Task<MessageDetailCompact?> GetMessageCompactAsync(GetMessageRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MessageDetailCompact?>(null);
+
+        public Task<IReadOnlyList<MessageDetailCompact>> GetMessagesCompactAsync(GetMessagesRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MessageDetailCompact>>(Array.Empty<MessageDetailCompact>());
+
+        public Task<SaveAttachmentsResult> SaveAttachmentsAsync(SaveAttachmentsRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new SaveAttachmentsResult());
+
+        public Task<SaveAttachmentsManyResult> SaveAttachmentsManyAsync(SaveAttachmentsManyRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new SaveAttachmentsManyResult());
+
+        public Task<OperationResult> SaveAttachmentAsync(SaveAttachmentRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success());
+    }
+
+    private sealed class ThrowingReadService : IMailReadService {
+        public Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailFolderQuery query, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("Lookup failed.");
+
+        public Task<IReadOnlyList<FolderRefCompact>> GetFoldersCompactAsync(MailFolderQuery query, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<FolderRefCompact>>(Array.Empty<FolderRefCompact>());
+
+        public Task<IReadOnlyList<MessageSummary>> SearchAsync(MailSearchRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MessageSummary>>(Array.Empty<MessageSummary>());
+
+        public Task<IReadOnlyList<MessageSummaryCompact>> SearchCompactAsync(MailSearchRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MessageSummaryCompact>>(Array.Empty<MessageSummaryCompact>());
+
+        public Task<IReadOnlyList<AttachmentSummary>> GetAttachmentsAsync(ListAttachmentsRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<AttachmentSummary>>(Array.Empty<AttachmentSummary>());
+
+        public Task<MessageDetail?> GetMessageAsync(GetMessageRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MessageDetail?>(null);
+
+        public Task<IReadOnlyList<MessageDetail>> GetMessagesAsync(GetMessagesRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MessageDetail>>(Array.Empty<MessageDetail>());
+
+        public Task<MessageDetailCompact?> GetMessageCompactAsync(GetMessageRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MessageDetailCompact?>(null);
+
+        public Task<IReadOnlyList<MessageDetailCompact>> GetMessagesCompactAsync(GetMessagesRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MessageDetailCompact>>(Array.Empty<MessageDetailCompact>());
+
+        public Task<SaveAttachmentsResult> SaveAttachmentsAsync(SaveAttachmentsRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new SaveAttachmentsResult());
+
+        public Task<SaveAttachmentsManyResult> SaveAttachmentsManyAsync(SaveAttachmentsManyRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new SaveAttachmentsManyResult());
+
+        public Task<OperationResult> SaveAttachmentAsync(SaveAttachmentRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success());
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationMessageActionBatchServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationMessageActionBatchServiceTests.cs
@@ -1,0 +1,96 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationMessageActionBatchServiceTests {
+    [Fact]
+    public async Task ExecuteAggregatesSuccessfulPlans() {
+        var planService = new FakePlanService(plan => Task.FromResult(new MessageActionResult {
+            Succeeded = true,
+            ProfileId = plan.ProfileId,
+            RequestedCount = plan.UniqueMessageCount,
+            SucceededCount = plan.UniqueMessageCount,
+            FailedCount = 0,
+            Message = $"Executed '{plan.Action}'."
+        }));
+        var batchService = new MailMessageActionBatchService(planService);
+
+        var result = await batchService.ExecuteAsync(new[] {
+            CreatePlan("mark-read", "SetReadState", "work-imap", "msg-1"),
+            CreatePlan("delete", "Delete", "work-imap", "msg-2")
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(2, result.RequestedPlanCount);
+        Assert.Equal(2, result.AttemptedPlanCount);
+        Assert.Equal(2, result.SucceededPlanCount);
+        Assert.Equal(0, result.FailedPlanCount);
+        Assert.Equal(0, result.SkippedPlanCount);
+        Assert.Equal(2, planService.ExecutedPlans.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteStopsAfterFailureWhenContinueOnErrorIsFalse() {
+        var planService = new FakePlanService(plan => Task.FromResult(plan.Action == "delete"
+            ? new MessageActionResult {
+                Succeeded = false,
+                Code = "delete_failed",
+                Message = "Delete failed.",
+                ProfileId = plan.ProfileId,
+                RequestedCount = plan.UniqueMessageCount,
+                FailedCount = plan.UniqueMessageCount
+            }
+            : new MessageActionResult {
+                Succeeded = true,
+                ProfileId = plan.ProfileId,
+                RequestedCount = plan.UniqueMessageCount,
+                SucceededCount = plan.UniqueMessageCount,
+                Message = $"Executed '{plan.Action}'."
+            }));
+        var batchService = new MailMessageActionBatchService(planService);
+
+        var result = await batchService.ExecuteAsync(new[] {
+            CreatePlan("mark-read", "SetReadState", "work-imap", "msg-1"),
+            CreatePlan("delete", "Delete", "work-imap", "msg-2"),
+            CreatePlan("move", "Move", "work-imap", "msg-3")
+        }, continueOnError: false);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(3, result.RequestedPlanCount);
+        Assert.Equal(2, result.AttemptedPlanCount);
+        Assert.Equal(1, result.SucceededPlanCount);
+        Assert.Equal(1, result.FailedPlanCount);
+        Assert.Equal(1, result.SkippedPlanCount);
+        Assert.Equal(2, planService.ExecutedPlans.Count);
+        Assert.Contains(result.Results, item => item.Code == "skipped_after_failure" && item.Index == 2);
+    }
+
+    private static MessageActionExecutionPlan CreatePlan(string action, string executionKind, string profileId, string messageId) =>
+        new() {
+            Succeeded = true,
+            Action = action,
+            ExecutionKind = executionKind,
+            ProfileId = profileId,
+            RequestedCount = 1,
+            UniqueMessageCount = 1,
+            MessageIds = { messageId }
+        };
+
+    private sealed class FakePlanService : IMailMessageActionPlanService {
+        private readonly Func<MessageActionExecutionPlan, Task<MessageActionResult>> _executor;
+
+        public FakePlanService(Func<MessageActionExecutionPlan, Task<MessageActionResult>> executor) {
+            _executor = executor;
+        }
+
+        public List<MessageActionExecutionPlan> ExecutedPlans { get; } = new();
+
+        public Task<MessageActionExecutionPlan> CreatePlanAsync(MessageActionExecutionPlanRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public async Task<MessageActionResult> ExecuteAsync(MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) {
+            ExecutedPlans.Add(plan);
+            return await _executor(plan).ConfigureAwait(false);
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationMessageActionPlanBatchStoreTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationMessageActionPlanBatchStoreTests.cs
@@ -1,0 +1,46 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationMessageActionPlanBatchStoreTests {
+    [Fact]
+    public async Task FileActionPlanBatchStoreRoundTripsBatches() {
+        var store = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var batch = new MailMessageActionPlanBatch {
+            Id = "quarterly-cleanup",
+            Name = "Quarterly cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Archive newsletter",
+                    Summary = "Archive newsletter (1 message)",
+                    Action = "move",
+                    ExecutionKind = "Move",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    RequestedDestinationFolderId = "Archive",
+                    MessageIds = { "msg-1" }
+                }
+            }
+        };
+
+        await store.SaveAsync(batch);
+        var saved = await store.GetByIdAsync("quarterly-cleanup");
+
+        Assert.NotNull(saved);
+        Assert.Equal("Quarterly cleanup", saved!.Name);
+        Assert.Single(saved.Plans);
+        Assert.Equal("Archive newsletter", saved.Plans[0].Name);
+        Assert.Equal("Archive newsletter (1 message)", saved.Plans[0].Summary);
+        Assert.Equal("move", saved.Plans[0].Action);
+        Assert.NotEqual(default, saved.CreatedAt);
+        Assert.NotEqual(default, saved.UpdatedAt);
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationMessageActionPlanRegistryServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationMessageActionPlanRegistryServiceTests.cs
@@ -1,0 +1,1289 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationMessageActionPlanRegistryServiceTests {
+    [Fact]
+    public async Task SaveAsyncRejectsBatchWhenPlanProfileIsMissing() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var planService = new PassThroughPlanService();
+        var previewService = new FakePreviewService();
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            new JsonMailMessageActionPlanExchangeService(),
+            previewService,
+            planService,
+            new MailMessageActionBatchService(planService),
+            profileStore);
+
+        var result = await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "missing-profile-batch",
+            Name = "Missing profile batch",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "missing-profile",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-1" }
+                }
+            }
+        });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("action_plan_profile_not_found", result.Code);
+    }
+
+    [Fact]
+    public async Task ImportAndExecuteUsesSharedRegistryPipeline() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var exchange = new JsonMailMessageActionPlanExchangeService();
+        var importPath = CreateTemporaryFilePath("plans.json");
+        await exchange.SaveBatchAsync(importPath, new[] {
+            new MessageActionExecutionPlan {
+                Succeeded = true,
+                Action = "mark-read",
+                ExecutionKind = "SetReadState",
+                ProfileId = "work-gmail",
+                RequestedCount = 1,
+                UniqueMessageCount = 1,
+                DesiredState = true,
+                MessageIds = { "msg-1" }
+            }
+        });
+
+        var planService = new PassThroughPlanService();
+        var batchService = new MailMessageActionBatchService(planService);
+        var service = new MailMessageActionPlanRegistryService(batchStore, exchange, new FakePreviewService(), planService, batchService, profileStore);
+
+        var importResult = await service.ImportAsync("cleanup", "Cleanup", importPath);
+        var compact = await service.GetBatchCompactAsync("cleanup");
+        var execution = await service.ExecuteAsync("cleanup");
+
+        Assert.True(importResult.Succeeded);
+        Assert.NotNull(compact);
+        Assert.Equal(1, compact!.PlanCount);
+        Assert.Equal(new[] { "mark-read (1 message)" }, compact.PlanNames);
+        Assert.True(execution.Succeeded);
+        Assert.Equal(1, execution.SucceededPlanCount);
+    }
+
+    [Fact]
+    public async Task GetBatchesCompactCanFilterByPlanNames() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            new JsonMailMessageActionPlanExchangeService(),
+            new FakePreviewService(),
+            new PassThroughPlanService(),
+            new MailMessageActionBatchService(new PassThroughPlanService()),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "cleanup",
+            Name = "Cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Delete spam",
+                    Summary = "Delete spam (1 message)",
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-1" }
+                }
+            }
+        });
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "review",
+            Name = "Review",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Archive newsletter",
+                    Summary = "Archive newsletter (1 message)",
+                    Action = "move",
+                    ExecutionKind = "Move",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    RequestedDestinationFolderId = "Archive",
+                    MessageIds = { "msg-2" }
+                }
+            }
+        });
+
+        var compact = await service.GetBatchesCompactAsync(new MailMessageActionPlanBatchQuery {
+            PlanNames = { "Delete spam" }
+        });
+
+        var batch = Assert.Single(compact);
+        Assert.Equal("cleanup", batch.Id);
+        Assert.Equal(new[] { "Delete spam" }, batch.PlanNames);
+    }
+
+    [Fact]
+    public async Task GetBatchesCompactCanFilterByProfileIds() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "ops-imap",
+            DisplayName = "Ops IMAP",
+            Kind = MailProfileKind.Imap
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            new JsonMailMessageActionPlanExchangeService(),
+            new FakePreviewService(),
+            new PassThroughPlanService(),
+            new MailMessageActionBatchService(new PassThroughPlanService()),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "cleanup",
+            Name = "Cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Delete spam",
+                    Summary = "Delete spam (1 message)",
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-1" }
+                }
+            }
+        });
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "ops-review",
+            Name = "Ops review",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Archive alerts",
+                    Summary = "Archive alerts (1 message)",
+                    Action = "move",
+                    ExecutionKind = "Move",
+                    ProfileId = "ops-imap",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    RequestedDestinationFolderId = "Archive",
+                    MessageIds = { "msg-2" }
+                }
+            }
+        });
+
+        var compact = await service.GetBatchesCompactAsync(new MailMessageActionPlanBatchQuery {
+            ProfileIds = { "ops-imap" }
+        });
+
+        var batch = Assert.Single(compact);
+        Assert.Equal("ops-review", batch.Id);
+        Assert.Equal(new[] { "Archive alerts" }, batch.PlanNames);
+    }
+
+    [Fact]
+    public async Task GetBatchesCompactCanFilterByActions() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            new JsonMailMessageActionPlanExchangeService(),
+            new FakePreviewService(),
+            new PassThroughPlanService(),
+            new MailMessageActionBatchService(new PassThroughPlanService()),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "cleanup",
+            Name = "Cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Delete spam",
+                    Summary = "Delete spam (1 message)",
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-1" }
+                }
+            }
+        });
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "review",
+            Name = "Review",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Archive newsletter",
+                    Summary = "Archive newsletter (1 message)",
+                    Action = "move",
+                    ExecutionKind = "Move",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    RequestedDestinationFolderId = "Archive",
+                    MessageIds = { "msg-2" }
+                }
+            }
+        });
+
+        var compact = await service.GetBatchesCompactAsync(new MailMessageActionPlanBatchQuery {
+            Actions = { "delete" }
+        });
+
+        var batch = Assert.Single(compact);
+        Assert.Equal("cleanup", batch.Id);
+        Assert.Equal(new[] { "Delete spam" }, batch.PlanNames);
+    }
+
+    [Fact]
+    public async Task GetBatchSummaryProvidesProfileIdsAndActionCounts() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "ops-imap",
+            DisplayName = "Ops IMAP",
+            Kind = MailProfileKind.Imap
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            new JsonMailMessageActionPlanExchangeService(),
+            new FakePreviewService(),
+            new PassThroughPlanService(),
+            new MailMessageActionBatchService(new PassThroughPlanService()),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "cleanup",
+            Name = "Cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Delete spam",
+                    Summary = "Delete spam (1 message)",
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-1" }
+                },
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Archive alerts",
+                    Summary = "Archive alerts (1 message)",
+                    Action = "move",
+                    ExecutionKind = "Move",
+                    ProfileId = "ops-imap",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    RequestedDestinationFolderId = "Archive",
+                    MessageIds = { "msg-2" }
+                },
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Delete junk",
+                    Summary = "Delete junk (1 message)",
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-3" }
+                }
+            }
+        });
+
+        var summary = await service.GetBatchSummaryAsync("cleanup");
+
+        Assert.NotNull(summary);
+        Assert.Equal(new[] { "ops-imap", "work-gmail" }, summary!.ProfileIds);
+        Assert.Equal(2, summary.ActionCounts["delete"]);
+        Assert.Equal(1, summary.ActionCounts["move"]);
+        Assert.Equal(3, summary.PlanCount);
+    }
+
+    [Fact]
+    public async Task GetBatchesSummaryCanSortByPlanCountDescending() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            new JsonMailMessageActionPlanExchangeService(),
+            new FakePreviewService(),
+            new PassThroughPlanService(),
+            new MailMessageActionBatchService(new PassThroughPlanService()),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "small",
+            Name = "Small",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-1" }
+                }
+            }
+        });
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "large",
+            Name = "Large",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-2" }
+                },
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "move",
+                    ExecutionKind = "Move",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    RequestedDestinationFolderId = "Archive",
+                    MessageIds = { "msg-3" }
+                }
+            }
+        });
+
+        var summaries = await service.GetBatchesSummaryAsync(new MailMessageActionPlanBatchQuery {
+            SortBy = MailMessageActionPlanBatchSortBy.PlanCount,
+            Descending = true
+        });
+
+        Assert.Equal(new[] { "large", "small" }, summaries.Select(summary => summary.Id));
+    }
+
+    [Fact]
+    public async Task AppendAndRemovePlanMutateStoredBatch() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var planService = new PassThroughPlanService();
+        var previewService = new FakePreviewService();
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            new JsonMailMessageActionPlanExchangeService(),
+            previewService,
+            planService,
+            new MailMessageActionBatchService(planService),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "cleanup",
+            Name = "Cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "mark-read",
+                    ExecutionKind = "SetReadState",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    DesiredState = true,
+                    MessageIds = { "msg-1" }
+                },
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-2" }
+                }
+            }
+        });
+
+        var appendResult = await service.AppendPlanAsync("cleanup", new MessageActionExecutionPlan {
+            Succeeded = true,
+            Action = "move",
+            ExecutionKind = "Move",
+            ProfileId = "work-gmail",
+            RequestedCount = 1,
+            UniqueMessageCount = 1,
+            RequestedDestinationFolderId = "Archive",
+            MessageIds = { "msg-3" }
+        });
+        var afterAppend = await service.GetBatchAsync("cleanup");
+        var removeResult = await service.RemovePlanAtAsync("cleanup", 1);
+        var afterRemove = await service.GetBatchAsync("cleanup");
+
+        Assert.True(appendResult.Succeeded);
+        Assert.NotNull(afterAppend);
+        Assert.Equal(3, afterAppend!.Plans.Count);
+        Assert.True(removeResult.Succeeded);
+        Assert.NotNull(afterRemove);
+        Assert.Equal(2, afterRemove!.Plans.Count);
+        Assert.DoesNotContain(afterRemove.Plans, plan => plan.Action == "delete");
+    }
+
+    [Fact]
+    public async Task CloneAndReplacePlanMutateStoredBatch() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var exchange = new JsonMailMessageActionPlanExchangeService();
+        var planService = new PassThroughPlanService();
+        var previewService = new FakePreviewService();
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            exchange,
+            previewService,
+            planService,
+            new MailMessageActionBatchService(planService),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "cleanup",
+            Name = "Cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "work-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-1" }
+                }
+            }
+        });
+
+        var cloneResult = await service.CloneAsync("cleanup", "cleanup-copy", "Cleanup copy");
+        var cloned = await service.GetBatchAsync("cleanup-copy");
+        var replaceResult = await service.ReplacePlanAtAsync("cleanup-copy", 0, new MessageActionExecutionPlan {
+            Succeeded = true,
+            Action = "move",
+            ExecutionKind = "Move",
+            ProfileId = "work-gmail",
+            RequestedCount = 1,
+            UniqueMessageCount = 1,
+            RequestedDestinationFolderId = "Archive",
+            MessageIds = { "msg-2" }
+        });
+        var replaced = await service.GetBatchAsync("cleanup-copy");
+
+        Assert.True(cloneResult.Succeeded);
+        Assert.NotNull(cloned);
+        Assert.Equal("Cleanup copy", cloned!.Name);
+        Assert.True(replaceResult.Succeeded);
+        Assert.NotNull(replaced);
+        Assert.Single(replaced!.Plans);
+        Assert.Equal("move", replaced.Plans[0].Action);
+    }
+
+    [Fact]
+    public async Task CreateCommonBatchBuildsAndStoresSupportedPlans() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var exchange = new JsonMailMessageActionPlanExchangeService();
+        var planService = new RecordingPlanService();
+        var previewService = new FakePreviewService {
+            NextCommonPreview = new CommonMessageActionsPreview {
+                Succeeded = true,
+                ProfileId = "work-gmail",
+                MailboxId = "primary",
+                FolderId = "Inbox",
+                RequestedDestinationFolderId = "Archive",
+                RequestedCount = 2,
+                UniqueMessageCount = 1,
+                DuplicateOrEmptyCount = 1,
+                MessageIds = { "msg-1" },
+                IncludedActionCount = 3,
+                SucceededActionCount = 2,
+                FailedActionCount = 1,
+                Actions = {
+                    new MessageActionPreviewItem {
+                        Action = "mark-read",
+                        DisplayName = "Mark as read",
+                        Succeeded = true,
+                        ConfirmationToken = "token-read"
+                    },
+                    new MessageActionPreviewItem {
+                        Action = "move",
+                        DisplayName = "Move to Archive",
+                        Succeeded = true,
+                        RequestedDestinationFolderId = "Archive",
+                        Destination = new MailFolderTargetResolution {
+                            ProfileId = "work-gmail",
+                            MailboxId = "primary",
+                            RequestedValue = "Archive",
+                            EffectiveFolderId = "Archive",
+                            IsSupported = true,
+                            IsResolved = true,
+                            Summary = "Archive"
+                        },
+                        ConfirmationToken = "token-move"
+                    },
+                    new MessageActionPreviewItem {
+                        Action = "unsupported",
+                        DisplayName = "Unsupported",
+                        Succeeded = false,
+                        Code = "action_not_supported"
+                    }
+                }
+            }
+        };
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            exchange,
+            previewService,
+            planService,
+            new MailMessageActionBatchService(planService),
+            profileStore);
+
+        var result = await service.CreateCommonBatchAsync(
+            "cleanup",
+            "Cleanup",
+            new CommonMessageActionsPreviewRequest {
+                ProfileId = "work-gmail",
+                MailboxId = "primary",
+                FolderId = "Inbox",
+                MessageIds = { "msg-1", "MSG-1" },
+                DestinationFolderId = "Archive"
+            },
+            new[] { "mark-read", "move", "unsupported" },
+            "Created from common actions");
+        var stored = await service.GetBatchAsync("cleanup");
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(previewService.LastCommonRequest);
+        Assert.Equal("work-gmail", previewService.LastCommonRequest!.ProfileId);
+        Assert.Equal("primary", previewService.LastCommonRequest.MailboxId);
+        Assert.Equal("Inbox", previewService.LastCommonRequest.FolderId);
+        Assert.Equal("Archive", previewService.LastCommonRequest.DestinationFolderId);
+        Assert.Equal(new[] { "msg-1", "MSG-1" }, previewService.LastCommonRequest.MessageIds);
+        Assert.Equal(2, planService.Requests.Count);
+        Assert.NotNull(stored);
+        Assert.Equal("Created from common actions", stored!.Description);
+        Assert.Equal(new[] { "mark-read", "move" }, stored.Plans.Select(plan => plan.Action));
+        Assert.Equal("Archive", stored.Plans.Single(plan => plan.Action == "move").RequestedDestinationFolderId);
+        Assert.Equal(new[] { "msg-1" }, stored.Plans[0].MessageIds);
+        Assert.Equal("token-read", planService.Requests[0].ConfirmationToken);
+        Assert.Equal("token-move", planService.Requests[1].ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task CreateCommonBatchFromPreviewUsesPreviewedActionsWithoutRestatingSelection() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-gmail",
+            DisplayName = "Work Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var exchange = new JsonMailMessageActionPlanExchangeService();
+        var planService = new RecordingPlanService();
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            exchange,
+            new FakePreviewService(),
+            planService,
+            new MailMessageActionBatchService(planService),
+            profileStore);
+
+        var result = await service.CreateCommonBatchFromPreviewAsync(
+            "cleanup-previewed",
+            "Cleanup Previewed",
+            new CommonMessageActionsPreview {
+                Succeeded = true,
+                ProfileId = "work-gmail",
+                MailboxId = "primary",
+                FolderId = "Inbox",
+                RequestedDestinationFolderId = "Projects/2026",
+                RequestedCount = 3,
+                UniqueMessageCount = 2,
+                DuplicateOrEmptyCount = 1,
+                MessageIds = { "msg-1", "msg-2" },
+                Actions = {
+                    new MessageActionPreviewItem {
+                        Action = "flag",
+                        DisplayName = "Flag",
+                        Succeeded = true,
+                        DesiredState = true,
+                        ConfirmationToken = "token-flag"
+                    },
+                    new MessageActionPreviewItem {
+                        Action = "move",
+                        DisplayName = "Move to Projects",
+                        Succeeded = true,
+                        RequestedDestinationFolderId = "Projects/2026",
+                        Destination = new MailFolderTargetResolution {
+                            ProfileId = "work-gmail",
+                            MailboxId = "primary",
+                            RequestedValue = "Projects/2026",
+                            EffectiveFolderId = "Projects/2026",
+                            IsSupported = true,
+                            IsResolved = true,
+                            Summary = "Projects/2026"
+                        },
+                        ConfirmationToken = "token-move"
+                    },
+                    new MessageActionPreviewItem {
+                        Action = "delete",
+                        DisplayName = "Delete",
+                        Succeeded = false,
+                        Code = "delete_not_supported"
+                    }
+                }
+            },
+            description: "Built from preview");
+        var stored = await service.GetBatchAsync("cleanup-previewed");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(2, planService.Requests.Count);
+        Assert.Equal(new[] { "flag", "move" }, planService.Requests.Select(request => request.Action));
+        Assert.All(planService.Requests, request => Assert.Equal(new[] { "msg-1", "msg-2" }, request.MessageIds));
+        Assert.Equal("token-flag", planService.Requests[0].ConfirmationToken);
+        Assert.Equal("token-move", planService.Requests[1].ConfirmationToken);
+        Assert.Equal("Projects/2026", planService.Requests[1].DestinationFolderId);
+        Assert.NotNull(stored);
+        Assert.Equal("Built from preview", stored!.Description);
+        Assert.Equal(2, stored.Plans.Count);
+    }
+
+    [Fact]
+    public async Task TransformCloneRewritesTargetsAndRegeneratesConfirmationTokens() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "source-gmail",
+            DisplayName = "Source Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "target-gmail",
+            DisplayName = "Target Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var exchange = new JsonMailMessageActionPlanExchangeService();
+        var planService = new RecordingPlanService();
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            exchange,
+            new FakePreviewService(),
+            planService,
+            new MailMessageActionBatchService(planService),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "cleanup",
+            Name = "Cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "mark-read",
+                    ExecutionKind = "SetReadState",
+                    ProfileId = "source-gmail",
+                    MailboxId = "source@example.com",
+                    FolderId = "Inbox",
+                    RequestedCount = 2,
+                    UniqueMessageCount = 2,
+                    DesiredState = true,
+                    MessageIds = { "msg-1", "msg-2" },
+                    ConfirmationToken = MessageActionConfirmationTokens.CreateReadStateToken("source-gmail", "source@example.com", "Inbox", new[] { "msg-1", "msg-2" }, true),
+                    ConfirmationProvided = true,
+                    ConfirmationValidated = true
+                },
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Archive newsletter",
+                    Summary = "Archive newsletter (1 message)",
+                    Action = "move",
+                    ExecutionKind = "Move",
+                    ProfileId = "source-gmail",
+                    MailboxId = "source@example.com",
+                    FolderId = "Inbox",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-3" },
+                    RequestedDestinationFolderId = "Archive",
+                    Destination = new MailFolderTargetResolution {
+                        ProfileId = "source-gmail",
+                        MailboxId = "source@example.com",
+                        RequestedValue = "Archive",
+                        EffectiveFolderId = "Archive",
+                        IsSupported = true,
+                        IsResolved = true,
+                        Summary = "Archive"
+                    },
+                    ConfirmationToken = MessageActionConfirmationTokens.CreateMoveToken("source-gmail", "source@example.com", "Inbox", new[] { "msg-3" }, "Archive"),
+                    ConfirmationProvided = true,
+                    ConfirmationValidated = true
+                },
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "source-gmail",
+                    MailboxId = "source@example.com",
+                    FolderId = "Inbox",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-4" },
+                    ConfirmationToken = MessageActionConfirmationTokens.CreateDeleteToken("source-gmail", "source@example.com", "Inbox", new[] { "msg-4" }),
+                    ConfirmationProvided = true,
+                    ConfirmationValidated = true
+                }
+            }
+        });
+
+        var result = await service.TransformCloneAsync(
+            "cleanup",
+            "cleanup-target",
+            "Cleanup Target",
+            new MessageActionPlanBatchTransformRequest {
+                ProfileId = "target-gmail",
+                MailboxId = "target@example.com",
+                FolderId = "Projects",
+                DestinationFolderId = "Projects/Archive"
+            },
+            "Remapped batch");
+        var transformed = await service.GetBatchAsync("cleanup-target");
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(transformed);
+        Assert.Equal("Remapped batch", transformed!.Description);
+        Assert.All(transformed.Plans, plan => {
+            Assert.Equal("target-gmail", plan.ProfileId);
+            Assert.Equal("target@example.com", plan.MailboxId);
+            Assert.Equal("Projects", plan.FolderId);
+            Assert.False(plan.ConfirmationProvided);
+            Assert.True(plan.ConfirmationValidated);
+            Assert.False(string.IsNullOrWhiteSpace(plan.ConfirmationToken));
+        });
+
+        var transformedMove = transformed.Plans.Single(plan => plan.Action == "move");
+        Assert.Equal("Projects/Archive", transformedMove.RequestedDestinationFolderId);
+        Assert.Null(transformedMove.Destination);
+        Assert.Equal(
+            MessageActionConfirmationTokens.CreateMoveToken("target-gmail", "target@example.com", "Projects", new[] { "msg-3" }, "Projects/Archive"),
+            transformedMove.ConfirmationToken);
+
+        var transformedRead = transformed.Plans.Single(plan => plan.Action == "mark-read");
+        Assert.Equal(
+            MessageActionConfirmationTokens.CreateReadStateToken("target-gmail", "target@example.com", "Projects", new[] { "msg-1", "msg-2" }, true),
+            transformedRead.ConfirmationToken);
+
+        var transformedDelete = transformed.Plans.Single(plan => plan.Action == "delete");
+        Assert.Equal(
+            MessageActionConfirmationTokens.CreateDeleteToken("target-gmail", "target@example.com", "Projects", new[] { "msg-4" }),
+            transformedDelete.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task PreviewTransformCloneReportsChangesAndValidationState() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "source-gmail",
+            DisplayName = "Source Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "target-gmail",
+            DisplayName = "Target Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var exchange = new JsonMailMessageActionPlanExchangeService();
+        var planService = new RecordingPlanService();
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            exchange,
+            new FakePreviewService(),
+            planService,
+            new MailMessageActionBatchService(planService),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "cleanup",
+            Name = "Cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "mark-read",
+                    ExecutionKind = "SetReadState",
+                    ProfileId = "source-gmail",
+                    MailboxId = "source@example.com",
+                    FolderId = "Inbox",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    DesiredState = true,
+                    MessageIds = { "msg-1" },
+                    ConfirmationToken = MessageActionConfirmationTokens.CreateReadStateToken("source-gmail", "source@example.com", "Inbox", new[] { "msg-1" }, true),
+                    ConfirmationProvided = true,
+                    ConfirmationValidated = true
+                },
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "move",
+                    ExecutionKind = "Move",
+                    ProfileId = "source-gmail",
+                    MailboxId = "source@example.com",
+                    FolderId = "Inbox",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-2" },
+                    RequestedDestinationFolderId = "Archive",
+                    Destination = new MailFolderTargetResolution {
+                        ProfileId = "source-gmail",
+                        MailboxId = "source@example.com",
+                        RequestedValue = "Archive",
+                        EffectiveFolderId = "Archive",
+                        IsSupported = true,
+                        IsResolved = true,
+                        Summary = "Archive"
+                    },
+                    ConfirmationToken = MessageActionConfirmationTokens.CreateMoveToken("source-gmail", "source@example.com", "Inbox", new[] { "msg-2" }, "Archive"),
+                    ConfirmationProvided = true,
+                    ConfirmationValidated = true
+                }
+            }
+        });
+
+        var preview = await service.PreviewTransformCloneAsync(
+            "cleanup",
+            new MessageActionPlanBatchTransformRequest {
+                ProfileId = "target-gmail",
+                MailboxId = "target@example.com",
+                FolderId = "Projects",
+                DestinationFolderId = "Projects/Archive"
+            });
+
+        Assert.True(preview.Succeeded);
+        Assert.Equal("cleanup", preview.SourceBatchId);
+        Assert.Equal("Cleanup", preview.SourceBatchName);
+        Assert.Equal(2, preview.PlanCount);
+        Assert.Equal(2, preview.ChangedPlanCount);
+        Assert.Equal(2, preview.ConfirmationTokenChangedCount);
+        Assert.True(preview.TargetProfileExists);
+        Assert.Equal(MailProfileKind.Gmail, preview.TargetProfileKind);
+        Assert.Empty(preview.Errors);
+        Assert.Equal(2, preview.Plans.Count);
+        Assert.All(preview.Plans, plan => Assert.True(plan.WillChange));
+        Assert.Contains(preview.Plans, plan => plan.Action == "move" && plan.TargetDestinationFolderId == "Projects/Archive" && plan.ConfirmationTokenWillChange);
+    }
+
+    [Fact]
+    public async Task PreviewTransformCloneFailsWhenTargetProfileIsMissing() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "source-gmail",
+            DisplayName = "Source Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var exchange = new JsonMailMessageActionPlanExchangeService();
+        var planService = new RecordingPlanService();
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            exchange,
+            new FakePreviewService(),
+            planService,
+            new MailMessageActionBatchService(planService),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "cleanup",
+            Name = "Cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "source-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-1" }
+                }
+            }
+        });
+
+        var preview = await service.PreviewTransformCloneAsync(
+            "cleanup",
+            new MessageActionPlanBatchTransformRequest {
+                ProfileId = "missing-profile"
+            });
+
+        Assert.False(preview.Succeeded);
+        Assert.Equal("action_plan_profile_not_found", preview.Code);
+        Assert.False(preview.TargetProfileExists);
+        Assert.Contains(preview.Errors, error => error.Contains("missing-profile", StringComparison.Ordinal));
+        Assert.Single(preview.Plans);
+    }
+
+    [Fact]
+    public async Task TransformCloneCanLimitSelectionToSpecificPlanIndexes() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "source-gmail",
+            DisplayName = "Source Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "target-gmail",
+            DisplayName = "Target Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var exchange = new JsonMailMessageActionPlanExchangeService();
+        var planService = new RecordingPlanService();
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            exchange,
+            new FakePreviewService(),
+            planService,
+            new MailMessageActionBatchService(planService),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "cleanup",
+            Name = "Cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "mark-read",
+                    ExecutionKind = "SetReadState",
+                    ProfileId = "source-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    DesiredState = true,
+                    MessageIds = { "msg-1" }
+                },
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "move",
+                    ExecutionKind = "Move",
+                    ProfileId = "source-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-2" },
+                    RequestedDestinationFolderId = "Archive"
+                },
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "source-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-3" }
+                }
+            }
+        });
+
+        var preview = await service.PreviewTransformCloneAsync(
+            "cleanup",
+            new MessageActionPlanBatchTransformRequest {
+                PlanIndexes = { 1, 2 },
+                ProfileId = "target-gmail",
+                DestinationFolderId = "Projects/Archive"
+            });
+        var result = await service.TransformCloneAsync(
+            "cleanup",
+            "cleanup-subset",
+            "Cleanup Subset",
+            new MessageActionPlanBatchTransformRequest {
+                PlanIndexes = { 1, 2 },
+                ProfileId = "target-gmail",
+                DestinationFolderId = "Projects/Archive"
+            });
+        var transformed = await service.GetBatchAsync("cleanup-subset");
+
+        Assert.True(preview.Succeeded);
+        Assert.Equal(2, preview.PlanCount);
+        Assert.Equal(new[] { 1, 2 }, preview.Plans.Select(plan => plan.Index));
+        Assert.True(result.Succeeded);
+        Assert.NotNull(transformed);
+        Assert.Equal(2, transformed!.Plans.Count);
+        Assert.Equal(new[] { "move", "delete" }, transformed.Plans.Select(plan => plan.Action));
+    }
+
+    [Fact]
+    public async Task TransformCloneCanLimitSelectionToSpecificPlanNames() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "source-gmail",
+            DisplayName = "Source Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "target-gmail",
+            DisplayName = "Target Gmail",
+            Kind = MailProfileKind.Gmail
+        });
+        var batchStore = new FileMailMessageActionPlanBatchStore(CreateTemporaryFilePath("action-plan-batches.json"));
+        var exchange = new JsonMailMessageActionPlanExchangeService();
+        var planService = new RecordingPlanService();
+        var service = new MailMessageActionPlanRegistryService(
+            batchStore,
+            exchange,
+            new FakePreviewService(),
+            planService,
+            new MailMessageActionBatchService(planService),
+            profileStore);
+
+        await service.SaveAsync(new MailMessageActionPlanBatch {
+            Id = "cleanup",
+            Name = "Cleanup",
+            Plans = {
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Read invoices",
+                    Summary = "Read invoices (1 message)",
+                    Action = "mark-read",
+                    ExecutionKind = "SetReadState",
+                    ProfileId = "source-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    DesiredState = true,
+                    MessageIds = { "msg-1" }
+                },
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Archive newsletter",
+                    Summary = "Archive newsletter (1 message)",
+                    Action = "move",
+                    ExecutionKind = "Move",
+                    ProfileId = "source-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-2" },
+                    RequestedDestinationFolderId = "Archive"
+                },
+                new MessageActionExecutionPlan {
+                    Succeeded = true,
+                    Name = "Delete spam",
+                    Summary = "Delete spam (1 message)",
+                    Action = "delete",
+                    ExecutionKind = "Delete",
+                    ProfileId = "source-gmail",
+                    RequestedCount = 1,
+                    UniqueMessageCount = 1,
+                    MessageIds = { "msg-3" }
+                }
+            }
+        });
+
+        var preview = await service.PreviewTransformCloneAsync(
+            "cleanup",
+            new MessageActionPlanBatchTransformRequest {
+                PlanNames = { "Archive newsletter", "Delete spam" },
+                ProfileId = "target-gmail"
+            });
+        var result = await service.TransformCloneAsync(
+            "cleanup",
+            "cleanup-named",
+            "Cleanup Named",
+            new MessageActionPlanBatchTransformRequest {
+                PlanNames = { "Archive newsletter", "Delete spam" },
+                ProfileId = "target-gmail"
+            });
+        var transformed = await service.GetBatchAsync("cleanup-named");
+
+        Assert.True(preview.Succeeded);
+        Assert.Equal(2, preview.PlanCount);
+        Assert.Equal(new[] { "Archive newsletter", "Delete spam" }, preview.Plans.Select(plan => plan.Action == "move" ? "Archive newsletter" : "Delete spam"));
+        Assert.True(result.Succeeded);
+        Assert.NotNull(transformed);
+        Assert.Equal(2, transformed!.Plans.Count);
+        Assert.Equal(new[] { "Archive newsletter", "Delete spam" }, transformed.Plans.Select(plan => plan.Name));
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+
+    private sealed class PassThroughPlanService : IMailMessageActionPlanService {
+        public Task<MessageActionExecutionPlan> CreatePlanAsync(MessageActionExecutionPlanRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<MessageActionResult> ExecuteAsync(MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MessageActionResult {
+                Succeeded = plan.Succeeded,
+                ProfileId = plan.ProfileId,
+                RequestedCount = plan.UniqueMessageCount,
+                SucceededCount = plan.Succeeded ? plan.UniqueMessageCount : 0,
+                FailedCount = plan.Succeeded ? 0 : plan.UniqueMessageCount,
+                Message = $"Executed '{plan.Action}'."
+            });
+    }
+
+    private sealed class RecordingPlanService : IMailMessageActionPlanService {
+        public List<MessageActionExecutionPlanRequest> Requests { get; } = new();
+
+        public Task<MessageActionExecutionPlan> CreatePlanAsync(MessageActionExecutionPlanRequest request, CancellationToken cancellationToken = default) {
+            Requests.Add(new MessageActionExecutionPlanRequest {
+                Action = request.Action,
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                MessageIds = request.MessageIds.ToList(),
+                DestinationFolderId = request.DestinationFolderId,
+                ConfirmationToken = request.ConfirmationToken
+            });
+
+            if (string.Equals(request.Action, "unsupported", StringComparison.OrdinalIgnoreCase)) {
+                return Task.FromResult(new MessageActionExecutionPlan {
+                    Succeeded = false,
+                    Code = "action_not_supported",
+                    Action = request.Action,
+                    ProfileId = request.ProfileId,
+                    MailboxId = request.MailboxId,
+                    FolderId = request.FolderId,
+                    RequestedCount = request.MessageIds.Count,
+                    UniqueMessageCount = request.MessageIds.Distinct(StringComparer.OrdinalIgnoreCase).Count(),
+                    MessageIds = request.MessageIds.ToList(),
+                    RequestedDestinationFolderId = request.DestinationFolderId
+                });
+            }
+
+            return Task.FromResult(new MessageActionExecutionPlan {
+                Succeeded = true,
+                Action = request.Action,
+                ExecutionKind = request.Action switch {
+                    "mark-read" or "mark-unread" => "SetReadState",
+                    "flag" or "unflag" => "SetFlaggedState",
+                    "move" or "archive" or "trash" => "Move",
+                    "delete" => "Delete",
+                    _ => "Custom"
+                },
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                RequestedCount = request.MessageIds.Count,
+                UniqueMessageCount = request.MessageIds.Distinct(StringComparer.OrdinalIgnoreCase).Count(),
+                MessageIds = request.MessageIds.ToList(),
+                RequestedDestinationFolderId = request.DestinationFolderId,
+                DesiredState = request.Action switch {
+                    "mark-read" => true,
+                    "mark-unread" => false,
+                    "flag" => true,
+                    "unflag" => false,
+                    _ => null
+                }
+            });
+        }
+
+        public Task<MessageActionResult> ExecuteAsync(MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MessageActionResult {
+                Succeeded = plan.Succeeded,
+                ProfileId = plan.ProfileId,
+                RequestedCount = plan.UniqueMessageCount,
+                SucceededCount = plan.Succeeded ? plan.UniqueMessageCount : 0,
+                FailedCount = plan.Succeeded ? 0 : plan.UniqueMessageCount,
+                Message = $"Executed '{plan.Action}'."
+            });
+    }
+
+    private sealed class FakePreviewService : IMailMessageActionPreviewService {
+        public CommonMessageActionsPreviewRequest? LastCommonRequest { get; private set; }
+
+        public CommonMessageActionsPreview? NextCommonPreview { get; set; }
+
+        public Task<CommonMessageActionsPreview> PreviewCommonActionsAsync(CommonMessageActionsPreviewRequest request, CancellationToken cancellationToken = default) {
+            LastCommonRequest = new CommonMessageActionsPreviewRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                DestinationFolderId = request.DestinationFolderId,
+                MessageIds = request.MessageIds.ToList()
+            };
+            return Task.FromResult(NextCommonPreview ?? new CommonMessageActionsPreview {
+                Succeeded = false,
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                RequestedDestinationFolderId = request.DestinationFolderId,
+                RequestedCount = request.MessageIds.Count,
+                UniqueMessageCount = request.MessageIds.Count,
+                MessageIds = request.MessageIds.ToList(),
+                Code = "no_supported_actions",
+                Message = "No supported actions."
+            });
+        }
+
+        public Task<MessageStateChangePreview> PreviewReadStateAsync(SetReadStateRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<MessageStateChangePreview> PreviewFlaggedStateAsync(SetFlaggedStateRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<MoveMessagesPreview> PreviewMoveAsync(MoveMessagesPreviewRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<DeleteMessagesPreview> PreviewDeleteAsync(DeleteMessagesPreviewRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StandardMessageActionsPreview> PreviewStandardActionsAsync(StandardMessageActionsPreviewRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationMessageActionPlanServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationMessageActionPlanServiceTests.cs
@@ -1,0 +1,186 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationMessageActionPlanServiceTests {
+    [Fact]
+    public async Task CreatePlanResolvesMoveDestinationAndValidatesToken() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var previewService = new MailMessageActionPreviewService(profileStore, new FakeFolderAliasService());
+        var actionService = new CapturingMessageActionService();
+        var planningService = new MailMessageActionPlanService(previewService, actionService);
+        var preview = await previewService.PreviewMoveAsync(new MoveMessagesPreviewRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "msg-1", "MSG-1" },
+            DestinationFolderId = MailFolderAliases.Archive
+        });
+
+        var plan = await planningService.CreatePlanAsync(new MessageActionExecutionPlanRequest {
+            Action = "archive",
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "msg-1", "MSG-1" },
+            ConfirmationToken = preview.ConfirmationToken
+        });
+
+        Assert.True(plan.Succeeded);
+        Assert.Equal("Move", plan.ExecutionKind);
+        Assert.Equal(1, plan.UniqueMessageCount);
+        Assert.True(plan.ConfirmationProvided);
+        Assert.True(plan.ConfirmationValidated);
+        Assert.Equal("archive-folder", plan.Destination!.EffectiveFolderId);
+    }
+
+    [Fact]
+    public async Task CreatePlanRejectsMismatchedToken() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var planningService = new MailMessageActionPlanService(
+            new MailMessageActionPreviewService(profileStore, new FakeFolderAliasService()),
+            new CapturingMessageActionService());
+
+        var plan = await planningService.CreatePlanAsync(new MessageActionExecutionPlanRequest {
+            Action = "delete",
+            ProfileId = "work-imap",
+            MessageIds = { "msg-1" },
+            ConfirmationToken = "mact_v1_invalid"
+        });
+
+        Assert.False(plan.Succeeded);
+        Assert.Equal("confirmation_token_mismatch", plan.Code);
+        Assert.True(plan.ConfirmationProvided);
+        Assert.False(plan.ConfirmationValidated);
+    }
+
+    [Fact]
+    public async Task ExecutePlanDispatchesNormalizedReadStateRequest() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var previewService = new MailMessageActionPreviewService(profileStore, new FakeFolderAliasService());
+        var actionService = new CapturingMessageActionService();
+        var planningService = new MailMessageActionPlanService(previewService, actionService);
+        var plan = await planningService.CreatePlanAsync(new MessageActionExecutionPlanRequest {
+            Action = "mark-unread",
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "msg-1", "MSG-1" }
+        });
+
+        var result = await planningService.ExecuteAsync(plan);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(actionService.LastReadStateRequest);
+        Assert.Equal("work-imap", actionService.LastReadStateRequest!.ProfileId);
+        Assert.Equal("shared@example.com", actionService.LastReadStateRequest.MailboxId);
+        Assert.Equal("Inbox", actionService.LastReadStateRequest.FolderId);
+        Assert.False(actionService.LastReadStateRequest.IsRead);
+        Assert.Equal(new[] { "msg-1" }, actionService.LastReadStateRequest.MessageIds);
+        Assert.Equal(plan.ConfirmationToken, actionService.LastReadStateRequest.ConfirmationToken);
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+
+    private sealed class CapturingMessageActionService : IMailMessageActionService {
+        public SetReadStateRequest? LastReadStateRequest { get; private set; }
+
+        public Task<MessageActionResult> SetReadStateAsync(SetReadStateRequest request, CancellationToken cancellationToken = default) {
+            LastReadStateRequest = request;
+            return Task.FromResult(new MessageActionResult {
+                Succeeded = true,
+                ProfileId = request.ProfileId,
+                RequestedCount = request.MessageIds.Count,
+                SucceededCount = request.MessageIds.Count
+            });
+        }
+
+        public Task<MessageActionResult> SetFlaggedStateAsync(SetFlaggedStateRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MessageActionResult {
+                Succeeded = true,
+                ProfileId = request.ProfileId,
+                RequestedCount = request.MessageIds.Count,
+                SucceededCount = request.MessageIds.Count
+            });
+
+        public Task<MessageActionResult> MoveAsync(MoveMessagesRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MessageActionResult {
+                Succeeded = true,
+                ProfileId = request.ProfileId,
+                RequestedCount = request.MessageIds.Count,
+                SucceededCount = request.MessageIds.Count
+            });
+
+        public Task<MessageActionResult> DeleteAsync(DeleteMessagesRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MessageActionResult {
+                Succeeded = true,
+                ProfileId = request.ProfileId,
+                RequestedCount = request.MessageIds.Count,
+                SucceededCount = request.MessageIds.Count
+            });
+    }
+
+    private sealed class FakeFolderAliasService : IMailFolderAliasService {
+        public Task<IReadOnlyList<MailFolderAliasSummary>> GetAliasesAsync(string profileId, string? mailboxId = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailFolderAliasSummary>>(new[] {
+                new MailFolderAliasSummary {
+                    ProfileId = profileId,
+                    MailboxId = mailboxId,
+                    Alias = MailFolderAliases.Archive,
+                    DisplayName = "Archive",
+                    IsSupported = true,
+                    IsResolved = true,
+                    FolderId = "archive-folder",
+                    FolderDisplayName = "Archive",
+                    FolderPath = "Archive",
+                    Summary = "Archive -> Archive"
+                }
+            });
+
+        public Task<MailFolderTargetResolution> ResolveAsync(string profileId, string targetFolderId, string? mailboxId = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MailFolderTargetResolution {
+                ProfileId = profileId,
+                MailboxId = mailboxId,
+                RequestedValue = targetFolderId,
+                IsAlias = true,
+                Alias = MailFolderAliases.Archive,
+                IsSupported = true,
+                IsResolved = true,
+                EffectiveFolderId = "archive-folder",
+                FolderDisplayName = "Archive",
+                FolderPath = "Archive",
+                Summary = "Archive -> Archive"
+            });
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationMessageActionPreviewServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationMessageActionPreviewServiceTests.cs
@@ -1,0 +1,383 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationMessageActionPreviewServiceTests {
+    [Fact]
+    public async Task PreviewReadStateNormalizesMessageIdsAndProducesToken() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var service = new MailMessageActionPreviewService(profileStore, new FakeFolderAliasService());
+        var preview = await service.PreviewReadStateAsync(new SetReadStateRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "msg-1", "MSG-1", "", "msg-2" },
+            IsRead = false
+        });
+
+        Assert.True(preview.Succeeded);
+        Assert.Equal("read-state", preview.Action);
+        Assert.False(preview.DesiredState);
+        Assert.Equal(2, preview.UniqueMessageCount);
+        Assert.Equal(
+            MessageActionConfirmationTokens.CreateReadStateToken("work-imap", "shared@example.com", "Inbox", new[] { "msg-1", "msg-2" }, isRead: false),
+            preview.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task PreviewFlaggedStateNormalizesMessageIdsAndProducesToken() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var service = new MailMessageActionPreviewService(profileStore, new FakeFolderAliasService());
+        var preview = await service.PreviewFlaggedStateAsync(new SetFlaggedStateRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "msg-1", "MSG-1", "", "msg-2" },
+            IsFlagged = false
+        });
+
+        Assert.True(preview.Succeeded);
+        Assert.Equal("flagged-state", preview.Action);
+        Assert.False(preview.DesiredState);
+        Assert.Equal(2, preview.UniqueMessageCount);
+        Assert.Equal(
+            MessageActionConfirmationTokens.CreateFlaggedStateToken("work-imap", "shared@example.com", "Inbox", new[] { "msg-1", "msg-2" }, isFlagged: false),
+            preview.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task PreviewMoveNormalizesMessageIdsAndResolvesDestination() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var service = new MailMessageActionPreviewService(profileStore, new FakeFolderAliasService());
+        var preview = await service.PreviewMoveAsync(new MoveMessagesPreviewRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            MessageIds = { "msg-1", "MSG-1", "", "msg-2" },
+            DestinationFolderId = "archive"
+        });
+
+        Assert.True(preview.Succeeded);
+        Assert.Equal(4, preview.RequestedCount);
+        Assert.Equal(2, preview.UniqueMessageCount);
+        Assert.Equal(2, preview.DuplicateOrEmptyCount);
+        Assert.Equal(new[] { "msg-1", "msg-2" }, preview.MessageIds);
+        Assert.NotNull(preview.Destination);
+        Assert.Equal("archive-folder", preview.Destination!.EffectiveFolderId);
+        Assert.Equal(
+            MessageActionConfirmationTokens.CreateMoveToken("work-imap", "shared@example.com", null, new[] { "msg-1", "msg-2" }, "archive-folder"),
+            preview.ConfirmationToken);
+        Assert.Contains(preview.Warnings, warning => warning.Contains("Ignored 2 duplicate or empty", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PreviewMoveFailsWhenDestinationIsUnsupported() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var service = new MailMessageActionPreviewService(profileStore, new UnsupportedFolderAliasService());
+        var preview = await service.PreviewMoveAsync(new MoveMessagesPreviewRequest {
+            ProfileId = "work-imap",
+            MessageIds = { "msg-1" },
+            DestinationFolderId = MailFolderAliases.Archive
+        });
+
+        Assert.False(preview.Succeeded);
+        Assert.Equal("destination_not_supported", preview.Code);
+    }
+
+    [Fact]
+    public async Task PreviewDeleteNormalizesMessageIds() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var service = new MailMessageActionPreviewService(profileStore, new FakeFolderAliasService());
+        var preview = await service.PreviewDeleteAsync(new DeleteMessagesPreviewRequest {
+            ProfileId = "work-imap",
+            MessageIds = { "msg-1", "MSG-1", "", "msg-2" }
+        });
+
+        Assert.True(preview.Succeeded);
+        Assert.Equal(4, preview.RequestedCount);
+        Assert.Equal(2, preview.UniqueMessageCount);
+        Assert.Equal(2, preview.DuplicateOrEmptyCount);
+        Assert.Equal(new[] { "msg-1", "msg-2" }, preview.MessageIds);
+        Assert.Equal(
+            MessageActionConfirmationTokens.CreateDeleteToken("work-imap", null, null, new[] { "msg-1", "msg-2" }),
+            preview.ConfirmationToken);
+        Assert.Contains(preview.Warnings, warning => warning.Contains("Ignored 2 duplicate or empty", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PreviewDeleteFailsWhenCapabilityIsUnsupported() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-smtp",
+            DisplayName = "Work SMTP",
+            Kind = MailProfileKind.Smtp,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "smtp.example.com"
+            }
+        });
+
+        var service = new MailMessageActionPreviewService(profileStore, new FakeFolderAliasService());
+        var preview = await service.PreviewDeleteAsync(new DeleteMessagesPreviewRequest {
+            ProfileId = "work-smtp",
+            MessageIds = { "msg-1" }
+        });
+
+        Assert.False(preview.Succeeded);
+        Assert.Equal("delete_not_supported", preview.Code);
+    }
+
+    [Fact]
+    public async Task PreviewStandardActionsCombinesArchiveTrashMoveAndDelete() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var service = new MailMessageActionPreviewService(profileStore, new FakeFolderAliasService());
+        var preview = await service.PreviewStandardActionsAsync(new StandardMessageActionsPreviewRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            MessageIds = { "msg-1", "MSG-1", "", "msg-2" },
+            DestinationFolderId = "Projects/2026"
+        });
+
+        Assert.True(preview.Succeeded);
+        Assert.Equal(4, preview.RequestedCount);
+        Assert.Equal(2, preview.UniqueMessageCount);
+        Assert.Equal(2, preview.DuplicateOrEmptyCount);
+        Assert.Equal(4, preview.IncludedActionCount);
+        Assert.Equal(4, preview.SucceededActionCount);
+        Assert.Equal(0, preview.FailedActionCount);
+        Assert.Contains(preview.Warnings, warning => warning.Contains("Ignored 2 duplicate or empty", StringComparison.Ordinal));
+
+        var archive = Assert.Single(preview.Actions, action => action.Action == "archive");
+        Assert.Equal("archive-folder", archive.Destination!.EffectiveFolderId);
+        Assert.NotNull(archive.ConfirmationToken);
+
+        var trash = Assert.Single(preview.Actions, action => action.Action == "trash");
+        Assert.Equal("trash-folder", trash.Destination!.EffectiveFolderId);
+        Assert.NotNull(trash.ConfirmationToken);
+
+        var move = Assert.Single(preview.Actions, action => action.Action == "move");
+        Assert.Equal("Projects/2026", move.Destination!.EffectiveFolderId);
+        Assert.NotNull(move.ConfirmationToken);
+
+        var delete = Assert.Single(preview.Actions, action => action.Action == "delete");
+        Assert.True(delete.Succeeded);
+        Assert.NotNull(delete.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task PreviewStandardActionsReportsUnsupportedActions() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-smtp",
+            DisplayName = "Work SMTP",
+            Kind = MailProfileKind.Smtp,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "smtp.example.com"
+            }
+        });
+
+        var service = new MailMessageActionPreviewService(profileStore, new FakeFolderAliasService());
+        var preview = await service.PreviewStandardActionsAsync(new StandardMessageActionsPreviewRequest {
+            ProfileId = "work-smtp",
+            MessageIds = { "msg-1" },
+            DestinationFolderId = "Archive"
+        });
+
+        Assert.False(preview.Succeeded);
+        Assert.Equal("no_supported_actions", preview.Code);
+        Assert.Equal(4, preview.IncludedActionCount);
+        Assert.Equal(0, preview.SucceededActionCount);
+        Assert.Equal(4, preview.FailedActionCount);
+        Assert.All(preview.Actions, action => Assert.False(action.Succeeded));
+        Assert.Contains(preview.Actions, action => action.Action == "move" && action.Code == "move_not_supported");
+        Assert.Contains(preview.Actions, action => action.Action == "delete" && action.Code == "delete_not_supported");
+    }
+
+    [Fact]
+    public async Task PreviewCommonActionsIncludesStateAndMailboxActions() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+
+        var service = new MailMessageActionPreviewService(profileStore, new FakeFolderAliasService());
+        var preview = await service.PreviewCommonActionsAsync(new CommonMessageActionsPreviewRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "msg-1", "MSG-1", "msg-2" },
+            DestinationFolderId = "Projects/2026"
+        });
+
+        Assert.True(preview.Succeeded);
+        Assert.Equal(8, preview.IncludedActionCount);
+        Assert.Equal(8, preview.SucceededActionCount);
+        Assert.Equal(0, preview.FailedActionCount);
+        Assert.Equal(2, preview.UniqueMessageCount);
+        Assert.Contains(preview.Actions, action => action.Action == "mark-read" && action.DesiredState == true);
+        Assert.Contains(preview.Actions, action => action.Action == "mark-unread" && action.DesiredState == false);
+        Assert.Contains(preview.Actions, action => action.Action == "flag" && action.DesiredState == true);
+        Assert.Contains(preview.Actions, action => action.Action == "unflag" && action.DesiredState == false);
+        Assert.Contains(preview.Actions, action => action.Action == "archive" && action.Destination!.EffectiveFolderId == "archive-folder");
+        Assert.Contains(preview.Actions, action => action.Action == "move" && action.Destination!.EffectiveFolderId == "Projects/2026");
+        Assert.All(preview.Actions, action => Assert.NotNull(action.ConfirmationToken));
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+
+    private sealed class FakeFolderAliasService : IMailFolderAliasService {
+        public Task<IReadOnlyList<MailFolderAliasSummary>> GetAliasesAsync(string profileId, string? mailboxId = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailFolderAliasSummary>>(new[] {
+                new MailFolderAliasSummary {
+                    ProfileId = profileId,
+                    MailboxId = mailboxId,
+                    Alias = MailFolderAliases.Archive,
+                    DisplayName = "Archive",
+                    IsSupported = true,
+                    IsResolved = true,
+                    FolderId = "archive-folder",
+                    FolderDisplayName = "Archive",
+                    FolderPath = "Archive",
+                    Summary = "Archive -> Archive"
+                },
+                new MailFolderAliasSummary {
+                    ProfileId = profileId,
+                    MailboxId = mailboxId,
+                    Alias = MailFolderAliases.Trash,
+                    DisplayName = "Trash",
+                    IsSupported = true,
+                    IsResolved = true,
+                    FolderId = "trash-folder",
+                    FolderDisplayName = "Trash",
+                    FolderPath = "Trash",
+                    Summary = "Trash -> Trash"
+                }
+            });
+
+        public Task<MailFolderTargetResolution> ResolveAsync(string profileId, string targetFolderId, string? mailboxId = null, CancellationToken cancellationToken = default) {
+            if (string.Equals(targetFolderId, MailFolderAliases.Trash, StringComparison.OrdinalIgnoreCase)) {
+                return Task.FromResult(new MailFolderTargetResolution {
+                    ProfileId = profileId,
+                    MailboxId = mailboxId,
+                    RequestedValue = targetFolderId,
+                    IsAlias = true,
+                    Alias = MailFolderAliases.Trash,
+                    IsSupported = true,
+                    IsResolved = true,
+                    EffectiveFolderId = "trash-folder",
+                    FolderDisplayName = "Trash",
+                    FolderPath = "Trash",
+                    Summary = "Trash -> Trash"
+                });
+            }
+
+            if (string.Equals(targetFolderId, "Projects/2026", StringComparison.OrdinalIgnoreCase)) {
+                return Task.FromResult(new MailFolderTargetResolution {
+                    ProfileId = profileId,
+                    MailboxId = mailboxId,
+                    RequestedValue = targetFolderId,
+                    IsAlias = false,
+                    IsSupported = true,
+                    IsResolved = true,
+                    EffectiveFolderId = "Projects/2026",
+                    FolderDisplayName = "Projects/2026",
+                    FolderPath = "Projects/2026",
+                    Summary = "Projects/2026"
+                });
+            }
+
+            return Task.FromResult(new MailFolderTargetResolution {
+                ProfileId = profileId,
+                MailboxId = mailboxId,
+                RequestedValue = targetFolderId,
+                IsAlias = true,
+                Alias = MailFolderAliases.Archive,
+                IsSupported = true,
+                IsResolved = true,
+                EffectiveFolderId = "archive-folder",
+                FolderDisplayName = "Archive",
+                FolderPath = "Archive",
+                Summary = "Archive -> Archive"
+            });
+        }
+    }
+
+    private sealed class UnsupportedFolderAliasService : IMailFolderAliasService {
+        public Task<IReadOnlyList<MailFolderAliasSummary>> GetAliasesAsync(string profileId, string? mailboxId = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailFolderAliasSummary>>(Array.Empty<MailFolderAliasSummary>());
+
+        public Task<MailFolderTargetResolution> ResolveAsync(string profileId, string targetFolderId, string? mailboxId = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MailFolderTargetResolution {
+                ProfileId = profileId,
+                MailboxId = mailboxId,
+                RequestedValue = targetFolderId,
+                IsAlias = true,
+                Alias = MailFolderAliases.Archive,
+                IsSupported = false,
+                IsResolved = false,
+                EffectiveFolderId = MailFolderAliases.Archive,
+                Summary = "Archive [unsupported]"
+            });
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationRoutingServicesTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationRoutingServicesTests.cs
@@ -124,6 +124,31 @@ public sealed class ApplicationRoutingServicesTests {
     }
 
     [Fact]
+    public async Task RoutedReadServiceBuildsBatchCompactMessageProjection() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeReadHandler(MailProfileKind.Imap);
+        var service = new RoutedMailReadService(store, new[] { handler });
+
+        var results = await service.GetMessagesCompactAsync(new GetMessagesRequest {
+            ProfileId = "work-imap",
+            MessageIds = { "msg-1", "msg-2" }
+        });
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("msg-1", results[0].Id);
+        Assert.Equal("msg-2", results[1].Id);
+        Assert.Equal("msg-1 Subject", results[0].SummaryText);
+        Assert.Equal("msg-2 Subject", results[1].SummaryText);
+    }
+
+    [Fact]
     public async Task RoutedReadServiceSavesFilteredAttachmentsThroughSharedBatchWorkflow() {
         var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
         await store.SaveAsync(new MailProfile {
@@ -147,6 +172,36 @@ public sealed class ApplicationRoutingServicesTests {
         Assert.Equal(1, result.MatchedCount);
         Assert.Equal(1, result.SavedCount);
         Assert.Equal(0, result.FailedCount);
+    }
+
+    [Fact]
+    public async Task RoutedReadServiceSavesFilteredAttachmentsAcrossMultipleMessages() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeReadHandler(MailProfileKind.Imap);
+        var service = new RoutedMailReadService(store, new[] { handler });
+
+        var result = await service.SaveAttachmentsManyAsync(new SaveAttachmentsManyRequest {
+            ProfileId = "work-imap",
+            MessageIds = { "msg-1", "msg-2" },
+            DestinationPath = @"C:\Temp",
+            FileNameContains = "report"
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(2, result.RequestedMessageCount);
+        Assert.Equal(2, result.AttemptedMessageCount);
+        Assert.Equal(2, result.SucceededMessageCount);
+        Assert.Equal(2, result.MatchedCount);
+        Assert.Equal(2, result.SavedCount);
+        Assert.Equal(0, result.FailedCount);
+        Assert.Equal(2, result.MessageResults.Count);
     }
 
     [Fact]
@@ -175,6 +230,245 @@ public sealed class ApplicationRoutingServicesTests {
 
         Assert.True(result.Succeeded);
         Assert.Equal(1, handler.SendCalls);
+    }
+
+    [Fact]
+    public async Task RoutedMessageActionServiceDispatchesToMatchingHandler() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeMessageActionHandler(MailProfileKind.Imap);
+        var service = new RoutedMailMessageActionService(store, new[] { handler });
+
+        var result = await service.SetReadStateAsync(new SetReadStateRequest {
+            ProfileId = "work-imap",
+            MessageIds = { "1", "2" },
+            IsRead = true
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(1, handler.SetReadStateCalls);
+    }
+
+    [Fact]
+    public async Task RoutedMessageActionServiceRejectsMismatchedReadStateConfirmationToken() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeMessageActionHandler(MailProfileKind.Imap);
+        var service = new RoutedMailMessageActionService(store, new[] { handler });
+
+        var result = await service.SetReadStateAsync(new SetReadStateRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "1", "2" },
+            IsRead = true,
+            ConfirmationToken = "mact_v1_invalid"
+        });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("confirmation_token_mismatch", result.Code);
+        Assert.Equal(0, handler.SetReadStateCalls);
+    }
+
+    [Fact]
+    public async Task RoutedMessageActionServiceDispatchesFlaggedStateToMatchingHandler() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeMessageActionHandler(MailProfileKind.Imap);
+        var service = new RoutedMailMessageActionService(store, new[] { handler });
+
+        var result = await service.SetFlaggedStateAsync(new SetFlaggedStateRequest {
+            ProfileId = "work-imap",
+            MessageIds = { "1", "2" },
+            IsFlagged = true
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(1, handler.SetFlaggedStateCalls);
+    }
+
+    [Fact]
+    public async Task RoutedMessageActionServiceRejectsMismatchedFlaggedStateConfirmationToken() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeMessageActionHandler(MailProfileKind.Imap);
+        var service = new RoutedMailMessageActionService(store, new[] { handler });
+
+        var result = await service.SetFlaggedStateAsync(new SetFlaggedStateRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "1", "2" },
+            IsFlagged = true,
+            ConfirmationToken = "mact_v1_invalid"
+        });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("confirmation_token_mismatch", result.Code);
+        Assert.Equal(0, handler.SetFlaggedStateCalls);
+    }
+
+    [Fact]
+    public async Task RoutedMessageActionServiceCanonicalizesKnownFolderAlias() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeMessageActionHandler(MailProfileKind.Imap);
+        var service = new RoutedMailMessageActionService(store, new[] { handler });
+
+        var result = await service.MoveAsync(new MoveMessagesRequest {
+            ProfileId = "work-imap",
+            MessageIds = { "1", "2" },
+            DestinationFolderId = "archive"
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(handler.LastMoveRequest);
+        Assert.Equal(MailFolderAliases.Archive, handler.LastMoveRequest!.DestinationFolderId);
+    }
+
+    [Fact]
+    public async Task RoutedMessageActionServiceResolvesKnownFolderAliasThroughSharedAliasService() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeMessageActionHandler(MailProfileKind.Imap);
+        var aliasService = new FakeFolderAliasService();
+        var service = new RoutedMailMessageActionService(store, new[] { handler }, aliasService);
+
+        var result = await service.MoveAsync(new MoveMessagesRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            MessageIds = { "1", "2" },
+            DestinationFolderId = MailFolderAliases.Archive
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("work-imap", aliasService.LastProfileId);
+        Assert.Equal("shared@example.com", aliasService.LastMailboxId);
+        Assert.NotNull(handler.LastMoveRequest);
+        Assert.Equal("archive-folder", handler.LastMoveRequest!.DestinationFolderId);
+    }
+
+    [Fact]
+    public async Task RoutedMessageActionServiceRejectsMismatchedMoveConfirmationToken() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeMessageActionHandler(MailProfileKind.Imap);
+        var aliasService = new FakeFolderAliasService();
+        var service = new RoutedMailMessageActionService(store, new[] { handler }, aliasService);
+
+        var result = await service.MoveAsync(new MoveMessagesRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "1", "2" },
+            DestinationFolderId = MailFolderAliases.Archive,
+            ConfirmationToken = "mact_v1_invalid"
+        });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("confirmation_token_mismatch", result.Code);
+        Assert.Null(handler.LastMoveRequest);
+    }
+
+    [Fact]
+    public async Task RoutedMessageActionServiceAcceptsMatchingMoveConfirmationToken() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeMessageActionHandler(MailProfileKind.Imap);
+        var aliasService = new FakeFolderAliasService();
+        var service = new RoutedMailMessageActionService(store, new[] { handler }, aliasService);
+        var confirmationToken = MessageActionConfirmationTokens.CreateMoveToken(
+            "work-imap",
+            "shared@example.com",
+            "Inbox",
+            new[] { "1", "2" },
+            "archive-folder");
+
+        var result = await service.MoveAsync(new MoveMessagesRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "1", "2" },
+            DestinationFolderId = MailFolderAliases.Archive,
+            ConfirmationToken = confirmationToken
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(handler.LastMoveRequest);
+        Assert.Equal(confirmationToken, handler.LastMoveRequest!.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task RoutedMessageActionServiceRejectsMismatchedDeleteConfirmationToken() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var handler = new FakeMessageActionHandler(MailProfileKind.Imap);
+        var service = new RoutedMailMessageActionService(store, new[] { handler });
+
+        var result = await service.DeleteAsync(new DeleteMessagesRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "1", "2" },
+            ConfirmationToken = "mact_v1_invalid"
+        });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("confirmation_token_mismatch", result.Code);
     }
 
     [Fact]
@@ -286,6 +580,101 @@ public sealed class ApplicationRoutingServicesTests {
                 Succeeded = true,
                 ProfileId = profile.Id,
                 ProfileKind = profile.Kind
+            });
+        }
+    }
+
+    private sealed class FakeMessageActionHandler : IMailMessageActionHandler {
+        public FakeMessageActionHandler(MailProfileKind kind) {
+            Kind = kind;
+        }
+
+        public MailProfileKind Kind { get; }
+
+        public int SetReadStateCalls { get; private set; }
+
+        public int SetFlaggedStateCalls { get; private set; }
+
+        public MoveMessagesRequest? LastMoveRequest { get; private set; }
+
+        public Task<MessageActionResult> SetReadStateAsync(MailProfile profile, SetReadStateRequest request, CancellationToken cancellationToken = default) {
+            SetReadStateCalls++;
+            return Task.FromResult(new MessageActionResult {
+                Succeeded = true,
+                ProfileId = profile.Id,
+                RequestedCount = request.MessageIds.Count,
+                SucceededCount = request.MessageIds.Count
+            });
+        }
+
+        public Task<MessageActionResult> SetFlaggedStateAsync(MailProfile profile, SetFlaggedStateRequest request, CancellationToken cancellationToken = default) {
+            SetFlaggedStateCalls++;
+            return Task.FromResult(new MessageActionResult {
+                Succeeded = true,
+                ProfileId = profile.Id,
+                RequestedCount = request.MessageIds.Count,
+                SucceededCount = request.MessageIds.Count
+            });
+        }
+
+        public Task<MessageActionResult> MoveAsync(MailProfile profile, MoveMessagesRequest request, CancellationToken cancellationToken = default) {
+            LastMoveRequest = request;
+            return Task.FromResult(new MessageActionResult {
+                Succeeded = true,
+                ProfileId = profile.Id,
+                RequestedCount = request.MessageIds.Count,
+                SucceededCount = request.MessageIds.Count
+            });
+        }
+
+        public Task<MessageActionResult> DeleteAsync(MailProfile profile, DeleteMessagesRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MessageActionResult {
+                Succeeded = true,
+                ProfileId = profile.Id,
+                RequestedCount = request.MessageIds.Count,
+                SucceededCount = request.MessageIds.Count
+            });
+    }
+
+    private sealed class FakeFolderAliasService : IMailFolderAliasService {
+        public string? LastProfileId { get; private set; }
+
+        public string? LastMailboxId { get; private set; }
+
+        public Task<IReadOnlyList<MailFolderAliasSummary>> GetAliasesAsync(string profileId, string? mailboxId = null, CancellationToken cancellationToken = default) {
+            LastProfileId = profileId;
+            LastMailboxId = mailboxId;
+            return Task.FromResult<IReadOnlyList<MailFolderAliasSummary>>(new[] {
+                new MailFolderAliasSummary {
+                    ProfileId = profileId,
+                    MailboxId = mailboxId,
+                    Alias = MailFolderAliases.Archive,
+                    DisplayName = "Archive",
+                    IsSupported = true,
+                    IsResolved = true,
+                    FolderId = "archive-folder",
+                    FolderDisplayName = "Archive",
+                    FolderPath = "Archive",
+                    Summary = "Archive -> Archive"
+                }
+            });
+        }
+
+        public Task<MailFolderTargetResolution> ResolveAsync(string profileId, string targetFolderId, string? mailboxId = null, CancellationToken cancellationToken = default) {
+            LastProfileId = profileId;
+            LastMailboxId = mailboxId;
+            return Task.FromResult(new MailFolderTargetResolution {
+                ProfileId = profileId,
+                MailboxId = mailboxId,
+                RequestedValue = targetFolderId,
+                IsAlias = true,
+                Alias = MailFolderAliases.Archive,
+                IsSupported = true,
+                IsResolved = true,
+                EffectiveFolderId = "archive-folder",
+                FolderDisplayName = "Archive",
+                FolderPath = "Archive",
+                Summary = "Archive -> Archive"
             });
         }
     }

--- a/Sources/Mailozaurr.Tests/CliRunnerTests.cs
+++ b/Sources/Mailozaurr.Tests/CliRunnerTests.cs
@@ -559,6 +559,127 @@ public sealed class CliRunnerTests {
     }
 
     [Fact]
+    public async Task MailFolderAliasesUseSharedFolderAliasService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "folder-aliases", "--profile", "work-imap", "--mailbox", "shared@example.com", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ReadService.LastFolderQuery);
+        Assert.Equal("work-imap", fixture.ReadService.LastFolderQuery!.ProfileId);
+        Assert.Equal("shared@example.com", fixture.ReadService.LastFolderQuery.MailboxId);
+        Assert.Contains("\"Alias\": \"Archive\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"IsResolved\": true", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailResolveFolderUsesSharedFolderAliasService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "resolve-folder", "--profile", "work-imap", "--mailbox", "shared@example.com", "--target-folder", "archive", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ReadService.LastFolderQuery);
+        Assert.Equal("shared@example.com", fixture.ReadService.LastFolderQuery!.MailboxId);
+        Assert.Contains("\"Alias\": \"Archive\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"EffectiveFolderId\": \"archive\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailPreviewMoveUsesSharedPreviewService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "preview-move",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "MSG-42",
+                "--target-folder", "archive",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"UniqueMessageCount\": 1", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"EffectiveFolderId\": \"archive\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"ConfirmationToken\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailPreviewActionsUsesSharedPreviewService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "preview-actions",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "MSG-42",
+                "--target-folder", "projects/2026",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"IncludedActionCount\": 4", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"SucceededActionCount\": 4", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Action\": \"archive\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Action\": \"move\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"EffectiveFolderId\": \"projects/2026\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"ConfirmationToken\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailPreviewDeleteUsesSharedPreviewService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "preview-delete",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "MSG-42",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"UniqueMessageCount\": 1", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"RequestedCount\": 2", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task MailSearchUsesApplicationReadService() {
         using var stdout = new StringWriter();
         using var stderr = new StringWriter();
@@ -644,6 +765,845 @@ public sealed class CliRunnerTests {
     }
 
     [Fact]
+    public async Task MailGetManyCompactUsesApplicationReadService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "get-many",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "msg-84",
+                "--compact",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ReadService.LastGetManyCompactRequest);
+        Assert.Equal("shared@example.com", fixture.ReadService.LastGetManyCompactRequest!.MailboxId);
+        Assert.Equal("Inbox", fixture.ReadService.LastGetManyCompactRequest.FolderId);
+        Assert.Equal(new[] { "msg-42", "msg-84" }, fixture.ReadService.LastGetManyCompactRequest.MessageIds);
+        Assert.Contains("\"Id\": \"msg-42\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Id\": \"msg-84\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailMarkReadUsesApplicationMessageActionService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        var confirmationToken = "mact_v1_mark";
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "mark-read",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "msg-84",
+                "--unread",
+                "--confirm-token", confirmationToken,
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionService.LastSetReadStateRequest);
+        Assert.Equal("shared@example.com", fixture.MessageActionService.LastSetReadStateRequest!.MailboxId);
+        Assert.Equal("Inbox", fixture.MessageActionService.LastSetReadStateRequest.FolderId);
+        Assert.False(fixture.MessageActionService.LastSetReadStateRequest.IsRead);
+        Assert.Equal(new[] { "msg-42", "msg-84" }, fixture.MessageActionService.LastSetReadStateRequest.MessageIds);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastSetReadStateRequest.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailFlagUsesApplicationMessageActionService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        var confirmationToken = "mact_v1_flag";
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "flag",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "msg-84",
+                "--unflag",
+                "--confirm-token", confirmationToken,
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionService.LastSetFlaggedStateRequest);
+        Assert.Equal("shared@example.com", fixture.MessageActionService.LastSetFlaggedStateRequest!.MailboxId);
+        Assert.Equal("Inbox", fixture.MessageActionService.LastSetFlaggedStateRequest.FolderId);
+        Assert.False(fixture.MessageActionService.LastSetFlaggedStateRequest.IsFlagged);
+        Assert.Equal(new[] { "msg-42", "msg-84" }, fixture.MessageActionService.LastSetFlaggedStateRequest.MessageIds);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastSetFlaggedStateRequest.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailPreviewMarkReadUsesSharedPreviewService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "preview-mark-read",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "MSG-42",
+                "--unread",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"Action\": \"read-state\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"DesiredState\": false", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"ConfirmationToken\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailPreviewFlagUsesSharedPreviewService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "preview-flag",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "MSG-42",
+                "--unflag",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"Action\": \"flagged-state\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"DesiredState\": false", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"ConfirmationToken\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailPreviewAllUsesSharedBundlePreviewService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "preview-all",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "MSG-42",
+                "--target-folder", "projects/2026",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"IncludedActionCount\": 8", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Action\": \"mark-read\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Action\": \"flag\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Action\": \"archive\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Action\": \"move\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailPlanActionUsesSharedPlanningService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "plan-action",
+                "--action", "move",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "MSG-42",
+                "--target-folder", "projects/2026",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"ExecutionKind\": \"Move\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"UniqueMessageCount\": 1", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"RequestedDestinationFolderId\": \"projects/2026\"", stdout.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"ConfirmationToken\":", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailExecutePlanUsesSharedPlanningAndBatchServices() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "execute-plan",
+                "--action", "move",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "MSG-42",
+                "--target-folder", "projects/2026",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionService.LastMoveRequest);
+        Assert.Equal("shared@example.com", fixture.MessageActionService.LastMoveRequest!.MailboxId);
+        Assert.Equal("Inbox", fixture.MessageActionService.LastMoveRequest.FolderId);
+        Assert.Equal("projects/2026", fixture.MessageActionService.LastMoveRequest.DestinationFolderId);
+        Assert.Contains("\"RequestedPlanCount\": 1", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"SucceededPlanCount\": 1", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailExportPlanUsesSharedPlanExchangeService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "export-plan",
+                "--action", "move",
+                "--profile", "work-imap",
+                "--message-id", "msg-42",
+                "--target-folder", "projects/2026",
+                "--path", @"C:\Temp\plan.json",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(@"C:\Temp\plan.json", fixture.MessageActionPlanExchangeService.LastSavedPath);
+        Assert.NotNull(fixture.MessageActionPlanExchangeService.LastSavedPlan);
+        Assert.Equal("move", fixture.MessageActionPlanExchangeService.LastSavedPlan!.Action);
+        Assert.Contains("Action plan exported", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailShowPlanUsesSharedPlanExchangeService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        fixture.MessageActionPlanExchangeService.NextPlan = new MessageActionExecutionPlan {
+            Succeeded = true,
+            Action = "delete",
+            ExecutionKind = "Delete",
+            ProfileId = "work-imap",
+            RequestedCount = 1,
+            UniqueMessageCount = 1,
+            MessageIds = { "msg-42" }
+        };
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "show-plan", "--path", @"C:\Temp\plan.json", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(@"C:\Temp\plan.json", fixture.MessageActionPlanExchangeService.LastLoadedPath);
+        Assert.Contains("\"Action\": \"delete\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailExecutePlanFileUsesSharedPlanExchangeService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        fixture.MessageActionPlanExchangeService.NextPlan = new MessageActionExecutionPlan {
+            Succeeded = true,
+            Action = "move",
+            ExecutionKind = "Move",
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            RequestedCount = 1,
+            UniqueMessageCount = 1,
+            RequestedDestinationFolderId = "projects/2026",
+            MessageIds = { "msg-42" }
+        };
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "execute-plan-file", "--path", @"C:\Temp\plan.json", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(@"C:\Temp\plan.json", fixture.MessageActionPlanExchangeService.LastLoadedPath);
+        Assert.NotNull(fixture.MessageActionService.LastMoveRequest);
+        Assert.Equal("projects/2026", fixture.MessageActionService.LastMoveRequest!.DestinationFolderId);
+        Assert.Contains("\"SucceededPlanCount\": 1", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailListPlanBatchesUsesSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "list-plan-batches", "--compact", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, fixture.MessageActionPlanRegistryService.ListCompactCalls);
+        Assert.Contains("\"Id\": \"cleanup\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"PlanNames\": [", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Delete spam\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailListPlanBatchesSummaryUsesSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "list-plan-batches", "--summary", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, fixture.MessageActionPlanRegistryService.ListSummaryCalls);
+        Assert.Contains("\"ActionCounts\": {", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"delete\": 1", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailListPlanBatchesPassesPlanNameFilterToSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "list-plan-batches", "--compact", "--plan-name", "Delete spam", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionPlanRegistryService.LastBatchQuery);
+        Assert.Equal(new[] { "Delete spam" }, fixture.MessageActionPlanRegistryService.LastBatchQuery!.PlanNames);
+    }
+
+    [Fact]
+    public async Task MailListPlanBatchesPassesProfileFilterToSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "list-plan-batches", "--compact", "--profile", "gmail-work", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionPlanRegistryService.LastBatchQuery);
+        Assert.Equal(new[] { "gmail-work" }, fixture.MessageActionPlanRegistryService.LastBatchQuery!.ProfileIds);
+    }
+
+    [Fact]
+    public async Task MailListPlanBatchesPassesActionFilterToSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "list-plan-batches", "--compact", "--action", "delete", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionPlanRegistryService.LastBatchQuery);
+        Assert.Equal(new[] { "delete" }, fixture.MessageActionPlanRegistryService.LastBatchQuery!.Actions);
+    }
+
+    [Fact]
+    public async Task MailListPlanBatchesPassesSortToSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "list-plan-batches", "--summary", "--sort", "plans", "--desc", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionPlanRegistryService.LastBatchQuery);
+        Assert.Equal(MailMessageActionPlanBatchSortBy.PlanCount, fixture.MessageActionPlanRegistryService.LastBatchQuery!.SortBy);
+        Assert.True(fixture.MessageActionPlanRegistryService.LastBatchQuery.Descending);
+    }
+
+    [Fact]
+    public async Task MailImportPlanBatchUsesSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "import-plan-batch",
+                "--batch", "cleanup",
+                "--name", "Cleanup batch",
+                "--path", @"C:\Temp\plans.json",
+                "--description", "Quarterly cleanup",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("cleanup", fixture.MessageActionPlanRegistryService.LastImportedBatchId);
+        Assert.Equal("Cleanup batch", fixture.MessageActionPlanRegistryService.LastImportedName);
+        Assert.Equal(@"C:\Temp\plans.json", fixture.MessageActionPlanRegistryService.LastImportedPath);
+    }
+
+    [Fact]
+    public async Task MailCreateCommonPlanBatchUsesSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "create-common-plan-batch",
+                "--batch", "cleanup",
+                "--name", "Cleanup batch",
+                "--profile", "work-imap",
+                "--message-id", "msg-1",
+                "--message-id", "MSG-1",
+                "--action", "archive",
+                "--action", "delete",
+                "--target-folder", "Archive",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--description", "Common action batch",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("cleanup", fixture.MessageActionPlanRegistryService.LastCreatedCommonBatchId);
+        Assert.Equal("Cleanup batch", fixture.MessageActionPlanRegistryService.LastCreatedCommonName);
+        Assert.Equal("Common action batch", fixture.MessageActionPlanRegistryService.LastCreatedCommonDescription);
+        Assert.Equal(new[] { "archive", "delete" }, fixture.MessageActionPlanRegistryService.LastCreatedCommonActions);
+        Assert.NotNull(fixture.MessageActionPlanRegistryService.LastCreatedCommonRequest);
+        Assert.Equal("work-imap", fixture.MessageActionPlanRegistryService.LastCreatedCommonRequest!.ProfileId);
+        Assert.Equal("shared@example.com", fixture.MessageActionPlanRegistryService.LastCreatedCommonRequest.MailboxId);
+        Assert.Equal("Inbox", fixture.MessageActionPlanRegistryService.LastCreatedCommonRequest.FolderId);
+        Assert.Equal("Archive", fixture.MessageActionPlanRegistryService.LastCreatedCommonRequest.DestinationFolderId);
+        Assert.Equal(new[] { "msg-1", "MSG-1" }, fixture.MessageActionPlanRegistryService.LastCreatedCommonRequest.MessageIds);
+    }
+
+    [Fact]
+    public async Task MailExecuteStoredPlanBatchUsesSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "execute-plan-batch-stored", "--batch", "cleanup", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("cleanup", fixture.MessageActionPlanRegistryService.LastExecutedBatchId);
+        Assert.Contains("\"SucceededPlanCount\": 1", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailAddPlanToBatchUsesSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "add-plan-to-batch",
+                "--batch", "cleanup",
+                "--action", "move",
+                "--profile", "work-imap",
+                "--message-id", "msg-42",
+                "--target-folder", "projects/2026",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("cleanup", fixture.MessageActionPlanRegistryService.LastAppendedBatchId);
+        Assert.NotNull(fixture.MessageActionPlanRegistryService.LastAppendedPlan);
+        Assert.Equal("move", fixture.MessageActionPlanRegistryService.LastAppendedPlan!.Action);
+    }
+
+    [Fact]
+    public async Task MailRemovePlanFromBatchUsesSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "remove-plan-from-batch", "--batch", "cleanup", "--index", "1", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("cleanup", fixture.MessageActionPlanRegistryService.LastRemovedBatchId);
+        Assert.Equal(1, fixture.MessageActionPlanRegistryService.LastRemovedIndex);
+    }
+
+    [Fact]
+    public async Task MailClonePlanBatchUsesSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "clone-plan-batch",
+                "--source-batch", "cleanup",
+                "--target-batch", "cleanup-copy",
+                "--name", "Cleanup copy",
+                "--description", "Cloned batch",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("cleanup", fixture.MessageActionPlanRegistryService.LastClonedSourceBatchId);
+        Assert.Equal("cleanup-copy", fixture.MessageActionPlanRegistryService.LastClonedTargetBatchId);
+    }
+
+    [Fact]
+    public async Task MailTransformPlanBatchUsesSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "transform-plan-batch",
+                "--source-batch", "cleanup",
+                "--target-batch", "cleanup-target",
+                "--name", "Cleanup Target",
+                "--index", "1",
+                "--index", "2",
+                "--plan-name", "Archive newsletter",
+                "--target-profile", "work-imap-target",
+                "--mailbox", "shared@example.com",
+                "--folder", "Projects",
+                "--target-folder", "Projects/Archive",
+                "--description", "Remapped batch",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("cleanup", fixture.MessageActionPlanRegistryService.LastTransformedSourceBatchId);
+        Assert.Equal("cleanup-target", fixture.MessageActionPlanRegistryService.LastTransformedTargetBatchId);
+        Assert.Equal("Cleanup Target", fixture.MessageActionPlanRegistryService.LastTransformedName);
+        Assert.Equal("Remapped batch", fixture.MessageActionPlanRegistryService.LastTransformedDescription);
+        Assert.NotNull(fixture.MessageActionPlanRegistryService.LastTransformRequest);
+        Assert.Equal("work-imap-target", fixture.MessageActionPlanRegistryService.LastTransformRequest!.ProfileId);
+        Assert.Equal(new[] { 1, 2 }, fixture.MessageActionPlanRegistryService.LastTransformRequest.PlanIndexes);
+        Assert.Equal(new[] { "Archive newsletter" }, fixture.MessageActionPlanRegistryService.LastTransformRequest.PlanNames);
+        Assert.Equal("shared@example.com", fixture.MessageActionPlanRegistryService.LastTransformRequest.MailboxId);
+        Assert.Equal("Projects", fixture.MessageActionPlanRegistryService.LastTransformRequest.FolderId);
+        Assert.Equal("Projects/Archive", fixture.MessageActionPlanRegistryService.LastTransformRequest.DestinationFolderId);
+    }
+
+    [Fact]
+    public async Task MailPreviewTransformPlanBatchUsesSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "preview-transform-plan-batch",
+                "--source-batch", "cleanup",
+                "--index", "1",
+                "--plan-name", "Archive newsletter",
+                "--target-profile", "work-imap-target",
+                "--mailbox", "shared@example.com",
+                "--folder", "Projects",
+                "--target-folder", "Projects/Archive",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("cleanup", fixture.MessageActionPlanRegistryService.LastPreviewedTransformSourceBatchId);
+        Assert.NotNull(fixture.MessageActionPlanRegistryService.LastPreviewedTransformRequest);
+        Assert.Equal("work-imap-target", fixture.MessageActionPlanRegistryService.LastPreviewedTransformRequest!.ProfileId);
+        Assert.Equal(new[] { 1 }, fixture.MessageActionPlanRegistryService.LastPreviewedTransformRequest.PlanIndexes);
+        Assert.Equal(new[] { "Archive newsletter" }, fixture.MessageActionPlanRegistryService.LastPreviewedTransformRequest.PlanNames);
+        Assert.Equal("shared@example.com", fixture.MessageActionPlanRegistryService.LastPreviewedTransformRequest.MailboxId);
+        Assert.Equal("Projects", fixture.MessageActionPlanRegistryService.LastPreviewedTransformRequest.FolderId);
+        Assert.Equal("Projects/Archive", fixture.MessageActionPlanRegistryService.LastPreviewedTransformRequest.DestinationFolderId);
+        Assert.Contains("\"ChangedPlanCount\": 1", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailReplacePlanInBatchUsesSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "replace-plan-in-batch",
+                "--batch", "cleanup",
+                "--index", "0",
+                "--action", "move",
+                "--profile", "work-imap",
+                "--message-id", "msg-42",
+                "--target-folder", "projects/2026",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("cleanup", fixture.MessageActionPlanRegistryService.LastReplacedBatchId);
+        Assert.Equal(0, fixture.MessageActionPlanRegistryService.LastReplacedIndex);
+        Assert.NotNull(fixture.MessageActionPlanRegistryService.LastReplacedPlan);
+        Assert.Equal("move", fixture.MessageActionPlanRegistryService.LastReplacedPlan!.Action);
+    }
+
+    [Fact]
+    public async Task MailExecutePlanBatchUsesSharedBatchService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        fixture.MessageActionPlanExchangeService.NextBatchPlans = new[] {
+            new MessageActionExecutionPlan {
+                Succeeded = true,
+                Action = "mark-read",
+                ExecutionKind = "SetReadState",
+                ProfileId = "work-imap",
+                MailboxId = "shared@example.com",
+                FolderId = "Inbox",
+                RequestedCount = 1,
+                UniqueMessageCount = 1,
+                DesiredState = true,
+                MessageIds = { "msg-1" }
+            },
+            new MessageActionExecutionPlan {
+                Succeeded = true,
+                Action = "move",
+                ExecutionKind = "Move",
+                ProfileId = "work-imap",
+                MailboxId = "shared@example.com",
+                FolderId = "Inbox",
+                RequestedCount = 1,
+                UniqueMessageCount = 1,
+                RequestedDestinationFolderId = "projects/2026",
+                MessageIds = { "msg-2" }
+            }
+        };
+        var path = @"C:\Temp\action-plans.json";
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "execute-plan-batch", "--path", path, "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(path, fixture.MessageActionPlanExchangeService.LastLoadedBatchPath);
+        Assert.NotNull(fixture.MessageActionService.LastSetReadStateRequest);
+        Assert.NotNull(fixture.MessageActionService.LastMoveRequest);
+        Assert.Equal("projects/2026", fixture.MessageActionService.LastMoveRequest!.DestinationFolderId);
+        Assert.Contains("\"AttemptedPlanCount\": 2", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"SucceededPlanCount\": 2", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailArchiveUsesSharedArchiveAlias() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        var confirmationToken = "mact_v1_archive";
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "archive",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--confirm-token", confirmationToken,
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionService.LastMoveRequest);
+        Assert.Equal(MailFolderAliases.Archive, fixture.MessageActionService.LastMoveRequest!.DestinationFolderId);
+        Assert.Equal("shared@example.com", fixture.MessageActionService.LastMoveRequest.MailboxId);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastMoveRequest.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailTrashUsesSharedTrashAlias() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        var confirmationToken = "mact_v1_trash";
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "trash",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--confirm-token", confirmationToken,
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionService.LastMoveRequest);
+        Assert.Equal(MailFolderAliases.Trash, fixture.MessageActionService.LastMoveRequest!.DestinationFolderId);
+        Assert.Equal("shared@example.com", fixture.MessageActionService.LastMoveRequest.MailboxId);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastMoveRequest.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailMoveUsesApplicationMessageActionService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        var confirmationToken = "mact_v1_move";
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "move",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--target-folder", "Archive",
+                "--confirm-token", confirmationToken,
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionService.LastMoveRequest);
+        Assert.Equal("Archive", fixture.MessageActionService.LastMoveRequest!.DestinationFolderId);
+        Assert.Equal("shared@example.com", fixture.MessageActionService.LastMoveRequest.MailboxId);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastMoveRequest.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailDeleteUsesApplicationMessageActionService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        var confirmationToken = "mact_v1_delete";
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "delete",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "msg-84",
+                "--confirm-token", confirmationToken,
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionService.LastDeleteRequest);
+        Assert.Equal("shared@example.com", fixture.MessageActionService.LastDeleteRequest!.MailboxId);
+        Assert.Equal(new[] { "msg-42", "msg-84" }, fixture.MessageActionService.LastDeleteRequest.MessageIds);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastDeleteRequest.ConfirmationToken);
+    }
+
+    [Fact]
     public async Task MailAttachmentsUsesApplicationReadService() {
         using var stdout = new StringWriter();
         using var stderr = new StringWriter();
@@ -666,6 +1626,44 @@ public sealed class CliRunnerTests {
         Assert.Equal("shared@example.com", fixture.ReadService.LastListAttachmentsRequest!.MailboxId);
         Assert.Equal("msg-42", fixture.ReadService.LastListAttachmentsRequest.MessageId);
         Assert.Contains("\"report.pdf\"", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MailSaveAttachmentsManyUsesApplicationReadService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "mail", "save-attachments-many",
+                "--profile", "work-imap",
+                "--mailbox", "shared@example.com",
+                "--folder", "Inbox",
+                "--message-id", "msg-42",
+                "--message-id", "msg-84",
+                "--path", @"C:\Temp",
+                "--attachment-id", "att-1",
+                "--name-contains", "report",
+                "--content-type", "pdf",
+                "--overwrite",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ReadService.LastSaveAttachmentsManyRequest);
+        Assert.Equal("shared@example.com", fixture.ReadService.LastSaveAttachmentsManyRequest!.MailboxId);
+        Assert.Equal("Inbox", fixture.ReadService.LastSaveAttachmentsManyRequest.FolderId);
+        Assert.Equal(@"C:\Temp", fixture.ReadService.LastSaveAttachmentsManyRequest.DestinationPath);
+        Assert.Equal(new[] { "msg-42", "msg-84" }, fixture.ReadService.LastSaveAttachmentsManyRequest.MessageIds);
+        Assert.Equal(new[] { "att-1" }, fixture.ReadService.LastSaveAttachmentsManyRequest.AttachmentIds);
+        Assert.Equal("report", fixture.ReadService.LastSaveAttachmentsManyRequest.FileNameContains);
+        Assert.Equal("pdf", fixture.ReadService.LastSaveAttachmentsManyRequest.ContentTypeContains);
+        Assert.True(fixture.ReadService.LastSaveAttachmentsManyRequest.Overwrite);
+        Assert.Contains("\"SavedCount\": 2", stdout.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1082,7 +2080,15 @@ public sealed class CliRunnerTests {
     }
 
     private sealed class FakeReadService : IMailReadService {
+        public MailFolderQuery? LastFolderQuery { get; private set; }
+
         public GetMessageRequest? LastGetCompactRequest { get; private set; }
+
+        public GetMessagesRequest? LastGetManyCompactRequest { get; private set; }
+
+        public GetMessagesRequest? LastGetManyRequest { get; private set; }
+
+        public SaveAttachmentsManyRequest? LastSaveAttachmentsManyRequest { get; private set; }
 
         public SaveAttachmentsRequest? LastSaveAttachmentsRequest { get; private set; }
 
@@ -1115,6 +2121,22 @@ public sealed class CliRunnerTests {
             });
         }
 
+        public Task<IReadOnlyList<MessageDetailCompact>> GetMessagesCompactAsync(GetMessagesRequest request, CancellationToken cancellationToken = default) {
+            LastGetManyCompactRequest = request;
+            return Task.FromResult<IReadOnlyList<MessageDetailCompact>>(request.MessageIds.Select(messageId => new MessageDetailCompact {
+                ProfileId = request.ProfileId,
+                Id = messageId,
+                Summary = new MessageSummaryCompact {
+                    ProfileId = request.ProfileId,
+                    Id = messageId,
+                    Subject = "Subject",
+                    Summary = $"{messageId} Subject"
+                },
+                TextBodyPreview = "Body",
+                SummaryText = $"{messageId} Subject"
+            }).ToArray());
+        }
+
         private MessageDetail CaptureGetRequest(GetMessageRequest request) {
             LastGetRequest = request;
             return new MessageDetail {
@@ -1127,6 +2149,20 @@ public sealed class CliRunnerTests {
                 },
                 TextBody = "Body"
             };
+        }
+
+        public Task<IReadOnlyList<MessageDetail>> GetMessagesAsync(GetMessagesRequest request, CancellationToken cancellationToken = default) {
+            LastGetManyRequest = request;
+            return Task.FromResult<IReadOnlyList<MessageDetail>>(request.MessageIds.Select(messageId => new MessageDetail {
+                ProfileId = request.ProfileId,
+                Id = messageId,
+                Summary = new MessageSummary {
+                    ProfileId = request.ProfileId,
+                    Id = messageId,
+                    Subject = "Subject"
+                },
+                TextBody = "Body"
+            }).ToArray());
         }
 
         public Task<IReadOnlyList<FolderRefCompact>> GetFoldersCompactAsync(MailFolderQuery query, CancellationToken cancellationToken = default) {
@@ -1143,16 +2179,35 @@ public sealed class CliRunnerTests {
             });
         }
 
-        public Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailFolderQuery query, CancellationToken cancellationToken = default) =>
-            Task.FromResult<IReadOnlyList<FolderRef>>(new[] {
+        public Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailFolderQuery query, CancellationToken cancellationToken = default) {
+            LastFolderQuery = query;
+            return Task.FromResult<IReadOnlyList<FolderRef>>(new[] {
                 new FolderRef {
                     ProfileId = query.ProfileId,
                     MailboxId = query.MailboxId,
                     Id = "inbox",
                     DisplayName = "Inbox",
-                    Path = "Inbox"
+                    Path = "Inbox",
+                    SpecialUse = "inbox"
+                },
+                new FolderRef {
+                    ProfileId = query.ProfileId,
+                    MailboxId = query.MailboxId,
+                    Id = "archive",
+                    DisplayName = "Archive",
+                    Path = "Archive",
+                    SpecialUse = "archive"
+                },
+                new FolderRef {
+                    ProfileId = query.ProfileId,
+                    MailboxId = query.MailboxId,
+                    Id = "trash",
+                    DisplayName = "Trash",
+                    Path = "Trash",
+                    SpecialUse = "trash"
                 }
             });
+        }
 
         public Task<OperationResult> SaveAttachmentAsync(SaveAttachmentRequest request, CancellationToken cancellationToken = default) {
             LastSaveAttachmentRequest = request;
@@ -1178,6 +2233,32 @@ public sealed class CliRunnerTests {
                         ContentType = "application/pdf"
                     }
                 }
+            });
+        }
+
+        public Task<SaveAttachmentsManyResult> SaveAttachmentsManyAsync(SaveAttachmentsManyRequest request, CancellationToken cancellationToken = default) {
+            LastSaveAttachmentsManyRequest = request;
+            return Task.FromResult(new SaveAttachmentsManyResult {
+                Succeeded = true,
+                ProfileId = request.ProfileId,
+                RequestedMessageCount = request.MessageIds.Count,
+                AttemptedMessageCount = request.MessageIds.Count,
+                SucceededMessageCount = request.MessageIds.Count,
+                MatchedCount = request.MessageIds.Count,
+                AttemptedCount = request.MessageIds.Count,
+                SavedCount = request.MessageIds.Count,
+                FailedCount = 0,
+                Message = $"Saved {request.MessageIds.Count} attachment(s) across {request.MessageIds.Count} message(s).",
+                MessageResults = request.MessageIds.Select(messageId => new SaveAttachmentsResult {
+                    Succeeded = true,
+                    ProfileId = request.ProfileId,
+                    MessageId = messageId,
+                    MatchedCount = 1,
+                    AttemptedCount = 1,
+                    SavedCount = 1,
+                    FailedCount = 0,
+                    Message = "Saved 1 attachment(s)."
+                }).ToList()
             });
         }
 
@@ -1228,6 +2309,471 @@ public sealed class CliRunnerTests {
                 Message = "Message sent successfully."
             });
         }
+    }
+
+    private sealed class FakeMessageActionService : IMailMessageActionService {
+        public SetReadStateRequest? LastSetReadStateRequest { get; private set; }
+
+        public SetFlaggedStateRequest? LastSetFlaggedStateRequest { get; private set; }
+
+        public MoveMessagesRequest? LastMoveRequest { get; private set; }
+
+        public DeleteMessagesRequest? LastDeleteRequest { get; private set; }
+
+        public Task<MessageActionResult> SetReadStateAsync(SetReadStateRequest request, CancellationToken cancellationToken = default) {
+            LastSetReadStateRequest = request;
+            return Task.FromResult(CreateResult(request.ProfileId, request.MessageIds, request.IsRead ? "Marked messages as read." : "Marked messages as unread."));
+        }
+
+        public Task<MessageActionResult> SetFlaggedStateAsync(SetFlaggedStateRequest request, CancellationToken cancellationToken = default) {
+            LastSetFlaggedStateRequest = request;
+            return Task.FromResult(CreateResult(request.ProfileId, request.MessageIds, request.IsFlagged ? "Flagged messages." : "Unflagged messages."));
+        }
+
+        public Task<MessageActionResult> MoveAsync(MoveMessagesRequest request, CancellationToken cancellationToken = default) {
+            LastMoveRequest = request;
+            return Task.FromResult(CreateResult(request.ProfileId, request.MessageIds, $"Moved messages to '{request.DestinationFolderId}'."));
+        }
+
+        public Task<MessageActionResult> DeleteAsync(DeleteMessagesRequest request, CancellationToken cancellationToken = default) {
+            LastDeleteRequest = request;
+            return Task.FromResult(CreateResult(request.ProfileId, request.MessageIds, "Deleted messages."));
+        }
+
+        private static MessageActionResult CreateResult(string profileId, IReadOnlyList<string> messageIds, string message) => new() {
+            Succeeded = true,
+            ProfileId = profileId,
+            RequestedCount = messageIds.Count,
+            SucceededCount = messageIds.Count,
+            FailedCount = 0,
+            Message = message,
+            Results = messageIds.Select(id => new MessageActionItemResult {
+                MessageId = id,
+                Succeeded = true
+            }).ToList()
+        };
+    }
+
+    private sealed class FakeMessageActionPlanExchangeService : IMailMessageActionPlanExchangeService {
+        public string? LastLoadedPath { get; private set; }
+
+        public string? LastLoadedBatchPath { get; private set; }
+
+        public string? LastSavedPath { get; private set; }
+
+        public string? LastSavedBatchPath { get; private set; }
+
+        public MessageActionExecutionPlan? LastSavedPlan { get; private set; }
+
+        public IReadOnlyList<MessageActionExecutionPlan>? LastSavedBatch { get; private set; }
+
+        public MessageActionExecutionPlan NextPlan { get; set; } = new() {
+            Succeeded = true,
+            Action = "mark-read",
+            ExecutionKind = "SetReadState",
+            ProfileId = "work-imap",
+            RequestedCount = 1,
+            UniqueMessageCount = 1,
+            DesiredState = true,
+            MessageIds = { "msg-1" }
+        };
+
+        public IReadOnlyList<MessageActionExecutionPlan> NextBatchPlans { get; set; } = Array.Empty<MessageActionExecutionPlan>();
+
+        public Task<MessageActionExecutionPlan> LoadAsync(string path, CancellationToken cancellationToken = default) {
+            LastLoadedPath = path;
+            return Task.FromResult(NextPlan);
+        }
+
+        public Task<IReadOnlyList<MessageActionExecutionPlan>> LoadBatchAsync(string path, CancellationToken cancellationToken = default) {
+            LastLoadedBatchPath = path;
+            return Task.FromResult(NextBatchPlans);
+        }
+
+        public Task SaveAsync(string path, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) {
+            LastSavedPath = path;
+            LastSavedPlan = plan;
+            return Task.CompletedTask;
+        }
+
+        public Task SaveBatchAsync(string path, IReadOnlyList<MessageActionExecutionPlan> plans, CancellationToken cancellationToken = default) {
+            LastSavedBatchPath = path;
+            LastSavedBatch = plans;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeMessageActionPlanRegistryService : IMailMessageActionPlanRegistryService {
+        public int ListCompactCalls { get; private set; }
+        public int ListSummaryCalls { get; private set; }
+        public MailMessageActionPlanBatchQuery? LastBatchQuery { get; private set; }
+
+        public string? LastAppendedBatchId { get; private set; }
+
+        public MessageActionExecutionPlan? LastAppendedPlan { get; private set; }
+
+        public string? LastClonedSourceBatchId { get; private set; }
+
+        public string? LastClonedTargetBatchId { get; private set; }
+
+        public string? LastImportedBatchId { get; private set; }
+
+        public string? LastImportedName { get; private set; }
+
+        public string? LastImportedPath { get; private set; }
+
+        public string? LastCreatedCommonBatchId { get; private set; }
+
+        public string? LastCreatedCommonName { get; private set; }
+
+        public string? LastCreatedCommonDescription { get; private set; }
+
+        public CommonMessageActionsPreviewRequest? LastCreatedCommonRequest { get; private set; }
+
+        public IReadOnlyList<string>? LastCreatedCommonActions { get; private set; }
+
+        public string? LastCreatedFromPreviewBatchId { get; private set; }
+
+        public string? LastCreatedFromPreviewName { get; private set; }
+
+        public string? LastCreatedFromPreviewDescription { get; private set; }
+
+        public CommonMessageActionsPreview? LastCreatedFromPreview { get; private set; }
+
+        public IReadOnlyList<string>? LastCreatedFromPreviewActions { get; private set; }
+
+        public string? LastTransformedSourceBatchId { get; private set; }
+
+        public string? LastTransformedTargetBatchId { get; private set; }
+
+        public string? LastTransformedName { get; private set; }
+
+        public string? LastTransformedDescription { get; private set; }
+
+        public MessageActionPlanBatchTransformRequest? LastTransformRequest { get; private set; }
+
+        public string? LastPreviewedTransformSourceBatchId { get; private set; }
+
+        public MessageActionPlanBatchTransformRequest? LastPreviewedTransformRequest { get; private set; }
+
+        public string? LastExecutedBatchId { get; private set; }
+
+        public string? LastRemovedBatchId { get; private set; }
+
+        public int? LastRemovedIndex { get; private set; }
+
+        public string? LastReplacedBatchId { get; private set; }
+
+        public int? LastReplacedIndex { get; private set; }
+
+        public MessageActionExecutionPlan? LastReplacedPlan { get; private set; }
+
+        public Task<OperationResult> AppendImportedPlanAsync(string batchId, string path, CancellationToken cancellationToken = default) {
+            LastAppendedBatchId = batchId;
+            LastImportedPath = path;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> AppendPlanAsync(string batchId, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) {
+            LastAppendedBatchId = batchId;
+            LastAppendedPlan = plan;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> CloneAsync(string sourceBatchId, string targetBatchId, string name, string? description = null, CancellationToken cancellationToken = default) {
+            LastClonedSourceBatchId = sourceBatchId;
+            LastClonedTargetBatchId = targetBatchId;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{targetBatchId}' saved."));
+        }
+
+        public Task<OperationResult> CreateCommonBatchAsync(
+            string batchId,
+            string name,
+            CommonMessageActionsPreviewRequest request,
+            IReadOnlyList<string>? actions = null,
+            string? description = null,
+            CancellationToken cancellationToken = default) {
+            LastCreatedCommonBatchId = batchId;
+            LastCreatedCommonName = name;
+            LastCreatedCommonDescription = description;
+            LastCreatedCommonRequest = new CommonMessageActionsPreviewRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                DestinationFolderId = request.DestinationFolderId,
+                MessageIds = request.MessageIds.ToList()
+            };
+            LastCreatedCommonActions = actions?.ToArray();
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> CreateCommonBatchFromPreviewAsync(
+            string batchId,
+            string name,
+            CommonMessageActionsPreview preview,
+            IReadOnlyList<string>? actions = null,
+            string? description = null,
+            CancellationToken cancellationToken = default) {
+            LastCreatedFromPreviewBatchId = batchId;
+            LastCreatedFromPreviewName = name;
+            LastCreatedFromPreviewDescription = description;
+            LastCreatedFromPreview = new CommonMessageActionsPreview {
+                ProfileId = preview.ProfileId,
+                MailboxId = preview.MailboxId,
+                FolderId = preview.FolderId,
+                RequestedDestinationFolderId = preview.RequestedDestinationFolderId,
+                RequestedCount = preview.RequestedCount,
+                UniqueMessageCount = preview.UniqueMessageCount,
+                DuplicateOrEmptyCount = preview.DuplicateOrEmptyCount,
+                MessageIds = preview.MessageIds.ToList(),
+                Actions = preview.Actions.Select(action => new MessageActionPreviewItem {
+                    Action = action.Action,
+                    DisplayName = action.DisplayName,
+                    Succeeded = action.Succeeded,
+                    Code = action.Code,
+                    Message = action.Message,
+                    RequestedDestinationFolderId = action.RequestedDestinationFolderId,
+                    DesiredState = action.DesiredState,
+                    ConfirmationToken = action.ConfirmationToken
+                }).ToList()
+            };
+            LastCreatedFromPreviewActions = actions?.ToArray();
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> TransformCloneAsync(
+            string sourceBatchId,
+            string targetBatchId,
+            string name,
+            MessageActionPlanBatchTransformRequest transform,
+            string? description = null,
+            CancellationToken cancellationToken = default) {
+            LastTransformedSourceBatchId = sourceBatchId;
+            LastTransformedTargetBatchId = targetBatchId;
+            LastTransformedName = name;
+            LastTransformedDescription = description;
+            LastTransformRequest = new MessageActionPlanBatchTransformRequest {
+                PlanIndexes = transform.PlanIndexes.ToList(),
+                PlanNames = transform.PlanNames.ToList(),
+                ProfileId = transform.ProfileId,
+                MailboxId = transform.MailboxId,
+                FolderId = transform.FolderId,
+                DestinationFolderId = transform.DestinationFolderId
+            };
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{targetBatchId}' saved."));
+        }
+
+        public Task<MailMessageActionPlanBatchTransformPreview> PreviewTransformCloneAsync(
+            string sourceBatchId,
+            MessageActionPlanBatchTransformRequest transform,
+            CancellationToken cancellationToken = default) {
+            LastPreviewedTransformSourceBatchId = sourceBatchId;
+            LastPreviewedTransformRequest = new MessageActionPlanBatchTransformRequest {
+                PlanIndexes = transform.PlanIndexes.ToList(),
+                PlanNames = transform.PlanNames.ToList(),
+                ProfileId = transform.ProfileId,
+                MailboxId = transform.MailboxId,
+                FolderId = transform.FolderId,
+                DestinationFolderId = transform.DestinationFolderId
+            };
+            return Task.FromResult(new MailMessageActionPlanBatchTransformPreview {
+                Succeeded = true,
+                SourceBatchId = sourceBatchId,
+                SourceBatchName = "Cleanup batch",
+                PlanCount = 1,
+                ChangedPlanCount = 1,
+                ConfirmationTokenChangedCount = 1,
+                TargetProfileExists = true,
+                Plans = {
+                    new MessageActionPlanBatchTransformPreviewItem {
+                        Index = 0,
+                        Action = "move",
+                        ExecutionKind = "Move",
+                        SourceProfileId = "work-imap",
+                        TargetProfileId = transform.ProfileId ?? "work-imap",
+                        SourceMailboxId = "source@example.com",
+                        TargetMailboxId = transform.MailboxId,
+                        SourceFolderId = "Inbox",
+                        TargetFolderId = transform.FolderId,
+                        SourceDestinationFolderId = "Archive",
+                        TargetDestinationFolderId = transform.DestinationFolderId,
+                        WillChange = true,
+                        ConfirmationTokenWillChange = true,
+                        Summary = "move: preview"
+                    }
+                },
+                Message = "Previewed transform."
+            });
+        }
+
+        public Task<OperationResult> DeleteAsync(string batchId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' deleted."));
+
+        public Task<MessageActionBatchExecutionResult> ExecuteAsync(string batchId, bool continueOnError = true, CancellationToken cancellationToken = default) {
+            LastExecutedBatchId = batchId;
+            return Task.FromResult(new MessageActionBatchExecutionResult {
+                Succeeded = true,
+                RequestedPlanCount = 1,
+                AttemptedPlanCount = 1,
+                SucceededPlanCount = 1,
+                Message = "Stored batch executed."
+            });
+        }
+
+        public Task<OperationResult> ExportAsync(string batchId, string path, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' exported."));
+
+        public Task<MailMessageActionPlanBatch?> GetBatchAsync(string batchId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MailMessageActionPlanBatch?>(new MailMessageActionPlanBatch {
+                Id = batchId,
+                Name = "Cleanup batch",
+                Plans = {
+                    new MessageActionExecutionPlan {
+                        Succeeded = true,
+                        Action = "delete",
+                        ExecutionKind = "Delete",
+                        ProfileId = "work-imap",
+                        RequestedCount = 1,
+                        UniqueMessageCount = 1,
+                        MessageIds = { "msg-1" }
+                    }
+                }
+            });
+
+        public Task<MailMessageActionPlanBatchCompact?> GetBatchCompactAsync(string batchId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MailMessageActionPlanBatchCompact?>(new MailMessageActionPlanBatchCompact {
+                Id = batchId,
+                Name = "Cleanup batch",
+                PlanCount = 1,
+                ReadyPlanCount = 1,
+                ProfileCount = 1,
+                PlanNames = { "Delete spam" },
+                Summary = $"{batchId} (1 plan(s), 1 ready)"
+            });
+
+        public Task<MailMessageActionPlanBatchSummary?> GetBatchSummaryAsync(string batchId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MailMessageActionPlanBatchSummary?>(new MailMessageActionPlanBatchSummary {
+                Id = batchId,
+                Name = "Cleanup batch",
+                PlanCount = 1,
+                ReadyPlanCount = 1,
+                ProfileIds = { "gmail-work" },
+                ActionCounts = {
+                    ["delete"] = 1
+                },
+                PlanNames = { "Delete spam" },
+                Summary = $"{batchId} (1 plan(s), 1 ready, 1 action type(s))"
+            });
+
+        public Task<IReadOnlyList<MailMessageActionPlanBatch>> GetBatchesAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default) {
+            LastBatchQuery = query == null
+                ? null
+                : new MailMessageActionPlanBatchQuery {
+                    PlanNames = query.PlanNames.ToList(),
+                    ProfileIds = query.ProfileIds.ToList(),
+                    Actions = query.Actions.ToList(),
+                    SortBy = query.SortBy,
+                    Descending = query.Descending
+                };
+            return Task.FromResult<IReadOnlyList<MailMessageActionPlanBatch>>(new[] {
+                new MailMessageActionPlanBatch {
+                    Id = "cleanup",
+                    Name = "Cleanup batch",
+                    Plans = {
+                        new MessageActionExecutionPlan {
+                            Succeeded = true,
+                            Action = "delete",
+                            ExecutionKind = "Delete",
+                            ProfileId = "work-imap",
+                            RequestedCount = 1,
+                            UniqueMessageCount = 1,
+                            MessageIds = { "msg-1" }
+                        }
+                    }
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<MailMessageActionPlanBatchCompact>> GetBatchesCompactAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default) {
+            LastBatchQuery = query == null
+                ? null
+                : new MailMessageActionPlanBatchQuery {
+                    PlanNames = query.PlanNames.ToList(),
+                    ProfileIds = query.ProfileIds.ToList(),
+                    Actions = query.Actions.ToList(),
+                    SortBy = query.SortBy,
+                    Descending = query.Descending
+                };
+            ListCompactCalls++;
+            return Task.FromResult<IReadOnlyList<MailMessageActionPlanBatchCompact>>(new[] {
+                new MailMessageActionPlanBatchCompact {
+                    Id = "cleanup",
+                    Name = "Cleanup batch",
+                    PlanCount = 1,
+                    ReadyPlanCount = 1,
+                    ProfileCount = 1,
+                    PlanNames = { "Delete spam" },
+                    Summary = "cleanup (1 plan(s), 1 ready)"
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<MailMessageActionPlanBatchSummary>> GetBatchesSummaryAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default) {
+            LastBatchQuery = query == null
+                ? null
+                : new MailMessageActionPlanBatchQuery {
+                    PlanNames = query.PlanNames.ToList(),
+                    ProfileIds = query.ProfileIds.ToList(),
+                    Actions = query.Actions.ToList(),
+                    SortBy = query.SortBy,
+                    Descending = query.Descending
+                };
+            ListSummaryCalls++;
+            return Task.FromResult<IReadOnlyList<MailMessageActionPlanBatchSummary>>(new[] {
+                new MailMessageActionPlanBatchSummary {
+                    Id = "cleanup",
+                    Name = "Cleanup batch",
+                    PlanCount = 1,
+                    ReadyPlanCount = 1,
+                    ProfileIds = { "gmail-work" },
+                    ActionCounts = {
+                        ["delete"] = 1
+                    },
+                    PlanNames = { "Delete spam" },
+                    Summary = "cleanup (1 plan(s), 1 ready, 1 action type(s))"
+                }
+            });
+        }
+
+        public Task<OperationResult> ImportAsync(string batchId, string name, string path, string? description = null, CancellationToken cancellationToken = default) {
+            LastImportedBatchId = batchId;
+            LastImportedName = name;
+            LastImportedPath = path;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> ReplaceImportedPlanAtAsync(string batchId, int index, string path, CancellationToken cancellationToken = default) {
+            LastReplacedBatchId = batchId;
+            LastReplacedIndex = index;
+            LastImportedPath = path;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> ReplacePlanAtAsync(string batchId, int index, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) {
+            LastReplacedBatchId = batchId;
+            LastReplacedIndex = index;
+            LastReplacedPlan = plan;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> RemovePlanAtAsync(string batchId, int index, CancellationToken cancellationToken = default) {
+            LastRemovedBatchId = batchId;
+            LastRemovedIndex = index;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> SaveAsync(MailMessageActionPlanBatch batch, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success($"Action plan batch '{batch.Id}' saved."));
     }
 
     private sealed class FakeQueueService : IMailQueueService {
@@ -1562,6 +3108,12 @@ public sealed class CliRunnerTests {
 
         public FakeSendService SendService { get; } = new();
 
+        public FakeMessageActionService MessageActionService { get; } = new();
+
+        public FakeMessageActionPlanExchangeService MessageActionPlanExchangeService { get; } = new();
+
+        public FakeMessageActionPlanRegistryService MessageActionPlanRegistryService { get; } = new();
+
         public FakeDraftService DraftService { get; } = new();
 
         public FakeDraftExchangeService DraftExchangeService { get; } = new();
@@ -1582,6 +3134,9 @@ public sealed class CliRunnerTests {
                 .UseDraftService(DraftService)
                 .UseDraftExchangeService(DraftExchangeService)
                 .UseReadService(ReadService)
+                .UseMessageActionService(MessageActionService)
+                .UseMessageActionPlanExchangeService(MessageActionPlanExchangeService)
+                .UseMessageActionPlanRegistryService(MessageActionPlanRegistryService)
                 .UseQueueService(QueueService)
                 .UseSendService(SendService);
 

--- a/Sources/Mailozaurr.Tests/CliRunnerTests.cs
+++ b/Sources/Mailozaurr.Tests/CliRunnerTests.cs
@@ -1192,6 +1192,24 @@ public sealed class CliRunnerTests {
     }
 
     [Fact]
+    public async Task MailListPlanBatchesPassesExplicitIdSortToSharedRegistryService() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] { "mail", "list-plan-batches", "--summary", "--sort", "id", "--json" },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.MessageActionPlanRegistryService.LastBatchQuery);
+        Assert.Equal(MailMessageActionPlanBatchSortBy.Id, fixture.MessageActionPlanRegistryService.LastBatchQuery!.SortBy);
+        Assert.False(fixture.MessageActionPlanRegistryService.LastBatchQuery.Descending);
+    }
+
+    [Fact]
     public async Task MailImportPlanBatchUsesSharedRegistryService() {
         using var stdout = new StringWriter();
         using var stderr = new StringWriter();

--- a/Sources/Mailozaurr.Tests/JsonMailMessageActionPlanExchangeServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/JsonMailMessageActionPlanExchangeServiceTests.cs
@@ -1,0 +1,72 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class JsonMailMessageActionPlanExchangeServiceTests {
+    [Fact]
+    public async Task SaveAndLoadRoundTripsSinglePlanJson() {
+        var service = new JsonMailMessageActionPlanExchangeService();
+        var path = CreateTemporaryFilePath("plan.json");
+        var plan = new MessageActionExecutionPlan {
+            Succeeded = true,
+            Action = "move",
+            ExecutionKind = "Move",
+            ProfileId = "work-gmail",
+            MailboxId = "primary",
+            FolderId = "Inbox",
+            RequestedCount = 2,
+            UniqueMessageCount = 1,
+            RequestedDestinationFolderId = "Archive",
+            MessageIds = { "msg-1" }
+        };
+
+        await service.SaveAsync(path, plan);
+        var loaded = await service.LoadAsync(path);
+
+        Assert.Equal("move", loaded.Action);
+        Assert.Equal("Move", loaded.ExecutionKind);
+        Assert.Equal("work-gmail", loaded.ProfileId);
+        Assert.Equal("Archive", loaded.RequestedDestinationFolderId);
+        Assert.Equal(new[] { "msg-1" }, loaded.MessageIds);
+    }
+
+    [Fact]
+    public async Task SaveAndLoadRoundTripsBatchJson() {
+        var service = new JsonMailMessageActionPlanExchangeService();
+        var path = CreateTemporaryFilePath("plans.json");
+        var plans = new[] {
+            new MessageActionExecutionPlan {
+                Succeeded = true,
+                Action = "mark-read",
+                ExecutionKind = "SetReadState",
+                ProfileId = "work-gmail",
+                RequestedCount = 1,
+                UniqueMessageCount = 1,
+                DesiredState = true,
+                MessageIds = { "msg-1" }
+            },
+            new MessageActionExecutionPlan {
+                Succeeded = true,
+                Action = "delete",
+                ExecutionKind = "Delete",
+                ProfileId = "work-gmail",
+                RequestedCount = 1,
+                UniqueMessageCount = 1,
+                MessageIds = { "msg-2" }
+            }
+        };
+
+        await service.SaveBatchAsync(path, plans);
+        var loaded = await service.LoadBatchAsync(path);
+
+        Assert.Equal(2, loaded.Count);
+        Assert.Equal("mark-read", loaded[0].Action);
+        Assert.Equal("delete", loaded[1].Action);
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+}

--- a/Sources/Mailozaurr.Tests/MailMcpToolsTests.cs
+++ b/Sources/Mailozaurr.Tests/MailMcpToolsTests.cs
@@ -483,6 +483,525 @@ public sealed class MailMcpToolsTests {
     }
 
     [Fact]
+    public async Task MailFolderAliasesListDelegatesToSharedFolderAliasService() {
+        using var fixture = new TestFixture();
+
+        var results = await fixture.Tools.mail_folder_aliases_list("gmail-work", mailboxId: "primary");
+
+        var archive = Assert.Single(results, result => result.Alias == MailFolderAliases.Archive);
+        Assert.True(archive.IsResolved);
+        Assert.Equal("archive", archive.FolderId);
+        Assert.NotNull(fixture.ReadService.LastFolderQuery);
+        Assert.Equal("gmail-work", fixture.ReadService.LastFolderQuery!.ProfileId);
+        Assert.Equal("primary", fixture.ReadService.LastFolderQuery.MailboxId);
+    }
+
+    [Fact]
+    public async Task MailFolderResolveDelegatesToSharedFolderAliasService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_folder_resolve("gmail-work", "archive", mailboxId: "primary");
+
+        Assert.True(result.IsAlias);
+        Assert.Equal(MailFolderAliases.Archive, result.Alias);
+        Assert.Equal("archive", result.EffectiveFolderId);
+        Assert.NotNull(fixture.ReadService.LastFolderQuery);
+        Assert.Equal("gmail-work", fixture.ReadService.LastFolderQuery!.ProfileId);
+        Assert.Equal("primary", fixture.ReadService.LastFolderQuery.MailboxId);
+    }
+
+    [Fact]
+    public async Task MailMovePreviewUsesSharedPreviewService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_move_preview(
+            "gmail-work",
+            new[] { "message-1", "MESSAGE-1" },
+            "archive",
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(2, result.RequestedCount);
+        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.NotNull(result.Destination);
+        Assert.Equal("archive", result.Destination!.EffectiveFolderId);
+        Assert.NotNull(result.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailActionsPreviewUsesSharedPreviewService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_actions_preview(
+            "gmail-work",
+            new[] { "message-1", "MESSAGE-1" },
+            destinationFolderId: "Projects/2026",
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(4, result.IncludedActionCount);
+        Assert.Equal(4, result.SucceededActionCount);
+        Assert.Equal(0, result.FailedActionCount);
+        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.Contains(result.Actions, action => action.Action == "archive" && action.Destination!.EffectiveFolderId == "archive");
+        Assert.Contains(result.Actions, action => action.Action == "move" && action.Destination!.EffectiveFolderId == "Projects/2026");
+        Assert.Contains(result.Actions, action => action.Action == "delete" && action.Succeeded);
+        Assert.All(result.Actions, action => Assert.NotNull(action.ConfirmationToken));
+    }
+
+    [Fact]
+    public async Task MailActionsBundlePreviewUsesSharedPreviewService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_actions_bundle_preview(
+            "gmail-work",
+            new[] { "message-1", "MESSAGE-1" },
+            destinationFolderId: "Projects/2026",
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(8, result.IncludedActionCount);
+        Assert.Equal(8, result.SucceededActionCount);
+        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.Contains(result.Actions, action => action.Action == "mark-read" && action.DesiredState == true);
+        Assert.Contains(result.Actions, action => action.Action == "mark-unread" && action.DesiredState == false);
+        Assert.Contains(result.Actions, action => action.Action == "flag" && action.DesiredState == true);
+        Assert.Contains(result.Actions, action => action.Action == "unflag" && action.DesiredState == false);
+        Assert.Contains(result.Actions, action => action.Action == "move" && action.Destination!.EffectiveFolderId == "Projects/2026");
+    }
+
+    [Fact]
+    public async Task MailActionPlanUsesSharedPlanningService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_plan(
+            action: "move",
+            profileId: "gmail-work",
+            messageIds: new[] { "message-1", "MESSAGE-1" },
+            destinationFolderId: "Projects/2026",
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("Move", result.ExecutionKind);
+        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.Equal("Projects/2026", result.RequestedDestinationFolderId);
+        Assert.NotNull(result.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailActionPlanExportUsesSharedPlanExchangeService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_plan_export(
+            action: "move",
+            profileId: "gmail-work",
+            messageIds: new[] { "message-1", "MESSAGE-1" },
+            path: @"C:\Temp\plan.json",
+            destinationFolderId: "Projects/2026",
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(@"C:\Temp\plan.json", fixture.PlanExchangeService.LastSavedPath);
+        Assert.NotNull(fixture.PlanExchangeService.LastSavedPlan);
+        Assert.Equal("move", fixture.PlanExchangeService.LastSavedPlan!.Action);
+    }
+
+    [Fact]
+    public async Task MailActionPlanImportUsesSharedPlanExchangeService() {
+        using var fixture = new TestFixture();
+        fixture.PlanExchangeService.NextPlan = new MessageActionExecutionPlan {
+            Succeeded = true,
+            Action = "delete",
+            ExecutionKind = "Delete",
+            ProfileId = "gmail-work",
+            RequestedCount = 1,
+            UniqueMessageCount = 1,
+            MessageIds = { "message-1" }
+        };
+
+        var result = await fixture.Tools.mail_action_plan_import(@"C:\Temp\plan.json");
+
+        Assert.Equal("delete", result.Action);
+        Assert.Equal(@"C:\Temp\plan.json", fixture.PlanExchangeService.LastLoadedPath);
+    }
+
+    [Fact]
+    public async Task MailActionBatchImportUsesSharedPlanExchangeService() {
+        using var fixture = new TestFixture();
+        fixture.PlanExchangeService.NextBatchPlans = new[] {
+            new MessageActionExecutionPlan {
+                Succeeded = true,
+                Action = "mark-read",
+                ExecutionKind = "SetReadState",
+                ProfileId = "gmail-work",
+                RequestedCount = 1,
+                UniqueMessageCount = 1,
+                DesiredState = true,
+                MessageIds = { "message-1" }
+            }
+        };
+
+        var result = await fixture.Tools.mail_action_batch_import(@"C:\Temp\plans.json");
+
+        Assert.Single(result);
+        Assert.Equal("mark-read", result[0].Action);
+        Assert.Equal(@"C:\Temp\plans.json", fixture.PlanExchangeService.LastLoadedBatchPath);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreListUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_compact_list();
+
+        var batch = Assert.Single(result);
+        Assert.Equal("cleanup", batch.Id);
+        Assert.Equal(new[] { "Delete spam" }, batch.PlanNames);
+        Assert.Equal(1, fixture.PlanRegistryService.ListCompactCalls);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreSummaryListUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_summary_list();
+
+        var batch = Assert.Single(result);
+        Assert.Equal("cleanup", batch.Id);
+        Assert.Equal(1, batch.ActionCounts["delete"]);
+        Assert.Equal(new[] { "gmail-work" }, batch.ProfileIds);
+        Assert.Equal(1, fixture.PlanRegistryService.ListSummaryCalls);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreSummaryListPassesSortToSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_summary_list(sortBy: "plans", descending: true);
+
+        var batch = Assert.Single(result);
+        Assert.Equal("cleanup", batch.Id);
+        Assert.NotNull(fixture.PlanRegistryService.LastBatchQuery);
+        Assert.Equal(MailMessageActionPlanBatchSortBy.PlanCount, fixture.PlanRegistryService.LastBatchQuery!.SortBy);
+        Assert.True(fixture.PlanRegistryService.LastBatchQuery.Descending);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreListPassesPlanNameFilterToSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_compact_list(new[] { "Delete spam" });
+
+        var batch = Assert.Single(result);
+        Assert.Equal("cleanup", batch.Id);
+        Assert.NotNull(fixture.PlanRegistryService.LastBatchQuery);
+        Assert.Equal(new[] { "Delete spam" }, fixture.PlanRegistryService.LastBatchQuery!.PlanNames);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreListPassesProfileFilterToSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_compact_list(profileIds: new[] { "gmail-work" });
+
+        var batch = Assert.Single(result);
+        Assert.Equal("cleanup", batch.Id);
+        Assert.NotNull(fixture.PlanRegistryService.LastBatchQuery);
+        Assert.Equal(new[] { "gmail-work" }, fixture.PlanRegistryService.LastBatchQuery!.ProfileIds);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreListPassesActionFilterToSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_compact_list(actions: new[] { "delete" });
+
+        var batch = Assert.Single(result);
+        Assert.Equal("cleanup", batch.Id);
+        Assert.NotNull(fixture.PlanRegistryService.LastBatchQuery);
+        Assert.Equal(new[] { "delete" }, fixture.PlanRegistryService.LastBatchQuery!.Actions);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreImportUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_import("cleanup", "Cleanup batch", @"C:\Temp\plans.json", "Quarterly cleanup");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("cleanup", fixture.PlanRegistryService.LastImportedBatchId);
+        Assert.Equal(@"C:\Temp\plans.json", fixture.PlanRegistryService.LastImportedPath);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreCreateCommonUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_create_common(
+            batchId: "cleanup",
+            name: "Cleanup batch",
+            profileId: "gmail-work",
+            messageIds: new[] { "message-1", "MESSAGE-1" },
+            actions: new[] { "archive", "delete" },
+            destinationFolderId: "Archive",
+            mailboxId: "primary",
+            folderId: "Inbox",
+            description: "Common action batch");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("cleanup", fixture.PlanRegistryService.LastCreatedCommonBatchId);
+        Assert.Equal("Cleanup batch", fixture.PlanRegistryService.LastCreatedCommonName);
+        Assert.Equal("Common action batch", fixture.PlanRegistryService.LastCreatedCommonDescription);
+        Assert.Equal(new[] { "archive", "delete" }, fixture.PlanRegistryService.LastCreatedCommonActions);
+        Assert.NotNull(fixture.PlanRegistryService.LastCreatedCommonRequest);
+        Assert.Equal("gmail-work", fixture.PlanRegistryService.LastCreatedCommonRequest!.ProfileId);
+        Assert.Equal("primary", fixture.PlanRegistryService.LastCreatedCommonRequest.MailboxId);
+        Assert.Equal("Inbox", fixture.PlanRegistryService.LastCreatedCommonRequest.FolderId);
+        Assert.Equal("Archive", fixture.PlanRegistryService.LastCreatedCommonRequest.DestinationFolderId);
+        Assert.Equal(new[] { "message-1", "MESSAGE-1" }, fixture.PlanRegistryService.LastCreatedCommonRequest.MessageIds);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreCreateFromPreviewUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var preview = await fixture.Tools.mail_actions_bundle_preview(
+            profileId: "gmail-work",
+            messageIds: new[] { "message-1", "MESSAGE-1" },
+            destinationFolderId: "Projects/2026",
+            mailboxId: "primary",
+            folderId: "Inbox");
+        var result = await fixture.Tools.mail_action_batch_store_create_from_preview(
+            batchId: "cleanup-previewed",
+            name: "Cleanup Previewed",
+            preview: preview,
+            actions: new[] { "move", "delete" },
+            description: "Built from preview");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("cleanup-previewed", fixture.PlanRegistryService.LastCreatedFromPreviewBatchId);
+        Assert.Equal("Cleanup Previewed", fixture.PlanRegistryService.LastCreatedFromPreviewName);
+        Assert.Equal("Built from preview", fixture.PlanRegistryService.LastCreatedFromPreviewDescription);
+        Assert.Equal(new[] { "move", "delete" }, fixture.PlanRegistryService.LastCreatedFromPreviewActions);
+        Assert.NotNull(fixture.PlanRegistryService.LastCreatedFromPreview);
+        Assert.Equal("gmail-work", fixture.PlanRegistryService.LastCreatedFromPreview!.ProfileId);
+        Assert.Equal("primary", fixture.PlanRegistryService.LastCreatedFromPreview.MailboxId);
+        Assert.Equal("Inbox", fixture.PlanRegistryService.LastCreatedFromPreview.FolderId);
+        Assert.Equal("Projects/2026", fixture.PlanRegistryService.LastCreatedFromPreview.RequestedDestinationFolderId);
+        Assert.Equal(new[] { "message-1" }, fixture.PlanRegistryService.LastCreatedFromPreview.MessageIds);
+        Assert.Contains(fixture.PlanRegistryService.LastCreatedFromPreview.Actions, action => action.Action == "move");
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreExecuteUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_execute("cleanup");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("cleanup", fixture.PlanRegistryService.LastExecutedBatchId);
+        Assert.Equal(1, result.SucceededPlanCount);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreAppendPlanUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_append_plan(
+            batchId: "cleanup",
+            action: "move",
+            profileId: "gmail-work",
+            messageIds: new[] { "message-1" },
+            destinationFolderId: "Archive",
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("cleanup", fixture.PlanRegistryService.LastAppendedBatchId);
+        Assert.NotNull(fixture.PlanRegistryService.LastAppendedPlan);
+        Assert.Equal("move", fixture.PlanRegistryService.LastAppendedPlan!.Action);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreRemovePlanUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_remove_plan("cleanup", 1);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("cleanup", fixture.PlanRegistryService.LastRemovedBatchId);
+        Assert.Equal(1, fixture.PlanRegistryService.LastRemovedIndex);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreCloneUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_clone("cleanup", "cleanup-copy", "Cleanup copy", "Cloned batch");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("cleanup", fixture.PlanRegistryService.LastClonedSourceBatchId);
+        Assert.Equal("cleanup-copy", fixture.PlanRegistryService.LastClonedTargetBatchId);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreTransformCloneUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_transform_clone(
+            sourceBatchId: "cleanup",
+            targetBatchId: "cleanup-target",
+            name: "Cleanup Target",
+            indexes: new[] { 1, 2 },
+            planNames: new[] { "Archive newsletter" },
+            profileId: "gmail-target",
+            mailboxId: "shared@example.com",
+            folderId: "Projects",
+            destinationFolderId: "Projects/Archive",
+            description: "Remapped batch");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("cleanup", fixture.PlanRegistryService.LastTransformedSourceBatchId);
+        Assert.Equal("cleanup-target", fixture.PlanRegistryService.LastTransformedTargetBatchId);
+        Assert.Equal("Cleanup Target", fixture.PlanRegistryService.LastTransformedName);
+        Assert.Equal("Remapped batch", fixture.PlanRegistryService.LastTransformedDescription);
+        Assert.NotNull(fixture.PlanRegistryService.LastTransformRequest);
+        Assert.Equal("gmail-target", fixture.PlanRegistryService.LastTransformRequest!.ProfileId);
+        Assert.Equal(new[] { 1, 2 }, fixture.PlanRegistryService.LastTransformRequest.PlanIndexes);
+        Assert.Equal(new[] { "Archive newsletter" }, fixture.PlanRegistryService.LastTransformRequest.PlanNames);
+        Assert.Equal("shared@example.com", fixture.PlanRegistryService.LastTransformRequest.MailboxId);
+        Assert.Equal("Projects", fixture.PlanRegistryService.LastTransformRequest.FolderId);
+        Assert.Equal("Projects/Archive", fixture.PlanRegistryService.LastTransformRequest.DestinationFolderId);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreTransformPreviewUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_transform_preview(
+            sourceBatchId: "cleanup",
+            indexes: new[] { 1 },
+            planNames: new[] { "Archive newsletter" },
+            profileId: "gmail-target",
+            mailboxId: "shared@example.com",
+            folderId: "Projects",
+            destinationFolderId: "Projects/Archive");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("cleanup", fixture.PlanRegistryService.LastPreviewedTransformSourceBatchId);
+        Assert.NotNull(fixture.PlanRegistryService.LastPreviewedTransformRequest);
+        Assert.Equal("gmail-target", fixture.PlanRegistryService.LastPreviewedTransformRequest!.ProfileId);
+        Assert.Equal(new[] { 1 }, fixture.PlanRegistryService.LastPreviewedTransformRequest.PlanIndexes);
+        Assert.Equal(new[] { "Archive newsletter" }, fixture.PlanRegistryService.LastPreviewedTransformRequest.PlanNames);
+        Assert.Equal("shared@example.com", fixture.PlanRegistryService.LastPreviewedTransformRequest.MailboxId);
+        Assert.Equal("Projects", fixture.PlanRegistryService.LastPreviewedTransformRequest.FolderId);
+        Assert.Equal("Projects/Archive", fixture.PlanRegistryService.LastPreviewedTransformRequest.DestinationFolderId);
+        Assert.Equal(1, result.ChangedPlanCount);
+    }
+
+    [Fact]
+    public async Task MailActionBatchStoreReplacePlanUsesSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_replace_plan(
+            batchId: "cleanup",
+            index: 0,
+            action: "move",
+            profileId: "gmail-work",
+            messageIds: new[] { "message-1" },
+            destinationFolderId: "Archive",
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("cleanup", fixture.PlanRegistryService.LastReplacedBatchId);
+        Assert.Equal(0, fixture.PlanRegistryService.LastReplacedIndex);
+        Assert.NotNull(fixture.PlanRegistryService.LastReplacedPlan);
+        Assert.Equal("move", fixture.PlanRegistryService.LastReplacedPlan!.Action);
+    }
+
+    [Fact]
+    public async Task MailActionExecuteUsesSharedBatchService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_execute(
+            action: "move",
+            profileId: "gmail-work",
+            messageIds: new[] { "message-1", "MESSAGE-1" },
+            destinationFolderId: "Projects/2026",
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(1, result.RequestedPlanCount);
+        Assert.Equal(1, result.SucceededPlanCount);
+        Assert.NotNull(fixture.MessageActionService.LastMoveRequest);
+        Assert.Equal("primary", fixture.MessageActionService.LastMoveRequest!.MailboxId);
+        Assert.Equal("Projects/2026", fixture.MessageActionService.LastMoveRequest.DestinationFolderId);
+    }
+
+    [Fact]
+    public async Task MailActionBatchExecuteUsesSharedBatchService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_execute(new[] {
+            new MessageActionExecutionPlan {
+                Succeeded = true,
+                Action = "mark-read",
+                ExecutionKind = "SetReadState",
+                ProfileId = "gmail-work",
+                MailboxId = "primary",
+                FolderId = "Inbox",
+                RequestedCount = 1,
+                UniqueMessageCount = 1,
+                DesiredState = true,
+                MessageIds = { "message-1" }
+            },
+            new MessageActionExecutionPlan {
+                Succeeded = true,
+                Action = "move",
+                ExecutionKind = "Move",
+                ProfileId = "gmail-work",
+                MailboxId = "primary",
+                FolderId = "Inbox",
+                RequestedCount = 1,
+                UniqueMessageCount = 1,
+                RequestedDestinationFolderId = "Projects/2026",
+                MessageIds = { "message-2" }
+            }
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(2, result.AttemptedPlanCount);
+        Assert.Equal(2, result.SucceededPlanCount);
+        Assert.NotNull(fixture.MessageActionService.LastSetReadStateRequest);
+        Assert.NotNull(fixture.MessageActionService.LastMoveRequest);
+        Assert.Equal("Projects/2026", fixture.MessageActionService.LastMoveRequest!.DestinationFolderId);
+    }
+
+    [Fact]
+    public async Task MailDeletePreviewUsesSharedPreviewService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_delete_preview(
+            "gmail-work",
+            new[] { "message-1", "MESSAGE-1" },
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(2, result.RequestedCount);
+        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.Equal("gmail-work", result.ProfileId);
+        Assert.NotNull(result.ConfirmationToken);
+    }
+
+    [Fact]
     public async Task MailSearchCompactDelegatesToApplicationReadService() {
         using var fixture = new TestFixture();
 
@@ -555,6 +1074,34 @@ public sealed class MailMcpToolsTests {
     }
 
     [Fact]
+    public async Task MailAttachmentsSaveManyDelegatesToApplicationReadService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_attachments_save_many(
+            "gmail-work",
+            new[] { "message-1", "message-2" },
+            @"C:\Temp",
+            mailboxId: "primary",
+            folderId: "Inbox",
+            attachmentIds: new[] { "attachment-1" },
+            fileNameContains: "invoice",
+            contentTypeContains: "pdf",
+            overwrite: true);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(fixture.ReadService.LastSaveAttachmentsManyRequest);
+        Assert.Equal("gmail-work", fixture.ReadService.LastSaveAttachmentsManyRequest!.ProfileId);
+        Assert.Equal("primary", fixture.ReadService.LastSaveAttachmentsManyRequest.MailboxId);
+        Assert.Equal("Inbox", fixture.ReadService.LastSaveAttachmentsManyRequest.FolderId);
+        Assert.Equal(@"C:\Temp", fixture.ReadService.LastSaveAttachmentsManyRequest.DestinationPath);
+        Assert.Equal(new[] { "message-1", "message-2" }, fixture.ReadService.LastSaveAttachmentsManyRequest.MessageIds);
+        Assert.Equal(new[] { "attachment-1" }, fixture.ReadService.LastSaveAttachmentsManyRequest.AttachmentIds);
+        Assert.Equal("invoice", fixture.ReadService.LastSaveAttachmentsManyRequest.FileNameContains);
+        Assert.Equal("pdf", fixture.ReadService.LastSaveAttachmentsManyRequest.ContentTypeContains);
+        Assert.True(fixture.ReadService.LastSaveAttachmentsManyRequest.Overwrite);
+    }
+
+    [Fact]
     public async Task MailGetCompactDelegatesToApplicationReadService() {
         using var fixture = new TestFixture();
 
@@ -572,6 +1119,183 @@ public sealed class MailMcpToolsTests {
         Assert.Equal("Inbox", fixture.ReadService.LastGetCompactRequest.FolderId);
         Assert.Equal("message-1", fixture.ReadService.LastGetCompactRequest.MessageId);
         Assert.True(fixture.ReadService.LastGetCompactRequest.IncludeRawContent);
+    }
+
+    [Fact]
+    public async Task MailGetManyCompactDelegatesToApplicationReadService() {
+        using var fixture = new TestFixture();
+
+        var results = await fixture.Tools.mail_get_many_compact(
+            "gmail-work",
+            new[] { "message-1", "message-2" },
+            mailboxId: "primary",
+            folderId: "Inbox",
+            includeRawContent: true);
+
+        Assert.Equal(2, results.Count);
+        Assert.NotNull(fixture.ReadService.LastGetManyCompactRequest);
+        Assert.Equal("gmail-work", fixture.ReadService.LastGetManyCompactRequest!.ProfileId);
+        Assert.Equal("primary", fixture.ReadService.LastGetManyCompactRequest.MailboxId);
+        Assert.Equal("Inbox", fixture.ReadService.LastGetManyCompactRequest.FolderId);
+        Assert.Equal(new[] { "message-1", "message-2" }, fixture.ReadService.LastGetManyCompactRequest.MessageIds);
+        Assert.True(fixture.ReadService.LastGetManyCompactRequest.IncludeRawContent);
+    }
+
+    [Fact]
+    public async Task MailMarkReadDelegatesToApplicationMessageActionService() {
+        using var fixture = new TestFixture();
+        const string confirmationToken = "mact_v1_mark";
+
+        var result = await fixture.Tools.mail_mark_read(
+            "gmail-work",
+            new[] { "message-1", "message-2" },
+            isRead: false,
+            mailboxId: "primary",
+            folderId: "Inbox",
+            confirmationToken: confirmationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(fixture.MessageActionService.LastSetReadStateRequest);
+        Assert.Equal("gmail-work", fixture.MessageActionService.LastSetReadStateRequest!.ProfileId);
+        Assert.Equal("primary", fixture.MessageActionService.LastSetReadStateRequest.MailboxId);
+        Assert.Equal("Inbox", fixture.MessageActionService.LastSetReadStateRequest.FolderId);
+        Assert.False(fixture.MessageActionService.LastSetReadStateRequest.IsRead);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastSetReadStateRequest.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailFlagDelegatesToApplicationMessageActionService() {
+        using var fixture = new TestFixture();
+        const string confirmationToken = "mact_v1_flag";
+
+        var result = await fixture.Tools.mail_flag(
+            "gmail-work",
+            new[] { "message-1", "message-2" },
+            isFlagged: false,
+            mailboxId: "primary",
+            folderId: "Inbox",
+            confirmationToken: confirmationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(fixture.MessageActionService.LastSetFlaggedStateRequest);
+        Assert.Equal("gmail-work", fixture.MessageActionService.LastSetFlaggedStateRequest!.ProfileId);
+        Assert.Equal("primary", fixture.MessageActionService.LastSetFlaggedStateRequest.MailboxId);
+        Assert.Equal("Inbox", fixture.MessageActionService.LastSetFlaggedStateRequest.FolderId);
+        Assert.False(fixture.MessageActionService.LastSetFlaggedStateRequest.IsFlagged);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastSetFlaggedStateRequest.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailMarkReadPreviewUsesSharedPreviewService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_mark_read_preview(
+            "gmail-work",
+            new[] { "message-1", "MESSAGE-1" },
+            isRead: false,
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("read-state", result.Action);
+        Assert.False(result.DesiredState);
+        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.NotNull(result.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailFlagPreviewUsesSharedPreviewService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_flag_preview(
+            "gmail-work",
+            new[] { "message-1", "MESSAGE-1" },
+            isFlagged: false,
+            mailboxId: "primary",
+            folderId: "Inbox");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("flagged-state", result.Action);
+        Assert.False(result.DesiredState);
+        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.NotNull(result.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailArchiveDelegatesToSharedArchiveAlias() {
+        using var fixture = new TestFixture();
+        const string confirmationToken = "mact_v1_archive";
+
+        var result = await fixture.Tools.mail_archive(
+            "gmail-work",
+            new[] { "message-1" },
+            mailboxId: "primary",
+            folderId: "Inbox",
+            confirmationToken: confirmationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(fixture.MessageActionService.LastMoveRequest);
+        Assert.Equal(MailFolderAliases.Archive, fixture.MessageActionService.LastMoveRequest!.DestinationFolderId);
+        Assert.Equal("primary", fixture.MessageActionService.LastMoveRequest.MailboxId);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastMoveRequest.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailTrashDelegatesToSharedTrashAlias() {
+        using var fixture = new TestFixture();
+        const string confirmationToken = "mact_v1_trash";
+
+        var result = await fixture.Tools.mail_trash(
+            "gmail-work",
+            new[] { "message-1" },
+            mailboxId: "primary",
+            folderId: "Inbox",
+            confirmationToken: confirmationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(fixture.MessageActionService.LastMoveRequest);
+        Assert.Equal(MailFolderAliases.Trash, fixture.MessageActionService.LastMoveRequest!.DestinationFolderId);
+        Assert.Equal("primary", fixture.MessageActionService.LastMoveRequest.MailboxId);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastMoveRequest.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailMoveDelegatesToApplicationMessageActionService() {
+        using var fixture = new TestFixture();
+        const string confirmationToken = "mact_v1_move";
+
+        var result = await fixture.Tools.mail_move(
+            "gmail-work",
+            new[] { "message-1" },
+            "Archive",
+            mailboxId: "primary",
+            folderId: "Inbox",
+            confirmationToken: confirmationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(fixture.MessageActionService.LastMoveRequest);
+        Assert.Equal("Archive", fixture.MessageActionService.LastMoveRequest!.DestinationFolderId);
+        Assert.Equal("primary", fixture.MessageActionService.LastMoveRequest.MailboxId);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastMoveRequest.ConfirmationToken);
+    }
+
+    [Fact]
+    public async Task MailDeleteDelegatesToApplicationMessageActionService() {
+        using var fixture = new TestFixture();
+        const string confirmationToken = "mact_v1_delete";
+
+        var result = await fixture.Tools.mail_delete(
+            "gmail-work",
+            new[] { "message-1", "message-2" },
+            mailboxId: "primary",
+            folderId: "Inbox",
+            confirmationToken: confirmationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(fixture.MessageActionService.LastDeleteRequest);
+        Assert.Equal("gmail-work", fixture.MessageActionService.LastDeleteRequest!.ProfileId);
+        Assert.Equal(new[] { "message-1", "message-2" }, fixture.MessageActionService.LastDeleteRequest.MessageIds);
+        Assert.Equal(confirmationToken, fixture.MessageActionService.LastDeleteRequest.ConfirmationToken);
     }
 
     [Fact]
@@ -807,6 +1531,9 @@ public sealed class MailMcpToolsTests {
             SecretStore = new InMemorySecretStore();
             ReadService = new FakeReadService();
             SendService = new FakeSendService();
+            MessageActionService = new FakeMessageActionService();
+            PlanExchangeService = new FakeMessageActionPlanExchangeService();
+            PlanRegistryService = new FakeMessageActionPlanRegistryService();
             QueueService = new FakeQueueService();
             ProfileAuthService = new FakeProfileAuthService(ProfileStore, SecretStore);
             ProfileConnectionService = new FakeProfileConnectionService();
@@ -818,6 +1545,9 @@ public sealed class MailMcpToolsTests {
                 .UseProfileAuthService(ProfileAuthService)
                 .UseProfileConnectionService(ProfileConnectionService)
                 .UseReadService(ReadService)
+                .UseMessageActionService(MessageActionService)
+                .UseMessageActionPlanExchangeService(PlanExchangeService)
+                .UseMessageActionPlanRegistryService(PlanRegistryService)
                 .UseSendService(SendService)
                 .UseQueueService(QueueService)
                 .Build();
@@ -837,6 +1567,12 @@ public sealed class MailMcpToolsTests {
 
         public FakeSendService SendService { get; }
 
+        public FakeMessageActionService MessageActionService { get; }
+
+        public FakeMessageActionPlanExchangeService PlanExchangeService { get; }
+
+        public FakeMessageActionPlanRegistryService PlanRegistryService { get; }
+
         public FakeQueueService QueueService { get; }
 
         public FakeProfileAuthService ProfileAuthService { get; }
@@ -850,6 +1586,425 @@ public sealed class MailMcpToolsTests {
                 Directory.Delete(_tempDirectory, recursive: true);
             }
         }
+    }
+
+    private sealed class FakeMessageActionPlanExchangeService : IMailMessageActionPlanExchangeService {
+        public string? LastLoadedPath { get; private set; }
+
+        public string? LastLoadedBatchPath { get; private set; }
+
+        public string? LastSavedPath { get; private set; }
+
+        public string? LastSavedBatchPath { get; private set; }
+
+        public MessageActionExecutionPlan? LastSavedPlan { get; private set; }
+
+        public IReadOnlyList<MessageActionExecutionPlan>? LastSavedBatch { get; private set; }
+
+        public MessageActionExecutionPlan NextPlan { get; set; } = new() {
+            Succeeded = true,
+            Action = "move",
+            ExecutionKind = "Move",
+            ProfileId = "gmail-work",
+            RequestedCount = 1,
+            UniqueMessageCount = 1,
+            RequestedDestinationFolderId = "Archive",
+            MessageIds = { "message-1" }
+        };
+
+        public IReadOnlyList<MessageActionExecutionPlan> NextBatchPlans { get; set; } = Array.Empty<MessageActionExecutionPlan>();
+
+        public Task<MessageActionExecutionPlan> LoadAsync(string path, CancellationToken cancellationToken = default) {
+            LastLoadedPath = path;
+            return Task.FromResult(NextPlan);
+        }
+
+        public Task<IReadOnlyList<MessageActionExecutionPlan>> LoadBatchAsync(string path, CancellationToken cancellationToken = default) {
+            LastLoadedBatchPath = path;
+            return Task.FromResult(NextBatchPlans);
+        }
+
+        public Task SaveAsync(string path, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) {
+            LastSavedPath = path;
+            LastSavedPlan = plan;
+            return Task.CompletedTask;
+        }
+
+        public Task SaveBatchAsync(string path, IReadOnlyList<MessageActionExecutionPlan> plans, CancellationToken cancellationToken = default) {
+            LastSavedBatchPath = path;
+            LastSavedBatch = plans;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeMessageActionPlanRegistryService : IMailMessageActionPlanRegistryService {
+        public int ListCompactCalls { get; private set; }
+        public int ListSummaryCalls { get; private set; }
+        public MailMessageActionPlanBatchQuery? LastBatchQuery { get; private set; }
+
+        public string? LastAppendedBatchId { get; private set; }
+
+        public MessageActionExecutionPlan? LastAppendedPlan { get; private set; }
+
+        public string? LastClonedSourceBatchId { get; private set; }
+
+        public string? LastClonedTargetBatchId { get; private set; }
+
+        public string? LastImportedBatchId { get; private set; }
+
+        public string? LastImportedPath { get; private set; }
+
+        public string? LastCreatedCommonBatchId { get; private set; }
+
+        public string? LastCreatedCommonName { get; private set; }
+
+        public string? LastCreatedCommonDescription { get; private set; }
+
+        public CommonMessageActionsPreviewRequest? LastCreatedCommonRequest { get; private set; }
+
+        public IReadOnlyList<string>? LastCreatedCommonActions { get; private set; }
+
+        public string? LastCreatedFromPreviewBatchId { get; private set; }
+
+        public string? LastCreatedFromPreviewName { get; private set; }
+
+        public string? LastCreatedFromPreviewDescription { get; private set; }
+
+        public CommonMessageActionsPreview? LastCreatedFromPreview { get; private set; }
+
+        public IReadOnlyList<string>? LastCreatedFromPreviewActions { get; private set; }
+
+        public string? LastTransformedSourceBatchId { get; private set; }
+
+        public string? LastTransformedTargetBatchId { get; private set; }
+
+        public string? LastTransformedName { get; private set; }
+
+        public string? LastTransformedDescription { get; private set; }
+
+        public MessageActionPlanBatchTransformRequest? LastTransformRequest { get; private set; }
+
+        public string? LastPreviewedTransformSourceBatchId { get; private set; }
+
+        public MessageActionPlanBatchTransformRequest? LastPreviewedTransformRequest { get; private set; }
+
+        public string? LastExecutedBatchId { get; private set; }
+
+        public string? LastRemovedBatchId { get; private set; }
+
+        public int? LastRemovedIndex { get; private set; }
+
+        public string? LastReplacedBatchId { get; private set; }
+
+        public int? LastReplacedIndex { get; private set; }
+
+        public MessageActionExecutionPlan? LastReplacedPlan { get; private set; }
+
+        public Task<OperationResult> AppendImportedPlanAsync(string batchId, string path, CancellationToken cancellationToken = default) {
+            LastAppendedBatchId = batchId;
+            LastImportedPath = path;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> AppendPlanAsync(string batchId, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) {
+            LastAppendedBatchId = batchId;
+            LastAppendedPlan = plan;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> CloneAsync(string sourceBatchId, string targetBatchId, string name, string? description = null, CancellationToken cancellationToken = default) {
+            LastClonedSourceBatchId = sourceBatchId;
+            LastClonedTargetBatchId = targetBatchId;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{targetBatchId}' saved."));
+        }
+
+        public Task<OperationResult> CreateCommonBatchAsync(
+            string batchId,
+            string name,
+            CommonMessageActionsPreviewRequest request,
+            IReadOnlyList<string>? actions = null,
+            string? description = null,
+            CancellationToken cancellationToken = default) {
+            LastCreatedCommonBatchId = batchId;
+            LastCreatedCommonName = name;
+            LastCreatedCommonDescription = description;
+            LastCreatedCommonRequest = new CommonMessageActionsPreviewRequest {
+                ProfileId = request.ProfileId,
+                MailboxId = request.MailboxId,
+                FolderId = request.FolderId,
+                DestinationFolderId = request.DestinationFolderId,
+                MessageIds = request.MessageIds.ToList()
+            };
+            LastCreatedCommonActions = actions?.ToArray();
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> CreateCommonBatchFromPreviewAsync(
+            string batchId,
+            string name,
+            CommonMessageActionsPreview preview,
+            IReadOnlyList<string>? actions = null,
+            string? description = null,
+            CancellationToken cancellationToken = default) {
+            LastCreatedFromPreviewBatchId = batchId;
+            LastCreatedFromPreviewName = name;
+            LastCreatedFromPreviewDescription = description;
+            LastCreatedFromPreview = new CommonMessageActionsPreview {
+                ProfileId = preview.ProfileId,
+                MailboxId = preview.MailboxId,
+                FolderId = preview.FolderId,
+                RequestedDestinationFolderId = preview.RequestedDestinationFolderId,
+                RequestedCount = preview.RequestedCount,
+                UniqueMessageCount = preview.UniqueMessageCount,
+                DuplicateOrEmptyCount = preview.DuplicateOrEmptyCount,
+                MessageIds = preview.MessageIds.ToList(),
+                Actions = preview.Actions.Select(action => new MessageActionPreviewItem {
+                    Action = action.Action,
+                    DisplayName = action.DisplayName,
+                    Succeeded = action.Succeeded,
+                    Code = action.Code,
+                    Message = action.Message,
+                    RequestedDestinationFolderId = action.RequestedDestinationFolderId,
+                    DesiredState = action.DesiredState,
+                    ConfirmationToken = action.ConfirmationToken
+                }).ToList()
+            };
+            LastCreatedFromPreviewActions = actions?.ToArray();
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> TransformCloneAsync(
+            string sourceBatchId,
+            string targetBatchId,
+            string name,
+            MessageActionPlanBatchTransformRequest transform,
+            string? description = null,
+            CancellationToken cancellationToken = default) {
+            LastTransformedSourceBatchId = sourceBatchId;
+            LastTransformedTargetBatchId = targetBatchId;
+            LastTransformedName = name;
+            LastTransformedDescription = description;
+            LastTransformRequest = new MessageActionPlanBatchTransformRequest {
+                PlanIndexes = transform.PlanIndexes.ToList(),
+                PlanNames = transform.PlanNames.ToList(),
+                ProfileId = transform.ProfileId,
+                MailboxId = transform.MailboxId,
+                FolderId = transform.FolderId,
+                DestinationFolderId = transform.DestinationFolderId
+            };
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{targetBatchId}' saved."));
+        }
+
+        public Task<MailMessageActionPlanBatchTransformPreview> PreviewTransformCloneAsync(
+            string sourceBatchId,
+            MessageActionPlanBatchTransformRequest transform,
+            CancellationToken cancellationToken = default) {
+            LastPreviewedTransformSourceBatchId = sourceBatchId;
+            LastPreviewedTransformRequest = new MessageActionPlanBatchTransformRequest {
+                PlanIndexes = transform.PlanIndexes.ToList(),
+                PlanNames = transform.PlanNames.ToList(),
+                ProfileId = transform.ProfileId,
+                MailboxId = transform.MailboxId,
+                FolderId = transform.FolderId,
+                DestinationFolderId = transform.DestinationFolderId
+            };
+            return Task.FromResult(new MailMessageActionPlanBatchTransformPreview {
+                Succeeded = true,
+                SourceBatchId = sourceBatchId,
+                SourceBatchName = "Cleanup batch",
+                PlanCount = 1,
+                ChangedPlanCount = 1,
+                ConfirmationTokenChangedCount = 1,
+                TargetProfileExists = true,
+                Plans = {
+                    new MessageActionPlanBatchTransformPreviewItem {
+                        Index = 0,
+                        Action = "move",
+                        ExecutionKind = "Move",
+                        SourceProfileId = "gmail-work",
+                        TargetProfileId = transform.ProfileId ?? "gmail-work",
+                        SourceMailboxId = "primary",
+                        TargetMailboxId = transform.MailboxId,
+                        SourceFolderId = "Inbox",
+                        TargetFolderId = transform.FolderId,
+                        SourceDestinationFolderId = "Archive",
+                        TargetDestinationFolderId = transform.DestinationFolderId,
+                        WillChange = true,
+                        ConfirmationTokenWillChange = true,
+                        Summary = "move: preview"
+                    }
+                },
+                Message = "Previewed transform."
+            });
+        }
+
+        public Task<OperationResult> DeleteAsync(string batchId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' deleted."));
+
+        public Task<MessageActionBatchExecutionResult> ExecuteAsync(string batchId, bool continueOnError = true, CancellationToken cancellationToken = default) {
+            LastExecutedBatchId = batchId;
+            return Task.FromResult(new MessageActionBatchExecutionResult {
+                Succeeded = true,
+                RequestedPlanCount = 1,
+                AttemptedPlanCount = 1,
+                SucceededPlanCount = 1,
+                Message = "Stored batch executed."
+            });
+        }
+
+        public Task<OperationResult> ExportAsync(string batchId, string path, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' exported."));
+
+        public Task<MailMessageActionPlanBatch?> GetBatchAsync(string batchId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MailMessageActionPlanBatch?>(new MailMessageActionPlanBatch {
+                Id = batchId,
+                Name = "Cleanup batch",
+                Plans = {
+                    new MessageActionExecutionPlan {
+                        Succeeded = true,
+                        Action = "delete",
+                        ExecutionKind = "Delete",
+                        ProfileId = "gmail-work",
+                        RequestedCount = 1,
+                        UniqueMessageCount = 1,
+                        MessageIds = { "message-1" }
+                    }
+                }
+            });
+
+        public Task<MailMessageActionPlanBatchCompact?> GetBatchCompactAsync(string batchId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MailMessageActionPlanBatchCompact?>(new MailMessageActionPlanBatchCompact {
+                Id = batchId,
+                Name = "Cleanup batch",
+                PlanCount = 1,
+                ReadyPlanCount = 1,
+                ProfileCount = 1,
+                PlanNames = { "Delete spam" },
+                Summary = $"{batchId} (1 plan(s), 1 ready)"
+            });
+
+        public Task<MailMessageActionPlanBatchSummary?> GetBatchSummaryAsync(string batchId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MailMessageActionPlanBatchSummary?>(new MailMessageActionPlanBatchSummary {
+                Id = batchId,
+                Name = "Cleanup batch",
+                PlanCount = 1,
+                ReadyPlanCount = 1,
+                ProfileIds = { "gmail-work" },
+                ActionCounts = {
+                    ["delete"] = 1
+                },
+                PlanNames = { "Delete spam" },
+                Summary = $"{batchId} (1 plan(s), 1 ready, 1 action type(s))"
+            });
+
+        public Task<IReadOnlyList<MailMessageActionPlanBatch>> GetBatchesAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default) {
+            LastBatchQuery = query == null
+                ? null
+                : new MailMessageActionPlanBatchQuery {
+                    PlanNames = query.PlanNames.ToList(),
+                    ProfileIds = query.ProfileIds.ToList(),
+                    Actions = query.Actions.ToList(),
+                    SortBy = query.SortBy,
+                    Descending = query.Descending
+                };
+            return Task.FromResult<IReadOnlyList<MailMessageActionPlanBatch>>(new[] {
+                new MailMessageActionPlanBatch {
+                    Id = "cleanup",
+                    Name = "Cleanup batch",
+                    Plans = {
+                        new MessageActionExecutionPlan {
+                            Succeeded = true,
+                            Action = "delete",
+                            ExecutionKind = "Delete",
+                            ProfileId = "gmail-work",
+                            RequestedCount = 1,
+                            UniqueMessageCount = 1,
+                            MessageIds = { "message-1" }
+                        }
+                    }
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<MailMessageActionPlanBatchCompact>> GetBatchesCompactAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default) {
+            LastBatchQuery = query == null
+                ? null
+                : new MailMessageActionPlanBatchQuery {
+                    PlanNames = query.PlanNames.ToList(),
+                    ProfileIds = query.ProfileIds.ToList(),
+                    Actions = query.Actions.ToList(),
+                    SortBy = query.SortBy,
+                    Descending = query.Descending
+                };
+            ListCompactCalls++;
+            return Task.FromResult<IReadOnlyList<MailMessageActionPlanBatchCompact>>(new[] {
+                new MailMessageActionPlanBatchCompact {
+                    Id = "cleanup",
+                    Name = "Cleanup batch",
+                    PlanCount = 1,
+                    ReadyPlanCount = 1,
+                    ProfileCount = 1,
+                    PlanNames = { "Delete spam" },
+                    Summary = "cleanup (1 plan(s), 1 ready)"
+                }
+            });
+        }
+
+        public Task<IReadOnlyList<MailMessageActionPlanBatchSummary>> GetBatchesSummaryAsync(MailMessageActionPlanBatchQuery? query = null, CancellationToken cancellationToken = default) {
+            LastBatchQuery = query == null
+                ? null
+                : new MailMessageActionPlanBatchQuery {
+                    PlanNames = query.PlanNames.ToList(),
+                    ProfileIds = query.ProfileIds.ToList(),
+                    Actions = query.Actions.ToList(),
+                    SortBy = query.SortBy,
+                    Descending = query.Descending
+                };
+            ListSummaryCalls++;
+            return Task.FromResult<IReadOnlyList<MailMessageActionPlanBatchSummary>>(new[] {
+                new MailMessageActionPlanBatchSummary {
+                    Id = "cleanup",
+                    Name = "Cleanup batch",
+                    PlanCount = 1,
+                    ReadyPlanCount = 1,
+                    ProfileIds = { "gmail-work" },
+                    ActionCounts = {
+                        ["delete"] = 1
+                    },
+                    PlanNames = { "Delete spam" },
+                    Summary = "cleanup (1 plan(s), 1 ready, 1 action type(s))"
+                }
+            });
+        }
+
+        public Task<OperationResult> ImportAsync(string batchId, string name, string path, string? description = null, CancellationToken cancellationToken = default) {
+            LastImportedBatchId = batchId;
+            LastImportedPath = path;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> ReplaceImportedPlanAtAsync(string batchId, int index, string path, CancellationToken cancellationToken = default) {
+            LastReplacedBatchId = batchId;
+            LastReplacedIndex = index;
+            LastImportedPath = path;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> ReplacePlanAtAsync(string batchId, int index, MessageActionExecutionPlan plan, CancellationToken cancellationToken = default) {
+            LastReplacedBatchId = batchId;
+            LastReplacedIndex = index;
+            LastReplacedPlan = plan;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> RemovePlanAtAsync(string batchId, int index, CancellationToken cancellationToken = default) {
+            LastRemovedBatchId = batchId;
+            LastRemovedIndex = index;
+            return Task.FromResult(OperationResult.Success($"Action plan batch '{batchId}' saved."));
+        }
+
+        public Task<OperationResult> SaveAsync(MailMessageActionPlanBatch batch, CancellationToken cancellationToken = default) =>
+            Task.FromResult(OperationResult.Success($"Action plan batch '{batch.Id}' saved."));
     }
 
     private sealed class InMemoryProfileStore : IMailProfileStore {
@@ -910,7 +2065,15 @@ public sealed class MailMcpToolsTests {
     }
 
     private sealed class FakeReadService : IMailReadService {
+        public MailFolderQuery? LastFolderQuery { get; private set; }
+
         public GetMessageRequest? LastGetCompactRequest { get; private set; }
+
+        public GetMessagesRequest? LastGetManyCompactRequest { get; private set; }
+
+        public GetMessagesRequest? LastGetManyRequest { get; private set; }
+
+        public SaveAttachmentsManyRequest? LastSaveAttachmentsManyRequest { get; private set; }
 
         public SaveAttachmentsRequest? LastSaveAttachmentsRequest { get; private set; }
 
@@ -936,14 +2099,35 @@ public sealed class MailMcpToolsTests {
             });
         }
 
-        public Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailFolderQuery query, CancellationToken cancellationToken = default) =>
-            Task.FromResult<IReadOnlyList<FolderRef>>(new[] {
+        public Task<IReadOnlyList<FolderRef>> GetFoldersAsync(MailFolderQuery query, CancellationToken cancellationToken = default) {
+            LastFolderQuery = query;
+            return Task.FromResult<IReadOnlyList<FolderRef>>(new[] {
                 new FolderRef {
+                    ProfileId = query.ProfileId,
+                    MailboxId = query.MailboxId,
                     Id = "Inbox",
                     DisplayName = "Inbox",
-                    Path = "Inbox"
+                    Path = "Inbox",
+                    SpecialUse = "inbox"
+                },
+                new FolderRef {
+                    ProfileId = query.ProfileId,
+                    MailboxId = query.MailboxId,
+                    Id = "archive",
+                    DisplayName = "Archive",
+                    Path = "Archive",
+                    SpecialUse = "archive"
+                },
+                new FolderRef {
+                    ProfileId = query.ProfileId,
+                    MailboxId = query.MailboxId,
+                    Id = "trash",
+                    DisplayName = "Trash",
+                    Path = "Trash",
+                    SpecialUse = "trash"
                 }
             });
+        }
 
         public Task<IReadOnlyList<MessageSummary>> SearchAsync(MailSearchRequest request, CancellationToken cancellationToken = default) {
             LastSearchRequest = request;
@@ -1002,6 +2186,32 @@ public sealed class MailMcpToolsTests {
             });
         }
 
+        public Task<SaveAttachmentsManyResult> SaveAttachmentsManyAsync(SaveAttachmentsManyRequest request, CancellationToken cancellationToken = default) {
+            LastSaveAttachmentsManyRequest = request;
+            return Task.FromResult(new SaveAttachmentsManyResult {
+                Succeeded = true,
+                ProfileId = request.ProfileId,
+                RequestedMessageCount = request.MessageIds.Count,
+                AttemptedMessageCount = request.MessageIds.Count,
+                SucceededMessageCount = request.MessageIds.Count,
+                MatchedCount = request.MessageIds.Count,
+                AttemptedCount = request.MessageIds.Count,
+                SavedCount = request.MessageIds.Count,
+                FailedCount = 0,
+                Message = $"Saved {request.MessageIds.Count} attachment(s) across {request.MessageIds.Count} message(s).",
+                MessageResults = request.MessageIds.Select(messageId => new SaveAttachmentsResult {
+                    Succeeded = true,
+                    ProfileId = request.ProfileId,
+                    MessageId = messageId,
+                    MatchedCount = 1,
+                    AttemptedCount = 1,
+                    SavedCount = 1,
+                    FailedCount = 0,
+                    Message = "Saved 1 attachment(s)."
+                }).ToList()
+            });
+        }
+
         public Task<MessageDetailCompact?> GetMessageCompactAsync(GetMessageRequest request, CancellationToken cancellationToken = default) {
             LastGetCompactRequest = request;
             return Task.FromResult<MessageDetailCompact?>(new MessageDetailCompact {
@@ -1020,6 +2230,24 @@ public sealed class MailMcpToolsTests {
             });
         }
 
+        public Task<IReadOnlyList<MessageDetailCompact>> GetMessagesCompactAsync(GetMessagesRequest request, CancellationToken cancellationToken = default) {
+            LastGetManyCompactRequest = request;
+            return Task.FromResult<IReadOnlyList<MessageDetailCompact>>(request.MessageIds.Select(messageId => new MessageDetailCompact {
+                ProfileId = request.ProfileId,
+                Id = messageId,
+                Summary = new MessageSummaryCompact {
+                    ProfileId = request.ProfileId,
+                    Id = messageId,
+                    Subject = "Retrieved message",
+                    Summary = $"{messageId} Retrieved message"
+                },
+                TextBodyPreview = "Preview",
+                HtmlBodyPreview = "<p>Preview</p>",
+                HasRawContent = request.IncludeRawContent,
+                SummaryText = $"{messageId} Retrieved message"
+            }).ToArray());
+        }
+
         public Task<MessageDetail?> GetMessageAsync(GetMessageRequest request, CancellationToken cancellationToken = default) =>
             Task.FromResult<MessageDetail?>(new MessageDetail {
                 ProfileId = request.ProfileId,
@@ -1030,6 +2258,19 @@ public sealed class MailMcpToolsTests {
                     Subject = "Retrieved message"
                 }
             });
+
+        public Task<IReadOnlyList<MessageDetail>> GetMessagesAsync(GetMessagesRequest request, CancellationToken cancellationToken = default) {
+            LastGetManyRequest = request;
+            return Task.FromResult<IReadOnlyList<MessageDetail>>(request.MessageIds.Select(messageId => new MessageDetail {
+                ProfileId = request.ProfileId,
+                Id = messageId,
+                Summary = new MessageSummary {
+                    ProfileId = request.ProfileId,
+                    Id = messageId,
+                    Subject = "Retrieved message"
+                }
+            }).ToArray());
+        }
 
         public Task<OperationResult> SaveAttachmentAsync(SaveAttachmentRequest request, CancellationToken cancellationToken = default) =>
             Task.FromResult(OperationResult.Success("Attachment saved."));
@@ -1050,6 +2291,49 @@ public sealed class MailMcpToolsTests {
                 Message = "Send handled."
             });
         }
+    }
+
+    private sealed class FakeMessageActionService : IMailMessageActionService {
+        public SetReadStateRequest? LastSetReadStateRequest { get; private set; }
+
+        public SetFlaggedStateRequest? LastSetFlaggedStateRequest { get; private set; }
+
+        public MoveMessagesRequest? LastMoveRequest { get; private set; }
+
+        public DeleteMessagesRequest? LastDeleteRequest { get; private set; }
+
+        public Task<MessageActionResult> SetReadStateAsync(SetReadStateRequest request, CancellationToken cancellationToken = default) {
+            LastSetReadStateRequest = request;
+            return Task.FromResult(CreateResult(request.ProfileId, request.MessageIds, request.IsRead ? "Marked messages as read." : "Marked messages as unread."));
+        }
+
+        public Task<MessageActionResult> SetFlaggedStateAsync(SetFlaggedStateRequest request, CancellationToken cancellationToken = default) {
+            LastSetFlaggedStateRequest = request;
+            return Task.FromResult(CreateResult(request.ProfileId, request.MessageIds, request.IsFlagged ? "Flagged messages." : "Unflagged messages."));
+        }
+
+        public Task<MessageActionResult> MoveAsync(MoveMessagesRequest request, CancellationToken cancellationToken = default) {
+            LastMoveRequest = request;
+            return Task.FromResult(CreateResult(request.ProfileId, request.MessageIds, $"Moved messages to '{request.DestinationFolderId}'."));
+        }
+
+        public Task<MessageActionResult> DeleteAsync(DeleteMessagesRequest request, CancellationToken cancellationToken = default) {
+            LastDeleteRequest = request;
+            return Task.FromResult(CreateResult(request.ProfileId, request.MessageIds, "Deleted messages."));
+        }
+
+        private static MessageActionResult CreateResult(string profileId, IReadOnlyList<string> messageIds, string message) => new() {
+            Succeeded = true,
+            ProfileId = profileId,
+            RequestedCount = messageIds.Count,
+            SucceededCount = messageIds.Count,
+            FailedCount = 0,
+            Message = message,
+            Results = messageIds.Select(id => new MessageActionItemResult {
+                MessageId = id,
+                Succeeded = true
+            }).ToList()
+        };
     }
 
     private sealed class FakeQueueService : IMailQueueService {

--- a/Sources/Mailozaurr.Tests/MailMcpToolsTests.cs
+++ b/Sources/Mailozaurr.Tests/MailMcpToolsTests.cs
@@ -692,6 +692,19 @@ public sealed class MailMcpToolsTests {
     }
 
     [Fact]
+    public async Task MailActionBatchStoreSummaryListPassesExplicitIdSortToSharedRegistryService() {
+        using var fixture = new TestFixture();
+
+        var result = await fixture.Tools.mail_action_batch_store_summary_list(sortBy: "id");
+
+        var batch = Assert.Single(result);
+        Assert.Equal("cleanup", batch.Id);
+        Assert.NotNull(fixture.PlanRegistryService.LastBatchQuery);
+        Assert.Equal(MailMessageActionPlanBatchSortBy.Id, fixture.PlanRegistryService.LastBatchQuery!.SortBy);
+        Assert.False(fixture.PlanRegistryService.LastBatchQuery.Descending);
+    }
+
+    [Fact]
     public async Task MailActionBatchStoreListPassesPlanNameFilterToSharedRegistryService() {
         using var fixture = new TestFixture();
 


### PR DESCRIPTION
## Summary
- add reusable message-action batching, preview, planning, storage, and registry services in Mailozaurr.Application
- extend the CLI and MCP surfaces with shared batch, preview, transform, summary, filtering, and sorting workflows
- update README and platform architecture docs to describe CLI, MCP, skills, and HTML-body integration direction

## Verification
- dotnet build Sources/Mailozaurr.sln -c Debug
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Debug --filter "ApplicationMessageActionPlanRegistryServiceTests|CliRunnerTests|MailMcpToolsTests|ApplicationBuilderTests"
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Debug --filter "ApplicationMessageActionPlanBatchStoreTests|ApplicationMessageActionPlanRegistryServiceTests|CliRunnerTests|MailMcpToolsTests|ApplicationBuilderTests"
