### PR TITLE
[codex] Fix zero-duration pending message lease fallback

### DIFF
--- a/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/PendingMessageProcessorTests.cs
@@ -547,6 +547,28 @@ public sealed class PendingMessageProcessorTests {
     }
 
     [Fact]
+    public async Task ProcessAsync_UsesSafeMinimumLeaseWhenConfiguredLeaseIsZero() {
+        var currentTime = DateTimeOffset.Parse("2024-06-11T08:00:00Z");
+        var repository = new InMemoryPendingMessageRepository();
+        var record = CreateRecord(currentTime.AddMinutes(-1));
+        repository.Add(record);
+        var sender = new RecordingPendingMessageSender();
+        var factory = new PendingMessageSenderFactory(new Dictionary<EmailProvider, IPendingMessageSender> {
+            { EmailProvider.None, sender }
+        });
+        var processor = new PendingMessageProcessor(
+            repository,
+            factory,
+            clock: () => currentTime,
+            processingLeaseDuration: TimeSpan.Zero);
+
+        await processor.ProcessAsync();
+
+        var sent = Assert.Single(sender.SentRecords);
+        Assert.Equal(currentTime + TimeSpan.FromSeconds(30), sent.NextAttemptAt);
+    }
+
+    [Fact]
     public async Task ProcessAsync_RetriesUsingDelaySelectorPerAttempt() {
         var currentTime = DateTimeOffset.Parse("2024-06-12T07:30:00Z");
         var repository = new InMemoryPendingMessageRepository();

--- a/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
+++ b/Sources/Mailozaurr/SentMessages/PendingMessageProcessor.cs
@@ -9,7 +9,7 @@ namespace Mailozaurr;
 /// Processes pending messages by dispatching them through provider specific senders.
 /// </summary>
 public sealed class PendingMessageProcessor {
-    private static readonly TimeSpan MinimumLeaseDuration = TimeSpan.FromTicks(1);
+    private static readonly TimeSpan MinimumLeaseDuration = TimeSpan.FromSeconds(30);
     private readonly IPendingMessageRepository repository;
     private readonly PendingMessageSenderFactory senderFactory;
     private readonly Func<int, TimeSpan> retryDelaySelector;
@@ -31,7 +31,10 @@ public sealed class PendingMessageProcessor {
     /// <param name="logger">Optional logger used to record processing diagnostics.</param>
     /// <param name="observer">Optional observer used to emit telemetry about processing outcomes.</param>
     /// <param name="permanentFailureDetector">Optional delegate that classifies whether a failure should skip retries.</param>
-    /// <param name="processingLeaseDuration">Optional duration used to lease records while they are being processed to avoid concurrent handling.</param>
+    /// <param name="processingLeaseDuration">
+    /// Optional duration used to lease records while they are being processed to avoid concurrent handling.
+    /// <see cref="TimeSpan.Zero"/> uses a minimum safety lease of 30 seconds.
+    /// </param>
     public PendingMessageProcessor(
         IPendingMessageRepository repository,
         PendingMessageSenderFactory? senderFactory = null,

--- a/Tests/Mailozaurr.Pester/Send-EmailPendingMessage.Filters.Tests.ps1
+++ b/Tests/Mailozaurr.Pester/Send-EmailPendingMessage.Filters.Tests.ps1
@@ -1,21 +1,15 @@
 $script:FilterSenderReferencedAssemblies = $null
 
-function Get-FilterSenderReferencedAssemblies {
+function global:Get-FilterSenderReferencedAssemblies {
     if ($null -eq $script:FilterSenderReferencedAssemblies) {
-        $sharedRoot = Join-Path ([Environment]::GetFolderPath('UserProfile')) '.dotnet/shared/Microsoft.NETCore.App'
-        $runtimeVersion = Get-ChildItem -Path $sharedRoot -Directory | Sort-Object Name -Descending | Select-Object -First 1
-        if (-not $runtimeVersion) {
-            throw 'Unable to locate .NET runtime assemblies required for Add-Type.'
+        $referenceDirectory = Join-Path $PSHOME 'ref'
+        if (-not (Test-Path -Path $referenceDirectory)) {
+            throw 'Unable to locate PowerShell reference assemblies required for Add-Type.'
         }
 
-        $runtimePath = $runtimeVersion.FullName
         $script:FilterSenderReferencedAssemblies = @(
-            [Mailozaurr.PendingMessageRecord].Assembly.Location,
-            (Join-Path $runtimePath 'System.Private.CoreLib.dll'),
-            (Join-Path $runtimePath 'System.Runtime.dll'),
-            (Join-Path $runtimePath 'System.Collections.dll'),
-            (Join-Path $runtimePath 'System.Collections.Concurrent.dll')
-        )
+            [Mailozaurr.PendingMessageRecord].Assembly.Location
+        ) + @(Get-ChildItem -Path $referenceDirectory -Filter '*.dll' -File | ForEach-Object { $_.FullName })
     }
 
     return $script:FilterSenderReferencedAssemblies


### PR DESCRIPTION
## Summary
- change `PendingMessageProcessor` so `processingLeaseDuration = TimeSpan.Zero` uses a 30-second safety lease instead of a one-tick fallback
- document the zero-duration lease semantics in the processor XML docs
- add a regression test for the new lease behavior and fix the related Pester filter test harness so the queue cmdlet coverage runs reliably

## Root cause
`AcquireProcessingLeaseAsync` treated `TimeSpan.Zero` as `TimeSpan.FromTicks(1)`, which made the lease effectively disappear and weakened contention protection for callers relying on the fallback.

## Impact
This makes queue processing safer under concurrent processors and keeps the surrounding PR #597 queue/filter tests stable across PowerShell environments.

## Validation
- `dotnet test Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj --filter "FullyQualifiedName~PendingMessageProcessorTests|FullyQualifiedName~PendingMessageProcessorFileRepositoryTests|FullyQualifiedName~GmailPendingMessageSenderTests|FullyQualifiedName~SmtpPendingMessageProcessorIntegrationTests"`
- `Invoke-Pester -Path ''Tests/Import-Module.Tests.ps1'',''Tests/Send-EmailPendingMessage.Tests.ps1'',''Tests/Mailozaurr.Pester/Send-EmailPendingMessage.Filters.Tests.ps1'' -CI`
