### PR TITLE
Add reusable compose profiles and mailbox thread helpers

### DIFF
--- a/Sources/Mailozaurr.Tests/ComposeProfileUtilitiesTests.cs
+++ b/Sources/Mailozaurr.Tests/ComposeProfileUtilitiesTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public class ComposeProfileUtilitiesTests {
+    [Fact]
+    public void NormalizeProfiles_AppliesFallbackValues_AndKeepsOneDefault() {
+        var profiles = new[] {
+            new MailComposeProfile {
+                Id = "sales",
+                Name = "Sales",
+                From = "sales@example.com",
+                IsDefault = true
+            },
+            new MailComposeProfile {
+                Name = "Billing",
+                From = "billing@example.com",
+                ReplyTo = "billing-replies@example.com"
+            }
+        };
+
+        var fallback = new MailComposeProfile {
+            ReplyTo = "reply@example.com",
+            SignatureText = "Regards",
+            IsDefault = true
+        };
+
+        var normalized = ComposeProfileUtilities.NormalizeProfiles(profiles, fallback);
+
+        Assert.Equal(2, normalized.Count);
+        Assert.Equal("sales", normalized[0].Id);
+        Assert.Equal("reply@example.com", normalized[0].ReplyTo);
+        Assert.Equal("Regards", normalized[0].SignatureText);
+        Assert.True(normalized[0].IsDefault);
+        Assert.Equal("billing", normalized[1].Id);
+        Assert.Equal("billing-replies@example.com", normalized[1].ReplyTo);
+        Assert.False(normalized[1].IsDefault);
+    }
+
+    [Fact]
+    public void NormalizeProfiles_SynthesizesFallbackProfile_WhenConfiguredProfilesMissing() {
+        var normalized = ComposeProfileUtilities.NormalizeProfiles(
+            profiles: null,
+            fallbackProfile: new MailComposeProfile {
+                From = "default@example.com",
+                ReplyTo = "reply@example.com",
+                SignatureText = "Thanks"
+            });
+
+        Assert.Single(normalized);
+        Assert.Equal("default", normalized[0].Id);
+        Assert.Equal("default@example.com", normalized[0].From);
+        Assert.True(normalized[0].IsDefault);
+    }
+
+    [Fact]
+    public void GetDefaultProfile_ReturnsFirstMarkedDefault() {
+        var profiles = new List<MailComposeProfile> {
+            new MailComposeProfile { Id = "one", IsDefault = false },
+            new MailComposeProfile { Id = "two", IsDefault = true }
+        };
+
+        var selected = ComposeProfileUtilities.GetDefaultProfile(profiles);
+
+        Assert.NotNull(selected);
+        Assert.Equal("two", selected!.Id);
+    }
+}

--- a/Sources/Mailozaurr.Tests/GmailMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GmailMailboxBrowserTests.cs
@@ -165,7 +165,7 @@ public sealed class GmailMailboxBrowserTests {
     public async System.Threading.Tasks.Task GetMessageContentAsync_ReturnsMimeAndFlags() {
         var mime = "From: a@example.test\r\nTo: b@example.test\r\nSubject: Sample\r\nMessage-Id: <m1@example.test>\r\n\r\nhello";
         var raw = Convert.ToBase64String(Encoding.UTF8.GetBytes(mime)).Replace('+', '-').Replace('/', '_').TrimEnd('=');
-        var rawJson = "{\"id\":\"m1\",\"labelIds\":[\"UNREAD\",\"STARRED\"],\"raw\":\"" + raw + "\"}";
+        var rawJson = "{\"id\":\"m1\",\"threadId\":\"thr-1\",\"labelIds\":[\"UNREAD\",\"STARRED\"],\"raw\":\"" + raw + "\"}";
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(rawJson) });
         var browser = CreateBrowser(handler);
 
@@ -175,6 +175,7 @@ public sealed class GmailMailboxBrowserTests {
         Assert.Equal("Sample", result.Message.Subject);
         Assert.False(result.Seen);
         Assert.True(result.Flagged);
+        Assert.Equal("thr-1", result.NativeThreadId);
     }
 
     [Fact]
@@ -455,6 +456,56 @@ public sealed class GmailMailboxBrowserTests {
         Assert.Equal(2, handler.Requests.Count);
         Assert.Contains("/users/me/threads/t1", handler.Requests[0].RequestUri!.ToString());
         Assert.Contains("/users/me/threads/t2", handler.Requests[1].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MoveThreadsAsync_UsesThreadModifyLabels() {
+        var labelsJson = "{\"labels\":[{\"id\":\"Label_1\",\"name\":\"Project\"}]}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(labelsJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"id\":\"t1\"}") });
+        var browser = CreateBrowser(handler);
+
+        var results = await browser.MoveThreadsAsync(new[] { "t1" }, sourceFolder: "INBOX", targetFolder: "Project");
+
+        Assert.Single(results);
+        Assert.True(results[0].Ok, results[0].Error);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("/users/me/labels", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("/users/me/threads/t1/modify", handler.Requests[1].RequestUri!.ToString());
+        var body = await handler.Requests[1].Content!.ReadAsStringAsync();
+        Assert.Contains("\"addLabelIds\":[\"Label_1\"]", body, StringComparison.Ordinal);
+        Assert.Contains("\"removeLabelIds\":[\"INBOX\",\"TRASH\"]", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SetThreadsSeenAsync_UsesThreadModifyLabels() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"id\":\"t1\"}") });
+        var browser = CreateBrowser(handler);
+
+        var results = await browser.SetThreadsSeenAsync(new[] { "t1" }, seen: true);
+
+        Assert.Single(results);
+        Assert.True(results[0].Ok, results[0].Error);
+        Assert.Single(handler.Requests);
+        Assert.Contains("/users/me/threads/t1/modify", handler.Requests[0].RequestUri!.ToString());
+        var body = await handler.Requests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"removeLabelIds\":[\"UNREAD\"]", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SetThreadsFlaggedAsync_UsesThreadModifyLabels() {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"id\":\"t1\"}") });
+        var browser = CreateBrowser(handler);
+
+        var results = await browser.SetThreadsFlaggedAsync(new[] { "t1" }, flagged: false);
+
+        Assert.Single(results);
+        Assert.True(results[0].Ok, results[0].Error);
+        Assert.Single(handler.Requests);
+        Assert.Contains("/users/me/threads/t1/modify", handler.Requests[0].RequestUri!.ToString());
+        var body = await handler.Requests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"removeLabelIds\":[\"STARRED\"]", body, StringComparison.Ordinal);
     }
 
     private static Dictionary<string, List<string>> ParseQueryParams(Uri uri) {

--- a/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphMailboxBrowserTests.cs
@@ -287,7 +287,7 @@ public class GraphMailboxBrowserTests {
 
     [Fact]
     public async System.Threading.Tasks.Task GetMessageContentAsync_ReturnsMimeAndFlags() {
-        var metaJson = "{\"id\":\"m1\",\"isRead\":true,\"flag\":{\"flagStatus\":\"flagged\"}}";
+        var metaJson = "{\"id\":\"m1\",\"isRead\":true,\"flag\":{\"flagStatus\":\"flagged\"},\"conversationId\":\"conv-1\"}";
         var mime = "From: a@example.test\r\nTo: b@example.test\r\nSubject: Sample\r\nMessage-Id: <m1@example.test>\r\n\r\nhello";
         var handler = new RecordingHandler(
             new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(metaJson) },
@@ -299,6 +299,7 @@ public class GraphMailboxBrowserTests {
 
         Assert.True(result.Seen);
         Assert.True(result.Flagged);
+        Assert.Equal("conv-1", result.NativeThreadId);
         Assert.Equal("Sample", result.Message.Subject);
         Assert.Equal(2, handler.Requests.Count);
         var metaUri = handler.Requests[0].RequestUri!.ToString();
@@ -306,6 +307,7 @@ public class GraphMailboxBrowserTests {
         Assert.Contains("$select=", metaUri);
         Assert.Contains("isRead", metaUri);
         Assert.Contains("flag", metaUri);
+        Assert.Contains("conversationId", metaUri);
         Assert.Contains("/me/messages/m1/$value", handler.Requests[1].RequestUri!.ToString());
     }
 
@@ -613,6 +615,47 @@ public class GraphMailboxBrowserTests {
         var body = await handler.Requests[1].Content!.ReadAsStringAsync();
         Assert.Contains("me/messages/m1", body, StringComparison.Ordinal);
         Assert.Contains("me/messages/m2", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SetConversationsSeenAsync_ExpandsAndBatchesReadStateChanges() {
+        var listJson = "{\"value\":[{\"id\":\"m1\"},{\"id\":\"m2\"}]}";
+        var batchJson = "{\"responses\":[{\"id\":\"1\",\"status\":200},{\"id\":\"2\",\"status\":200}]}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(listJson) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(batchJson) });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var results = await browser.SetConversationsSeenAsync(new[] { "conv-1" }, seen: true);
+
+        Assert.Single(results);
+        Assert.True(results[0].Ok, results[0].Error);
+        Assert.Equal("conv-1", results[0].Id);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("/me/messages?", handler.Requests[0].RequestUri!.ToString());
+        Assert.Contains("conversationId", handler.Requests[0].RequestUri!.ToString());
+        var body = await handler.Requests[1].Content!.ReadAsStringAsync();
+        Assert.Contains("me/messages/m1", body, StringComparison.Ordinal);
+        Assert.Contains("isRead", body, StringComparison.Ordinal);
+        Assert.Contains("true", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SetConversationsFlaggedAsync_MapsConversationFailures() {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("boom") });
+        var client = CreateClient(handler);
+        var browser = new GraphMailboxBrowser(client);
+
+        var results = await browser.SetConversationsFlaggedAsync(new[] { "conv-1" }, flagged: true);
+
+        Assert.Single(results);
+        Assert.Equal("conv-1", results[0].Id);
+        Assert.False(results[0].Ok);
+        Assert.Contains("conversation list failed", results[0].Error ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(handler.Requests);
+        Assert.Contains("/me/messages?", handler.Requests[0].RequestUri!.ToString());
     }
 
     private static GraphApiClient CreateClient(HttpMessageHandler handler) {

--- a/Sources/Mailozaurr/ComposeProfileUtilities.cs
+++ b/Sources/Mailozaurr/ComposeProfileUtilities.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Helper methods for normalizing reusable compose profiles.
+/// </summary>
+public static class ComposeProfileUtilities {
+    /// <summary>
+    /// Normalizes compose profiles and guarantees at most one default entry.
+    /// </summary>
+    /// <param name="profiles">Configured profiles.</param>
+    /// <param name="fallbackProfile">Fallback values applied to profiles missing fields.</param>
+    /// <returns>Normalized profile list.</returns>
+    public static IReadOnlyList<MailComposeProfile> NormalizeProfiles(
+        IEnumerable<MailComposeProfile>? profiles,
+        MailComposeProfile? fallbackProfile = null) {
+        var normalizedFallback = NormalizeSingle(fallbackProfile, "default", 0, fallbackProfile);
+        var items = new List<MailComposeProfile>();
+        var index = 0;
+
+        if (profiles is not null) {
+            foreach (var profile in profiles) {
+                var normalized = NormalizeSingle(profile, profile?.Id, index, normalizedFallback);
+                if (normalized is not null) {
+                    items.Add(normalized);
+                }
+                index++;
+            }
+        }
+
+        if (items.Count == 0 && HasMeaningfulContent(normalizedFallback)) {
+            items.Add(new MailComposeProfile {
+                Id = normalizedFallback!.Id,
+                Name = normalizedFallback.Name,
+                From = normalizedFallback.From,
+                ReplyTo = normalizedFallback.ReplyTo,
+                SignatureText = normalizedFallback.SignatureText,
+                IsDefault = true
+            });
+        }
+
+        if (items.Count == 0) {
+            return items;
+        }
+
+        var selectedIndex = items.FindIndex(static profile => profile.IsDefault);
+        if (selectedIndex < 0) {
+            selectedIndex = 0;
+        }
+
+        for (var i = 0; i < items.Count; i++) {
+            items[i].IsDefault = i == selectedIndex;
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Resolves the default profile from a list of profiles.
+    /// </summary>
+    /// <param name="profiles">Profiles to inspect.</param>
+    /// <returns>The default profile, when available.</returns>
+    public static MailComposeProfile? GetDefaultProfile(IEnumerable<MailComposeProfile>? profiles) {
+        if (profiles is null) {
+            return null;
+        }
+
+        MailComposeProfile? first = null;
+        foreach (var profile in profiles) {
+            first ??= profile;
+            if (profile?.IsDefault == true) {
+                return profile;
+            }
+        }
+
+        return first;
+    }
+
+    private static MailComposeProfile? NormalizeSingle(
+        MailComposeProfile? profile,
+        string? rawId,
+        int index,
+        MailComposeProfile? fallbackProfile) {
+        var normalizedId = NormalizeOptional(profile?.Id) ?? NormalizeOptional(rawId);
+        var from = NormalizeOptional(profile?.From) ?? NormalizeOptional(fallbackProfile?.From);
+        var replyTo = NormalizeOptional(profile?.ReplyTo) ?? NormalizeOptional(fallbackProfile?.ReplyTo);
+        var signature = NormalizeOptional(profile?.SignatureText) ?? NormalizeOptional(fallbackProfile?.SignatureText);
+        var name = NormalizeOptional(profile?.Name);
+
+        if (string.IsNullOrWhiteSpace(name) &&
+            string.IsNullOrWhiteSpace(from) &&
+            string.IsNullOrWhiteSpace(replyTo) &&
+            string.IsNullOrWhiteSpace(signature)) {
+            return null;
+        }
+
+        normalizedId = BuildProfileId(normalizedId, name, from, index);
+        name ??= from ?? normalizedId;
+
+        return new MailComposeProfile {
+            Id = normalizedId,
+            Name = name,
+            From = from,
+            ReplyTo = replyTo,
+            SignatureText = signature,
+            IsDefault = profile?.IsDefault ?? fallbackProfile?.IsDefault ?? false
+        };
+    }
+
+    private static bool HasMeaningfulContent(MailComposeProfile? profile) =>
+        !string.IsNullOrWhiteSpace(profile?.Name) ||
+        !string.IsNullOrWhiteSpace(profile?.From) ||
+        !string.IsNullOrWhiteSpace(profile?.ReplyTo) ||
+        !string.IsNullOrWhiteSpace(profile?.SignatureText);
+
+    private static string BuildProfileId(string? rawId, string? name, string? from, int index) {
+        if (rawId is not null) {
+            var trimmedId = rawId.Trim();
+            if (trimmedId.Length > 0) {
+                return trimmedId;
+            }
+        }
+
+        string? source = null;
+        if (name is not null) {
+            var trimmedName = name.Trim();
+            if (trimmedName.Length > 0) {
+                source = trimmedName;
+            }
+        }
+        if (source is null && from is not null) {
+            var trimmedFrom = from.Trim();
+            if (trimmedFrom.Length > 0) {
+                source = trimmedFrom;
+            }
+        }
+
+        if (source is not null) {
+            var normalizedSource = source.Trim();
+            var chars = normalizedSource
+                .Trim()
+                .ToLowerInvariant()
+                .Select(ch => char.IsLetterOrDigit(ch) ? ch : '-')
+                .ToArray();
+            var collapsed = new string(chars).Trim('-');
+            if (!string.IsNullOrWhiteSpace(collapsed)) {
+                return collapsed;
+            }
+        }
+
+        return $"profile-{index + 1}";
+    }
+
+    private static string? NormalizeOptional(string? value) {
+        if (value is null) {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0) {
+            return null;
+        }
+
+        return trimmed;
+    }
+}

--- a/Sources/Mailozaurr/Definitions/MailComposeProfile.cs
+++ b/Sources/Mailozaurr/Definitions/MailComposeProfile.cs
@@ -1,0 +1,36 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents a reusable compose identity/profile.
+/// </summary>
+public sealed class MailComposeProfile {
+    /// <summary>
+    /// Gets or sets the stable identifier for the profile.
+    /// </summary>
+    public string? Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user-facing profile name.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the from address for the profile.
+    /// </summary>
+    public string? From { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reply-to address for the profile.
+    /// </summary>
+    public string? ReplyTo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the signature text for the profile.
+    /// </summary>
+    public string? SignatureText { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this profile is the default.
+    /// </summary>
+    public bool IsDefault { get; set; }
+}

--- a/Sources/Mailozaurr/Gmail/GmailMailboxBrowser.cs
+++ b/Sources/Mailozaurr/Gmail/GmailMailboxBrowser.cs
@@ -18,7 +18,7 @@ public sealed class GmailMailboxBrowser {
     private const string ListFields = "messages(id,threadId),nextPageToken,resultSizeEstimate";
     private const string MessageSummaryFields = "id,threadId,internalDate,labelIds,payload(headers,name,value,parts,filename,body/attachmentId,body/size,mimeType)";
     private const string ThreadFields = "id,messages(id,threadId,internalDate,labelIds,payload(headers,name,value,parts,filename,body/attachmentId,body/size,mimeType))";
-    private const string RawFields = "id,internalDate,labelIds,raw";
+    private const string RawFields = "id,threadId,internalDate,labelIds,raw";
     private readonly GmailApiClient _gmail;
     private readonly string _userId;
 
@@ -609,7 +609,8 @@ public sealed class GmailMailboxBrowser {
         return new GmailMailboxGetResult {
             Message = mimeMessage,
             Seen = !HasLabel(message.LabelIds, "UNREAD"),
-            Flagged = HasLabel(message.LabelIds, "STARRED")
+            Flagged = HasLabel(message.LabelIds, "STARRED"),
+            NativeThreadId = NormalizeOptional(message.ThreadId)
         };
     }
 
@@ -776,6 +777,44 @@ public sealed class GmailMailboxBrowser {
     }
 
     /// <summary>
+    /// Sets read/unread state on a single thread.
+    /// </summary>
+    public async Task SetThreadSeenAsync(
+        string threadId,
+        bool seen,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(threadId)) {
+            throw new ArgumentException("threadId is required.", nameof(threadId));
+        }
+
+        _ = await _gmail.ModifyThreadLabelsAsync(
+            _userId,
+            threadId.Trim(),
+            addLabelIds: seen ? Array.Empty<string>() : new[] { "UNREAD" },
+            removeLabelIds: seen ? new[] { "UNREAD" } : Array.Empty<string>(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets flagged/unflagged state on a single thread.
+    /// </summary>
+    public async Task SetThreadFlaggedAsync(
+        string threadId,
+        bool flagged,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(threadId)) {
+            throw new ArgumentException("threadId is required.", nameof(threadId));
+        }
+
+        _ = await _gmail.ModifyThreadLabelsAsync(
+            _userId,
+            threadId.Trim(),
+            addLabelIds: flagged ? new[] { "STARRED" } : Array.Empty<string>(),
+            removeLabelIds: flagged ? Array.Empty<string>() : new[] { "STARRED" },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Moves many messages to a target folder/label.
     /// </summary>
     public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> MoveMessagesAsync(
@@ -817,6 +856,66 @@ public sealed class GmailMailboxBrowser {
             addLabelIds: new[] { targetLabelId },
             removeLabelIds: remove,
             batchSize,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves a single thread to a target folder/label.
+    /// </summary>
+    public async Task MoveThreadAsync(
+        string threadId,
+        string? sourceFolder,
+        string targetFolder,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(threadId)) {
+            throw new ArgumentException("threadId is required.", nameof(threadId));
+        }
+        if (string.IsNullOrWhiteSpace(targetFolder)) {
+            throw new ArgumentException("targetFolder is required.", nameof(targetFolder));
+        }
+
+        var targetRaw = targetFolder.Trim();
+        if (targetRaw.Equals("Archive", StringComparison.OrdinalIgnoreCase)) {
+            await ArchiveThreadAsync(threadId, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var targetLabelId = NormalizeOptional(await ResolveLabelIdAsync(targetRaw, cancellationToken).ConfigureAwait(false));
+        if (targetLabelId == null) {
+            throw new InvalidOperationException("Unable to resolve Gmail target folder/label.");
+        }
+
+        if (targetLabelId.Equals("TRASH", StringComparison.OrdinalIgnoreCase)) {
+            await TrashThreadAsync(threadId, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var remove = new List<string>();
+        var sourceLabelId = NormalizeOptional(await ResolveLabelIdAsync(sourceFolder, cancellationToken).ConfigureAwait(false));
+        if (sourceLabelId != null) {
+            remove.Add(sourceLabelId);
+        }
+        remove.Add("TRASH");
+
+        _ = await _gmail.ModifyThreadLabelsAsync(
+            _userId,
+            threadId.Trim(),
+            addLabelIds: new[] { targetLabelId },
+            removeLabelIds: remove,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves many threads to a target folder/label.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> MoveThreadsAsync(
+        IEnumerable<string> threadIds,
+        string? sourceFolder,
+        string targetFolder,
+        CancellationToken cancellationToken = default) {
+        return await ExecuteThreadActionAsync(
+            threadIds,
+            (threadId, token) => MoveThreadAsync(threadId, sourceFolder, targetFolder, token),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -975,6 +1074,32 @@ public sealed class GmailMailboxBrowser {
         IEnumerable<string> threadIds,
         CancellationToken cancellationToken = default) {
         return await ExecuteThreadActionAsync(threadIds, DeleteThreadAsync, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets read/unread state on many threads.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> SetThreadsSeenAsync(
+        IEnumerable<string> threadIds,
+        bool seen,
+        CancellationToken cancellationToken = default) {
+        return await ExecuteThreadActionAsync(
+            threadIds,
+            (threadId, token) => SetThreadSeenAsync(threadId, seen, token),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets flagged/unflagged state on many threads.
+    /// </summary>
+    public async Task<IReadOnlyList<GmailMailboxBulkOperationResult>> SetThreadsFlaggedAsync(
+        IEnumerable<string> threadIds,
+        bool flagged,
+        CancellationToken cancellationToken = default) {
+        return await ExecuteThreadActionAsync(
+            threadIds,
+            (threadId, token) => SetThreadFlaggedAsync(threadId, flagged, token),
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1739,6 +1864,9 @@ public sealed class GmailMailboxBrowser {
 
         /// <summary>Flagged state from Gmail labels.</summary>
         public bool? Flagged { get; set; }
+
+        /// <summary>Gmail thread id.</summary>
+        public string? NativeThreadId { get; set; }
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMailboxBrowser.cs
@@ -620,12 +620,21 @@ public sealed class GraphMailboxBrowser {
         }
 
         var normalizedId = messageId.Trim();
-        var meta = await _graph.GetMessageAsync(normalizedId, select: "id,isRead,flag", cancellationToken: cancellationToken).ConfigureAwait(false);
+        var meta = await _graph.GetMessageAsync(normalizedId, select: "id,isRead,flag,conversationId", cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (meta == null) {
+            throw new InvalidDataException("Graph message metadata was not returned.");
+        }
         var mimeBytes = await _graph.GetMessageMimeAsync(normalizedId, maxBytes: maxMimeBytes, cancellationToken: cancellationToken).ConfigureAwait(false);
+        string? conversationId = null;
+        var trimmedConversationId = meta.ConversationId?.Trim();
+        if (!string.IsNullOrWhiteSpace(trimmedConversationId)) {
+            conversationId = trimmedConversationId;
+        }
         try {
             return new GraphMailboxGetResult {
                 Seen = meta.IsRead,
                 Flagged = meta.Flag == null ? null : IsFlagged(meta.Flag),
+                NativeThreadId = conversationId,
                 Message = MimeMessage.Load(new MemoryStream(mimeBytes, writable: false))
             };
         } catch (Exception ex) {
@@ -819,6 +828,52 @@ public sealed class GraphMailboxBrowser {
     }
 
     /// <summary>
+    /// Sets read/unread state on many conversations.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> SetConversationsSeenAsync(
+        IEnumerable<string> conversationIds,
+        bool seen,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        if (conversationIds == null) {
+            throw new ArgumentNullException(nameof(conversationIds));
+        }
+
+        return await ExecuteConversationMessageActionAsync(
+            conversationIds,
+            (messageIds, token) => _graph.BatchSetMessagesIsReadAsync(
+                messageIds,
+                seen,
+                batchSize: batchSize,
+                cancellationToken: token),
+            "Graph conversation set-seen failed.",
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets flagged/unflagged state on many conversations.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphBulkOperationResult>> SetConversationsFlaggedAsync(
+        IEnumerable<string> conversationIds,
+        bool flagged,
+        int batchSize = 20,
+        CancellationToken cancellationToken = default) {
+        if (conversationIds == null) {
+            throw new ArgumentNullException(nameof(conversationIds));
+        }
+
+        return await ExecuteConversationMessageActionAsync(
+            conversationIds,
+            (messageIds, token) => _graph.BatchSetMessagesFlaggedAsync(
+                messageIds,
+                flagged,
+                batchSize: batchSize,
+                cancellationToken: token),
+            "Graph conversation set-flagged failed.",
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Moves many conversations to a target folder alias/id.
     /// </summary>
     public async Task<IReadOnlyList<GraphBulkOperationResult>> MoveConversationsAsync(
@@ -878,6 +933,84 @@ public sealed class GraphMailboxBrowser {
             conversationIds,
             batchSize: batchSize,
             cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<GraphBulkOperationResult>> ExecuteConversationMessageActionAsync(
+        IEnumerable<string> conversationIds,
+        Func<IReadOnlyList<string>, CancellationToken, Task<IReadOnlyList<GraphBulkOperationResult>>> operationAsync,
+        string fallbackError,
+        CancellationToken cancellationToken) {
+        if (conversationIds == null) {
+            throw new ArgumentNullException(nameof(conversationIds));
+        }
+        if (operationAsync == null) {
+            throw new ArgumentNullException(nameof(operationAsync));
+        }
+
+        var conversations = NormalizeConversationIds(conversationIds);
+        if (conversations.Count == 0) {
+            return Array.Empty<GraphBulkOperationResult>();
+        }
+
+        var output = new List<GraphBulkOperationResult>(conversations.Count);
+        foreach (var conversationId in conversations) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            IReadOnlyList<string> messageIds;
+            try {
+                messageIds = await _graph.ListConversationMessageIdsAsync(
+                    conversationId,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                output.Add(new GraphBulkOperationResult {
+                    Id = conversationId,
+                    Ok = false,
+                    Error = ex.Message
+                });
+                continue;
+            }
+
+            if (messageIds.Count == 0) {
+                output.Add(new GraphBulkOperationResult { Id = conversationId, Ok = true });
+                continue;
+            }
+
+            var results = await operationAsync(messageIds, cancellationToken).ConfigureAwait(false);
+            var failed = results.FirstOrDefault(result => result != null && !result.Ok);
+            if (failed is not null) {
+                output.Add(new GraphBulkOperationResult {
+                    Id = conversationId,
+                    Ok = false,
+                    Error = failed.Error ?? fallbackError
+                });
+                continue;
+            }
+
+            output.Add(new GraphBulkOperationResult { Id = conversationId, Ok = true });
+        }
+
+        return output;
+    }
+
+    private static List<string> NormalizeConversationIds(IEnumerable<string> conversationIds) {
+        var output = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var raw in conversationIds) {
+            if (string.IsNullOrWhiteSpace(raw)) {
+                continue;
+            }
+
+            var trimmed = raw.Trim();
+            if (trimmed.Length == 0 || !seen.Add(trimmed)) {
+                continue;
+            }
+
+            output.Add(trimmed);
+        }
+
+        return output;
     }
 
     private async Task UploadLargeAttachmentsAsync(
@@ -1426,6 +1559,9 @@ public sealed class GraphMailboxBrowser {
 
         /// <summary>Flagged state from Graph metadata.</summary>
         public bool? Flagged { get; set; }
+
+        /// <summary>Graph conversation id.</summary>
+        public string? NativeThreadId { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add reusable compose profile definitions and normalization helpers
- expose provider native thread ids from Gmail and Graph message-content reads
- add Gmail and Graph thread/conversation read, flagged, and move helpers with coverage

## Validation
- dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj -f net8.0 --filter "ComposeProfileUtilitiesTests|GraphMailboxBrowserTests|GmailMailboxBrowserTests"
- dotnet build Sources/Mailozaurr/Mailozaurr.csproj -f net472