### PR TITLE
Add configuration and usage guide for CLI and MCP

### DIFF
--- a/Docs/Configuration-and-Usage.md
+++ b/Docs/Configuration-and-Usage.md
@@ -26,10 +26,10 @@ A profile contains:
 
 The shared model is implemented in:
 
-- [MailProfile.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailProfile.cs)
-- [MailProfileKind.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailProfileKind.cs)
-- [MailProfileSettingsKeys.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailProfileSettingsKeys.cs)
-- [MailSecretNames.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailSecretNames.cs)
+- [MailProfile.cs](../Sources/Mailozaurr.Application/MailProfile.cs)
+- [MailProfileKind.cs](../Sources/Mailozaurr.Application/MailProfileKind.cs)
+- [MailProfileSettingsKeys.cs](../Sources/Mailozaurr.Application/MailProfileSettingsKeys.cs)
+- [MailSecretNames.cs](../Sources/Mailozaurr.Application/MailSecretNames.cs)
 
 ## Supported profile kinds
 
@@ -48,7 +48,7 @@ Current shared profile kinds are:
 
 Mailozaurr does not pretend every provider supports the same operations.
 
-Default capabilities are defined in [MailCapabilityCatalog.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailCapabilityCatalog.cs).
+Default capabilities are defined in [MailCapabilityCatalog.cs](../Sources/Mailozaurr.Application/MailCapabilityCatalog.cs).
 
 In practice:
 
@@ -93,7 +93,7 @@ Common secret names include:
 
 ## Minimum provider guidance
 
-The shared validator lives in [MailProfileValidator.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailProfileValidator.cs).
+The shared validator lives in [MailProfileValidator.cs](../Sources/Mailozaurr.Application/MailProfileValidator.cs).
 
 The practical minimum shape by provider is:
 
@@ -147,7 +147,7 @@ These are send-only profiles. The exact provider-specific settings are still bes
 
 By default, the application layer stores reusable state under a `Mailozaurr` directory inside local application data.
 
-The path resolver is implemented in [MailApplicationPaths.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailApplicationPaths.cs).
+The path resolver is implemented in [MailApplicationPaths.cs](../Sources/Mailozaurr.Application/MailApplicationPaths.cs).
 
 Default subdirectories are:
 
@@ -172,7 +172,7 @@ The CLI also supports per-run overrides:
 
 ## CLI usage overview
 
-The executable is built from [Mailozaurr.Cli](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Cli).
+The executable is built from [Mailozaurr.Cli](../Sources/Mailozaurr.Cli).
 
 To inspect current commands:
 
@@ -285,7 +285,7 @@ The MCP server is hosted by the same executable:
 mailozaurr mcp serve
 ```
 
-The MCP tool surface is implemented in [MailMcpTools.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Cli\Mcp\MailMcpTools.cs).
+The MCP tool surface is implemented in [MailMcpTools.cs](../Sources/Mailozaurr.Cli/Mcp/MailMcpTools.cs).
 
 Current tool areas include:
 
@@ -311,10 +311,10 @@ PowerShell remains a first-class surface, but it does not use the same profile-o
 
 Today the best PowerShell references are:
 
-- [README.MD](C:\Support\GitHub\Mailozaurr\README.MD) for module usage and examples
-- [OAuthFlows.md](C:\Support\GitHub\Mailozaurr\Docs\OAuthFlows.md) for OAuth flows
-- [PGP.md](C:\Support\GitHub\Mailozaurr\Docs\PGP.md) for PGP support
-- the scripts under [Examples](C:\Support\GitHub\Mailozaurr\Examples)
+- [README.MD](../README.MD) for module usage and examples
+- [OAuthFlows.md](./OAuthFlows.md) for OAuth flows
+- [PGP.md](./PGP.md) for PGP support
+- the scripts under [Examples](../Examples)
 
 ## Recipes and provider-specific guidance
 
@@ -327,4 +327,4 @@ When adding a new provider recipe:
 - include a live verification command such as `profile test`
 - keep reusable logic in shared layers and keep wrapper-specific steps in wrapper docs
 
-If a feature is reusable across CLI, MCP, GUI, or PowerShell, it should follow the placement rules in [Platform-Architecture.md](C:\Support\GitHub\Mailozaurr\Docs\Platform-Architecture.md).
+If a feature is reusable across CLI, MCP, GUI, or PowerShell, it should follow the placement rules in [Platform-Architecture.md](./Platform-Architecture.md).

--- a/Docs/Configuration-and-Usage.md
+++ b/Docs/Configuration-and-Usage.md
@@ -1,0 +1,330 @@
+# Mailozaurr Configuration and Usage
+
+This document collects the practical configuration model for Mailozaurr across its reusable application layer, the `mailozaurr` executable, and MCP usage.
+
+It is meant to answer:
+
+- how Mailozaurr models accounts and providers
+- what settings and secrets belong to a profile
+- which providers support which kinds of operations
+- how to configure CLI storage and run common flows
+- where PowerShell still fits today
+
+## Core idea: profiles
+
+Mailozaurr uses reusable `MailProfile` definitions for mailbox and send configuration.
+
+A profile contains:
+
+- `Id`: stable identifier such as `work-imap` or `alerts-smtp`
+- `DisplayName`: human-friendly name
+- `Kind`: provider/technology such as `imap`, `graph`, `gmail`, or `smtp`
+- `DefaultSender`: default sender for send-capable profiles
+- `DefaultMailbox`: default mailbox or principal for read-capable profiles
+- `Settings`: non-secret provider settings
+- secrets stored separately from the profile document
+
+The shared model is implemented in:
+
+- [MailProfile.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailProfile.cs)
+- [MailProfileKind.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailProfileKind.cs)
+- [MailProfileSettingsKeys.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailProfileSettingsKeys.cs)
+- [MailSecretNames.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailSecretNames.cs)
+
+## Supported profile kinds
+
+Current shared profile kinds are:
+
+- `imap`
+- `pop3`
+- `graph`
+- `gmail`
+- `smtp`
+- `sendgrid`
+- `mailgun`
+- `ses`
+
+## Capability model
+
+Mailozaurr does not pretend every provider supports the same operations.
+
+Default capabilities are defined in [MailCapabilityCatalog.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailCapabilityCatalog.cs).
+
+In practice:
+
+| Kind | Read/Search | Folders | Move/Mark/Delete | Send | Notes |
+|---|---|---|---|---|---|
+| `imap` | Yes | Yes | Yes | No | strong mailbox model |
+| `pop3` | Yes | No real folder model | Delete only style workflows | No | limited mailbox model |
+| `graph` | Yes | Yes | Yes | Yes | also supports rules/events/permissions |
+| `gmail` | Yes | Yes | Yes | Yes | Gmail-specific threads/labels |
+| `smtp` | No | No | No | Yes | send only |
+| `sendgrid` | No | No | No | Yes | send only |
+| `mailgun` | No | No | No | Yes | send only |
+| `ses` | No | No | No | Yes | send only |
+
+## Common settings and secrets
+
+Common non-secret setting keys include:
+
+- `server`
+- `port`
+- `userName`
+- `folder`
+- `mailbox`
+- `clientId`
+- `tenantId`
+- `certificatePath`
+- `redirectUri`
+- `authFlow`
+- `loginHint`
+- `tokenExpiresOn`
+- `authMode`
+- `secureSocketOptions`
+- `useSsl`
+
+Common secret names include:
+
+- `password`
+- `clientSecret`
+- `accessToken`
+- `refreshToken`
+- `certificatePassword`
+
+## Minimum provider guidance
+
+The shared validator lives in [MailProfileValidator.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailProfileValidator.cs).
+
+The practical minimum shape by provider is:
+
+### IMAP / POP3 / SMTP
+
+Usually define:
+
+- `kind`
+- `server`
+- optional `port`
+- optional `userName`
+- `password` secret when using username/password auth
+
+Recommended:
+
+- `defaultMailbox` for read profiles
+- `defaultSender` for send profiles
+
+### Graph
+
+Usually define:
+
+- `kind=graph`
+- mailbox through `defaultMailbox` or `mailbox`
+
+Then choose one auth story:
+
+- interactive login and saved tokens
+- access token
+- `clientId` + `tenantId` + `clientSecret`
+- `clientId` + `tenantId` + `certificatePath`
+
+### Gmail
+
+Usually define:
+
+- `kind=gmail`
+- mailbox through `defaultMailbox` or `mailbox`
+
+Then choose one auth story:
+
+- interactive login and saved tokens
+- access token
+- `clientId` + `clientSecret` + `refreshToken`
+
+### SendGrid / Mailgun / SES
+
+These are send-only profiles. The exact provider-specific settings are still best treated as provider-specific recipes, but they fit the same profile model and shared send surface.
+
+## Storage locations
+
+By default, the application layer stores reusable state under a `Mailozaurr` directory inside local application data.
+
+The path resolver is implemented in [MailApplicationPaths.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Application\MailApplicationPaths.cs).
+
+Default subdirectories are:
+
+- `Profiles`
+- `Secrets`
+- `Drafts`
+- `ActionPlanBatches`
+
+Environment variable overrides:
+
+- `MAILOZAURR_PROFILE_DIRECTORY`
+- `MAILOZAURR_SECRET_DIRECTORY`
+- `MAILOZAURR_DRAFT_DIRECTORY`
+- `MAILOZAURR_ACTION_PLAN_DIRECTORY`
+
+The CLI also supports per-run overrides:
+
+- `--profiles-dir`
+- `--secrets-dir`
+- `--drafts-dir`
+- `--plan-batches-dir`
+
+## CLI usage overview
+
+The executable is built from [Mailozaurr.Cli](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Cli).
+
+To inspect current commands:
+
+```powershell
+dotnet run --project Sources/Mailozaurr.Cli -- --help
+```
+
+Main command groups:
+
+- `profile ...`
+- `draft ...`
+- `send ...`
+- `queue ...`
+- `mail ...`
+- `mcp serve`
+
+Most commands support `--json`, which is the preferred mode for automation.
+
+## Common CLI recipes
+
+### Generic IMAP profile
+
+```powershell
+mailozaurr profile create --profile work-imap --kind imap --name "Work IMAP" `
+  --default-mailbox user@example.com `
+  --setting server=imap.example.com `
+  --setting port=993 `
+  --setting userName=user@example.com `
+  --json
+
+mailozaurr profile set-secret --profile work-imap --name password --value "secret" --json
+mailozaurr profile test --profile work-imap --scope mailbox --json
+```
+
+### Generic SMTP profile
+
+```powershell
+mailozaurr profile create --profile alerts-smtp --kind smtp --name "Alerts SMTP" `
+  --default-sender alerts@example.com `
+  --setting server=smtp.example.com `
+  --setting port=587 `
+  --setting userName=alerts@example.com `
+  --setting useSsl=true `
+  --json
+
+mailozaurr profile set-secret --profile alerts-smtp --name password --value "secret" --json
+mailozaurr profile test --profile alerts-smtp --scope send --json
+```
+
+### Microsoft Graph profile
+
+```powershell
+mailozaurr profile graph-bootstrap --profile work-graph --name "Work Graph" `
+  --mailbox user@example.com `
+  --client-id <app-id> `
+  --tenant-id <tenant-id> `
+  --client-secret <secret> `
+  --json
+
+mailozaurr profile auth-status --profile work-graph --json
+mailozaurr profile test --profile work-graph --scope mailbox --json
+```
+
+### Gmail profile
+
+```powershell
+mailozaurr profile gmail-bootstrap --profile personal-gmail --name "Personal Gmail" `
+  --mailbox user@gmail.com `
+  --client-id <client-id> `
+  --client-secret <secret> `
+  --refresh-token <token> `
+  --json
+
+mailozaurr profile auth-status --profile personal-gmail --json
+mailozaurr profile test --profile personal-gmail --scope mailbox --json
+```
+
+### Search and retrieve mail
+
+```powershell
+mailozaurr mail folders --profile work-imap --compact --json
+mailozaurr mail search --profile work-imap --folder Inbox --query Invoice --compact --json
+mailozaurr mail get --profile work-imap --folder Inbox --message-id 123 --compact --json
+mailozaurr mail attachments --profile work-imap --folder Inbox --message-id 123 --json
+```
+
+### Save drafts and queue sends
+
+```powershell
+mailozaurr draft save --draft weekly-update --name "Weekly update" --profile alerts-smtp `
+  --to team@example.com --subject "Weekly update" --text "Status attached." --json
+
+mailozaurr send --draft weekly-update --json
+mailozaurr queue list --compact --json
+mailozaurr queue process --json
+```
+
+### Preview before destructive actions
+
+```powershell
+mailozaurr mail preview-delete --profile work-imap --folder Inbox --message-id 123 --json
+mailozaurr mail delete --profile work-imap --folder Inbox --message-id 123 --confirm-token <token> --json
+```
+
+## MCP usage overview
+
+The MCP server is hosted by the same executable:
+
+```powershell
+mailozaurr mcp serve
+```
+
+The MCP tool surface is implemented in [MailMcpTools.cs](C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.Cli\Mcp\MailMcpTools.cs).
+
+Current tool areas include:
+
+- profile listing, save, delete, bootstrap, login, auth status, and live tests
+- folder listing and folder-alias discovery
+- search, get, batch get, and attachment save
+- drafts, send, and queue operations
+- preview and execution for read/flag/move/archive/trash/delete actions
+- action-plan import/export, execution, and stored batch management
+
+A minimal MCP client entry looks like:
+
+```json
+{
+  "command": "mailozaurr",
+  "args": ["mcp", "serve"]
+}
+```
+
+## PowerShell usage today
+
+PowerShell remains a first-class surface, but it does not use the same profile-oriented headless workflow yet in the same way as the CLI and MCP layers.
+
+Today the best PowerShell references are:
+
+- [README.MD](C:\Support\GitHub\Mailozaurr\README.MD) for module usage and examples
+- [OAuthFlows.md](C:\Support\GitHub\Mailozaurr\Docs\OAuthFlows.md) for OAuth flows
+- [PGP.md](C:\Support\GitHub\Mailozaurr\Docs\PGP.md) for PGP support
+- the scripts under [Examples](C:\Support\GitHub\Mailozaurr\Examples)
+
+## Recipes and provider-specific guidance
+
+Because Mailozaurr supports many providers and auth stories, examples matter.
+
+When adding a new provider recipe:
+
+- document the minimum profile shape
+- show both settings and secrets
+- include a live verification command such as `profile test`
+- keep reusable logic in shared layers and keep wrapper-specific steps in wrapper docs
+
+If a feature is reusable across CLI, MCP, GUI, or PowerShell, it should follow the placement rules in [Platform-Architecture.md](C:\Support\GitHub\Mailozaurr\Docs\Platform-Architecture.md).

--- a/README.MD
+++ b/README.MD
@@ -62,6 +62,7 @@ Additional dependency:
 ## Architecture notes
 
 - [Platform Architecture](Docs/Platform-Architecture.md) - layering and reuse rules for future library, PowerShell, CLI, MCP, and GUI work
+- [Configuration and Usage](Docs/Configuration-and-Usage.md) - profile model, provider setup guidance, CLI storage, recipes, and MCP usage
 
 ## Additional surfaces
 
@@ -75,6 +76,116 @@ Mailozaurr is no longer only a library and PowerShell module. The repository now
 CLI and MCP are intended to sit on top of shared Mailozaurr services instead of duplicating mailbox, draft, queue, send, and message-action behavior independently.
 
 If you want the placement rules and longer-term cross-surface direction, see [Platform Architecture](Docs/Platform-Architecture.md).
+If you want practical profile setup and usage guidance for CLI and MCP, see [Configuration and Usage](Docs/Configuration-and-Usage.md).
+
+## CLI and MCP usage
+
+The repository now includes a cross-platform `mailozaurr` executable and an MCP server hosted by that same executable.
+
+To see the current command surface from source:
+
+```powershell
+dotnet run --project Sources/Mailozaurr.Cli -- --help
+```
+
+After building, the executable is available at:
+
+- `Sources/Mailozaurr.Cli/bin/Debug/net8.0/mailozaurr.exe` on Windows
+- `Sources/Mailozaurr.Cli/bin/Debug/net8.0/mailozaurr` on macOS/Linux
+
+### CLI command groups
+
+The executable currently supports:
+
+- `profile ...` for profile creation, bootstrap, login, auth refresh, readiness checks, summaries, validation, and secret management
+- `draft ...` for saving, listing, exporting, importing, and deleting reusable drafts
+- `send ...` for sending from a stored draft, a draft file, or direct command-line fields
+- `queue ...` for viewing and processing queued outbound messages
+- `mail ...` for folders, folder aliases, search, message retrieval, attachment export, mailbox actions, previews, and reusable action-plan batches
+- `mcp serve` for exposing the same shared services as MCP tools over stdio
+
+Most list and inspection commands support `--json`, which makes the executable useful in scripts, CI, and other automation surfaces.
+
+### CLI examples
+
+Create a profile and inspect it:
+
+```powershell
+mailozaurr profile create --profile work-imap --kind imap --name "Work IMAP" `
+  --setting server=imap.example.com --setting port=993 --json
+
+mailozaurr profile set-secret --profile work-imap --name password --value "secret" --json
+mailozaurr profile summary --profile work-imap --json
+mailozaurr profile test --profile work-imap --scope mailbox --json
+```
+
+Search and inspect mail:
+
+```powershell
+mailozaurr mail folders --profile work-imap --compact --json
+mailozaurr mail search --profile work-imap --folder Inbox --query Invoice --compact --json
+mailozaurr mail get --profile work-imap --folder Inbox --message-id 123 --compact --json
+mailozaurr mail attachments --profile work-imap --folder Inbox --message-id 123 --json
+mailozaurr mail save-attachments --profile work-imap --folder Inbox --message-id 123 --path C:\Temp\Attachments --json
+```
+
+Draft, send, and queue mail:
+
+```powershell
+mailozaurr draft save --draft weekly-update --name "Weekly update" --profile work-smtp `
+  --to team@example.com --subject "Weekly update" --text "Status attached." --json
+
+mailozaurr send --draft weekly-update --json
+mailozaurr queue list --compact --json
+mailozaurr queue process --json
+```
+
+Preview and execute mailbox actions:
+
+```powershell
+mailozaurr mail preview-delete --profile work-imap --folder Inbox --message-id 123 --json
+mailozaurr mail delete --profile work-imap --folder Inbox --message-id 123 --confirm-token <token> --json
+
+mailozaurr mail preview-move --profile work-imap --folder Inbox --message-id 123 --target-folder Archive --json
+mailozaurr mail move --profile work-imap --folder Inbox --message-id 123 --target-folder Archive --confirm-token <token> --json
+```
+
+### MCP server usage
+
+Mailozaurr can also run as an MCP server over stdio:
+
+```powershell
+mailozaurr mcp serve
+```
+
+The MCP surface is built on top of the same shared services as the CLI. Current tool areas include:
+
+- profile and auth management
+- folder and folder-alias discovery
+- mail search, get, batch get, and attachment save
+- draft, send, and queue operations
+- mailbox action preview and execution
+- action-plan import/export, execution, and stored batch management
+
+A minimal MCP client entry typically points to the executable and passes `mcp serve` as arguments:
+
+```json
+{
+  "command": "mailozaurr",
+  "args": ["mcp", "serve"]
+}
+```
+
+If your client prefers an absolute path, point it to the built executable instead.
+
+### Skills and MCP
+
+Skills are a good fit on top of the MCP server, but they are not a replacement for the server itself.
+
+- `mailozaurr mcp serve` provides the actual mailbox and send tools
+- skills provide workflow guidance, safety rules, and task-specific behavior for an MCP client or agent
+
+In practice, that means Mailozaurr should own the reusable mailbox, queue, send, and action logic, while skills can teach an agent how to use those tools safely and consistently.
 
 This started with a single goal to replace `Send-MailMessage` which is deprecated/obsolete with something more modern, but since MailKit and MimeKit have lots of options why not build on that?
 
@@ -401,6 +512,7 @@ You can also utilize Examples which should help to understand use cases. Of cour
 - [ImapIdleListenerExample.cs](Sources/Mailozaurr.Examples/ImapIdleListenerExample.cs) - C# sample listening for new mail.
 - [PGP documentation](Docs/PGP.md) - overview of OpenPGP support.
 - [OAuth flow documentation](Docs/OAuthFlows.md) - device code and on-behalf-of usage.
+- [Configuration and Usage](Docs/Configuration-and-Usage.md) - profile configuration, provider recipes, CLI usage, and MCP usage.
 
 -Some useful examples:
 - `Examples/Example-AcquireO365TokenInteractive.ps1` – demonstrates `Connect-OAuthO365`, `ConvertFrom-OAuth2Credential`, and using the token with `Send-EmailMessage`, IMAP, and POP3.


### PR DESCRIPTION
## Summary
- add a dedicated configuration and usage guide for Mailozaurr profiles, providers, CLI storage, and MCP usage
- link the new guide from the README architecture and documentation entry points
- document practical recipes for IMAP, SMTP, Graph, and Gmail profile setup

## Notes
- docs only
- no code changes