### PR TITLE
Preserve message id casing in confirmation tokens

### DIFF
--- a/Sources/Mailozaurr.Application/MailMessageActionPreviewService.cs
+++ b/Sources/Mailozaurr.Application/MailMessageActionPreviewService.cs
@@ -354,7 +354,7 @@ public sealed class MailMessageActionPreviewService : IMailMessageActionPreviewS
         messageIds
             .Where(id => !string.IsNullOrWhiteSpace(id))
             .Select(id => id.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct(StringComparer.Ordinal)
             .ToList();
 
     private static MoveMessagesPreview CreateMovePreview(

--- a/Sources/Mailozaurr.Application/MessageActionConfirmationTokens.cs
+++ b/Sources/Mailozaurr.Application/MessageActionConfirmationTokens.cs
@@ -62,8 +62,8 @@ public static class MessageActionConfirmationTokens {
         var normalizedMessageIds = messageIds
             .Where(id => !string.IsNullOrWhiteSpace(id))
             .Select(id => id.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(id => id, StringComparer.Ordinal)
             .ToArray();
 
         var payload = string.Join("|", new[] {

--- a/Sources/Mailozaurr.Tests/ApplicationMessageActionConfirmationTokensTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationMessageActionConfirmationTokensTests.cs
@@ -1,0 +1,40 @@
+using Mailozaurr.Application;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ApplicationMessageActionConfirmationTokensTests {
+    [Fact]
+    public void CreateDeleteTokenPreservesMessageIdCasing() {
+        var lowerToken = MessageActionConfirmationTokens.CreateDeleteToken(
+            "work-imap",
+            "shared@example.com",
+            "Inbox",
+            new[] { "abc123" });
+
+        var upperToken = MessageActionConfirmationTokens.CreateDeleteToken(
+            "work-imap",
+            "shared@example.com",
+            "Inbox",
+            new[] { "ABC123" });
+
+        Assert.NotEqual(lowerToken, upperToken);
+    }
+
+    [Fact]
+    public void CreateDeleteTokenIgnoresMessageIdOrdering() {
+        var firstToken = MessageActionConfirmationTokens.CreateDeleteToken(
+            "work-imap",
+            "shared@example.com",
+            "Inbox",
+            new[] { "msg-b", "msg-a" });
+
+        var secondToken = MessageActionConfirmationTokens.CreateDeleteToken(
+            "work-imap",
+            "shared@example.com",
+            "Inbox",
+            new[] { "msg-a", "msg-b" });
+
+        Assert.Equal(firstToken, secondToken);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationMessageActionPreviewServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationMessageActionPreviewServiceTests.cs
@@ -27,9 +27,9 @@ public sealed class ApplicationMessageActionPreviewServiceTests {
         Assert.True(preview.Succeeded);
         Assert.Equal("read-state", preview.Action);
         Assert.False(preview.DesiredState);
-        Assert.Equal(2, preview.UniqueMessageCount);
+        Assert.Equal(3, preview.UniqueMessageCount);
         Assert.Equal(
-            MessageActionConfirmationTokens.CreateReadStateToken("work-imap", "shared@example.com", "Inbox", new[] { "msg-1", "msg-2" }, isRead: false),
+            MessageActionConfirmationTokens.CreateReadStateToken("work-imap", "shared@example.com", "Inbox", new[] { "msg-1", "MSG-1", "msg-2" }, isRead: false),
             preview.ConfirmationToken);
     }
 
@@ -57,9 +57,9 @@ public sealed class ApplicationMessageActionPreviewServiceTests {
         Assert.True(preview.Succeeded);
         Assert.Equal("flagged-state", preview.Action);
         Assert.False(preview.DesiredState);
-        Assert.Equal(2, preview.UniqueMessageCount);
+        Assert.Equal(3, preview.UniqueMessageCount);
         Assert.Equal(
-            MessageActionConfirmationTokens.CreateFlaggedStateToken("work-imap", "shared@example.com", "Inbox", new[] { "msg-1", "msg-2" }, isFlagged: false),
+            MessageActionConfirmationTokens.CreateFlaggedStateToken("work-imap", "shared@example.com", "Inbox", new[] { "msg-1", "MSG-1", "msg-2" }, isFlagged: false),
             preview.ConfirmationToken);
     }
 
@@ -85,15 +85,15 @@ public sealed class ApplicationMessageActionPreviewServiceTests {
 
         Assert.True(preview.Succeeded);
         Assert.Equal(4, preview.RequestedCount);
-        Assert.Equal(2, preview.UniqueMessageCount);
-        Assert.Equal(2, preview.DuplicateOrEmptyCount);
-        Assert.Equal(new[] { "msg-1", "msg-2" }, preview.MessageIds);
+        Assert.Equal(3, preview.UniqueMessageCount);
+        Assert.Equal(1, preview.DuplicateOrEmptyCount);
+        Assert.Equal(new[] { "msg-1", "MSG-1", "msg-2" }, preview.MessageIds);
         Assert.NotNull(preview.Destination);
         Assert.Equal("archive-folder", preview.Destination!.EffectiveFolderId);
         Assert.Equal(
-            MessageActionConfirmationTokens.CreateMoveToken("work-imap", "shared@example.com", null, new[] { "msg-1", "msg-2" }, "archive-folder"),
+            MessageActionConfirmationTokens.CreateMoveToken("work-imap", "shared@example.com", null, new[] { "msg-1", "MSG-1", "msg-2" }, "archive-folder"),
             preview.ConfirmationToken);
-        Assert.Contains(preview.Warnings, warning => warning.Contains("Ignored 2 duplicate or empty", StringComparison.Ordinal));
+        Assert.Contains(preview.Warnings, warning => warning.Contains("Ignored 1 duplicate or empty", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -139,13 +139,13 @@ public sealed class ApplicationMessageActionPreviewServiceTests {
 
         Assert.True(preview.Succeeded);
         Assert.Equal(4, preview.RequestedCount);
-        Assert.Equal(2, preview.UniqueMessageCount);
-        Assert.Equal(2, preview.DuplicateOrEmptyCount);
-        Assert.Equal(new[] { "msg-1", "msg-2" }, preview.MessageIds);
+        Assert.Equal(3, preview.UniqueMessageCount);
+        Assert.Equal(1, preview.DuplicateOrEmptyCount);
+        Assert.Equal(new[] { "msg-1", "MSG-1", "msg-2" }, preview.MessageIds);
         Assert.Equal(
-            MessageActionConfirmationTokens.CreateDeleteToken("work-imap", null, null, new[] { "msg-1", "msg-2" }),
+            MessageActionConfirmationTokens.CreateDeleteToken("work-imap", null, null, new[] { "msg-1", "MSG-1", "msg-2" }),
             preview.ConfirmationToken);
-        Assert.Contains(preview.Warnings, warning => warning.Contains("Ignored 2 duplicate or empty", StringComparison.Ordinal));
+        Assert.Contains(preview.Warnings, warning => warning.Contains("Ignored 1 duplicate or empty", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -192,12 +192,12 @@ public sealed class ApplicationMessageActionPreviewServiceTests {
 
         Assert.True(preview.Succeeded);
         Assert.Equal(4, preview.RequestedCount);
-        Assert.Equal(2, preview.UniqueMessageCount);
-        Assert.Equal(2, preview.DuplicateOrEmptyCount);
+        Assert.Equal(3, preview.UniqueMessageCount);
+        Assert.Equal(1, preview.DuplicateOrEmptyCount);
         Assert.Equal(4, preview.IncludedActionCount);
         Assert.Equal(4, preview.SucceededActionCount);
         Assert.Equal(0, preview.FailedActionCount);
-        Assert.Contains(preview.Warnings, warning => warning.Contains("Ignored 2 duplicate or empty", StringComparison.Ordinal));
+        Assert.Contains(preview.Warnings, warning => warning.Contains("Ignored 1 duplicate or empty", StringComparison.Ordinal));
 
         var archive = Assert.Single(preview.Actions, action => action.Action == "archive");
         Assert.Equal("archive-folder", archive.Destination!.EffectiveFolderId);
@@ -270,7 +270,7 @@ public sealed class ApplicationMessageActionPreviewServiceTests {
         Assert.Equal(8, preview.IncludedActionCount);
         Assert.Equal(8, preview.SucceededActionCount);
         Assert.Equal(0, preview.FailedActionCount);
-        Assert.Equal(2, preview.UniqueMessageCount);
+        Assert.Equal(3, preview.UniqueMessageCount);
         Assert.Contains(preview.Actions, action => action.Action == "mark-read" && action.DesiredState == true);
         Assert.Contains(preview.Actions, action => action.Action == "mark-unread" && action.DesiredState == false);
         Assert.Contains(preview.Actions, action => action.Action == "flag" && action.DesiredState == true);

--- a/Sources/Mailozaurr.Tests/ApplicationRoutingServicesTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationRoutingServicesTests.cs
@@ -447,6 +447,42 @@ public sealed class ApplicationRoutingServicesTests {
     }
 
     [Fact]
+    public async Task RoutedMessageActionServiceAcceptsPreviewGeneratedDeleteConfirmationTokenWithCaseDistinctIds() {
+        var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        await store.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> { [MailProfileSettingsKeys.Server] = "imap.example.com" }
+        });
+
+        var previewService = new MailMessageActionPreviewService(store, new FakeFolderAliasService());
+        var preview = await previewService.PreviewDeleteAsync(new DeleteMessagesPreviewRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "msg-1", "MSG-1", "msg-2" }
+        });
+
+        Assert.True(preview.Succeeded);
+        Assert.NotNull(preview.ConfirmationToken);
+
+        var handler = new FakeMessageActionHandler(MailProfileKind.Imap);
+        var service = new RoutedMailMessageActionService(store, new[] { handler }, new FakeFolderAliasService());
+        var result = await service.DeleteAsync(new DeleteMessagesRequest {
+            ProfileId = "work-imap",
+            MailboxId = "shared@example.com",
+            FolderId = "Inbox",
+            MessageIds = { "msg-1", "MSG-1", "msg-2" },
+            ConfirmationToken = preview.ConfirmationToken
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(handler.LastDeleteRequest);
+        Assert.Equal(preview.ConfirmationToken, handler.LastDeleteRequest!.ConfirmationToken);
+    }
+
+    [Fact]
     public async Task RoutedMessageActionServiceRejectsMismatchedDeleteConfirmationToken() {
         var store = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
         await store.SaveAsync(new MailProfile {
@@ -597,6 +633,8 @@ public sealed class ApplicationRoutingServicesTests {
 
         public MoveMessagesRequest? LastMoveRequest { get; private set; }
 
+        public DeleteMessagesRequest? LastDeleteRequest { get; private set; }
+
         public Task<MessageActionResult> SetReadStateAsync(MailProfile profile, SetReadStateRequest request, CancellationToken cancellationToken = default) {
             SetReadStateCalls++;
             return Task.FromResult(new MessageActionResult {
@@ -627,13 +665,15 @@ public sealed class ApplicationRoutingServicesTests {
             });
         }
 
-        public Task<MessageActionResult> DeleteAsync(MailProfile profile, DeleteMessagesRequest request, CancellationToken cancellationToken = default) =>
-            Task.FromResult(new MessageActionResult {
+        public Task<MessageActionResult> DeleteAsync(MailProfile profile, DeleteMessagesRequest request, CancellationToken cancellationToken = default) {
+            LastDeleteRequest = request;
+            return Task.FromResult(new MessageActionResult {
                 Succeeded = true,
                 ProfileId = profile.Id,
                 RequestedCount = request.MessageIds.Count,
                 SucceededCount = request.MessageIds.Count
             });
+        }
     }
 
     private sealed class FakeFolderAliasService : IMailFolderAliasService {


### PR DESCRIPTION
## Summary
- preserve exact message-id casing when generating confirmation tokens
- keep message ordering normalized without collapsing case-distinct ids
- add regression coverage for casing-sensitive token generation

## Verification
- `dotnet build Sources/Mailozaurr.sln -c Debug`
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Debug --filter "ApplicationMessageActionConfirmationTokensTests|ApplicationRoutingServicesTests|ApplicationMessageActionPreviewServiceTests"`