### PR TITLE
Fix post-merge CI regressions

### DIFF
--- a/Sources/Mailozaurr.Tests/ApplicationMessageActionPlanRegistryServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationMessageActionPlanRegistryServiceTests.cs
@@ -1200,7 +1200,7 @@ public sealed class ApplicationMessageActionPlanRegistryServiceTests {
                     MailboxId = request.MailboxId,
                     FolderId = request.FolderId,
                     RequestedCount = request.MessageIds.Count,
-                    UniqueMessageCount = request.MessageIds.Distinct(StringComparer.OrdinalIgnoreCase).Count(),
+                    UniqueMessageCount = request.MessageIds.Distinct(StringComparer.Ordinal).Count(),
                     MessageIds = request.MessageIds.ToList(),
                     RequestedDestinationFolderId = request.DestinationFolderId
                 });
@@ -1220,7 +1220,7 @@ public sealed class ApplicationMessageActionPlanRegistryServiceTests {
                 MailboxId = request.MailboxId,
                 FolderId = request.FolderId,
                 RequestedCount = request.MessageIds.Count,
-                UniqueMessageCount = request.MessageIds.Distinct(StringComparer.OrdinalIgnoreCase).Count(),
+                UniqueMessageCount = request.MessageIds.Distinct(StringComparer.Ordinal).Count(),
                 MessageIds = request.MessageIds.ToList(),
                 RequestedDestinationFolderId = request.DestinationFolderId,
                 DesiredState = request.Action switch {

--- a/Sources/Mailozaurr.Tests/ApplicationMessageActionPlanServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationMessageActionPlanServiceTests.cs
@@ -37,7 +37,7 @@ public sealed class ApplicationMessageActionPlanServiceTests {
 
         Assert.True(plan.Succeeded);
         Assert.Equal("Move", plan.ExecutionKind);
-        Assert.Equal(1, plan.UniqueMessageCount);
+        Assert.Equal(2, plan.UniqueMessageCount);
         Assert.True(plan.ConfirmationProvided);
         Assert.True(plan.ConfirmationValidated);
         Assert.Equal("archive-folder", plan.Destination!.EffectiveFolderId);
@@ -103,7 +103,7 @@ public sealed class ApplicationMessageActionPlanServiceTests {
         Assert.Equal("shared@example.com", actionService.LastReadStateRequest.MailboxId);
         Assert.Equal("Inbox", actionService.LastReadStateRequest.FolderId);
         Assert.False(actionService.LastReadStateRequest.IsRead);
-        Assert.Equal(new[] { "msg-1" }, actionService.LastReadStateRequest.MessageIds);
+        Assert.Equal(new[] { "msg-1", "MSG-1" }, actionService.LastReadStateRequest.MessageIds);
         Assert.Equal(plan.ConfirmationToken, actionService.LastReadStateRequest.ConfirmationToken);
     }
 

--- a/Sources/Mailozaurr.Tests/CliRunnerTests.cs
+++ b/Sources/Mailozaurr.Tests/CliRunnerTests.cs
@@ -619,7 +619,7 @@ public sealed class CliRunnerTests {
             _ => fixture.CreateBuilder());
 
         Assert.Equal(0, exitCode);
-        Assert.Contains("\"UniqueMessageCount\": 1", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"UniqueMessageCount\": 2", stdout.ToString(), StringComparison.Ordinal);
         Assert.Contains("\"EffectiveFolderId\": \"archive\"", stdout.ToString(), StringComparison.Ordinal);
         Assert.Contains("\"ConfirmationToken\":", stdout.ToString(), StringComparison.Ordinal);
     }
@@ -675,7 +675,7 @@ public sealed class CliRunnerTests {
             _ => fixture.CreateBuilder());
 
         Assert.Equal(0, exitCode);
-        Assert.Contains("\"UniqueMessageCount\": 1", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"UniqueMessageCount\": 2", stdout.ToString(), StringComparison.Ordinal);
         Assert.Contains("\"RequestedCount\": 2", stdout.ToString(), StringComparison.Ordinal);
     }
 
@@ -965,7 +965,7 @@ public sealed class CliRunnerTests {
 
         Assert.Equal(0, exitCode);
         Assert.Contains("\"ExecutionKind\": \"Move\"", stdout.ToString(), StringComparison.Ordinal);
-        Assert.Contains("\"UniqueMessageCount\": 1", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"UniqueMessageCount\": 2", stdout.ToString(), StringComparison.Ordinal);
         Assert.Contains("\"RequestedDestinationFolderId\": \"projects/2026\"", stdout.ToString(), StringComparison.OrdinalIgnoreCase);
         Assert.Contains("\"ConfirmationToken\":", stdout.ToString(), StringComparison.Ordinal);
     }

--- a/Sources/Mailozaurr.Tests/MailMcpToolsTests.cs
+++ b/Sources/Mailozaurr.Tests/MailMcpToolsTests.cs
@@ -523,7 +523,7 @@ public sealed class MailMcpToolsTests {
 
         Assert.True(result.Succeeded);
         Assert.Equal(2, result.RequestedCount);
-        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.Equal(2, result.UniqueMessageCount);
         Assert.NotNull(result.Destination);
         Assert.Equal("archive", result.Destination!.EffectiveFolderId);
         Assert.NotNull(result.ConfirmationToken);
@@ -544,7 +544,7 @@ public sealed class MailMcpToolsTests {
         Assert.Equal(4, result.IncludedActionCount);
         Assert.Equal(4, result.SucceededActionCount);
         Assert.Equal(0, result.FailedActionCount);
-        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.Equal(2, result.UniqueMessageCount);
         Assert.Contains(result.Actions, action => action.Action == "archive" && action.Destination!.EffectiveFolderId == "archive");
         Assert.Contains(result.Actions, action => action.Action == "move" && action.Destination!.EffectiveFolderId == "Projects/2026");
         Assert.Contains(result.Actions, action => action.Action == "delete" && action.Succeeded);
@@ -565,7 +565,7 @@ public sealed class MailMcpToolsTests {
         Assert.True(result.Succeeded);
         Assert.Equal(8, result.IncludedActionCount);
         Assert.Equal(8, result.SucceededActionCount);
-        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.Equal(2, result.UniqueMessageCount);
         Assert.Contains(result.Actions, action => action.Action == "mark-read" && action.DesiredState == true);
         Assert.Contains(result.Actions, action => action.Action == "mark-unread" && action.DesiredState == false);
         Assert.Contains(result.Actions, action => action.Action == "flag" && action.DesiredState == true);
@@ -587,7 +587,7 @@ public sealed class MailMcpToolsTests {
 
         Assert.True(result.Succeeded);
         Assert.Equal("Move", result.ExecutionKind);
-        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.Equal(2, result.UniqueMessageCount);
         Assert.Equal("Projects/2026", result.RequestedDestinationFolderId);
         Assert.NotNull(result.ConfirmationToken);
     }
@@ -806,7 +806,7 @@ public sealed class MailMcpToolsTests {
         Assert.Equal("primary", fixture.PlanRegistryService.LastCreatedFromPreview.MailboxId);
         Assert.Equal("Inbox", fixture.PlanRegistryService.LastCreatedFromPreview.FolderId);
         Assert.Equal("Projects/2026", fixture.PlanRegistryService.LastCreatedFromPreview.RequestedDestinationFolderId);
-        Assert.Equal(new[] { "message-1" }, fixture.PlanRegistryService.LastCreatedFromPreview.MessageIds);
+        Assert.Equal(new[] { "message-1", "MESSAGE-1" }, fixture.PlanRegistryService.LastCreatedFromPreview.MessageIds);
         Assert.Contains(fixture.PlanRegistryService.LastCreatedFromPreview.Actions, action => action.Action == "move");
     }
 
@@ -1009,7 +1009,7 @@ public sealed class MailMcpToolsTests {
 
         Assert.True(result.Succeeded);
         Assert.Equal(2, result.RequestedCount);
-        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.Equal(2, result.UniqueMessageCount);
         Assert.Equal("gmail-work", result.ProfileId);
         Assert.NotNull(result.ConfirmationToken);
     }
@@ -1212,7 +1212,7 @@ public sealed class MailMcpToolsTests {
         Assert.True(result.Succeeded);
         Assert.Equal("read-state", result.Action);
         Assert.False(result.DesiredState);
-        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.Equal(2, result.UniqueMessageCount);
         Assert.NotNull(result.ConfirmationToken);
     }
 
@@ -1230,7 +1230,7 @@ public sealed class MailMcpToolsTests {
         Assert.True(result.Succeeded);
         Assert.Equal("flagged-state", result.Action);
         Assert.False(result.DesiredState);
-        Assert.Equal(1, result.UniqueMessageCount);
+        Assert.Equal(2, result.UniqueMessageCount);
         Assert.NotNull(result.ConfirmationToken);
     }
 

--- a/Sources/Mailozaurr.Tests/TokenCacheHelperTests.cs
+++ b/Sources/Mailozaurr.Tests/TokenCacheHelperTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -6,9 +7,24 @@ using System.Threading.Tasks;
 
 namespace Mailozaurr.Tests;
 
-public sealed class TokenCacheHelperTests {
+public sealed class TokenCacheHelperTests : IDisposable {
+    private readonly string _cachePath;
+
     public TokenCacheHelperTests() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", "TokenCache", Process.GetCurrentProcess().Id.ToString(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        _cachePath = Path.Combine(directory, "msal_cache.bin");
+        Environment.SetEnvironmentVariable("MAILOZAURR_MSAL_CACHE_PATH", _cachePath);
         DeleteCacheFile();
+    }
+
+    public void Dispose() {
+        DeleteCacheFile();
+        var directory = Path.GetDirectoryName(_cachePath);
+        if (!string.IsNullOrWhiteSpace(directory) && Directory.Exists(directory)) {
+            Directory.Delete(directory, recursive: true);
+        }
+        Environment.SetEnvironmentVariable("MAILOZAURR_MSAL_CACHE_PATH", null);
     }
 
     [Fact]
@@ -73,8 +89,7 @@ public sealed class TokenCacheHelperTests {
     }
 
     private static string GetCacheFilePath() {
-        var pathField = typeof(TokenCacheHelper).GetField("CacheFilePath", BindingFlags.Static | BindingFlags.NonPublic);
-        return (string)pathField!.GetValue(null)!;
+        return Environment.GetEnvironmentVariable("MAILOZAURR_MSAL_CACHE_PATH")!;
     }
 
     private static void DeleteCacheFile() {

--- a/Sources/Mailozaurr/Authentication/TokenCacheHelper.cs
+++ b/Sources/Mailozaurr/Authentication/TokenCacheHelper.cs
@@ -11,10 +11,8 @@ namespace Mailozaurr;
 internal static class TokenCacheHelper {
     private static readonly object FileLock = new();
     private const int IoRetryCount = 5;
-    private static readonly string CacheFilePath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "Mailozaurr",
-        "msal_cache.bin");
+    private const string CachePathEnvironmentVariable = "MAILOZAURR_MSAL_CACHE_PATH";
+    private static string CacheFilePath => ResolveCacheFilePath();
 
     /// <summary>
     /// Registers callbacks to persist the token cache before and after access.
@@ -128,4 +126,16 @@ internal static class TokenCacheHelper {
     }
 
     private static int GetRetryDelay(int attempt) => 25 * (attempt + 1);
+
+    private static string ResolveCacheFilePath() {
+        var overriddenPath = Environment.GetEnvironmentVariable(CachePathEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(overriddenPath)) {
+            return overriddenPath.Trim();
+        }
+
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Mailozaurr",
+            "msal_cache.bin");
+    }
 }


### PR DESCRIPTION
## Summary
- align preview/plan CLI and MCP tests with case-sensitive confirmation-token normalization
- preserve isolated MSAL cache paths during tests so net8.0 and net472 runners do not share the same cache file
- keep the merged main branch green after PR #601

## Verification
- dotnet build Sources/Mailozaurr.sln -c Debug
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -c Debug --filter "ApplicationMessageActionPlanServiceTests|ApplicationMessageActionPlanRegistryServiceTests|CliRunnerTests|MailMcpToolsTests|TokenCacheHelperTests|ApplicationMessageActionPreviewServiceTests|ApplicationRoutingServicesTests"
- dotnet test Sources/Mailozaurr.sln -c Debug --no-build --verbosity minimal --logger "console;verbosity=minimal"