### PR TITLE
Harden secret handling and auth flows

### DIFF
--- a/Examples/Example-AcquireGoogleTokenInteractive.ps1
+++ b/Examples/Example-AcquireGoogleTokenInteractive.ps1
@@ -2,10 +2,10 @@ Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
 $GmailAccount = 'user@gmail.com'
 $ClientID = 'Your-Client-ID'
-$ClientSecret = 'Your-Client-Secret'
+$ClientSecret = Read-Host 'Google client secret' -AsSecureString
 $Scopes = @('https://mail.google.com/')
 
-$Credential = Connect-OAuthGoogle -GmailAccount $GmailAccount -ClientID $ClientID -ClientSecret $ClientSecret -Scope $Scopes
+$Credential = Connect-OAuthGoogle -GmailAccount $GmailAccount -ClientID $ClientID -ClientSecretSecureString $ClientSecret -Scope $Scopes
 
 $CredInfo = ConvertFrom-OAuth2Credential -Credential $Credential
 $CredInfo | Format-List

--- a/Examples/Example-ClearGraphJunk.ps1
+++ b/Examples/Example-ClearGraphJunk.ps1
@@ -1,40 +1,40 @@
 Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
-$cred = ConvertTo-GraphCredential -ClientId 'id' -ClientSecret 'secret' -DirectoryId 'tenant'
-Connect-EmailGraph -Credential $cred | Out-Null
+$graph = Connect-EmailGraph -ClientId 'id' -DirectoryId 'tenant' -ClientSecretSecretName 'graph-client-secret' -ClientSecretVaultName 'MailSecrets'
+$graph | Out-Null
 
 # Example 1: remove everything from junk
-Clear-GraphJunk -UserPrincipalName 'user@example.com'
+Clear-GraphJunk -UserPrincipalName 'user@example.com' -Connection $graph
 
 # Example 2: preview cleanup using -Preview
-Clear-GraphJunk -UserPrincipalName 'user@example.com' -Preview
+Clear-GraphJunk -UserPrincipalName 'user@example.com' -Connection $graph -Preview
 
 # Example 3: simulate cleanup with -WhatIf
-Clear-GraphJunk -UserPrincipalName 'user@example.com' -WhatIf
+Clear-GraphJunk -UserPrincipalName 'user@example.com' -Connection $graph -WhatIf
 
 # Example 4: skip messages from a sender
-Clear-GraphJunk -UserPrincipalName 'user@example.com' -SkipFrom 'boss@example.com'
+Clear-GraphJunk -UserPrincipalName 'user@example.com' -Connection $graph -SkipFrom 'boss@example.com'
 
 # Example 5: skip messages sent to a specific recipient
-Clear-GraphJunk -UserPrincipalName 'user@example.com' -SkipTo 'reports@example.com'
+Clear-GraphJunk -UserPrincipalName 'user@example.com' -Connection $graph -SkipTo 'reports@example.com'
 
 # Example 6: skip messages containing a subject keyword
-Clear-GraphJunk -UserPrincipalName 'user@example.com' -SkipSubjectContains 'VIP'
+Clear-GraphJunk -UserPrincipalName 'user@example.com' -Connection $graph -SkipSubjectContains 'VIP'
 
 # Example 7: skip specific message IDs
-Clear-GraphJunk -UserPrincipalName 'user@example.com' -SkipId '1','2','3'
+Clear-GraphJunk -UserPrincipalName 'user@example.com' -Connection $graph -SkipId '1','2','3'
 
 # Example 8: combine multiple skip filters
-Clear-GraphJunk -UserPrincipalName 'user@example.com' -SkipFrom 'boss@example.com' -SkipSubjectContains 'Important'
+Clear-GraphJunk -UserPrincipalName 'user@example.com' -Connection $graph -SkipFrom 'boss@example.com' -SkipSubjectContains 'Important'
 
 # Example 9: skip messages that have any attachment
-Clear-GraphJunk -UserPrincipalName 'user@example.com' -SkipHasAttachment
+Clear-GraphJunk -UserPrincipalName 'user@example.com' -Connection $graph -SkipHasAttachment
 
 # Example 10: skip messages containing PDF attachments
-Clear-GraphJunk -UserPrincipalName 'user@example.com' -SkipAttachmentExtension 'pdf'
+Clear-GraphJunk -UserPrincipalName 'user@example.com' -Connection $graph -SkipAttachmentExtension 'pdf'
 
 # Example 11: preview with additional properties
-Clear-GraphJunk -UserPrincipalName 'user@example.com' -Preview -Property subject,from
+Clear-GraphJunk -UserPrincipalName 'user@example.com' -Connection $graph -Preview -Property subject,from
 
 # Example 12: clean junk via raw Graph requests
 Clear-GraphJunk -UserPrincipalName 'user@example.com' -MgGraphRequest

--- a/Examples/Example-GetGraphMailboxStatistics-Console.ps1
+++ b/Examples/Example-GetGraphMailboxStatistics-Console.ps1
@@ -1,7 +1,6 @@
 Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
-$cred = ConvertTo-GraphCredential -ClientId 'id' -ClientSecret 'secret' -DirectoryId 'tenant'
-$graph = Connect-EmailGraph -Credential $cred
+$graph = Connect-EmailGraph -ClientId 'id' -DirectoryId 'tenant' -ClientSecretSecretName 'graph-client-secret' -ClientSecretVaultName 'MailSecrets'
 
 $stats = Get-GraphMailboxStatistics -UserPrincipalName 'user@example.com' -Connection $graph
 

--- a/Examples/Example-GetGraphMailboxStatistics.ps1
+++ b/Examples/Example-GetGraphMailboxStatistics.ps1
@@ -1,7 +1,6 @@
 Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
-$cred = ConvertTo-GraphCredential -ClientId 'id' -ClientSecret 'secret' -DirectoryId 'tenant'
-$graph = Connect-EmailGraph -Credential $cred
+$graph = Connect-EmailGraph -ClientId 'id' -DirectoryId 'tenant' -ClientSecretSecretName 'graph-client-secret' -ClientSecretVaultName 'MailSecrets'
 
 Get-GraphMailboxStatistics -UserPrincipalName 'user@example.com' -Connection $graph |
     Select-Object UserPrincipalName, MessageCount, MessagesWithAttachments, TotalAttachmentSize, TotalFolders, FolderStatistics |

--- a/Examples/Example-GmailApi-01-OAuth.ps1
+++ b/Examples/Example-GmailApi-01-OAuth.ps1
@@ -1,10 +1,12 @@
 Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
 # Connect-OAuthGoogle launches a browser sign-in flow and returns a credential with the acquired token
-$oauthCred = Connect-OAuthGoogle -GmailAccount 'user@gmail.com' -ClientID 'id' -ClientSecret 'secret' -Scope https://mail.google.com/
+$clientSecret = Read-Host 'Google client secret' -AsSecureString
+$oauthCred = Connect-OAuthGoogle -GmailAccount 'user@gmail.com' -ClientID 'id' -ClientSecretSecureString $clientSecret -Scope https://mail.google.com/
 
 # If you already obtained an access token elsewhere, ConvertTo-OAuth2Credential wraps it as a PSCredential
-$tokenCred = ConvertTo-OAuth2Credential -UserName 'user@gmail.com' -Token 'ya29.a0Af...'
+$accessToken = Read-Host 'OAuth access token' -AsSecureString
+$tokenCred = ConvertTo-OAuth2Credential -UserName 'user@gmail.com' -TokenSecureString $accessToken
 
 $oauthCred
 $tokenCred

--- a/Examples/Example-GmailApi-15-GetDmarcReport.ps1
+++ b/Examples/Example-GmailApi-15-GetDmarcReport.ps1
@@ -1,6 +1,7 @@
 Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
-$cred = Connect-OAuthGoogle -GmailAccount 'user@gmail.com' -ClientID 'id' -ClientSecret 'secret' -Scope https://mail.google.com/
+$clientSecret = Read-Host 'Google client secret' -AsSecureString
+$cred = Connect-OAuthGoogle -GmailAccount 'user@gmail.com' -ClientID 'id' -ClientSecretSecureString $clientSecret -Scope https://mail.google.com/
 
 Get-DmarcReport -Protocol GmailApi -GmailAccount 'user@gmail.com' -Credential $cred -Since (Get-Date).AddDays(-7) |
     ForEach-Object {

--- a/Examples/Example-ListImapRootFoldersOAuth.ps1
+++ b/Examples/Example-ListImapRootFoldersOAuth.ps1
@@ -1,7 +1,8 @@
 Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
 # Acquire OAuth token first
-$token = Connect-OAuthGoogle -ClientId 'id' -ClientSecret 'secret' -GmailAccount 'user@example.com' -Scope https://mail.google.com/
+$clientSecret = Read-Host 'Google client secret' -AsSecureString
+$token = Connect-OAuthGoogle -ClientId 'id' -ClientSecretSecureString $clientSecret -GmailAccount 'user@example.com' -Scope https://mail.google.com/
 
 # Connect using the OAuth token and list folders
 $client = Connect-IMAP -Server 'imap.gmail.com' -Port 993 -Credential $token -OAuth2

--- a/Examples/Example-SendEmail-Graph.ps1
+++ b/Examples/Example-SendEmail-Graph.ps1
@@ -8,9 +8,9 @@ $Body = EmailBody {
 # Credentials for Graph
 $ClientID = 'f8f134f3-78c7-48f4-a371-5d6eefa447cd'
 $DirectoryID = 'ceb371f6-8745-4876-a040-69f2d10a9d1a'
-$ClientSecret = Get-Content -Raw -Path "C:\Support\Important\Secretf8f134f3-78c7-48f4-a371-5d6eefa447cd.txt"
+$ClientSecret = Read-Host 'Graph client secret' -AsSecureString
 
-$Credential = ConvertTo-GraphCredential -ClientID $ClientID -ClientSecret $ClientSecret -DirectoryID $DirectoryID
+$Credential = ConvertTo-GraphCredential -ClientID $ClientID -ClientSecretSecureString $ClientSecret -DirectoryID $DirectoryID
 
 # Sending email
 Send-EmailMessage -From @{ Name = 'Przemysław Kłys'; Email = 'przemyslaw.klys@evotec.pl' } -To 'przemyslaw.klys@evotec.pl' `

--- a/Examples/Example-SendEmail-Mailgun.ps1
+++ b/Examples/Example-SendEmail-Mailgun.ps1
@@ -1,8 +1,8 @@
 Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
 # Use Mailgun API
-$Key = Get-Content -Raw -Path "C:\Support\Important\Mailgun.txt"
-$Credential = ConvertTo-MailgunCredential -ApiKey $Key
+$Key = Read-Host 'Mailgun API key' -AsSecureString
+$Credential = ConvertTo-MailgunCredential -ApiKeySecureString $Key
 
 $sendEmailMessageSplat = @{
     From          = 'postmaster@sandbox814085ede3524b939d4b7f518ef9877a.mailgun.org'

--- a/Examples/Example-SendEmail-SendGrid02.ps1
+++ b/Examples/Example-SendEmail-SendGrid02.ps1
@@ -1,9 +1,9 @@
 ﻿Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
 # Use SendGrid Api
-$Key = Get-Content -Raw -Path "C:\Support\Important\SendGrid.txt"
+$Key = Read-Host 'SendGrid API key' -AsSecureString
 
-$Credential = ConvertTo-SendGridCredential -ApiKey $Key
+$Credential = ConvertTo-SendGridCredential -ApiKeySecureString $Key
 
 Send-EmailMessage -From 'przemyslaw.klys@evo.cool' `
     -To 'przemyslaw.klys@evotec.pl', 'evotectest@gmail.com' `

--- a/Mailozaurr.Tests.ps1
+++ b/Mailozaurr.Tests.ps1
@@ -6,6 +6,10 @@ if (-not $PrimaryModule) {
 if ($PrimaryModule.Count -ne 1) {
     throw 'More than one PSD1 files detected. Failing tests.'
 }
+$developmentBuildPath = Join-Path $PSScriptRoot 'Sources\Mailozaurr.PowerShell\bin\Debug'
+if (-not $env:MAILOZAURR_DEVELOPMENT -and (Test-Path $developmentBuildPath)) {
+    $env:MAILOZAURR_DEVELOPMENT = '1'
+}
 $PSDInformation = Import-PowerShellDataFile -Path $PrimaryModule.FullName
 $RequiredModules = @(
     'Pester'

--- a/README.MD
+++ b/README.MD
@@ -283,8 +283,9 @@ $imap = Connect-IMAP -Server 'imap.example.com' -UserName 'user@example.com' -Pa
 $cred = Get-Credential
 $pop3 = Connect-POP3 -Server 'pop.example.com' -Credential $cred
 
-# OAuth2 token
-$oauth = Connect-OAuthGoogle -ClientId 'id' -ClientSecret 'secret' -GmailAccount 'user@example.com' -Scope https://mail.google.com/
+# OAuth2 token with a SecureString client secret
+$googleClientSecret = Read-Host 'Google client secret' -AsSecureString
+$oauth = Connect-OAuthGoogle -ClientId 'id' -ClientSecretSecureString $googleClientSecret -GmailAccount 'user@example.com' -Scope https://mail.google.com/
 $imapOAuth = Connect-IMAP -Server 'imap.gmail.com' -Credential $oauth -OAuth2
 ```
 
@@ -300,7 +301,7 @@ Get-IMAPFolder -Client $client -Root
 Using OAuth tokens works the same:
 
 ```powershell
-$token = Connect-OAuthGoogle -ClientId 'id' -ClientSecret 'secret' -GmailAccount 'user@example.com' -Scope https://mail.google.com/
+$token = Connect-OAuthGoogle -ClientId 'id' -ClientSecretSecretName 'gmail-client-secret' -ClientSecretVaultName 'MailSecrets' -GmailAccount 'user@example.com' -Scope https://mail.google.com/
 $client = Connect-IMAP -Server 'imap.gmail.com' -Credential $token -OAuth2
 Get-IMAPFolder -Client $client -Root
 ```
@@ -388,7 +389,7 @@ PowerShell
 
 ```powershell
 # Graph send with conservative retry/backoff and concurrency
-$cred = ConvertTo-GraphCredential -ClientId $ClientId -ClientSecret $ClientSecret -DirectoryId $TenantId
+$cred = ConvertTo-GraphCredential -ClientId $ClientId -SecretName 'graph-client-secret' -VaultName 'MailSecrets' -DirectoryId $TenantId
 
 Send-EmailMessage -Graph -From 'sender@example.com' -To 'user@example.com' `
   -Credential $cred -HTML '<b>Hello</b>' -Subject 'Graph policy demo' `
@@ -533,7 +534,7 @@ The module supports two ways of calling Microsoft Graph. Use `-Graph` when you c
 **Example using `-Graph`**
 
 ```powershell
-$cred = ConvertTo-GraphCredential -ClientId $ClientId -ClientSecret $ClientSecret -DirectoryId $TenantId
+$cred = ConvertTo-GraphCredential -ClientId $ClientId -SecretName 'graph-client-secret' -VaultName 'MailSecrets' -DirectoryId $TenantId
 Connect-EmailGraph -Credential $cred
 Send-EmailMessage -From 'user@example.com' -To 'user@example.com' -Subject 'Graph Test' -Graph
 Disconnect-EmailGraph

--- a/Sources/Mailozaurr.Application/FileMailSecretStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailSecretStore.cs
@@ -105,6 +105,7 @@ public sealed class FileMailSecretStore : IMailSecretStore {
         Directory.CreateDirectory(directory);
 
         var tempPath = Path.Combine(directory, Path.GetRandomFileName());
+        var backupPath = Path.Combine(directory, Path.GetRandomFileName());
         try {
             using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
                 await JsonSerializer.SerializeAsync(stream, document, SerializerOptions, cancellationToken).ConfigureAwait(false);
@@ -112,7 +113,13 @@ public sealed class FileMailSecretStore : IMailSecretStore {
             }
 
             if (File.Exists(_filePath)) {
-                File.Delete(_filePath);
+                File.Replace(tempPath, _filePath, backupPath);
+                tempPath = string.Empty;
+                if (File.Exists(backupPath)) {
+                    File.Delete(backupPath);
+                }
+                backupPath = string.Empty;
+                return;
             }
 
             File.Move(tempPath, _filePath);
@@ -120,6 +127,9 @@ public sealed class FileMailSecretStore : IMailSecretStore {
         } finally {
             if (!string.IsNullOrEmpty(tempPath) && File.Exists(tempPath)) {
                 File.Delete(tempPath);
+            }
+            if (!string.IsNullOrEmpty(backupPath) && File.Exists(backupPath)) {
+                File.Delete(backupPath);
             }
         }
     }

--- a/Sources/Mailozaurr.Application/GmailProfileBootstrapRequest.cs
+++ b/Sources/Mailozaurr.Application/GmailProfileBootstrapRequest.cs
@@ -28,9 +28,18 @@ public sealed class GmailProfileBootstrapRequest {
     /// <summary>Optional Google OAuth client secret to store securely.</summary>
     public string? ClientSecret { get; set; }
 
+    /// <summary>Optional secret reference for the client secret, in the form <c>&lt;profile-id&gt;:&lt;secret-name&gt;</c> or <c>&lt;secret-name&gt;</c>.</summary>
+    public string? ClientSecretReference { get; set; }
+
     /// <summary>Optional refresh token to store securely.</summary>
     public string? RefreshToken { get; set; }
 
+    /// <summary>Optional secret reference for the refresh token, in the form <c>&lt;profile-id&gt;:&lt;secret-name&gt;</c> or <c>&lt;secret-name&gt;</c>.</summary>
+    public string? RefreshTokenReference { get; set; }
+
     /// <summary>Optional explicit access token to store securely.</summary>
     public string? AccessToken { get; set; }
+
+    /// <summary>Optional secret reference for the access token, in the form <c>&lt;profile-id&gt;:&lt;secret-name&gt;</c> or <c>&lt;secret-name&gt;</c>.</summary>
+    public string? AccessTokenReference { get; set; }
 }

--- a/Sources/Mailozaurr.Application/GmailProfileLoginRequest.cs
+++ b/Sources/Mailozaurr.Application/GmailProfileLoginRequest.cs
@@ -16,6 +16,9 @@ public sealed class GmailProfileLoginRequest {
     /// <summary>Optional OAuth client secret override.</summary>
     public string? ClientSecret { get; set; }
 
+    /// <summary>Optional secret reference for the client secret, in the form <c>&lt;profile-id&gt;:&lt;secret-name&gt;</c> or <c>&lt;secret-name&gt;</c>.</summary>
+    public string? ClientSecretReference { get; set; }
+
     /// <summary>Optional scopes override. Defaults to the Mailozaurr Gmail mail scope.</summary>
     public IReadOnlyList<string>? Scopes { get; set; }
 }

--- a/Sources/Mailozaurr.Application/GraphProfileBootstrapRequest.cs
+++ b/Sources/Mailozaurr.Application/GraphProfileBootstrapRequest.cs
@@ -31,12 +31,21 @@ public sealed class GraphProfileBootstrapRequest {
     /// <summary>Optional confidential-client secret to store securely.</summary>
     public string? ClientSecret { get; set; }
 
+    /// <summary>Optional secret reference for the client secret, in the form <c>&lt;profile-id&gt;:&lt;secret-name&gt;</c> or <c>&lt;secret-name&gt;</c>.</summary>
+    public string? ClientSecretReference { get; set; }
+
     /// <summary>Optional explicit access token to store securely.</summary>
     public string? AccessToken { get; set; }
+
+    /// <summary>Optional secret reference for the access token, in the form <c>&lt;profile-id&gt;:&lt;secret-name&gt;</c> or <c>&lt;secret-name&gt;</c>.</summary>
+    public string? AccessTokenReference { get; set; }
 
     /// <summary>Optional certificate path for certificate-based authentication.</summary>
     public string? CertificatePath { get; set; }
 
     /// <summary>Optional certificate password to store securely.</summary>
     public string? CertificatePassword { get; set; }
+
+    /// <summary>Optional secret reference for the certificate password, in the form <c>&lt;profile-id&gt;:&lt;secret-name&gt;</c> or <c>&lt;secret-name&gt;</c>.</summary>
+    public string? CertificatePasswordReference { get; set; }
 }

--- a/Sources/Mailozaurr.Application/IMailProfileSecretService.cs
+++ b/Sources/Mailozaurr.Application/IMailProfileSecretService.cs
@@ -7,6 +7,9 @@ public interface IMailProfileSecretService {
     /// <summary>Saves or replaces a secret for an existing profile.</summary>
     Task<OperationResult> SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default);
 
+    /// <summary>Saves or replaces a secret for an existing profile, optionally by copying from another stored secret reference.</summary>
+    Task<OperationResult> SetSecretAsync(string profileId, string secretName, string? secretValue, string? secretReference, CancellationToken cancellationToken = default);
+
     /// <summary>Removes a secret from an existing profile.</summary>
     Task<OperationResult> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default);
 }

--- a/Sources/Mailozaurr.Application/MailProfileAuthService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileAuthService.cs
@@ -102,6 +102,18 @@ public sealed class MailProfileAuthService : IMailProfileAuthService {
         }
 
         var profile = profileResult.Profile!;
+        string? requestClientSecret;
+        try {
+            requestClientSecret = await MailSecretReferenceResolver.ResolveAsync(
+                _secretStore,
+                profile.Id,
+                MailSecretNames.ClientSecret,
+                request.ClientSecret,
+                request.ClientSecretReference,
+                cancellationToken).ConfigureAwait(false);
+        } catch (InvalidOperationException ex) {
+            return Failure("secret_reference_invalid", ex.Message, profile.Id, MailProfileKind.Gmail);
+        }
         var gmailAccount = FirstNonEmpty(
             request.GmailAccount,
             profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailboxSetting) ? mailboxSetting : null,
@@ -110,7 +122,7 @@ public sealed class MailProfileAuthService : IMailProfileAuthService {
             request.ClientId,
             profile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientIdSetting) ? clientIdSetting : null);
         var clientSecret = FirstNonEmpty(
-            request.ClientSecret,
+            requestClientSecret,
             await TryReadSecretAsync(profile.Id, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false));
 
         if (string.IsNullOrWhiteSpace(gmailAccount)) {
@@ -128,6 +140,7 @@ public sealed class MailProfileAuthService : IMailProfileAuthService {
             GmailAccount = gmailAccount,
             ClientId = clientId,
             ClientSecret = clientSecret,
+            ClientSecretReference = null,
             Scopes = NormalizeScopes(request.Scopes, MailProfileAuthDefaults.GmailScopes)
         };
         var credential = await _loginGmailAsync(effectiveRequest, cancellationToken).ConfigureAwait(false);

--- a/Sources/Mailozaurr.Application/MailProfileBootstrapService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileBootstrapService.cs
@@ -28,13 +28,41 @@ public sealed class MailProfileBootstrapService : IMailProfileBootstrapService {
         var mailbox = request.Mailbox.Trim();
         var defaultSender = string.IsNullOrWhiteSpace(request.DefaultSender) ? mailbox : request.DefaultSender!.Trim();
         var existing = await _profiles.GetProfileAsync(profileId, cancellationToken).ConfigureAwait(false);
+        string? clientSecret;
+        string? accessToken;
+        string? certificatePassword;
+        try {
+            clientSecret = await MailSecretReferenceResolver.ResolveAsync(
+                _secretStore,
+                profileId,
+                MailSecretNames.ClientSecret,
+                request.ClientSecret,
+                request.ClientSecretReference,
+                cancellationToken).ConfigureAwait(false);
+            accessToken = await MailSecretReferenceResolver.ResolveAsync(
+                _secretStore,
+                profileId,
+                MailSecretNames.AccessToken,
+                request.AccessToken,
+                request.AccessTokenReference,
+                cancellationToken).ConfigureAwait(false);
+            certificatePassword = await MailSecretReferenceResolver.ResolveAsync(
+                _secretStore,
+                profileId,
+                MailSecretNames.CertificatePassword,
+                request.CertificatePassword,
+                request.CertificatePasswordReference,
+                cancellationToken).ConfigureAwait(false);
+        } catch (InvalidOperationException ex) {
+            return OperationResult.Failure("secret_reference_invalid", ex.Message);
+        }
 
         var effectiveClientId = FirstNonEmpty(request.ClientId, existing?.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var existingClientId) == true ? existingClientId : null);
         var effectiveTenantId = FirstNonEmpty(request.TenantId, existing?.Settings.TryGetValue(MailProfileSettingsKeys.TenantId, out var existingTenantId) == true ? existingTenantId : null);
         var effectiveCertificatePath = FirstNonEmpty(request.CertificatePath, existing?.Settings.TryGetValue(MailProfileSettingsKeys.CertificatePath, out var existingCertificatePath) == true ? existingCertificatePath : null);
-        var hasAccessToken = !string.IsNullOrWhiteSpace(request.AccessToken) ||
+        var hasAccessToken = !string.IsNullOrWhiteSpace(accessToken) ||
                              await HasStoredSecretAsync(profileId, MailSecretNames.AccessToken, cancellationToken).ConfigureAwait(false);
-        var hasClientSecret = !string.IsNullOrWhiteSpace(request.ClientSecret) ||
+        var hasClientSecret = !string.IsNullOrWhiteSpace(clientSecret) ||
                               await HasStoredSecretAsync(profileId, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false);
         var hasCertificate = !string.IsNullOrWhiteSpace(effectiveCertificatePath);
 
@@ -53,7 +81,7 @@ public sealed class MailProfileBootstrapService : IMailProfileBootstrapService {
                 "graph_auth_required",
                 "Graph profiles require either an access token or a client-id and tenant-id with a client secret or certificate path.");
         }
-        if (!string.IsNullOrWhiteSpace(request.CertificatePassword) && !hasCertificate) {
+        if (!string.IsNullOrWhiteSpace(certificatePassword) && !hasCertificate) {
             return OperationResult.Failure("certificate_path_required", "Certificate password requires a certificate path.");
         }
 
@@ -81,20 +109,20 @@ public sealed class MailProfileBootstrapService : IMailProfileBootstrapService {
             return saveResult;
         }
 
-        if (!string.IsNullOrWhiteSpace(request.ClientSecret)) {
-            var clientSecretResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.ClientSecret, request.ClientSecret!.Trim(), cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(clientSecret)) {
+            var clientSecretResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.ClientSecret, clientSecret!.Trim(), cancellationToken).ConfigureAwait(false);
             if (!clientSecretResult.Succeeded) {
                 return clientSecretResult;
             }
         }
-        if (!string.IsNullOrWhiteSpace(request.AccessToken)) {
-            var accessTokenResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.AccessToken, request.AccessToken!.Trim(), cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(accessToken)) {
+            var accessTokenResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.AccessToken, accessToken!.Trim(), cancellationToken).ConfigureAwait(false);
             if (!accessTokenResult.Succeeded) {
                 return accessTokenResult;
             }
         }
-        if (!string.IsNullOrWhiteSpace(request.CertificatePassword)) {
-            var certificatePasswordResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.CertificatePassword, request.CertificatePassword!.Trim(), cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(certificatePassword)) {
+            var certificatePasswordResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.CertificatePassword, certificatePassword!.Trim(), cancellationToken).ConfigureAwait(false);
             if (!certificatePasswordResult.Succeeded) {
                 return certificatePasswordResult;
             }
@@ -113,12 +141,40 @@ public sealed class MailProfileBootstrapService : IMailProfileBootstrapService {
         var displayName = request.DisplayName.Trim();
         var mailbox = string.IsNullOrWhiteSpace(request.Mailbox) ? "me" : request.Mailbox!.Trim();
         var existing = await _profiles.GetProfileAsync(profileId, cancellationToken).ConfigureAwait(false);
+        string? clientSecret;
+        string? refreshToken;
+        string? accessToken;
+        try {
+            clientSecret = await MailSecretReferenceResolver.ResolveAsync(
+                _secretStore,
+                profileId,
+                MailSecretNames.ClientSecret,
+                request.ClientSecret,
+                request.ClientSecretReference,
+                cancellationToken).ConfigureAwait(false);
+            refreshToken = await MailSecretReferenceResolver.ResolveAsync(
+                _secretStore,
+                profileId,
+                MailSecretNames.RefreshToken,
+                request.RefreshToken,
+                request.RefreshTokenReference,
+                cancellationToken).ConfigureAwait(false);
+            accessToken = await MailSecretReferenceResolver.ResolveAsync(
+                _secretStore,
+                profileId,
+                MailSecretNames.AccessToken,
+                request.AccessToken,
+                request.AccessTokenReference,
+                cancellationToken).ConfigureAwait(false);
+        } catch (InvalidOperationException ex) {
+            return OperationResult.Failure("secret_reference_invalid", ex.Message);
+        }
         var effectiveClientId = FirstNonEmpty(request.ClientId, existing?.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var existingClientId) == true ? existingClientId : null);
-        var hasAccessToken = !string.IsNullOrWhiteSpace(request.AccessToken) ||
+        var hasAccessToken = !string.IsNullOrWhiteSpace(accessToken) ||
                              await HasStoredSecretAsync(profileId, MailSecretNames.AccessToken, cancellationToken).ConfigureAwait(false);
-        var hasRefreshToken = !string.IsNullOrWhiteSpace(request.RefreshToken) ||
+        var hasRefreshToken = !string.IsNullOrWhiteSpace(refreshToken) ||
                               await HasStoredSecretAsync(profileId, MailSecretNames.RefreshToken, cancellationToken).ConfigureAwait(false);
-        var hasClientSecret = !string.IsNullOrWhiteSpace(request.ClientSecret) ||
+        var hasClientSecret = !string.IsNullOrWhiteSpace(clientSecret) ||
                               await HasStoredSecretAsync(profileId, MailSecretNames.ClientSecret, cancellationToken).ConfigureAwait(false);
 
         if (profileId.Length == 0) {
@@ -159,20 +215,20 @@ public sealed class MailProfileBootstrapService : IMailProfileBootstrapService {
             return saveResult;
         }
 
-        if (!string.IsNullOrWhiteSpace(request.ClientSecret)) {
-            var clientSecretResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.ClientSecret, request.ClientSecret!.Trim(), cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(clientSecret)) {
+            var clientSecretResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.ClientSecret, clientSecret!.Trim(), cancellationToken).ConfigureAwait(false);
             if (!clientSecretResult.Succeeded) {
                 return clientSecretResult;
             }
         }
-        if (!string.IsNullOrWhiteSpace(request.RefreshToken)) {
-            var refreshTokenResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.RefreshToken, request.RefreshToken!.Trim(), cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(refreshToken)) {
+            var refreshTokenResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.RefreshToken, refreshToken!.Trim(), cancellationToken).ConfigureAwait(false);
             if (!refreshTokenResult.Succeeded) {
                 return refreshTokenResult;
             }
         }
-        if (!string.IsNullOrWhiteSpace(request.AccessToken)) {
-            var accessTokenResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.AccessToken, request.AccessToken!.Trim(), cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(accessToken)) {
+            var accessTokenResult = await _profileSecrets.SetSecretAsync(profile.Id, MailSecretNames.AccessToken, accessToken!.Trim(), cancellationToken).ConfigureAwait(false);
             if (!accessTokenResult.Succeeded) {
                 return accessTokenResult;
             }

--- a/Sources/Mailozaurr.Application/MailProfileSecretService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileSecretService.cs
@@ -16,17 +16,39 @@ public sealed class MailProfileSecretService : IMailProfileSecretService {
     }
 
     /// <inheritdoc />
-    public async Task<OperationResult> SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
-        if (string.IsNullOrWhiteSpace(secretValue)) {
-            return OperationResult.Failure("secret_value_required", "Secret value is required.");
-        }
+    public Task<OperationResult> SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) =>
+        SetSecretAsync(profileId, secretName, secretValue, null, cancellationToken);
 
+    /// <inheritdoc />
+    public async Task<OperationResult> SetSecretAsync(
+        string profileId,
+        string secretName,
+        string? secretValue,
+        string? secretReference,
+        CancellationToken cancellationToken = default) {
         var validationResult = await ValidateAsync(profileId, secretName, cancellationToken).ConfigureAwait(false);
         if (!validationResult.Succeeded) {
             return validationResult;
         }
 
-        await _secretStore.SetSecretAsync(profileId, secretName, secretValue, cancellationToken).ConfigureAwait(false);
+        string? resolvedSecret;
+        try {
+            resolvedSecret = await MailSecretReferenceResolver.ResolveAsync(
+                _secretStore,
+                profileId,
+                secretName,
+                secretValue,
+                secretReference,
+                cancellationToken).ConfigureAwait(false);
+        } catch (InvalidOperationException ex) {
+            return OperationResult.Failure("secret_reference_invalid", ex.Message);
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedSecret)) {
+            return OperationResult.Failure("secret_value_required", "Secret value is required.");
+        }
+
+        await _secretStore.SetSecretAsync(profileId, secretName, resolvedSecret!, cancellationToken).ConfigureAwait(false);
         return OperationResult.Success("Secret saved.");
     }
 

--- a/Sources/Mailozaurr.Application/MailSecretReferenceResolver.cs
+++ b/Sources/Mailozaurr.Application/MailSecretReferenceResolver.cs
@@ -1,0 +1,62 @@
+namespace Mailozaurr.Application;
+
+internal static class MailSecretReferenceResolver {
+    public static async Task<string?> ResolveAsync(
+        IMailSecretStore secretStore,
+        string targetProfileId,
+        string targetSecretName,
+        string? inlineValue,
+        string? secretReference,
+        CancellationToken cancellationToken = default) {
+        if (secretStore == null) {
+            throw new ArgumentNullException(nameof(secretStore));
+        }
+
+        var hasInline = !string.IsNullOrWhiteSpace(inlineValue);
+        var hasReference = !string.IsNullOrWhiteSpace(secretReference);
+        if (hasInline && hasReference) {
+            throw new InvalidOperationException(
+                $"Provide either an inline secret or a secret reference for '{targetSecretName}', not both.");
+        }
+
+        if (!hasReference) {
+            return hasInline ? inlineValue : null;
+        }
+
+        var (sourceProfileId, sourceSecretName) = Parse(secretReference!, targetProfileId);
+        var resolved = await secretStore.GetSecretAsync(sourceProfileId, sourceSecretName, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(resolved)) {
+            throw new InvalidOperationException(
+                $"Secret reference '{secretReference}' for '{targetSecretName}' was not found.");
+        }
+
+        return resolved;
+    }
+
+    public static (string ProfileId, string SecretName) Parse(string secretReference, string defaultProfileId) {
+        var normalized = secretReference == null ? null : secretReference.Trim();
+        if (string.IsNullOrWhiteSpace(normalized)) {
+            throw new InvalidOperationException("Secret reference cannot be empty.");
+        }
+
+        var value = normalized!;
+        var colonIndex = value.IndexOf(':');
+        var slashIndex = value.IndexOf('/');
+        var separatorIndex = colonIndex >= 0 && slashIndex >= 0
+            ? Math.Min(colonIndex, slashIndex)
+            : Math.Max(colonIndex, slashIndex);
+
+        if (separatorIndex < 0) {
+            return (defaultProfileId, value);
+        }
+
+        var profileId = value.Substring(0, separatorIndex).Trim();
+        var secretName = value.Substring(separatorIndex + 1).Trim();
+        if (string.IsNullOrWhiteSpace(profileId) || string.IsNullOrWhiteSpace(secretName)) {
+            throw new InvalidOperationException(
+                $"Secret reference '{secretReference}' must use '<profile-id>:<secret-name>' or '<secret-name>'.");
+        }
+
+        return (profileId, secretName);
+    }
+}

--- a/Sources/Mailozaurr.Cli/CliRunner.cs
+++ b/Sources/Mailozaurr.Cli/CliRunner.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text.Json;
 using Mailozaurr.Application;
 using Mailozaurr.Cli.Mcp;
@@ -13,7 +14,8 @@ public static class CliRunner {
         string[] args,
         TextWriter output,
         TextWriter error,
-        Func<MailApplicationOptions, MailApplicationBuilder>? builderFactory = null) {
+        Func<MailApplicationOptions, MailApplicationBuilder>? builderFactory = null,
+        TextReader? input = null) {
         if (args == null) {
             throw new ArgumentNullException(nameof(args));
         }
@@ -25,6 +27,7 @@ public static class CliRunner {
         }
 
         var parseResult = CliArguments.Parse(args);
+        input ??= TextReader.Null;
         if (parseResult.ShowHelp || parseResult.Positionals.Count == 0) {
             WriteHelp(output);
             return 0;
@@ -53,9 +56,9 @@ public static class CliRunner {
             .Build();
 
         try {
-            return await ExecuteAsync(application, parseResult, output, error).ConfigureAwait(false);
+            return await ExecuteAsync(application, parseResult, output, error, input).ConfigureAwait(false);
         } catch (Exception ex) {
-            await error.WriteLineAsync(ex.Message).ConfigureAwait(false);
+            await WriteExceptionAsync(error, ex, parseResult.HasFlag("json")).ConfigureAwait(false);
             return 1;
         }
     }
@@ -64,10 +67,11 @@ public static class CliRunner {
         MailApplication application,
         CliArguments parseResult,
         TextWriter output,
-        TextWriter error) {
+        TextWriter error,
+        TextReader input) {
         var command = parseResult.Positionals[0];
         return command switch {
-            "profile" => await ExecuteProfileAsync(application, parseResult, output, error).ConfigureAwait(false),
+            "profile" => await ExecuteProfileAsync(application, parseResult, output, error, input).ConfigureAwait(false),
             "draft" => await ExecuteDraftAsync(application, parseResult, output, error).ConfigureAwait(false),
             "mail" => await ExecuteMailAsync(application, parseResult, output, error).ConfigureAwait(false),
             "mcp" => await ExecuteMcpAsync(application, parseResult, error).ConfigureAwait(false),
@@ -81,7 +85,8 @@ public static class CliRunner {
         MailApplication application,
         CliArguments parseResult,
         TextWriter output,
-        TextWriter error) {
+        TextWriter error,
+        TextReader input) {
         if (parseResult.Positionals.Count < 2) {
             await error.WriteLineAsync("Missing profile command. Use 'profile list', 'profile create', 'profile graph-bootstrap', 'profile gmail-bootstrap', 'profile graph-login', 'profile gmail-login', 'profile refresh-auth', 'profile auth-status', 'profile test', 'profile summary', 'profile capabilities', 'profile show', 'profile validate', 'profile doctor', 'profile delete', 'profile set-default', 'profile set-secret', or 'profile remove-secret'.").ConfigureAwait(false);
             return 1;
@@ -119,10 +124,13 @@ public static class CliRunner {
                     IsDefault = parseResult.HasFlag("is-default"),
                     ClientId = parseResult.GetOption("client-id"),
                     TenantId = parseResult.GetOption("tenant-id"),
-                    ClientSecret = parseResult.GetOption("client-secret"),
-                    AccessToken = parseResult.GetOption("access-token"),
+                    ClientSecret = await ResolveSensitiveOptionAsync(parseResult, "client-secret", input).ConfigureAwait(false),
+                    ClientSecretReference = parseResult.GetOption("client-secret-ref"),
+                    AccessToken = await ResolveSensitiveOptionAsync(parseResult, "access-token", input).ConfigureAwait(false),
+                    AccessTokenReference = parseResult.GetOption("access-token-ref"),
                     CertificatePath = parseResult.GetOption("certificate-path"),
-                    CertificatePassword = parseResult.GetOption("certificate-password")
+                    CertificatePassword = await ResolveSensitiveOptionAsync(parseResult, "certificate-password", input).ConfigureAwait(false),
+                    CertificatePasswordReference = parseResult.GetOption("certificate-password-ref")
                 }).ConfigureAwait(false);
                 await WriteItemAsync(output, graphBootstrapResult, json, value => value.Message ?? "Graph profile saved.").ConfigureAwait(false);
                 return graphBootstrapResult.Succeeded ? 0 : 1;
@@ -135,9 +143,12 @@ public static class CliRunner {
                     DefaultSender = parseResult.GetOption("default-sender"),
                     IsDefault = parseResult.HasFlag("is-default"),
                     ClientId = parseResult.GetOption("client-id"),
-                    ClientSecret = parseResult.GetOption("client-secret"),
-                    RefreshToken = parseResult.GetOption("refresh-token"),
-                    AccessToken = parseResult.GetOption("access-token")
+                    ClientSecret = await ResolveSensitiveOptionAsync(parseResult, "client-secret", input).ConfigureAwait(false),
+                    ClientSecretReference = parseResult.GetOption("client-secret-ref"),
+                    RefreshToken = await ResolveSensitiveOptionAsync(parseResult, "refresh-token", input).ConfigureAwait(false),
+                    RefreshTokenReference = parseResult.GetOption("refresh-token-ref"),
+                    AccessToken = await ResolveSensitiveOptionAsync(parseResult, "access-token", input).ConfigureAwait(false),
+                    AccessTokenReference = parseResult.GetOption("access-token-ref")
                 }).ConfigureAwait(false);
                 await WriteItemAsync(output, gmailBootstrapResult, json, value => value.Message ?? "Gmail profile saved.").ConfigureAwait(false);
                 return gmailBootstrapResult.Succeeded ? 0 : 1;
@@ -161,7 +172,8 @@ public static class CliRunner {
                     ProfileId = RequireOption(parseResult, "profile"),
                     GmailAccount = parseResult.GetOption("mailbox"),
                     ClientId = parseResult.GetOption("client-id"),
-                    ClientSecret = parseResult.GetOption("client-secret"),
+                    ClientSecret = await ResolveSensitiveOptionAsync(parseResult, "client-secret", input).ConfigureAwait(false),
+                    ClientSecretReference = parseResult.GetOption("client-secret-ref"),
                     Scopes = parseResult.GetOptionValues("scope")
                         .Where(value => !string.IsNullOrWhiteSpace(value))
                         .Select(value => value!)
@@ -247,10 +259,17 @@ public static class CliRunner {
                 await WriteItemAsync(output, setDefaultResult, json, value => value.Message ?? "Default profile updated.").ConfigureAwait(false);
                 return setDefaultResult.Succeeded ? 0 : 1;
             case "set-secret":
+                var secretValue = await ResolveSensitiveOptionAsync(parseResult, "value", input).ConfigureAwait(false);
+                var secretReference = parseResult.GetOption("value-ref");
+                if (secretValue == null && string.IsNullOrWhiteSpace(secretReference)) {
+                    throw new InvalidOperationException(
+                        "Missing required option '--value'. You can also use '--value-env <name>', '--value-stdin', or '--value-ref <profile-id:secret-name>'.");
+                }
                 var setSecretResult = await application.ProfileSecrets.SetSecretAsync(
                     RequireOption(parseResult, "profile"),
                     RequireOption(parseResult, "name"),
-                    RequireOption(parseResult, "value")).ConfigureAwait(false);
+                    secretValue,
+                    secretReference).ConfigureAwait(false);
                 await WriteItemAsync(output, setSecretResult, json, value => value.Message ?? "Secret saved.").ConfigureAwait(false);
                 return setSecretResult.Succeeded ? 0 : 1;
             case "remove-secret":
@@ -1253,16 +1272,74 @@ public static class CliRunner {
         }
     }
 
+    private static async Task<string?> ResolveSensitiveOptionAsync(
+        CliArguments parseResult,
+        string optionName,
+        TextReader input,
+        bool required = false) {
+        var directValue = parseResult.GetOption(optionName);
+        var envName = parseResult.GetOption($"{optionName}-env");
+        var stdinRequested = parseResult.HasFlag($"{optionName}-stdin");
+
+        var sourceCount = 0;
+        if (directValue != null) {
+            sourceCount++;
+        }
+        if (!string.IsNullOrWhiteSpace(envName)) {
+            sourceCount++;
+        }
+        if (stdinRequested) {
+            sourceCount++;
+        }
+
+        if (sourceCount > 1) {
+            throw new InvalidOperationException($"Option '--{optionName}' accepts only one secret source at a time.");
+        }
+
+        string? resolvedValue = directValue;
+        if (!string.IsNullOrWhiteSpace(envName)) {
+            resolvedValue = Environment.GetEnvironmentVariable(envName!);
+            if (resolvedValue == null) {
+                throw new InvalidOperationException($"Environment variable '{envName}' was not found for '--{optionName}-env'.");
+            }
+        } else if (stdinRequested) {
+            resolvedValue = await input.ReadToEndAsync().ConfigureAwait(false);
+            resolvedValue = resolvedValue.TrimEnd('\r', '\n');
+        }
+
+        if (required && resolvedValue == null) {
+            throw new InvalidOperationException(
+                $"Missing required option '--{optionName}'. You can also use '--{optionName}-env <name>' or '--{optionName}-stdin'.");
+        }
+
+        return resolvedValue;
+    }
+
+    private static async Task WriteExceptionAsync(TextWriter error, Exception exception, bool json) {
+        if (json) {
+            var payload = new CliErrorEnvelope {
+                Error = new CliError {
+                    Type = exception.GetType().Name,
+                    Message = exception.Message
+                }
+            };
+            await error.WriteLineAsync(JsonSerializer.Serialize(payload, JsonOptions)).ConfigureAwait(false);
+            return;
+        }
+
+        await error.WriteLineAsync(exception.Message).ConfigureAwait(false);
+    }
+
     private static void WriteHelp(TextWriter output) {
         output.WriteLine("Mailozaurr CLI");
         output.WriteLine();
         output.WriteLine("Commands:");
         output.WriteLine("  profile list [--summary] [--compact] [--kind <kind>] [--ready-only] [--can-read] [--can-send] [--default-only] [--sort <id|kind|readiness>] [--desc] [--json]");
         output.WriteLine("  profile create --profile <id> --kind <kind> --name <display-name> [--description <text>] [--default-sender <email>] [--default-mailbox <value>] [--is-default] [--setting <key=value>] [--json]");
-        output.WriteLine("  profile graph-bootstrap --profile <id> --name <display-name> --mailbox <address> [--description <text>] [--default-sender <email>] [--is-default] [--client-id <id>] [--tenant-id <id>] [--client-secret <secret>] [--access-token <token>] [--certificate-path <path>] [--certificate-password <secret>] [--json]");
-        output.WriteLine("  profile gmail-bootstrap --profile <id> --name <display-name> [--mailbox <address|me>] [--description <text>] [--default-sender <email>] [--is-default] [--client-id <id>] [--client-secret <secret>] [--refresh-token <token>] [--access-token <token>] [--json]");
+        output.WriteLine("  profile graph-bootstrap --profile <id> --name <display-name> --mailbox <address> [--description <text>] [--default-sender <email>] [--is-default] [--client-id <id>] [--tenant-id <id>] [--client-secret <secret>|--client-secret-env <name>|--client-secret-stdin|--client-secret-ref <profile-id:secret-name>] [--access-token <token>|--access-token-env <name>|--access-token-stdin|--access-token-ref <profile-id:secret-name>] [--certificate-path <path>] [--certificate-password <secret>|--certificate-password-env <name>|--certificate-password-stdin|--certificate-password-ref <profile-id:secret-name>] [--json]");
+        output.WriteLine("  profile gmail-bootstrap --profile <id> --name <display-name> [--mailbox <address|me>] [--description <text>] [--default-sender <email>] [--is-default] [--client-id <id>] [--client-secret <secret>|--client-secret-env <name>|--client-secret-stdin|--client-secret-ref <profile-id:secret-name>] [--refresh-token <token>|--refresh-token-env <name>|--refresh-token-stdin|--refresh-token-ref <profile-id:secret-name>] [--access-token <token>|--access-token-env <name>|--access-token-stdin|--access-token-ref <profile-id:secret-name>] [--json]");
         output.WriteLine("  profile graph-login --profile <id> [--login <upn>] [--mailbox <address>] [--client-id <id>] [--tenant-id <id>] [--redirect-uri <uri>] [--scope <value>] [--scope <value>] [--json]");
-        output.WriteLine("  profile gmail-login --profile <id> [--mailbox <address>] [--client-id <id>] [--client-secret <secret>] [--scope <value>] [--scope <value>] [--json]");
+        output.WriteLine("  profile gmail-login --profile <id> [--mailbox <address>] [--client-id <id>] [--client-secret <secret>|--client-secret-env <name>|--client-secret-stdin|--client-secret-ref <profile-id:secret-name>] [--scope <value>] [--scope <value>] [--json]");
         output.WriteLine("  profile refresh-auth --profile <id> [--json]");
         output.WriteLine("  profile auth-status --profile <id> [--json]");
         output.WriteLine("  profile test --profile <id> [--scope <auto|auth|mailbox|send>] [--json]");
@@ -1273,7 +1350,7 @@ public static class CliRunner {
         output.WriteLine("  profile doctor --profile <id> [--json]");
         output.WriteLine("  profile delete --profile <id> [--json]");
         output.WriteLine("  profile set-default --profile <id> [--json]");
-        output.WriteLine("  profile set-secret --profile <id> --name <secret-name> --value <secret-value> [--json]");
+        output.WriteLine("  profile set-secret --profile <id> --name <secret-name> [--value <secret-value>|--value-env <name>|--value-stdin|--value-ref <profile-id:secret-name>] [--json]");
         output.WriteLine("  profile remove-secret --profile <id> --name <secret-name> [--json]");
         output.WriteLine("  draft list [--compact] [--json]");
         output.WriteLine("  draft save --file <path> [--draft <id>] [--name <display-name>] [--json]");
@@ -1381,5 +1458,15 @@ public static class CliRunner {
         }
 
         throw new InvalidOperationException($"Unsupported profile overview sort '{rawSort}'.");
+    }
+
+    private sealed class CliErrorEnvelope {
+        public required CliError Error { get; init; }
+    }
+
+    private sealed class CliError {
+        public required string Type { get; init; }
+
+        public required string Message { get; init; }
     }
 }

--- a/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.cs
+++ b/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.cs
@@ -163,10 +163,13 @@ public sealed class MailMcpTools {
         [Description("When true, marks this profile as the default profile.")] bool isDefault = false,
         [Description("Optional Graph client/application identifier.")] string? clientId = null,
         [Description("Optional Graph tenant/directory identifier.")] string? tenantId = null,
-        [Description("Optional confidential client secret to store securely.")] string? clientSecret = null,
-        [Description("Optional explicit access token to store securely.")] string? accessToken = null,
+        [Description("Optional confidential client secret to store securely. Prefer using clientSecretReference for MCP hosts.")] string? clientSecret = null,
+        [Description("Optional secret reference in the form '<profile-id>:<secret-name>' or '<secret-name>' for the Graph client secret.")] string? clientSecretReference = null,
+        [Description("Optional explicit access token to store securely. Prefer using accessTokenReference for MCP hosts.")] string? accessToken = null,
+        [Description("Optional secret reference in the form '<profile-id>:<secret-name>' or '<secret-name>' for the Graph access token.")] string? accessTokenReference = null,
         [Description("Optional certificate path for certificate-based auth.")] string? certificatePath = null,
-        [Description("Optional certificate password to store securely.")] string? certificatePassword = null,
+        [Description("Optional certificate password to store securely. Prefer using certificatePasswordReference for MCP hosts.")] string? certificatePassword = null,
+        [Description("Optional secret reference in the form '<profile-id>:<secret-name>' or '<secret-name>' for the certificate password.")] string? certificatePasswordReference = null,
         CancellationToken cancellationToken = default) {
         var result = await _application.ProfileBootstrap.SaveGraphProfileAsync(new GraphProfileBootstrapRequest {
             ProfileId = profileId,
@@ -178,9 +181,12 @@ public sealed class MailMcpTools {
             ClientId = clientId,
             TenantId = tenantId,
             ClientSecret = clientSecret,
+            ClientSecretReference = clientSecretReference,
             AccessToken = accessToken,
+            AccessTokenReference = accessTokenReference,
             CertificatePath = certificatePath,
-            CertificatePassword = certificatePassword
+            CertificatePassword = certificatePassword,
+            CertificatePasswordReference = certificatePasswordReference
         }, cancellationToken).ConfigureAwait(false);
         if (!result.Succeeded) {
             throw new InvalidOperationException(result.Message ?? $"Graph profile '{profileId}' could not be saved.");
@@ -199,9 +205,12 @@ public sealed class MailMcpTools {
         [Description("Optional default sender email address. Defaults to the mailbox when appropriate.")] string? defaultSender = null,
         [Description("When true, marks this profile as the default profile.")] bool isDefault = false,
         [Description("Optional Google OAuth client identifier.")] string? clientId = null,
-        [Description("Optional Google OAuth client secret to store securely.")] string? clientSecret = null,
-        [Description("Optional Google OAuth refresh token to store securely.")] string? refreshToken = null,
-        [Description("Optional explicit access token to store securely.")] string? accessToken = null,
+        [Description("Optional Google OAuth client secret to store securely. Prefer using clientSecretReference for MCP hosts.")] string? clientSecret = null,
+        [Description("Optional secret reference in the form '<profile-id>:<secret-name>' or '<secret-name>' for the Gmail client secret.")] string? clientSecretReference = null,
+        [Description("Optional Google OAuth refresh token to store securely. Prefer using refreshTokenReference for MCP hosts.")] string? refreshToken = null,
+        [Description("Optional secret reference in the form '<profile-id>:<secret-name>' or '<secret-name>' for the Gmail refresh token.")] string? refreshTokenReference = null,
+        [Description("Optional explicit access token to store securely. Prefer using accessTokenReference for MCP hosts.")] string? accessToken = null,
+        [Description("Optional secret reference in the form '<profile-id>:<secret-name>' or '<secret-name>' for the Gmail access token.")] string? accessTokenReference = null,
         CancellationToken cancellationToken = default) {
         var result = await _application.ProfileBootstrap.SaveGmailProfileAsync(new GmailProfileBootstrapRequest {
             ProfileId = profileId,
@@ -212,8 +221,11 @@ public sealed class MailMcpTools {
             IsDefault = isDefault,
             ClientId = clientId,
             ClientSecret = clientSecret,
+            ClientSecretReference = clientSecretReference,
             RefreshToken = refreshToken,
-            AccessToken = accessToken
+            RefreshTokenReference = refreshTokenReference,
+            AccessToken = accessToken,
+            AccessTokenReference = accessTokenReference
         }, cancellationToken).ConfigureAwait(false);
         if (!result.Succeeded) {
             throw new InvalidOperationException(result.Message ?? $"Gmail profile '{profileId}' could not be saved.");
@@ -249,7 +261,8 @@ public sealed class MailMcpTools {
         [Description("The saved Gmail profile identifier to authenticate.")] string profileId,
         [Description("Optional Gmail account override used for the login flow.")] string? mailbox = null,
         [Description("Optional OAuth client identifier override.")] string? clientId = null,
-        [Description("Optional OAuth client secret override.")] string? clientSecret = null,
+        [Description("Optional OAuth client secret override. Prefer using clientSecretReference for MCP hosts.")] string? clientSecret = null,
+        [Description("Optional secret reference in the form '<profile-id>:<secret-name>' or '<secret-name>' for the Gmail client secret override.")] string? clientSecretReference = null,
         [Description("Optional scopes override.")] string[]? scopes = null,
         CancellationToken cancellationToken = default) =>
         _application.ProfileAuth.LoginGmailAsync(new GmailProfileLoginRequest {
@@ -257,6 +270,7 @@ public sealed class MailMcpTools {
             GmailAccount = mailbox,
             ClientId = clientId,
             ClientSecret = clientSecret,
+            ClientSecretReference = clientSecretReference,
             Scopes = scopes
         }, cancellationToken);
 
@@ -303,9 +317,15 @@ public sealed class MailMcpTools {
     public Task<OperationResult> mail_profile_secret_set(
         [Description("The profile identifier that owns the secret.")] string profileId,
         [Description("The stable secret name, such as password, client-secret, or refresh-token.")] string secretName,
-        [Description("The secret value to store.")] string secretValue,
+        [Description("The secret value to store. Prefer using secretReference for MCP hosts when the secret already exists in the shared store.")] string? secretValue = null,
+        [Description("Optional secret reference in the form '<profile-id>:<secret-name>' or '<secret-name>' to copy without re-exposing the secret value.")] string? secretReference = null,
         CancellationToken cancellationToken = default) =>
-        _application.ProfileSecrets.SetSecretAsync(profileId, secretName, secretValue, cancellationToken);
+        _application.ProfileSecrets.SetSecretAsync(
+            profileId,
+            secretName,
+            secretValue,
+            secretReference,
+            cancellationToken);
 
     [McpServerTool]
     [Description("Removes a secret associated with an existing Mailozaurr profile.")]

--- a/Sources/Mailozaurr.Cli/Program.cs
+++ b/Sources/Mailozaurr.Cli/Program.cs
@@ -5,4 +5,5 @@ return await CliRunner.RunAsync(
     args,
     Console.Out,
     Console.Error,
-    builderFactory: options => new MailApplicationBuilder(options));
+    builderFactory: options => new MailApplicationBuilder(options),
+    input: Console.In);

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -1,11 +1,26 @@
 using System.Management.Automation;
+using System.Security;
 using System.Threading.Tasks;
 using Mailozaurr;
 
 namespace Mailozaurr.PowerShell;
 
 /// <summary>
-/// Connects to Microsoft Graph using application credentials.
+/// <para type="synopsis">Connects to Microsoft Graph using application credentials, certificates, device code, or on-behalf-of authentication.</para>
+/// <para type="description">The <c>Connect-EmailGraph</c> cmdlet creates a Microsoft Graph connection for Mailozaurr cmdlets. It supports client secret, certificate, device code, and on-behalf-of flows, and can authenticate directly or from a prebuilt <see cref="PSCredential"/>.</para>
+/// <para type="description">For new scripts, prefer the <c>SecureString</c> or <c>SecretManagement</c> parameter sets instead of passing secrets and tokens in plain text.</para>
+/// <example>
+///   <summary>Connect to Microsoft Graph using a vault-backed client secret</summary>
+///   <code>Connect-EmailGraph -ClientId "id" -DirectoryId "tenant" -ClientSecretSecretName "graph-client-secret" -ClientSecretVaultName "MailSecrets"</code>
+/// </example>
+/// <example>
+///   <summary>Connect to Microsoft Graph using a certificate password stored as a SecureString</summary>
+///   <code>$certificatePassword = Read-Host "Certificate password" -AsSecureString
+/// Connect-EmailGraph -ClientId "id" -DirectoryId "tenant" -CertificatePath "cert.pfx" -CertificatePasswordSecureString $certificatePassword</code>
+/// </example>
+/// <remarks>
+/// The vault example requires a <c>Get-Secret</c> implementation such as Microsoft.PowerShell.SecretManagement.
+/// </remarks>
 /// </summary>
 [Cmdlet(VerbsCommunications.Connect, "EmailGraph")]
 [OutputType(typeof(GraphConnectionInfo))]
@@ -26,6 +41,14 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "CertificatePem")]
     [Parameter(Mandatory = true, ParameterSetName = "DeviceCode")]
     [Parameter(Mandatory = true, ParameterSetName = "OnBehalfOf")]
+    [Parameter(Mandatory = true, ParameterSetName = "PlainSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytesSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "OnBehalfOfSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "PlainSecretManagement")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateSecretManagement")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytesSecretManagement")]
+    [Parameter(Mandatory = true, ParameterSetName = "OnBehalfOfSecretManagement")]
     [ValidateNotNullOrEmpty]
     public string? ClientId { get; set; }
 
@@ -38,6 +61,29 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     public string? ClientSecret { get; set; }
 
     /// <summary>
+    /// Secret associated with the application (for app-only auth) as a SecureString.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "PlainSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "OnBehalfOfSecureString")]
+    [ValidateNotNull]
+    public SecureString? ClientSecretSecureString { get; set; }
+
+    /// <summary>
+    /// Secret name used with Get-Secret for the application client secret.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "PlainSecretManagement")]
+    [Parameter(Mandatory = true, ParameterSetName = "OnBehalfOfSecretManagement")]
+    [ValidateNotNullOrEmpty]
+    public string? ClientSecretSecretName { get; set; }
+
+    /// <summary>
+    /// Optional vault name used with Get-Secret for the application client secret.
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "PlainSecretManagement")]
+    [Parameter(Mandatory = false, ParameterSetName = "OnBehalfOfSecretManagement")]
+    public string? ClientSecretVaultName { get; set; }
+
+    /// <summary>
     /// Directory (tenant) identifier.
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Plain")]
@@ -46,6 +92,14 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "CertificatePem")]
     [Parameter(Mandatory = true, ParameterSetName = "DeviceCode")]
     [Parameter(Mandatory = true, ParameterSetName = "OnBehalfOf")]
+    [Parameter(Mandatory = true, ParameterSetName = "PlainSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytesSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "OnBehalfOfSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "PlainSecretManagement")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateSecretManagement")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytesSecretManagement")]
+    [Parameter(Mandatory = true, ParameterSetName = "OnBehalfOfSecretManagement")]
     [ValidateNotNullOrEmpty]
     public string? DirectoryId { get; set; }
 
@@ -53,6 +107,8 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     /// Path to a PFX certificate used for authentication.
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Certificate")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateSecretManagement")]
     [ValidateNotNullOrEmpty]
     public string? CertificatePath { get; set; }
 
@@ -60,6 +116,8 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     /// Raw bytes of a PFX certificate used for authentication.
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "CertificateBytes")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytesSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytesSecretManagement")]
     [ValidateNotNull]
     public byte[]? CertificateBytes { get; set; }
 
@@ -79,6 +137,29 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     public string? CertificatePassword { get; set; }
 
     /// <summary>
+    /// Password used to decrypt the certificate file as a SecureString.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateSecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytesSecureString")]
+    [ValidateNotNull]
+    public SecureString? CertificatePasswordSecureString { get; set; }
+
+    /// <summary>
+    /// Secret name used with Get-Secret for the certificate password.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateSecretManagement")]
+    [Parameter(Mandatory = true, ParameterSetName = "CertificateBytesSecretManagement")]
+    [ValidateNotNullOrEmpty]
+    public string? CertificatePasswordSecretName { get; set; }
+
+    /// <summary>
+    /// Optional vault name used with Get-Secret for the certificate password.
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "CertificateSecretManagement")]
+    [Parameter(Mandatory = false, ParameterSetName = "CertificateBytesSecretManagement")]
+    public string? CertificatePasswordVaultName { get; set; }
+
+    /// <summary>
     /// Use the device code flow for authentication.
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "DeviceCode")]
@@ -92,10 +173,32 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     public string? OnBehalfOfToken { get; set; }
 
     /// <summary>
+    /// Access token to use for on-behalf-of authentication as a SecureString.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "OnBehalfOfSecureString")]
+    [ValidateNotNull]
+    public SecureString? OnBehalfOfTokenSecureString { get; set; }
+
+    /// <summary>
+    /// Secret name used with Get-Secret for the on-behalf-of token.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "OnBehalfOfSecretManagement")]
+    [ValidateNotNullOrEmpty]
+    public string? OnBehalfOfTokenSecretName { get; set; }
+
+    /// <summary>
+    /// Optional vault name used with Get-Secret for the on-behalf-of token.
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "OnBehalfOfSecretManagement")]
+    public string? OnBehalfOfTokenVaultName { get; set; }
+
+    /// <summary>
     /// Microsoft Graph permission scopes to request.
     /// </summary>
     [Parameter(ParameterSetName = "DeviceCode")]
     [Parameter(ParameterSetName = "OnBehalfOf")]
+    [Parameter(ParameterSetName = "OnBehalfOfSecureString")]
+    [Parameter(ParameterSetName = "OnBehalfOfSecretManagement")]
     public string[] Scopes { get; set; } = new[] { "https://graph.microsoft.com/.default" };
 
     /// <summary>
@@ -135,6 +238,15 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
     protected override async Task ProcessRecordAsync() {
         GraphCredential cred;
         OAuthCredential? oauth = null;
+        var clientSecret = ParameterSetName == "PlainSecretManagement" || ParameterSetName == "OnBehalfOfSecretManagement"
+            ? CredentialHelpers.ToPlainText(CredentialHelpers.ResolveSecretFromVault(ClientSecretSecretName!, ClientSecretVaultName))
+            : CredentialHelpers.ToPlainText(ClientSecretSecureString);
+        var certificatePassword = ParameterSetName == "CertificateSecretManagement" || ParameterSetName == "CertificateBytesSecretManagement"
+            ? CredentialHelpers.ToPlainText(CredentialHelpers.ResolveSecretFromVault(CertificatePasswordSecretName!, CertificatePasswordVaultName))
+            : CredentialHelpers.ToPlainText(CertificatePasswordSecureString);
+        var onBehalfOfToken = ParameterSetName == "OnBehalfOfSecretManagement"
+            ? CredentialHelpers.ToPlainText(CredentialHelpers.ResolveSecretFromVault(OnBehalfOfTokenSecretName!, OnBehalfOfTokenVaultName))
+            : CredentialHelpers.ToPlainText(OnBehalfOfTokenSecureString);
         if (ParameterSetName == "Credential") {
             cred = MicrosoftGraphUtils.ConvertFromGraphCredential(
                 Credential!.UserName,
@@ -146,12 +258,40 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
                 CertificatePath = CertificatePath!,
                 CertificatePassword = CertificatePassword!
             };
+        } else if (ParameterSetName == "CertificateSecureString") {
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                DirectoryId = DirectoryId!,
+                CertificatePath = CertificatePath!,
+                CertificatePassword = certificatePassword
+            };
+        } else if (ParameterSetName == "CertificateSecretManagement") {
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                DirectoryId = DirectoryId!,
+                CertificatePath = CertificatePath!,
+                CertificatePassword = certificatePassword
+            };
         } else if (ParameterSetName == "CertificateBytes") {
             cred = new GraphCredential {
                 ClientId = ClientId!,
                 DirectoryId = DirectoryId!,
                 CertificateBytes = CertificateBytes!,
                 CertificatePassword = CertificatePassword!
+            };
+        } else if (ParameterSetName == "CertificateBytesSecureString") {
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                DirectoryId = DirectoryId!,
+                CertificateBytes = CertificateBytes!,
+                CertificatePassword = certificatePassword
+            };
+        } else if (ParameterSetName == "CertificateBytesSecretManagement") {
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                DirectoryId = DirectoryId!,
+                CertificateBytes = CertificateBytes!,
+                CertificatePassword = certificatePassword
             };
         } else if (ParameterSetName == "CertificatePem") {
             cred = new GraphCredential {
@@ -180,6 +320,42 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
                 ClientSecret!,
                 OnBehalfOfToken!,
                 Scopes);
+        } else if (ParameterSetName == "OnBehalfOfSecureString") {
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                ClientSecret = clientSecret,
+                DirectoryId = DirectoryId!
+            };
+            oauth = await OAuthHelpers.AcquireO365TokenOnBehalfOfAsync(
+                ClientId!,
+                DirectoryId!,
+                clientSecret,
+                onBehalfOfToken,
+                Scopes);
+        } else if (ParameterSetName == "OnBehalfOfSecretManagement") {
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                ClientSecret = clientSecret,
+                DirectoryId = DirectoryId!
+            };
+            oauth = await OAuthHelpers.AcquireO365TokenOnBehalfOfAsync(
+                ClientId!,
+                DirectoryId!,
+                clientSecret,
+                onBehalfOfToken,
+                Scopes);
+        } else if (ParameterSetName == "PlainSecureString") {
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                ClientSecret = clientSecret,
+                DirectoryId = DirectoryId!
+            };
+        } else if (ParameterSetName == "PlainSecretManagement") {
+            cred = new GraphCredential {
+                ClientId = ClientId!,
+                ClientSecret = clientSecret,
+                DirectoryId = DirectoryId!
+            };
         } else {
             cred = new GraphCredential {
                 ClientId = ClientId!,
@@ -188,8 +364,11 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
             };
         }
 
+        MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
+        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
+
         bool connected = false;
-        if (ParameterSetName == "DeviceCode" || ParameterSetName == "OnBehalfOf") {
+        if (ParameterSetName == "DeviceCode" || ParameterSetName == "OnBehalfOf" || ParameterSetName == "OnBehalfOfSecureString" || ParameterSetName == "OnBehalfOfSecretManagement") {
             connected = oauth != null;
         } else {
             try {
@@ -204,21 +383,6 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
             } catch (GraphApiException ex) {
                 WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
             }
-        }
-        
-        MicrosoftGraphUtils.TimeoutSeconds = TimeoutSeconds;
-        MicrosoftGraphUtils.MaxConcurrentRequests = MaxConcurrentRequests;
-        try {
-            var token = await MicrosoftGraphUtils.ConnectO365GraphWithRetryAsync(
-                cred,
-                cred.DirectoryId!,
-                RetryCount,
-                RetryDelayMilliseconds,
-                RetryDelayBackoff,
-                "https://graph.microsoft.com");
-            connected = !string.IsNullOrWhiteSpace(token);
-        } catch (GraphApiException ex) {
-            WriteError(new ErrorRecord(ex, "GraphApiError", ErrorCategory.InvalidOperation, null));
         }
 
         var info = new GraphConnectionInfo { Credential = cred, IsConnected = connected, OAuthCredential = oauth };

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectEmailGraph.cs
@@ -308,6 +308,7 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
                 ClientId!,
                 DirectoryId!,
                 Scopes);
+            cred.AccessToken = oauth.AccessToken;
         } else if (ParameterSetName == "OnBehalfOf") {
             cred = new GraphCredential {
                 ClientId = ClientId!,
@@ -320,6 +321,7 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
                 ClientSecret!,
                 OnBehalfOfToken!,
                 Scopes);
+            cred.AccessToken = oauth.AccessToken;
         } else if (ParameterSetName == "OnBehalfOfSecureString") {
             cred = new GraphCredential {
                 ClientId = ClientId!,
@@ -332,6 +334,7 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
                 clientSecret,
                 onBehalfOfToken,
                 Scopes);
+            cred.AccessToken = oauth.AccessToken;
         } else if (ParameterSetName == "OnBehalfOfSecretManagement") {
             cred = new GraphCredential {
                 ClientId = ClientId!,
@@ -344,6 +347,7 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
                 clientSecret,
                 onBehalfOfToken,
                 Scopes);
+            cred.AccessToken = oauth.AccessToken;
         } else if (ParameterSetName == "PlainSecureString") {
             cred = new GraphCredential {
                 ClientId = ClientId!,
@@ -369,7 +373,7 @@ public sealed class CmdletConnectEmailGraph : AsyncPSCmdlet {
 
         bool connected = false;
         if (ParameterSetName == "DeviceCode" || ParameterSetName == "OnBehalfOf" || ParameterSetName == "OnBehalfOfSecureString" || ParameterSetName == "OnBehalfOfSecretManagement") {
-            connected = oauth != null;
+            connected = !string.IsNullOrWhiteSpace(cred.AccessToken);
         } else {
             try {
                 var token = await MicrosoftGraphUtils.ConnectO365GraphWithRetryAsync(

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectIMAP.cs
@@ -17,7 +17,8 @@ namespace Mailozaurr.PowerShell;
 /// </example>
 /// <example>
 ///   <summary>Connect to Gmail IMAP using OAuth2</summary>
-///   <code>$cred = Connect-OAuthGoogle -GmailAccount "user@gmail.com" -ClientID "id" -ClientSecret "secret"
+///   <code>$clientSecret = Read-Host "Google client secret" -AsSecureString
+/// $cred = Connect-OAuthGoogle -GmailAccount "user@gmail.com" -ClientID "id" -ClientSecretSecureString $clientSecret
 /// Connect-IMAP -Server "imap.gmail.com" -Credential $cred -OAuth2</code>
 /// </example>
 /// <example>

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectOAuthGoogle.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Security;
 using System.Threading.Tasks;
 
 namespace Mailozaurr.PowerShell;
@@ -6,17 +7,23 @@ namespace Mailozaurr.PowerShell;
 /// <summary>
 /// <para type="synopsis">Obtains an OAuth2 access token for a Google (Gmail) account for use with IMAP, SMTP, or other Google APIs.</para>
 /// <para type="description">The <c>Connect-OAuthGoogle</c> cmdlet initiates an interactive OAuth2 authentication flow for a Gmail account, returning a <see cref="PSCredential"/> object containing the access token. This credential can be used with other cmdlets (such as <c>Connect-IMAP</c>) that support OAuth2 authentication.</para>
+/// <para type="description">For new scripts, prefer <c>-ClientSecretSecureString</c> or <c>-ClientSecretSecretName</c> rather than passing the client secret as plain text.</para>
 /// <example>
-///   <summary>Obtain an OAuth2 credential for Gmail</summary>
-///   <code>Connect-OAuthGoogle -GmailAccount "user@gmail.com" -ClientID "id" -ClientSecret "secret"</code>
+///   <summary>Obtain an OAuth2 credential for Gmail using a SecureString secret</summary>
+///   <code>$clientSecret = Read-Host "Google client secret" -AsSecureString
+/// Connect-OAuthGoogle -GmailAccount "user@gmail.com" -ClientID "id" -ClientSecretSecureString $clientSecret</code>
+/// </example>
+/// <example>
+///   <summary>Obtain an OAuth2 credential for Gmail using a vault secret</summary>
+///   <code>Connect-OAuthGoogle -GmailAccount "user@gmail.com" -ClientID "id" -ClientSecretSecretName "gmail-client-secret" -ClientSecretVaultName "MailSecrets"</code>
 /// </example>
 /// <remarks>
-/// The returned PSCredential contains the access token as the password. Use with IMAP/SMTP cmdlets that support OAuth2.
+/// The returned PSCredential contains the access token as the password. Use with IMAP/SMTP cmdlets that support OAuth2. The vault example requires a <c>Get-Secret</c> implementation such as Microsoft.PowerShell.SecretManagement.
 /// </remarks>
 /// <seealso cref="CmdletConnectIMAP"/>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>
 /// </summary>
-[Cmdlet(VerbsCommunications.Connect, "OAuthGoogle")]
+[Cmdlet(VerbsCommunications.Connect, "OAuthGoogle", DefaultParameterSetName = "PlainText")]
 [OutputType(typeof(PSCredential))]
 public sealed class CmdletConnectOAuthGoogle : AsyncPSCmdlet {
     /// <summary>
@@ -36,9 +43,29 @@ public sealed class CmdletConnectOAuthGoogle : AsyncPSCmdlet {
     /// <summary>
     /// <para type="description">Specifies the OAuth2 client secret from the Google Developer Console.</para>
     /// </summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = "PlainText")]
     [ValidateNotNullOrEmpty]
     public string? ClientSecret { get; set; }
+
+    /// <summary>
+    /// <para type="description">Specifies the OAuth2 client secret from the Google Developer Console as a SecureString.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecureString")]
+    [ValidateNotNull]
+    public SecureString? ClientSecretSecureString { get; set; }
+
+    /// <summary>
+    /// <para type="description">Specifies the name of a secret to resolve using Get-Secret for the OAuth2 client secret.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecretManagement")]
+    [ValidateNotNullOrEmpty]
+    public string? ClientSecretSecretName { get; set; }
+
+    /// <summary>
+    /// <para type="description">Optional vault name used with Get-Secret for the OAuth2 client secret.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "SecretManagement")]
+    public string? ClientSecretVaultName { get; set; }
 
     /// <summary>
     /// <para type="description">Specifies the OAuth2 scopes to request. Default is "https://mail.google.com/".</para>
@@ -50,7 +77,13 @@ public sealed class CmdletConnectOAuthGoogle : AsyncPSCmdlet {
     /// Performs the interactive OAuth2 authentication and returns a PSCredential with the access token.
     /// </summary>
     protected override async Task ProcessRecordAsync() {
-        if (GmailAccount is null || ClientID is null || ClientSecret is null || Scope is null) {
+        var clientSecret = this.ParameterSetName == "SecureString"
+            ? CredentialHelpers.ToPlainText(ClientSecretSecureString)
+            : this.ParameterSetName == "SecretManagement"
+                ? CredentialHelpers.ToPlainText(CredentialHelpers.ResolveSecretFromVault(ClientSecretSecretName!, ClientSecretVaultName))
+                : ClientSecret;
+
+        if (GmailAccount is null || ClientID is null || string.IsNullOrWhiteSpace(clientSecret) || Scope is null) {
             WriteError(new ErrorRecord(new PSArgumentNullException("GmailAccount"), "OAuthGoogleInvalidParameters", ErrorCategory.InvalidArgument, null));
             return;
         }
@@ -58,7 +91,7 @@ public sealed class CmdletConnectOAuthGoogle : AsyncPSCmdlet {
         OAuthCredential? cred = null;
         try {
             cred = await Mailozaurr.OAuthHelpers
-                .AcquireGoogleTokenCachedAsync(GmailAccount, ClientID, ClientSecret, Scope);
+                .AcquireGoogleTokenCachedAsync(GmailAccount, ClientID, clientSecret!, Scope);
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(ex, "OAuthGoogleAuthFailed", ErrorCategory.AuthenticationError, null));
             return;

--- a/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConnectPOP3.cs
@@ -16,7 +16,8 @@ namespace Mailozaurr.PowerShell;
 /// </example>
 /// <example>
 ///   <summary>Connect to Gmail POP3 using OAuth2</summary>
-///   <code>$cred = Connect-OAuthGoogle -GmailAccount "user@gmail.com" -ClientID "id" -ClientSecret "secret"
+///   <code>$clientSecret = Read-Host "Google client secret" -AsSecureString
+/// $cred = Connect-OAuthGoogle -GmailAccount "user@gmail.com" -ClientID "id" -ClientSecretSecureString $clientSecret
 /// Connect-POP3 -Server "pop.gmail.com" -Credential $cred -OAuth2</code>
 /// </example>
 /// <example>

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCertificateCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCertificateCredential.cs
@@ -7,15 +7,21 @@ using System.Threading.Tasks;
 /// <summary>
 /// <para type="synopsis">Creates a PSCredential containing a Microsoft Graph access token obtained using certificate authentication.</para>
 /// <para type="description">The <c>ConvertTo-GraphCertificateCredential</c> cmdlet authenticates with Microsoft Graph using a client certificate and returns a <see cref="PSCredential"/> with the access token. Use the resulting credential with cmdlets that accept Graph tokens.</para>
+/// <para type="description">For new scripts, prefer <c>-CertificatePasswordSecureString</c> or <c>-SecretName</c> rather than passing the certificate password as plain text.</para>
 /// <example>
-///   <summary>Acquire a token using a certificate</summary>
-///   <code>ConvertTo-GraphCertificateCredential -ClientId "id" -TenantId "tenant" -CertificatePath "cert.pfx" -CertificatePassword "pass"</code>
+///   <summary>Acquire a token using a certificate and SecureString password</summary>
+///   <code>$certificatePassword = Read-Host "Certificate password" -AsSecureString
+/// ConvertTo-GraphCertificateCredential -ClientId "id" -TenantId "tenant" -CertificatePath "cert.pfx" -CertificatePasswordSecureString $certificatePassword</code>
+/// </example>
+/// <example>
+///   <summary>Acquire a token using a certificate password from a vault secret</summary>
+///   <code>ConvertTo-GraphCertificateCredential -ClientId "id" -TenantId "tenant" -CertificatePath "cert.pfx" -SecretName "graph-certificate-password" -VaultName "MailSecrets"</code>
 /// </example>
 /// <remarks>
-/// This cmdlet simplifies obtaining an app-only token for Microsoft Graph when using certificate authentication.
+/// This cmdlet simplifies obtaining an app-only token for Microsoft Graph when using certificate authentication. The vault example requires a <c>Get-Secret</c> implementation such as Microsoft.PowerShell.SecretManagement.
 /// </remarks>
 /// </summary>
-[Cmdlet(VerbsData.ConvertTo, "GraphCertificateCredential")]
+[Cmdlet(VerbsData.ConvertTo, "GraphCertificateCredential", DefaultParameterSetName = "PlainText")]
 [OutputType(typeof(PSCredential))]
 public class CmdletConvertToGraphCertificateCredential : AsyncPSCmdlet {
     /// <summary>
@@ -42,9 +48,29 @@ public class CmdletConvertToGraphCertificateCredential : AsyncPSCmdlet {
     /// <summary>
     /// Password for the client certificate.
     /// </summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = "PlainText")]
     [ValidateNotNullOrEmpty]
     public string? CertificatePassword { get; set; }
+
+    /// <summary>
+    /// Password for the client certificate as a SecureString.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecureString")]
+    [ValidateNotNull]
+    public SecureString? CertificatePasswordSecureString { get; set; }
+
+    /// <summary>
+    /// Name of the certificate password secret resolved via Get-Secret.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecretManagement")]
+    [ValidateNotNullOrEmpty]
+    public string? SecretName { get; set; }
+
+    /// <summary>
+    /// Optional vault name used with Get-Secret.
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "SecretManagement")]
+    public string? VaultName { get; set; }
 
     /// <summary>
     /// Optional scopes to request.
@@ -56,13 +82,19 @@ public class CmdletConvertToGraphCertificateCredential : AsyncPSCmdlet {
     /// Acquires an app-only access token using certificate authentication and returns it as a credential.
     /// </summary>
     protected override async Task ProcessRecordAsync() {
+        var certificatePassword = this.ParameterSetName == "SecureString"
+            ? CredentialHelpers.ToPlainText(CertificatePasswordSecureString)
+            : this.ParameterSetName == "SecretManagement"
+                ? CredentialHelpers.ToPlainText(CredentialHelpers.ResolveSecretFromVault(SecretName!, VaultName))
+            : CertificatePassword;
+
         GraphAuthorization token;
         try {
             token = await Mailozaurr.OAuthHelpers.AcquireGraphCertificateTokenAsync(
                     ClientId!,
                     TenantId!,
                     CertificatePath!,
-                    CertificatePassword!,
+                    certificatePassword!,
                     Scopes);
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(ex, "GraphCertificateAuthFailed", ErrorCategory.AuthenticationError, null));

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToGraphCredential.cs
@@ -5,21 +5,23 @@ using System.Security;
 
 /// <summary>
 /// <para type="synopsis">Creates a PSCredential object for Microsoft Graph authentication from client ID, secret, and directory ID.</para>
-/// <para type="description">The <c>ConvertTo-GraphCredential</c> cmdlet creates a <see cref="PSCredential"/> object suitable for Microsoft Graph authentication, using the provided client ID, client secret (clear or encrypted), and directory (tenant) ID. The resulting credential can be used with cmdlets that require Graph authentication.</para>
+/// <para type="description">The <c>ConvertTo-GraphCredential</c> cmdlet creates a <see cref="PSCredential"/> object suitable for Microsoft Graph authentication, using the provided client ID, client secret, and directory (tenant) ID. The resulting credential can be used with cmdlets that require Graph authentication.</para>
+/// <para type="description">For new scripts, prefer <c>-ClientSecretSecureString</c> or <c>-SecretName</c> instead of passing the client secret in plain text.</para>
 /// <example>
-///   <summary>Create a Graph credential from clear text secret</summary>
-///   <code>ConvertTo-GraphCredential -ClientId "id" -ClientSecret "secret" -DirectoryId "tenant"</code>
+///   <summary>Create a Graph credential from a SecureString secret</summary>
+///   <code>$secret = Read-Host "Graph client secret" -AsSecureString
+/// ConvertTo-GraphCredential -ClientId "id" -ClientSecretSecureString $secret -DirectoryId "tenant"</code>
 /// </example>
 /// <example>
-///   <summary>Create a Graph credential from encrypted secret</summary>
-///   <code>ConvertTo-GraphCredential -ClientId "id" -ClientSecretEncrypted "..." -DirectoryId "tenant"</code>
+///   <summary>Create a Graph credential from a vault secret</summary>
+///   <code>ConvertTo-GraphCredential -ClientId "id" -SecretName "graph-client-secret" -VaultName "MailSecrets" -DirectoryId "tenant"</code>
 /// </example>
 /// <remarks>
-/// Use this cmdlet to prepare credentials for use with Microsoft Graph cmdlets in automation scenarios.
+/// Use this cmdlet to prepare credentials for use with Microsoft Graph cmdlets in automation scenarios. The vault example requires a <c>Get-Secret</c> implementation such as Microsoft.PowerShell.SecretManagement.
 /// </remarks>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>
 /// </summary>
-[Cmdlet(VerbsData.ConvertTo, "GraphCredential")]
+[Cmdlet(VerbsData.ConvertTo, "GraphCredential", DefaultParameterSetName = "ClearText")]
 [OutputType(typeof(PSCredential))]
 public class CmdletConvertToGraphCredential: PSCmdlet {
     /// <summary>
@@ -27,6 +29,8 @@ public class CmdletConvertToGraphCredential: PSCmdlet {
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "ClearText")]
     [Parameter(Mandatory = true, ParameterSetName = "Encrypted")]
+    [Parameter(Mandatory = true, ParameterSetName = "SecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "SecretManagement")]
     [ValidateNotNullOrEmpty]
     public string? ClientId { get; set; }
 
@@ -45,10 +49,32 @@ public class CmdletConvertToGraphCredential: PSCmdlet {
     public string? ClientSecretEncrypted { get; set; }
 
     /// <summary>
+    /// <para type="description">Specifies the client secret as a SecureString. Use only with the SecureString parameter set.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecureString")]
+    [ValidateNotNull]
+    public SecureString? ClientSecretSecureString { get; set; }
+
+    /// <summary>
+    /// <para type="description">Specifies the name of a secret to resolve using Get-Secret. Use only with the SecretManagement parameter set.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecretManagement")]
+    [ValidateNotNullOrEmpty]
+    public string? SecretName { get; set; }
+
+    /// <summary>
+    /// <para type="description">Optional vault name used with Get-Secret. Use only with the SecretManagement parameter set.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "SecretManagement")]
+    public string? VaultName { get; set; }
+
+    /// <summary>
     /// <para type="description">Specifies the directory (tenant) ID for Microsoft Graph authentication.</para>
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "ClearText")]
     [Parameter(Mandatory = true, ParameterSetName = "Encrypted")]
+    [Parameter(Mandatory = true, ParameterSetName = "SecureString")]
+    [Parameter(Mandatory = true, ParameterSetName = "SecretManagement")]
     [ValidateNotNullOrEmpty]
     public string? DirectoryId { get; set; }
 
@@ -58,7 +84,11 @@ public class CmdletConvertToGraphCredential: PSCmdlet {
     protected override void ProcessRecord() {
         SecureString secret = this.ParameterSetName == "Encrypted"
             ? CredentialHelpers.ToSecureString(ClientSecretEncrypted)
-            : CredentialHelpers.ToSecureString(ClientSecret);
+            : this.ParameterSetName == "SecureString"
+                ? ClientSecretSecureString!
+                : this.ParameterSetName == "SecretManagement"
+                    ? CredentialHelpers.ResolveSecretFromVault(SecretName!, VaultName)
+                : CredentialHelpers.ToSecureString(ClientSecret);
         var username = $"{ClientId}@{DirectoryId}";
         var credential = new PSCredential(username, secret);
         WriteObject(credential);

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToMailgunCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToMailgunCredential.cs
@@ -6,26 +6,56 @@ using System.Security;
 /// <summary>
 /// <para type="synopsis">Creates a PSCredential object for Mailgun API authentication from an API key.</para>
 /// <para type="description">Use <c>ConvertTo-MailgunCredential</c> to generate a <see cref="PSCredential"/> that can be passed to <c>Send-EmailMessage</c> when using the Mailgun provider.</para>
+/// <para type="description">For new scripts, prefer <c>-ApiKeySecureString</c> or <c>-SecretName</c> instead of passing the API key as plain text.</para>
 /// <example>
-///   <summary>Create a Mailgun credential</summary>
-///   <code>ConvertTo-MailgunCredential -ApiKey "key-xxxxx"</code>
+///   <summary>Create a Mailgun credential from a SecureString API key</summary>
+///   <code>$apiKey = Read-Host "Mailgun API key" -AsSecureString
+/// ConvertTo-MailgunCredential -ApiKeySecureString $apiKey</code>
+/// </example>
+/// <example>
+///   <summary>Create a Mailgun credential from a vault secret</summary>
+///   <code>ConvertTo-MailgunCredential -SecretName "mailgun-api-key" -VaultName "MailSecrets"</code>
 /// </example>
 /// </summary>
-[Cmdlet(VerbsData.ConvertTo, "MailgunCredential")]
+[Cmdlet(VerbsData.ConvertTo, "MailgunCredential", DefaultParameterSetName = "PlainText")]
 [OutputType(typeof(PSCredential))]
 public class CmdletConvertToMailgunCredential : PSCmdlet {
     /// <summary>
     /// Mailgun API key used for authentication.
     /// </summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = "PlainText")]
     [ValidateNotNullOrEmpty]
     public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Mailgun API key used for authentication as a SecureString.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecureString")]
+    [ValidateNotNull]
+    public SecureString? ApiKeySecureString { get; set; }
+
+    /// <summary>
+    /// Mailgun secret name used with Get-Secret.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecretManagement")]
+    [ValidateNotNullOrEmpty]
+    public string? SecretName { get; set; }
+
+    /// <summary>
+    /// Optional vault name used with Get-Secret.
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "SecretManagement")]
+    public string? VaultName { get; set; }
 
     /// <summary>
     /// Converts the provided API key into a PSCredential for Mailgun.
     /// </summary>
     protected override void ProcessRecord() {
-        SecureString secret = CredentialHelpers.ToSecureString(ApiKey);
+        SecureString secret = this.ParameterSetName == "SecureString"
+            ? ApiKeySecureString!
+            : this.ParameterSetName == "SecretManagement"
+                ? CredentialHelpers.ResolveSecretFromVault(SecretName!, VaultName)
+            : CredentialHelpers.ToSecureString(ApiKey);
         var credential = new PSCredential("Mailgun", secret);
         WriteObject(credential);
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToOAuth2Credential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToOAuth2Credential.cs
@@ -6,16 +6,22 @@ using System.Security;
 /// <summary>
 /// <para type="synopsis">Creates a PSCredential object for OAuth2 authentication from a username and token.</para>
 /// <para type="description">The <c>ConvertTo-OAuth2Credential</c> cmdlet creates a <see cref="PSCredential"/> object suitable for OAuth2 authentication, using the provided username and access token. The resulting credential can be used with cmdlets that require OAuth2 authentication (such as IMAP, SMTP, or POP3 with OAuth2).</para>
+/// <para type="description">For automation and interactive use, prefer <c>-TokenSecureString</c> or <c>-SecretName</c> over passing the token as plain text.</para>
 /// <example>
-///   <summary>Create an OAuth2 credential</summary>
-///   <code>ConvertTo-OAuth2Credential -UserName "user@example.com" -Token "ya29.a0Af..."</code>
+///   <summary>Create an OAuth2 credential from a SecureString token</summary>
+///   <code>$token = Read-Host "OAuth token" -AsSecureString
+/// ConvertTo-OAuth2Credential -UserName "user@example.com" -TokenSecureString $token</code>
+/// </example>
+/// <example>
+///   <summary>Create an OAuth2 credential from a vault secret</summary>
+///   <code>ConvertTo-OAuth2Credential -UserName "user@example.com" -SecretName "gmail-access-token" -VaultName "MailSecrets"</code>
 /// </example>
 /// <remarks>
-/// Use this cmdlet to prepare credentials for use with OAuth2-enabled cmdlets in automation scenarios.
+/// Use this cmdlet to prepare credentials for use with OAuth2-enabled cmdlets in automation scenarios. The vault example requires a <c>Get-Secret</c> implementation such as Microsoft.PowerShell.SecretManagement.
 /// </remarks>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>
 /// </summary>
-[Cmdlet(VerbsData.ConvertTo, "OAuth2Credential")]
+[Cmdlet(VerbsData.ConvertTo, "OAuth2Credential", DefaultParameterSetName = "PlainText")]
 [OutputType(typeof(PSCredential))]
 public class CmdletConvertToOAuth2Credential : PSCmdlet {
     /// <summary>
@@ -27,15 +33,39 @@ public class CmdletConvertToOAuth2Credential : PSCmdlet {
     /// <summary>
     /// <para type="description">Specifies the OAuth2 access token.</para>
     /// </summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = "PlainText")]
     [ValidateNotNullOrEmpty]
     public string? Token { get; set; }
+
+    /// <summary>
+    /// <para type="description">Specifies the OAuth2 access token as a SecureString.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecureString")]
+    [ValidateNotNull]
+    public SecureString? TokenSecureString { get; set; }
+
+    /// <summary>
+    /// <para type="description">Specifies the name of a secret to resolve using Get-Secret.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecretManagement")]
+    [ValidateNotNullOrEmpty]
+    public string? SecretName { get; set; }
+
+    /// <summary>
+    /// <para type="description">Optional vault name used with Get-Secret.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "SecretManagement")]
+    public string? VaultName { get; set; }
 
     /// <summary>
     /// Creates a PSCredential object for OAuth2 authentication.
     /// </summary>
     protected override void ProcessRecord() {
-        var secret = CredentialHelpers.ToSecureString(Token);
+        var secret = this.ParameterSetName switch {
+            "SecureString" => TokenSecureString!,
+            "SecretManagement" => CredentialHelpers.ResolveSecretFromVault(SecretName!, VaultName),
+            _ => CredentialHelpers.ToSecureString(Token)
+        };
         var credential = new PSCredential(UserName, secret);
         WriteObject(credential);
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletConvertToSendGridCredential.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletConvertToSendGridCredential.cs
@@ -6,30 +6,60 @@ using System.Security;
 /// <summary>
 /// <para type="synopsis">Creates a PSCredential object for SendGrid API authentication from an API key.</para>
 /// <para type="description">The <c>ConvertTo-SendGridCredential</c> cmdlet creates a <see cref="PSCredential"/> object suitable for SendGrid API authentication, using the provided API key. The resulting credential can be used with cmdlets that require SendGrid authentication (such as <c>Send-EmailMessage</c> with the <c>-SendGrid</c> switch).</para>
+/// <para type="description">For new scripts, prefer <c>-ApiKeySecureString</c> or <c>-SecretName</c> instead of passing the API key as plain text.</para>
 /// <example>
-///   <summary>Create a SendGrid credential</summary>
-///   <code>ConvertTo-SendGridCredential -ApiKey "SG.xxxxx..."</code>
+///   <summary>Create a SendGrid credential from a SecureString API key</summary>
+///   <code>$apiKey = Read-Host "SendGrid API key" -AsSecureString
+/// ConvertTo-SendGridCredential -ApiKeySecureString $apiKey</code>
+/// </example>
+/// <example>
+///   <summary>Create a SendGrid credential from a vault secret</summary>
+///   <code>ConvertTo-SendGridCredential -SecretName "sendgrid-api-key" -VaultName "MailSecrets"</code>
 /// </example>
 /// <remarks>
-/// Use this cmdlet to prepare credentials for use with SendGrid-enabled cmdlets in automation scenarios.
+/// Use this cmdlet to prepare credentials for use with SendGrid-enabled cmdlets in automation scenarios. The vault example requires a <c>Get-Secret</c> implementation such as Microsoft.PowerShell.SecretManagement.
 /// </remarks>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>
 /// </summary>
-[Cmdlet(VerbsData.ConvertTo, "SendGridCredential")]
+[Cmdlet(VerbsData.ConvertTo, "SendGridCredential", DefaultParameterSetName = "PlainText")]
 [OutputType(typeof(PSCredential))]
 public class CmdletConvertToSendGridCredential : PSCmdlet {
     /// <summary>
     /// <para type="description">Specifies the SendGrid API key.</para>
     /// </summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = "PlainText")]
     [ValidateNotNullOrEmpty]
     public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// <para type="description">Specifies the SendGrid API key as a SecureString.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecureString")]
+    [ValidateNotNull]
+    public SecureString? ApiKeySecureString { get; set; }
+
+    /// <summary>
+    /// <para type="description">Specifies the name of a secret to resolve using Get-Secret.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SecretManagement")]
+    [ValidateNotNullOrEmpty]
+    public string? SecretName { get; set; }
+
+    /// <summary>
+    /// <para type="description">Optional vault name used with Get-Secret.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "SecretManagement")]
+    public string? VaultName { get; set; }
 
     /// <summary>
     /// Creates a PSCredential object for SendGrid API authentication.
     /// </summary>
     protected override void ProcessRecord() {
-        var secret = CredentialHelpers.ToSecureString(ApiKey);
+        var secret = this.ParameterSetName == "SecureString"
+            ? ApiKeySecureString!
+            : this.ParameterSetName == "SecretManagement"
+                ? CredentialHelpers.ResolveSecretFromVault(SecretName!, VaultName)
+                : CredentialHelpers.ToSecureString(ApiKey);
         var credential = new PSCredential("SendGrid", secret);
         WriteObject(credential);
     }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphFolder.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphFolder.cs
@@ -10,8 +10,7 @@ namespace Mailozaurr.PowerShell;
 /// <para type="description">The <c>Get-EmailGraphFolder</c> cmdlet retrieves mail folders for the specified user principal name using Microsoft Graph API. Provide a <see cref="GraphConnectionInfo"/> object created with <c>Connect-EmailGraph</c> or authenticate via <c>Connect-MgGraph</c>.</para>
 /// <example>
 ///   <summary>Get mail folders using application permissions</summary>
-///   <code>$cred = ConvertTo-GraphCredential -ClientId "id" -ClientSecret "secret" -DirectoryId "tenant"
-///   $graph = Connect-EmailGraph -Credential $cred
+///   <code>$graph = Connect-EmailGraph -ClientId "id" -DirectoryId "tenant" -ClientSecretSecretName "graph-client-secret" -ClientSecretVaultName "MailSecrets"
 ///   Get-EmailGraphFolder -UserPrincipalName "user@domain.com" -Connection $graph</code>
 /// </example>
 /// <example>

--- a/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetEmailGraphMessageAttachment.cs
@@ -12,8 +12,8 @@ namespace Mailozaurr.PowerShell;
 /// <para type="description">The <c>Get-EmailGraphMessageAttachment</c> cmdlet retrieves attachments for the specified mail message ID and user principal name using Microsoft Graph API. Provide a <see cref="GraphConnectionInfo"/> object created with <c>Connect-EmailGraph</c> or authenticate via <c>Connect-MgGraph</c>.</para>
 /// <example>
 ///   <summary>Get attachments for a mail message</summary>
-///   <code>$cred = ConvertTo-GraphCredential -ClientId "id" -ClientSecret "secret" -DirectoryId "tenant"
-///   Get-EmailGraphMessageAttachment -UserPrincipalName "user@domain.com" -MessageId "AAMk..." -Credential $cred</code>
+///   <code>$graph = Connect-EmailGraph -ClientId "id" -DirectoryId "tenant" -ClientSecretSecretName "graph-client-secret" -ClientSecretVaultName "MailSecrets"
+///   Get-EmailGraphMessageAttachment -UserPrincipalName "user@domain.com" -MessageId "AAMk..." -Connection $graph</code>
 /// </example>
 /// <remarks>
 /// Use this cmdlet to enumerate attachments for mailbox management, reporting, or migration scenarios.

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -52,7 +52,9 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             }
         }
 
-        SmtpConnectionPool.Configure(UseConnectionPool.IsPresent, ConnectionPoolSize);
+        if (UseConnectionPool.IsPresent) {
+            SmtpConnectionPool.SetMaxPoolSize(ConnectionPoolSize);
+        }
     }
     /// <summary>
     /// Process the record.
@@ -466,6 +468,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         smtpClient.RetryAlways = RetryAlways.IsPresent;
         smtpClient.MaxDelayMilliseconds = MaxDelayMilliseconds;
         smtpClient.JitterMilliseconds = JitterMilliseconds;
+        smtpClient.UseConnectionPool = UseConnectionPool.IsPresent;
         if (UseDefaultCredentials) {
             smtpClient.ConnectionPoolIdentity = "default";
         } else if (Credential != null) {

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.cs
@@ -24,13 +24,13 @@ namespace Mailozaurr.PowerShell;
 /// <example>
 ///   <summary>Send an email using SendGrid API</summary>
 ///   <prefix>PS&gt; </prefix>
-///   <code>$cred = ConvertTo-SendGridCredential -ApiKey 'YOUR_SENDGRID_KEY'
+///   <code>$cred = ConvertTo-SendGridCredential -SecretName 'sendgrid-api-key' -VaultName 'MailSecrets'
 /// Send-EmailMessage -From 'john.doe@example.com' -To 'recipient@example.com' -Subject 'SendGrid Test' -Body 'Hello from SendGrid' -SendGrid -Credential $cred</code>
 /// </example>
 /// <example>
 ///   <summary>Send an email using Microsoft Graph API</summary>
 ///   <prefix>PS&gt; </prefix>
-///   <code>$cred = ConvertTo-GraphCredential -ClientID 'CLIENT_ID' -ClientSecret 'SECRET' -DirectoryID 'TENANT_ID'
+///   <code>$cred = ConvertTo-GraphCredential -ClientID 'CLIENT_ID' -SecretName 'graph-client-secret' -VaultName 'MailSecrets' -DirectoryID 'TENANT_ID'
 /// Send-EmailMessage -From @{ Name = 'John Doe'; Email = 'john.doe@example.com' } -To 'recipient@example.com' -Credential $cred -HTML '<b>Hello</b>' -Subject 'Graph API Email' -Graph</code>
 /// </example>
 /// <seealso href="https://github.com/EvotecIT/Mailozaurr">Mailozaurr Documentation</seealso>

--- a/Sources/Mailozaurr.PowerShell/CmdletUnprotectMimeMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletUnprotectMimeMessage.cs
@@ -29,7 +29,9 @@ public sealed class CmdletUnprotectMimeMessage : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        MimeMessage? message = InputObject switch {
+        var input = InputObject is PSObject psObject ? psObject.BaseObject : InputObject;
+
+        MimeMessage? message = input switch {
             MimeMessage m => m,
             ImapMessageInfo info => info.Raw.Message,
             ImapEmailMessage imap => imap.Message,

--- a/Sources/Mailozaurr.PowerShell/CredentialHelpers.cs
+++ b/Sources/Mailozaurr.PowerShell/CredentialHelpers.cs
@@ -2,6 +2,8 @@ namespace Mailozaurr.PowerShell;
 
 using System.Security;
 using System.Net;
+using System.Management.Automation;
+using System.Collections.ObjectModel;
 
 /// <summary>
 /// Helper class for converting strings to SecureString.
@@ -25,5 +27,64 @@ public static class CredentialHelpers {
             ss.MakeReadOnly();
             return ss;
         }
+    }
+
+    /// <summary>
+    /// Converts a SecureString to plain text.
+    /// </summary>
+    /// <param name="secureString"></param>
+    /// <returns></returns>
+    public static string ToPlainText(SecureString? secureString) {
+        if (secureString == null || secureString.Length == 0) {
+            return string.Empty;
+        }
+
+        return new NetworkCredential(string.Empty, secureString).Password;
+    }
+
+    /// <summary>
+    /// Resolves a secret from the current PowerShell runspace using Get-Secret.
+    /// </summary>
+    /// <param name="secretName"></param>
+    /// <param name="vaultName"></param>
+    /// <returns></returns>
+    public static SecureString ResolveSecretFromVault(string secretName, string? vaultName = null) {
+        if (string.IsNullOrWhiteSpace(secretName)) {
+            throw new PSArgumentException("Secret name is required.", nameof(secretName));
+        }
+
+        using var powerShell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
+        powerShell.AddCommand("Get-Secret").AddParameter("Name", secretName);
+        if (!string.IsNullOrWhiteSpace(vaultName)) {
+            powerShell.AddParameter("Vault", vaultName);
+        }
+
+        Collection<PSObject> results;
+        try {
+            results = powerShell.Invoke();
+        } catch (CommandNotFoundException ex) {
+            throw new PSInvalidOperationException(
+                "Get-Secret is not available in the current PowerShell session. Install/import Microsoft.PowerShell.SecretManagement or provide the secret directly.", ex);
+        }
+
+        if (powerShell.HadErrors) {
+            var firstError = powerShell.Streams.Error.FirstOrDefault();
+            throw new PSInvalidOperationException(
+                firstError?.Exception?.Message ?? $"Secret '{secretName}' could not be resolved from the current PowerShell session.",
+                firstError?.Exception);
+        }
+
+        var value = results.FirstOrDefault()?.BaseObject;
+        if (value == null) {
+            throw new PSInvalidOperationException($"Secret '{secretName}' was not found.");
+        }
+
+        return value switch {
+            SecureString secureString => secureString,
+            string text => ToSecureString(text),
+            PSCredential credential => credential.Password,
+            byte[] bytes => ToSecureString(System.Text.Encoding.UTF8.GetString(bytes)),
+            _ => ToSecureString(value.ToString())
+        };
     }
 }

--- a/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
+++ b/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
@@ -79,11 +79,22 @@
 
     <ItemGroup>
         <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0">
+        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0" GeneratePathProperty="true">
             <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <ExcludeAssets>build;buildTransitive</ExcludeAssets>
         </PackageReference>
     </ItemGroup>
+
+    <!-- XmlDoc2CmdletDoc help is only needed for the hostable PowerShell builds.
+    Skipping netstandard2.0 avoids duplicate standalone-build help generation and file locking. -->
+    <Target Name="XmlDoc2CmdletDoc"
+        BeforeTargets="PostBuildEvent"
+        Inputs="$(TargetPath)"
+        Outputs="$(TargetPath)-Help.xml"
+        Condition="'$(IsCrossTargetingBuild)' != 'true' and '$(TargetFramework)' != 'netstandard2.0'">
+        <Exec Command='dotnet --roll-forward Major "$(PkgMatejKafka_XmlDoc2CmdletDoc)\tools\MatejKafka.XmlDoc2CmdletDoc.dll" $(XmlDoc2CmdletDocArguments) "$(TargetPath)"'
+            IgnoreExitCode="true" />
+    </Target>
 
     <!-- Copy help documentation to publish output after publish -->
     <Target Name="CopyHelpDocumentationToPublishOutput" AfterTargets="Publish">

--- a/Sources/Mailozaurr.Tests/ApplicationProfileAuthServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileAuthServiceTests.cs
@@ -124,6 +124,47 @@ public sealed class ApplicationProfileAuthServiceTests {
     }
 
     [Fact]
+    public async Task LoginGmailAsyncSupportsClientSecretReferences() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "gmail-work",
+                DisplayName = "Work Gmail",
+                Kind = MailProfileKind.Gmail,
+                Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [MailProfileSettingsKeys.Mailbox] = "user@gmail.com",
+                    [MailProfileSettingsKeys.ClientId] = "client-id"
+                }
+            }
+        });
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("shared-secrets", MailSecretNames.ClientSecret, "client-secret-from-reference");
+        GmailProfileLoginRequest? capturedRequest = null;
+        var service = new MailProfileAuthService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore,
+            (request, _) => {
+                capturedRequest = request;
+                return Task.FromResult(new OAuthCredential {
+                    UserName = request.GmailAccount!,
+                    AccessToken = "gmail-access-token",
+                    RefreshToken = "gmail-refresh-token",
+                    ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+                });
+            });
+
+        var result = await service.LoginGmailAsync(new GmailProfileLoginRequest {
+            ProfileId = "gmail-work",
+            ClientSecretReference = $"shared-secrets:{MailSecretNames.ClientSecret}"
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("client-secret-from-reference", capturedRequest!.ClientSecret);
+        Assert.Null(capturedRequest.ClientSecretReference);
+    }
+
+    [Fact]
     public async Task LoginGraphAsyncPersistsAccessTokenAndProfileSettings() {
         var profileStore = new InMemoryProfileStore(new[] {
             new MailProfile {

--- a/Sources/Mailozaurr.Tests/ApplicationProfileBootstrapServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileBootstrapServiceTests.cs
@@ -38,6 +38,31 @@ public sealed class ApplicationProfileBootstrapServiceTests {
     }
 
     [Fact]
+    public async Task SaveGraphProfileAsyncSupportsSecretReferences() {
+        var profileStore = new InMemoryProfileStore();
+        var secretStore = new InMemorySecretStore();
+        await secretStore.SetSecretAsync("shared-secrets", MailSecretNames.ClientSecret, "shared-client-secret");
+        var service = new MailProfileBootstrapService(
+            new MailProfileService(profileStore, secretStore),
+            new MailProfileSecretService(profileStore, secretStore),
+            secretStore);
+
+        var result = await service.SaveGraphProfileAsync(new GraphProfileBootstrapRequest {
+            ProfileId = "graph-work",
+            DisplayName = "Work Graph",
+            Mailbox = "shared@example.com",
+            ClientId = "client-id",
+            TenantId = "tenant-id",
+            ClientSecretReference = $"shared-secrets:{MailSecretNames.ClientSecret}"
+        });
+
+        var clientSecret = await secretStore.GetSecretAsync("graph-work", MailSecretNames.ClientSecret);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("shared-client-secret", clientSecret);
+    }
+
+    [Fact]
     public async Task SaveGraphProfileAsyncRequiresAuthenticationMaterial() {
         var profileStore = new InMemoryProfileStore();
         var secretStore = new InMemorySecretStore();

--- a/Sources/Mailozaurr.Tests/ApplicationProfileSecretServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileSecretServiceTests.cs
@@ -37,6 +37,38 @@ public sealed class ApplicationProfileSecretServiceTests {
         Assert.Equal("secret", stored);
     }
 
+    [Fact]
+    public async Task SetSecretAsyncSupportsReferenceCopyForExistingProfile() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var secretStore = new FileMailSecretStore(CreateTemporaryFilePath("secrets.json"), new TestCredentialProtector());
+        var service = new MailProfileSecretService(profileStore, secretStore);
+
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work-imap",
+            DisplayName = "Work IMAP",
+            Kind = MailProfileKind.Imap,
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Server] = "imap.example.com"
+            }
+        });
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "shared-secrets",
+            DisplayName = "Shared Secrets",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Mailbox] = "shared@example.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await secretStore.SetSecretAsync("shared-secrets", MailSecretNames.Password, "copied-secret");
+
+        var result = await service.SetSecretAsync("work-imap", MailSecretNames.Password, null, $"shared-secrets:{MailSecretNames.Password}");
+        var stored = await secretStore.GetSecretAsync("work-imap", MailSecretNames.Password);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("copied-secret", stored);
+    }
+
     private static string CreateTemporaryFilePath(string fileName) {
         var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);

--- a/Sources/Mailozaurr.Tests/ApplicationSecretStoreTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationSecretStoreTests.cs
@@ -43,6 +43,23 @@ public sealed class ApplicationSecretStoreTests {
         Assert.Null(loaded);
     }
 
+    [Fact]
+    public async Task UpdatingSecretReplacesFileWithoutLeavingTemporaryArtifacts() {
+        var filePath = CreateTemporaryFilePath();
+        var protector = new TestCredentialProtector();
+        var store = new FileMailSecretStore(filePath, protector);
+
+        await store.SetSecretAsync("work-imap", "password", "initial");
+        await store.SetSecretAsync("work-imap", "password", "updated");
+
+        var loaded = await store.GetSecretAsync("work-imap", "password");
+        var files = Directory.GetFiles(Path.GetDirectoryName(filePath)!);
+
+        Assert.Equal("updated", loaded);
+        Assert.Single(files);
+        Assert.Equal(filePath, files[0], StringComparer.OrdinalIgnoreCase);
+    }
+
     private static string CreateTemporaryFilePath() {
         var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);

--- a/Sources/Mailozaurr.Tests/CliRunnerTests.cs
+++ b/Sources/Mailozaurr.Tests/CliRunnerTests.cs
@@ -181,6 +181,76 @@ public sealed class CliRunnerTests {
     }
 
     [Fact]
+    public async Task ProfileGraphBootstrapSupportsSecretValuesFromEnvironmentVariables() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        const string envName = "MAILOZAURR_TEST_GRAPH_SECRET";
+        Environment.SetEnvironmentVariable(envName, "env-client-secret");
+
+        try {
+            var exitCode = await CliRunner.RunAsync(
+                new[] {
+                    "profile", "graph-bootstrap",
+                    "--profile", "graph-env",
+                    "--name", "Graph Env",
+                    "--mailbox", "shared@example.com",
+                    "--client-id", "client-id",
+                    "--tenant-id", "tenant-id",
+                    "--client-secret-env", envName,
+                    "--json"
+                },
+                stdout,
+                stderr,
+                _ => fixture.CreateBuilder());
+
+            var clientSecret = await fixture.SecretStore.GetSecretAsync("graph-env", MailSecretNames.ClientSecret);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal("env-client-secret", clientSecret);
+        } finally {
+            Environment.SetEnvironmentVariable(envName, null);
+        }
+    }
+
+    [Fact]
+    public async Task ProfileGraphBootstrapSupportsSecretReferences() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "shared-secrets",
+            DisplayName = "Shared Secrets",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "shared@example.com",
+                [MailProfileSettingsKeys.ClientId] = "shared-client"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("shared-secrets", MailSecretNames.ClientSecret, "shared-client-secret");
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "profile", "graph-bootstrap",
+                "--profile", "graph-ref",
+                "--name", "Graph Ref",
+                "--mailbox", "shared@example.com",
+                "--client-id", "client-id",
+                "--tenant-id", "tenant-id",
+                "--client-secret-ref", $"shared-secrets:{MailSecretNames.ClientSecret}",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        var clientSecret = await fixture.SecretStore.GetSecretAsync("graph-ref", MailSecretNames.ClientSecret);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("shared-client-secret", clientSecret);
+    }
+
+    [Fact]
     public async Task ProfileGmailBootstrapSavesProfileAndSecretsThroughApplicationServices() {
         using var stdout = new StringWriter();
         using var stderr = new StringWriter();
@@ -213,6 +283,61 @@ public sealed class CliRunnerTests {
         Assert.Equal("client-id", profile.Settings[MailProfileSettingsKeys.ClientId]);
         Assert.Equal("client-secret", clientSecret);
         Assert.Equal("refresh-token", refreshToken);
+    }
+
+    [Fact]
+    public async Task ProfileSetSecretSupportsReadingValueFromStandardInput() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        using var stdin = new StringReader("stdin-secret\r\n");
+        var fixture = CreateFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "stdin-profile",
+            DisplayName = "stdin",
+            Kind = MailProfileKind.Imap
+        });
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "profile", "set-secret",
+                "--profile", "stdin-profile",
+                "--name", "password",
+                "--value-stdin",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder(),
+            stdin);
+
+        var secret = await fixture.SecretStore.GetSecretAsync("stdin-profile", "password");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("stdin-secret", secret);
+    }
+
+    [Fact]
+    public async Task JsonErrorsAreWrittenAsStructuredPayloads() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "profile", "set-secret",
+                "--profile", "missing-value",
+                "--name", "password",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        using var document = JsonDocument.Parse(stderr.ToString());
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("InvalidOperationException", document.RootElement.GetProperty("Error").GetProperty("Type").GetString());
+        Assert.Contains("--value", document.RootElement.GetProperty("Error").GetProperty("Message").GetString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -272,6 +397,38 @@ public sealed class CliRunnerTests {
         Assert.Equal("gmail-refresh-token", refreshToken);
         Assert.NotNull(fixture.ProfileAuthService.LastGmailRequest);
         Assert.Equal("user@gmail.com", fixture.ProfileAuthService.LastGmailRequest!.GmailAccount);
+    }
+
+    [Fact]
+    public async Task ProfileGmailLoginSupportsClientSecretReference() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-login-ref",
+            DisplayName = "Gmail Login Ref",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "user@gmail.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("shared-secrets", MailSecretNames.ClientSecret, "client-secret-from-reference");
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "profile", "gmail-login",
+                "--profile", "gmail-login-ref",
+                "--client-secret-ref", $"shared-secrets:{MailSecretNames.ClientSecret}",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(fixture.ProfileAuthService.LastGmailRequest);
+        Assert.Equal("client-secret-from-reference", fixture.ProfileAuthService.LastGmailRequest!.ClientSecret);
     }
 
     [Fact]
@@ -461,6 +618,40 @@ public sealed class CliRunnerTests {
 
         Assert.Equal(0, exitCode);
         Assert.Equal("super-secret", secretValue);
+    }
+
+    [Fact]
+    public async Task ProfileSetSecretSupportsReferenceCopy() {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "shared-secrets",
+            DisplayName = "Shared Secrets",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "shared@example.com",
+                [MailProfileSettingsKeys.ClientId] = "shared-client"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("shared-secrets", MailSecretNames.Password, "copied-secret");
+
+        var exitCode = await CliRunner.RunAsync(
+            new[] {
+                "profile", "set-secret",
+                "--profile", "work-imap",
+                "--name", MailSecretNames.Password,
+                "--value-ref", $"shared-secrets:{MailSecretNames.Password}",
+                "--json"
+            },
+            stdout,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        var secretValue = await fixture.SecretStore.GetSecretAsync("work-imap", MailSecretNames.Password);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("copied-secret", secretValue);
     }
 
     [Fact]
@@ -3013,6 +3204,11 @@ public sealed class CliRunnerTests {
             var profile = await _profileStore.GetByIdAsync(request.ProfileId, cancellationToken);
             Assert.NotNull(profile);
             var savedProfile = profile!;
+            var clientSecret = request.ClientSecret;
+            if (string.IsNullOrWhiteSpace(clientSecret) && !string.IsNullOrWhiteSpace(request.ClientSecretReference)) {
+                var (sourceProfileId, sourceSecretName) = ParseSecretReference(request.ClientSecretReference!, request.ProfileId);
+                clientSecret = await _secretStore.GetSecretAsync(sourceProfileId, sourceSecretName, cancellationToken);
+            }
             var account = request.GmailAccount
                 ?? (savedProfile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) ? mailbox : null)
                 ?? "user@gmail.com";
@@ -3020,7 +3216,7 @@ public sealed class CliRunnerTests {
                 ProfileId = request.ProfileId,
                 GmailAccount = account,
                 ClientId = request.ClientId ?? (savedProfile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientId) ? clientId : null),
-                ClientSecret = request.ClientSecret,
+                ClientSecret = clientSecret,
                 Scopes = request.Scopes
             };
             savedProfile.Settings[MailProfileSettingsKeys.Mailbox] = account;
@@ -3072,6 +3268,21 @@ public sealed class CliRunnerTests {
                     ProfileKind = profile.Kind
                 }
             };
+        }
+
+        private static (string ProfileId, string SecretName) ParseSecretReference(string secretReference, string defaultProfileId) {
+            var normalized = secretReference.Trim();
+            var colonIndex = normalized.IndexOf(':');
+            var slashIndex = normalized.IndexOf('/');
+            var separatorIndex = colonIndex >= 0 && slashIndex >= 0
+                ? Math.Min(colonIndex, slashIndex)
+                : Math.Max(colonIndex, slashIndex);
+
+            if (separatorIndex < 0) {
+                return (defaultProfileId, normalized);
+            }
+
+            return (normalized[..separatorIndex], normalized[(separatorIndex + 1)..]);
         }
     }
 

--- a/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
@@ -186,6 +186,35 @@ public class GraphBatchAndRetryTests {
     }
 
     [Fact]
+    public async Task ConnectO365GraphAsync_UsesProvidedAccessTokenWithoutHttpCall() {
+        var handler = new RetryHandler();
+        var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var client = (HttpClient)field.GetValue(null)!;
+        var handlerField = GetHandlerField();
+        var original = (HttpMessageHandler)handlerField.GetValue(client)!;
+        handlerField.SetValue(client, handler);
+        var cacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cache = (System.Collections.Concurrent.ConcurrentDictionary<string, GraphAuthorization>)cacheField.GetValue(null)!;
+        cache.Clear();
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        OAuthCacheTestHelper.DeleteOAuthCacheFile();
+        try {
+            var credential = new GraphCredential {
+                ClientId = "id",
+                DirectoryId = "tenant",
+                AccessToken = "delegated-token"
+            };
+
+            string token = await MicrosoftGraphUtils.ConnectO365GraphAsync(credential, "tenant");
+
+            Assert.Equal("Bearer delegated-token", token);
+            Assert.Equal(0, handler.CallCount);
+        } finally {
+            handlerField.SetValue(client, original);
+        }
+    }
+
+    [Fact]
     public async Task ConnectO365GraphWithRetryAsync_NoRetriesThrowsException() {
         var handler = new AlwaysFailHandler();
         var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;

--- a/Sources/Mailozaurr.Tests/MailMcpToolsTests.cs
+++ b/Sources/Mailozaurr.Tests/MailMcpToolsTests.cs
@@ -175,6 +175,33 @@ public sealed class MailMcpToolsTests {
     }
 
     [Fact]
+    public async Task MailProfileGraphBootstrapSupportsSecretReferences() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "shared-secrets",
+            DisplayName = "Shared Secrets",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "shared@example.com",
+                [MailProfileSettingsKeys.ClientId] = "shared-client"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("shared-secrets", MailSecretNames.ClientSecret, "shared-client-secret");
+
+        var profile = await fixture.Tools.mail_profile_graph_bootstrap(
+            profileId: "graph-ref",
+            displayName: "Graph Ref",
+            mailbox: "shared@example.com",
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecretReference: $"shared-secrets:{MailSecretNames.ClientSecret}");
+        var storedSecret = await fixture.SecretStore.GetSecretAsync("graph-ref", MailSecretNames.ClientSecret);
+
+        Assert.Equal("graph-ref", profile.Id);
+        Assert.Equal("shared-client-secret", storedSecret);
+    }
+
+    [Fact]
     public async Task MailProfileGmailBootstrapCreatesProfileAndStoresSecrets() {
         using var fixture = new TestFixture();
 
@@ -261,6 +288,29 @@ public sealed class MailMcpToolsTests {
         Assert.Equal("gmail-refresh-token", refreshToken);
         Assert.NotNull(fixture.ProfileAuthService.LastGmailRequest);
         Assert.Equal("user@gmail.com", fixture.ProfileAuthService.LastGmailRequest!.GmailAccount);
+    }
+
+    [Fact]
+    public async Task MailProfileGmailLoginSupportsSameProfileSecretReference() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "gmail-login-ref",
+            DisplayName = "Gmail Login Ref",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "user@gmail.com",
+                [MailProfileSettingsKeys.ClientId] = "client-id"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("gmail-login-ref", MailSecretNames.ClientSecret, "client-secret-from-store");
+
+        var result = await fixture.Tools.mail_profile_gmail_login(
+            "gmail-login-ref",
+            clientSecretReference: MailSecretNames.ClientSecret);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(fixture.ProfileAuthService.LastGmailRequest);
+        Assert.Equal("client-secret-from-store", fixture.ProfileAuthService.LastGmailRequest!.ClientSecret);
     }
 
     [Fact]
@@ -420,6 +470,30 @@ public sealed class MailMcpToolsTests {
         Assert.Equal("secret-value", storedSecret);
         Assert.True(removeResult.Succeeded);
         Assert.Null(removedSecret);
+    }
+
+    [Fact]
+    public async Task MailProfileSecretSetSupportsReferenceCopy() {
+        using var fixture = new TestFixture();
+        await fixture.ProfileStore.SaveAsync(new MailProfile {
+            Id = "shared-secrets",
+            DisplayName = "Shared Secrets",
+            Kind = MailProfileKind.Gmail,
+            Settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [MailProfileSettingsKeys.Mailbox] = "shared@example.com",
+                [MailProfileSettingsKeys.ClientId] = "shared-client"
+            }
+        });
+        await fixture.SecretStore.SetSecretAsync("shared-secrets", MailSecretNames.RefreshToken, "copied-secret");
+
+        var setResult = await fixture.Tools.mail_profile_secret_set(
+            profileId: "gmail-work",
+            secretName: MailSecretNames.RefreshToken,
+            secretReference: $"shared-secrets:{MailSecretNames.RefreshToken}");
+        var storedSecret = await fixture.SecretStore.GetSecretAsync("gmail-work", MailSecretNames.RefreshToken);
+
+        Assert.True(setResult.Succeeded);
+        Assert.Equal("copied-secret", storedSecret);
     }
 
     [Fact]
@@ -2465,6 +2539,11 @@ public sealed class MailMcpToolsTests {
             var profile = await _profileStore.GetByIdAsync(request.ProfileId, cancellationToken);
             Assert.NotNull(profile);
             var savedProfile = profile!;
+            var clientSecret = request.ClientSecret;
+            if (string.IsNullOrWhiteSpace(clientSecret) && !string.IsNullOrWhiteSpace(request.ClientSecretReference)) {
+                var (sourceProfileId, sourceSecretName) = ParseSecretReference(request.ClientSecretReference!, request.ProfileId);
+                clientSecret = await _secretStore.GetSecretAsync(sourceProfileId, sourceSecretName, cancellationToken);
+            }
             var account = request.GmailAccount
                 ?? (savedProfile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) ? mailbox : null)
                 ?? "user@gmail.com";
@@ -2472,7 +2551,7 @@ public sealed class MailMcpToolsTests {
                 ProfileId = request.ProfileId,
                 GmailAccount = account,
                 ClientId = request.ClientId ?? (savedProfile.Settings.TryGetValue(MailProfileSettingsKeys.ClientId, out var clientId) ? clientId : null),
-                ClientSecret = request.ClientSecret,
+                ClientSecret = clientSecret,
                 Scopes = request.Scopes
             };
             savedProfile.Settings[MailProfileSettingsKeys.Mailbox] = account;
@@ -2522,6 +2601,21 @@ public sealed class MailMcpToolsTests {
                     ProfileKind = profile.Kind
                 }
             };
+        }
+
+        private static (string ProfileId, string SecretName) ParseSecretReference(string secretReference, string defaultProfileId) {
+            var normalized = secretReference.Trim();
+            var colonIndex = normalized.IndexOf(':');
+            var slashIndex = normalized.IndexOf('/');
+            var separatorIndex = colonIndex >= 0 && slashIndex >= 0
+                ? Math.Min(colonIndex, slashIndex)
+                : Math.Max(colonIndex, slashIndex);
+
+            if (separatorIndex < 0) {
+                return (defaultProfileId, normalized);
+            }
+
+            return (normalized[..separatorIndex], normalized[(separatorIndex + 1)..]);
         }
     }
 

--- a/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpConnectionPoolTests.cs
@@ -15,6 +15,10 @@ public class SmtpConnectionPoolTests {
             ConnectCalls++;
             _connected = true;
         }
+
+        public override void Disconnect(bool quit, CancellationToken cancellationToken = default) {
+            _connected = false;
+        }
     }
 
     private sealed class TrackingClient : ClientSmtp {
@@ -55,6 +59,55 @@ public class SmtpConnectionPoolTests {
         Smtp.ClientFactory = logger => new ClientSmtp();
         SmtpConnectionPool.ClearConnectionPool();
         SmtpConnectionPool.SetPoolingEnabled(false);
+    }
+
+    [Fact]
+    public void InstancePoolOverrideFalse_DoesNotUseGlobalPool() {
+        SmtpConnectionPool.SetPoolingEnabled(true);
+        SmtpConnectionPool.ClearConnectionPool();
+
+        var fake = new FakeClient();
+        Smtp.ClientFactory = _ => fake;
+
+        var smtp1 = new Smtp { UseConnectionPool = false };
+        smtp1.Connect("h", 25);
+        smtp1.Disconnect();
+
+        Smtp.ClientFactory = _ => new FakeClient();
+        var smtp2 = new Smtp { UseConnectionPool = false };
+        smtp2.Connect("h", 25);
+
+        Assert.NotSame(fake, smtp2.Client);
+        Assert.Equal(0, SmtpConnectionPool.CurrentPoolSize);
+
+        smtp2.Dispose();
+        Smtp.ClientFactory = _ => new ClientSmtp();
+        SmtpConnectionPool.ClearConnectionPool();
+        SmtpConnectionPool.SetPoolingEnabled(false);
+    }
+
+    [Fact]
+    public void InstancePoolOverrideTrue_UsesPoolWhenGlobalPoolingIsDisabled() {
+        SmtpConnectionPool.SetPoolingEnabled(false);
+        SmtpConnectionPool.ClearConnectionPool();
+
+        var fake = new FakeClient();
+        Smtp.ClientFactory = _ => fake;
+
+        var smtp1 = new Smtp { UseConnectionPool = true };
+        smtp1.Connect("h", 25);
+        smtp1.Disconnect();
+
+        var smtp2 = new Smtp { UseConnectionPool = true };
+        Smtp.ClientFactory = _ => new FakeClient();
+        smtp2.Connect("h", 25);
+
+        Assert.Same(fake, smtp2.Client);
+        Assert.Equal(1, fake.ConnectCalls);
+
+        smtp2.Dispose();
+        Smtp.ClientFactory = _ => new ClientSmtp();
+        SmtpConnectionPool.ClearConnectionPool();
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/TemporarySmimeCertificateTests.cs
+++ b/Sources/Mailozaurr.Tests/TemporarySmimeCertificateTests.cs
@@ -43,4 +43,49 @@ public class TemporarySmimeCertificateTests
         var encryptResult = smtp.Encrypt(cert);
         Assert.True(encryptResult.Status);
     }
+
+    [Fact]
+    public void Certificate_CanVerifySmimeSignature()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return;
+        }
+
+        using X509Certificate2 cert = TemporarySmimeCertificate.CreateSelfSigned();
+        var smtp = new Smtp();
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "c@d.com" };
+        smtp.Subject = "test";
+        smtp.TextBody = "body";
+        smtp.CreateMessage();
+
+        var signResult = smtp.Sign(cert);
+
+        Assert.True(signResult.Status);
+        Assert.True(MimeKitUtils.VerifySmimeSignature(smtp.Message, cert));
+    }
+
+    [Fact]
+    public void Certificate_CanDecryptSmimeMessage()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return;
+        }
+
+        using X509Certificate2 cert = TemporarySmimeCertificate.CreateSelfSigned();
+        var smtp = new Smtp();
+        smtp.From = "a@b.com";
+        smtp.To = new object[] { "c@d.com" };
+        smtp.Subject = "test";
+        smtp.TextBody = "body";
+        smtp.CreateMessage();
+
+        var encryptResult = smtp.Encrypt(cert);
+        var decrypted = MimeKitUtils.DecryptSmime(smtp.Message, cert);
+
+        Assert.True(encryptResult.Status);
+        Assert.Equal("body", decrypted.TextBody);
+    }
 }

--- a/Sources/Mailozaurr/Connections/Pop3Connector.cs
+++ b/Sources/Mailozaurr/Connections/Pop3Connector.cs
@@ -10,10 +10,17 @@ namespace Mailozaurr;
 /// Provides helper methods for connecting to POP3 servers with retry logic.
 /// </summary>
 public static class Pop3Connector {
+    private static Pop3Client CreateDefaultClient() => new Pop3Client();
+
     /// <summary>
     /// Factory used to create <see cref="Pop3Client"/> instances.
     /// </summary>
-    public static Func<Pop3Client> ClientFactory { get; set; } = () => new Pop3Client();
+    public static Func<Pop3Client> ClientFactory { get; set; } = CreateDefaultClient;
+
+    /// <summary>
+    /// Restores the default POP3 client factory.
+    /// </summary>
+    public static void ResetClientFactory() => ClientFactory = CreateDefaultClient;
 
     /// <summary>
     /// Delegate used to delay between connection retries.

--- a/Sources/Mailozaurr/GraphCredential.cs
+++ b/Sources/Mailozaurr/GraphCredential.cs
@@ -24,6 +24,11 @@ public class GraphCredential {
     public string? ClientSecret { get; set; }
 
     /// <summary>
+    /// Gets or sets an access token for delegated Microsoft Graph operations.
+    /// </summary>
+    public string? AccessToken { get; set; }
+
+    /// <summary>
     /// Gets or sets the path to a certificate used for authentication.
     /// </summary>
     public string? CertificatePath { get; set; }

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -145,6 +145,14 @@ namespace Mailozaurr {
         /// Connects to O365 Graph and returns the Authorization header value ("Bearer ...").
         /// </summary>
         public static async Task<string> ConnectO365GraphAsync(GraphCredential credential, string tenantDomain, string resource = "https://manage.office.com", CancellationToken cancellationToken = default) {
+            var delegatedAccessToken = credential.AccessToken;
+            if (delegatedAccessToken != null && delegatedAccessToken.Trim().Length > 0) {
+                var accessToken = delegatedAccessToken.Trim();
+                return accessToken.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+                    ? accessToken
+                    : $"Bearer {accessToken}";
+            }
+
             var key = $"{credential.ClientId}|{tenantDomain}|{credential.CertificatePath}|{credential.ClientSecret}|{resource}";
             if (TokenCache.TryGetValue(key, out var cached) && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
                 return $"{cached.TokenType} {cached.AccessToken}";

--- a/Sources/Mailozaurr/MimeKitUtils.cs
+++ b/Sources/Mailozaurr/MimeKitUtils.cs
@@ -192,7 +192,7 @@ public static class MimeKitUtils {
         }
 
         var signatures = signed.Verify(ctx);
-        foreach (var sig in signatures) sig.Verify();
+        foreach (var sig in signatures) sig.Verify(true);
         return true;
     }
 }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -80,6 +80,12 @@ public partial class ClientSmtp : SmtpClient {
     }
 
     /// <summary>
+    /// Returns the currently negotiated SMTP capabilities.
+    /// Overridable for tests that need to fake server features.
+    /// </summary>
+    public virtual SmtpCapabilities GetCapabilitiesSnapshot() => Capabilities;
+
+    /// <summary>
     /// Determines which delivery status notifications should be requested for the specified recipient.
     /// </summary>
     /// <param name="message">The message being sent.</param>

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -25,9 +25,13 @@ namespace Mailozaurr;
 /// are serialized so that only one send executes at a time per instance.</para>
 /// </remarks>
 public class Smtp {
+    private static ClientSmtp CreateDefaultClient(ProtocolLogger? logger) => logger == null ? new ClientSmtp() : new ClientSmtp(logger);
 
     /// <summary>Factory used to create <see cref="ClientSmtp"/> instances.</summary>
-    public static Func<ProtocolLogger?, ClientSmtp> ClientFactory { get; set; } = logger => logger == null ? new ClientSmtp() : new ClientSmtp(logger);
+    public static Func<ProtocolLogger?, ClientSmtp> ClientFactory { get; set; } = CreateDefaultClient;
+
+    /// <summary>Restores the default SMTP client factory.</summary>
+    public static void ResetClientFactory() => ClientFactory = CreateDefaultClient;
     /// <summary>Configuration used for protocol logging.</summary>
     public LoggingConfigurator? Logging;
 
@@ -85,6 +89,12 @@ public class Smtp {
     /// Optional identity hint used to isolate SMTP connection pooling by credentials.
     /// </summary>
     public string? ConnectionPoolIdentity { get; set; }
+
+    /// <summary>
+    /// Optional per-instance override controlling whether this SMTP session should
+    /// use the shared connection pool.
+    /// </summary>
+    public bool? UseConnectionPool { get; set; }
 
     /// <summary>Subject of the message.</summary>
     public string Subject {
@@ -234,6 +244,8 @@ public class Smtp {
     private bool _skipCertificateValidation;
     private readonly SemaphoreSlim _sendLock = new(1, 1);
     private string? _poolIdentity;
+
+    private bool IsConnectionPoolingEnabled => UseConnectionPool ?? SmtpConnectionPool.PoolingEnabled;
     /// <summary>Skip server certificate validation.</summary>
     public bool SkipCertificateValidation {
         get => _skipCertificateValidation;
@@ -372,7 +384,7 @@ public class Smtp {
             persistent = false;
         }
 
-        var info = new SmtpConnectionInfo(server, port, banner, software, smtp.Client.Capabilities, persistent);
+        var info = new SmtpConnectionInfo(server, port, banner, software, smtp.Client.GetCapabilitiesSnapshot(), persistent);
         smtp.Disconnect();
         smtp.Dispose();
         return info;
@@ -483,9 +495,9 @@ public class Smtp {
         }
         if (Client.IsConnected)
         {
-            if (SmtpConnectionPool.PoolingEnabled)
+            if (IsConnectionPoolingEnabled)
             {
-                SmtpConnectionPool.ReturnClient(oldServer, oldPort, Client, oldPoolIdentity);
+                SmtpConnectionPool.ReturnClient(oldServer, oldPort, Client, oldPoolIdentity, IsConnectionPoolingEnabled);
             }
             else
             {
@@ -495,7 +507,7 @@ public class Smtp {
         }
 
         var poolIdentity = GetConnectionPoolIdentity();
-        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port, poolIdentity) : null;
+        var pooled = SmtpConnectionPool.TryRentClient(server, port, poolIdentity, IsConnectionPoolingEnabled);
         if (pooled != null)
         {
             Client = pooled;
@@ -587,9 +599,9 @@ public class Smtp {
         }
         if (Client.IsConnected)
         {
-            if (SmtpConnectionPool.PoolingEnabled)
+            if (IsConnectionPoolingEnabled)
             {
-                SmtpConnectionPool.ReturnClient(oldServer, oldPort, Client, oldPoolIdentity);
+                SmtpConnectionPool.ReturnClient(oldServer, oldPort, Client, oldPoolIdentity, IsConnectionPoolingEnabled);
             }
             else
             {
@@ -599,7 +611,7 @@ public class Smtp {
         }
 
         var poolIdentity = GetConnectionPoolIdentity();
-        var pooled = SmtpConnectionPool.PoolingEnabled ? SmtpConnectionPool.TryRentClient(server, port, poolIdentity) : null;
+        var pooled = SmtpConnectionPool.TryRentClient(server, port, poolIdentity, IsConnectionPoolingEnabled);
         if (pooled != null)
         {
             Client = pooled;
@@ -1436,9 +1448,9 @@ public class Smtp {
     /// </summary>
     public void Disconnect() {
         if (Client.IsConnected) {
-            if (SmtpConnectionPool.PoolingEnabled) {
+            if (IsConnectionPoolingEnabled) {
                 var identity = _poolIdentity ?? GetConnectionPoolIdentity();
-                SmtpConnectionPool.ReturnClient(Server, Port, Client, identity);
+                SmtpConnectionPool.ReturnClient(Server, Port, Client, identity, IsConnectionPoolingEnabled);
                 Client = ClientFactory(Logging?.ProtocolLogger);
             } else {
                 Client.Disconnect(true);
@@ -1451,15 +1463,18 @@ public class Smtp {
     /// Releases the SMTP connection and associated resources.
     /// </summary>
     public void Dispose() {
+        var clientToDispose = Client;
         if (Client.IsConnected) {
-            if (SmtpConnectionPool.PoolingEnabled) {
+            if (IsConnectionPoolingEnabled) {
                 var identity = _poolIdentity ?? GetConnectionPoolIdentity();
-                SmtpConnectionPool.ReturnClient(Server, Port, Client, identity);
+                SmtpConnectionPool.ReturnClient(Server, Port, Client, identity, IsConnectionPoolingEnabled);
+                Client = ClientFactory(Logging?.ProtocolLogger);
+                clientToDispose = Client;
             } else {
                 Client.Disconnect(true);
             }
         }
-        Client.Dispose();
+        clientToDispose.Dispose();
         Stopwatch.Stop();
     }
 

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionPool.cs
@@ -91,8 +91,11 @@ public static class SmtpConnectionPool {
         return $"{serverKey}:{port}:{identityKey}";
     }
 
-    internal static ClientSmtp? TryRentClient(string server, int port, string? identity = null) {
-        if (!PoolingEnabled) {
+    internal static ClientSmtp? TryRentClient(string server, int port, string? identity = null) =>
+        TryRentClient(server, port, identity, PoolingEnabled);
+
+    internal static ClientSmtp? TryRentClient(string server, int port, string? identity, bool poolingEnabled) {
+        if (!poolingEnabled) {
             return null;
         }
 
@@ -112,8 +115,11 @@ public static class SmtpConnectionPool {
         return null;
     }
 
-    internal static void ReturnClient(string server, int port, ClientSmtp client, string? identity = null) {
-        if (!PoolingEnabled) {
+    internal static void ReturnClient(string server, int port, ClientSmtp client, string? identity = null) =>
+        ReturnClient(server, port, client, identity, PoolingEnabled);
+
+    internal static void ReturnClient(string server, int port, ClientSmtp client, string? identity, bool poolingEnabled) {
+        if (!poolingEnabled) {
             client.Dispose();
             return;
         }

--- a/Tests/Clear-SmtpConnectionPool.Tests.ps1
+++ b/Tests/Clear-SmtpConnectionPool.Tests.ps1
@@ -1,15 +1,21 @@
 Describe 'Clear-SmtpConnectionPool' {
     It 'Forces new connection after clearing pool' {
         $refs = @(
+            [Mailozaurr.Smtp].Assembly.Location,
             [Mailozaurr.ClientSmtp].Assembly.Location,
+            [MimeKit.MimeMessage].Assembly.Location,
             [MailKit.Security.SecureSocketOptions].Assembly.Location
         )
-        Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+        if (-not ('FakeClientPsClearPool' -as [type])) {
+            Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
 using Mailozaurr;
+using MailKit;
 using MailKit.Security;
+using MimeKit;
 using System.Threading;
+using System.Threading.Tasks;
 public class FakeClientPs2 : ClientSmtp {
-    public int ConnectCalls;
+    public static int ConnectCalls;
     private bool _connected;
     public override bool IsConnected => _connected;
     public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {
@@ -19,26 +25,38 @@ public class FakeClientPs2 : ClientSmtp {
     public override void Disconnect(bool quit, CancellationToken cancellationToken = default) {
         _connected = false;
     }
+    public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken, ITransferProgress progress) {
+        message.MessageId = message.MessageId ?? "fake-" + ConnectCalls.ToString();
+        return Task.FromResult(message.MessageId);
+    }
+}
+public static class FakeClientPsClearPool {
+    public static ClientSmtp Create(ProtocolLogger logger) => new FakeClientPs2();
+    public static void Install() => Smtp.ClientFactory = Create;
+    public static void Reset() => FakeClientPs2.ConnectCalls = 0;
 }
 "@
+        }
 
-        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($true)
-        [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
-        $fake = [FakeClientPs2]::new()
-        [Mailozaurr.Smtp]::ClientFactory = { $fake }
+        try {
+            [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($false)
+            [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
+            [FakeClientPsClearPool]::Reset()
+            [FakeClientPsClearPool]::Install()
 
-        $params = @{ From='a@b.com'; To='c@d.com'; Server='h'; Subject='t'; Text='b'; WhatIf=$true; UseConnectionPool=$true }
-        Send-EmailMessage @params | Out-Null
-        Send-EmailMessage @params | Out-Null
+            $params = @{ From='a@b.com'; To='c@d.com'; Server='h'; Subject='t'; Text='b'; UseConnectionPool=$true }
+            Send-EmailMessage @params | Out-Null
+            Send-EmailMessage @params | Out-Null
 
-        Clear-SmtpConnectionPool
+            Clear-SmtpConnectionPool
 
-        Send-EmailMessage @params | Out-Null
+            Send-EmailMessage @params | Out-Null
 
-        $fake.ConnectCalls | Should -Be 2
-
-        [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
-        [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
-        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($false)
+            [FakeClientPs2]::ConnectCalls | Should -Be 2
+        } finally {
+            [Mailozaurr.Smtp]::ResetClientFactory()
+            [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
+            [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($false)
+        }
     }
 }

--- a/Tests/Connect-EmailGraph.Tests.ps1
+++ b/Tests/Connect-EmailGraph.Tests.ps1
@@ -1,0 +1,48 @@
+Describe 'Connect-EmailGraph cmdlet' {
+    It 'Cmdlet derives from AsyncPSCmdlet' {
+        $base = [Mailozaurr.PowerShell.CmdletConnectEmailGraph].BaseType
+        $base.FullName | Should -Be 'Mailozaurr.PowerShell.AsyncPSCmdlet'
+    }
+
+    It 'exposes ClientSecretSecureString as a SecureString parameter' {
+        $command = Get-Command Connect-EmailGraph
+
+        $command.Parameters.ContainsKey('ClientSecretSecureString') | Should -BeTrue
+        $command.Parameters['ClientSecretSecureString'].ParameterType | Should -Be ([securestring])
+    }
+
+    It 'exposes CertificatePasswordSecureString as a SecureString parameter' {
+        $command = Get-Command Connect-EmailGraph
+
+        $command.Parameters.ContainsKey('CertificatePasswordSecureString') | Should -BeTrue
+        $command.Parameters['CertificatePasswordSecureString'].ParameterType | Should -Be ([securestring])
+    }
+
+    It 'exposes OnBehalfOfTokenSecureString as a SecureString parameter' {
+        $command = Get-Command Connect-EmailGraph
+
+        $command.Parameters.ContainsKey('OnBehalfOfTokenSecureString') | Should -BeTrue
+        $command.Parameters['OnBehalfOfTokenSecureString'].ParameterType | Should -Be ([securestring])
+    }
+
+    It 'exposes ClientSecretSecretName for vault-based client secret resolution' {
+        $command = Get-Command Connect-EmailGraph
+
+        $command.Parameters.ContainsKey('ClientSecretSecretName') | Should -BeTrue
+        $command.Parameters['ClientSecretSecretName'].ParameterType | Should -Be ([string])
+    }
+
+    It 'exposes CertificatePasswordSecretName for vault-based certificate password resolution' {
+        $command = Get-Command Connect-EmailGraph
+
+        $command.Parameters.ContainsKey('CertificatePasswordSecretName') | Should -BeTrue
+        $command.Parameters['CertificatePasswordSecretName'].ParameterType | Should -Be ([string])
+    }
+
+    It 'exposes OnBehalfOfTokenSecretName for vault-based token resolution' {
+        $command = Get-Command Connect-EmailGraph
+
+        $command.Parameters.ContainsKey('OnBehalfOfTokenSecretName') | Should -BeTrue
+        $command.Parameters['OnBehalfOfTokenSecretName'].ParameterType | Should -Be ([string])
+    }
+}

--- a/Tests/Connect-OAuthGoogle.Tests.ps1
+++ b/Tests/Connect-OAuthGoogle.Tests.ps1
@@ -3,4 +3,25 @@ Describe 'Connect-OAuthGoogle cmdlet' {
         $base = [Mailozaurr.PowerShell.CmdletConnectOAuthGoogle].BaseType
         $base.FullName | Should -Be 'Mailozaurr.PowerShell.AsyncPSCmdlet'
     }
+
+    It 'exposes ClientSecretSecureString as a SecureString parameter' {
+        $command = Get-Command Connect-OAuthGoogle
+
+        $command.Parameters.ContainsKey('ClientSecretSecureString') | Should -BeTrue
+        $command.Parameters['ClientSecretSecureString'].ParameterType | Should -Be ([securestring])
+    }
+
+    It 'exposes ClientSecretSecretName for vault-based resolution' {
+        $command = Get-Command Connect-OAuthGoogle
+
+        $command.Parameters.ContainsKey('ClientSecretSecretName') | Should -BeTrue
+        $command.Parameters['ClientSecretSecretName'].ParameterType | Should -Be ([string])
+    }
+
+    It 'exposes ClientSecretVaultName for vault selection' {
+        $command = Get-Command Connect-OAuthGoogle
+
+        $command.Parameters.ContainsKey('ClientSecretVaultName') | Should -BeTrue
+        $command.Parameters['ClientSecretVaultName'].ParameterType | Should -Be ([string])
+    }
 }

--- a/Tests/Connect-POP3.Tests.ps1
+++ b/Tests/Connect-POP3.Tests.ps1
@@ -1,10 +1,13 @@
 Describe 'Connect-POP3 SSL Options' {
     It 'Forwards provided enum to Pop3Connector' {
         $refs = @(
+            [Mailozaurr.Pop3Connector].Assembly.Location,
             [MailKit.Net.Pop3.Pop3Client].Assembly.Location,
             [MailKit.Security.SecureSocketOptions].Assembly.Location
         )
-        Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+        if (-not ('FakePop3Client' -as [type])) {
+            Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+using Mailozaurr;
 using MailKit.Net.Pop3;
 using MailKit.Security;
 using System.Threading;
@@ -15,29 +18,37 @@ public class FakePop3Client : Pop3Client {
         Passed = options;
         return Task.CompletedTask;
     }
-    public override Task AuthenticateAsync(string userName, string password, CancellationToken cancellationToken = default) => Task.CompletedTask;
     public override bool IsConnected => true;
     public override bool IsAuthenticated => true;
 }
+public static class FakePop3ClientFactory {
+    public static Pop3Client Client;
+    public static Pop3Client Create() => Client;
+    public static void Install() => Pop3Connector.ClientFactory = Create;
+}
 "@
+        }
 
         $fake = [FakePop3Client]::new()
-        [Mailozaurr.Pop3Connector]::ClientFactory = { $fake }
+        [FakePop3ClientFactory]::Client = $fake
+        [FakePop3ClientFactory]::Install()
 
-        $cred = [System.Management.Automation.PSCredential]::new('u',(ConvertTo-SecureString 'p' -AsPlainText -Force))
-        Connect-POP3 -Server 'h' -Credential $cred -Port 995 -Options SslOnConnect | Out-Null
+        Connect-POP3 -Server 'h' -UserName 'u' -Password 'p' -Port 995 -Options SslOnConnect | Out-Null
 
         $fake.Passed | Should -Be ([MailKit.Security.SecureSocketOptions]::SslOnConnect)
 
-        [Mailozaurr.Pop3Connector]::ClientFactory = { [MailKit.Net.Pop3.Pop3Client]::new() }
+        [Mailozaurr.Pop3Connector]::ResetClientFactory()
     }
 
     It 'Uses StartTls when EnableExplicit set and Auto option' {
         $refs = @(
+            [Mailozaurr.Pop3Connector].Assembly.Location,
             [MailKit.Net.Pop3.Pop3Client].Assembly.Location,
             [MailKit.Security.SecureSocketOptions].Assembly.Location
         )
-        Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+        if (-not ('FakePop3Client' -as [type])) {
+            Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+using Mailozaurr;
 using MailKit.Net.Pop3;
 using MailKit.Security;
 using System.Threading;
@@ -48,20 +59,25 @@ public class FakePop3Client : Pop3Client {
         Passed = options;
         return Task.CompletedTask;
     }
-    public override Task AuthenticateAsync(string userName, string password, CancellationToken cancellationToken = default) => Task.CompletedTask;
     public override bool IsConnected => true;
     public override bool IsAuthenticated => true;
 }
+public static class FakePop3ClientFactory {
+    public static Pop3Client Client;
+    public static Pop3Client Create() => Client;
+    public static void Install() => Pop3Connector.ClientFactory = Create;
+}
 "@
+        }
 
         $fake = [FakePop3Client]::new()
-        [Mailozaurr.Pop3Connector]::ClientFactory = { $fake }
+        [FakePop3ClientFactory]::Client = $fake
+        [FakePop3ClientFactory]::Install()
 
-        $cred = [System.Management.Automation.PSCredential]::new('u',(ConvertTo-SecureString 'p' -AsPlainText -Force))
-        Connect-POP3 -Server 'h' -Credential $cred -Port 995 -EnableExplicit | Out-Null
+        Connect-POP3 -Server 'h' -UserName 'u' -Password 'p' -Port 995 -EnableExplicit | Out-Null
 
         $fake.Passed | Should -Be ([MailKit.Security.SecureSocketOptions]::StartTls)
 
-        [Mailozaurr.Pop3Connector]::ClientFactory = { [MailKit.Net.Pop3.Pop3Client]::new() }
+        [Mailozaurr.Pop3Connector]::ResetClientFactory()
     }
 }

--- a/Tests/ConvertTo-GraphCertificateCredential.Tests.ps1
+++ b/Tests/ConvertTo-GraphCertificateCredential.Tests.ps1
@@ -3,5 +3,25 @@ Describe 'ConvertTo-GraphCertificateCredential cmdlet' {
         $base = [Mailozaurr.PowerShell.CmdletConvertToGraphCertificateCredential].BaseType
         $base.FullName | Should -Be 'Mailozaurr.PowerShell.AsyncPSCmdlet'
     }
-}
 
+    It 'exposes CertificatePasswordSecureString as a SecureString parameter' {
+        $command = Get-Command ConvertTo-GraphCertificateCredential
+
+        $command.Parameters.ContainsKey('CertificatePasswordSecureString') | Should -BeTrue
+        $command.Parameters['CertificatePasswordSecureString'].ParameterType | Should -Be ([securestring])
+    }
+
+    It 'exposes SecretName for vault-based certificate password resolution' {
+        $command = Get-Command ConvertTo-GraphCertificateCredential
+
+        $command.Parameters.ContainsKey('SecretName') | Should -BeTrue
+        $command.Parameters['SecretName'].ParameterType | Should -Be ([string])
+    }
+
+    It 'exposes VaultName for vault selection' {
+        $command = Get-Command ConvertTo-GraphCertificateCredential
+
+        $command.Parameters.ContainsKey('VaultName') | Should -BeTrue
+        $command.Parameters['VaultName'].ParameterType | Should -Be ([string])
+    }
+}

--- a/Tests/ConvertTo-GraphCredential.Tests.ps1
+++ b/Tests/ConvertTo-GraphCredential.Tests.ps1
@@ -1,0 +1,37 @@
+Describe 'ConvertTo-GraphCredential cmdlet' {
+    It 'accepts ClientSecretSecureString and returns a PSCredential' {
+        $secret = ConvertTo-SecureString 'graph-secret' -AsPlainText -Force
+
+        $credential = ConvertTo-GraphCredential -ClientId 'client' -ClientSecretSecureString $secret -DirectoryId 'tenant'
+
+        $credential | Should -BeOfType ([pscredential])
+        $credential.UserName | Should -Be 'client@tenant'
+        $credential.GetNetworkCredential().Password | Should -Be 'graph-secret'
+    }
+
+    It 'accepts SecretName and resolves the client secret via Get-Secret' {
+        function Get-Secret {
+            param(
+                [string] $Name,
+                [string] $Vault
+            )
+
+            $script:LastVaultName = $Vault
+            if ($Name -ne 'graph-client-secret') {
+                throw "Unexpected secret name: $Name"
+            }
+
+            ConvertTo-SecureString 'graph-secret-from-vault' -AsPlainText -Force
+        }
+
+        try {
+            $credential = ConvertTo-GraphCredential -ClientId 'client' -DirectoryId 'tenant' -SecretName 'graph-client-secret' -VaultName 'LocalVault'
+
+            $credential.GetNetworkCredential().Password | Should -Be 'graph-secret-from-vault'
+            $script:LastVaultName | Should -Be 'LocalVault'
+        } finally {
+            Remove-Item Function:\Get-Secret -ErrorAction SilentlyContinue
+            Remove-Variable LastVaultName -Scope Script -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/Tests/ConvertTo-MailgunCredential.Tests.ps1
+++ b/Tests/ConvertTo-MailgunCredential.Tests.ps1
@@ -1,0 +1,37 @@
+Describe 'ConvertTo-MailgunCredential cmdlet' {
+    It 'accepts ApiKeySecureString and returns a PSCredential' {
+        $secret = ConvertTo-SecureString 'mailgun-secret' -AsPlainText -Force
+
+        $credential = ConvertTo-MailgunCredential -ApiKeySecureString $secret
+
+        $credential | Should -BeOfType ([pscredential])
+        $credential.UserName | Should -Be 'Mailgun'
+        $credential.GetNetworkCredential().Password | Should -Be 'mailgun-secret'
+    }
+
+    It 'accepts SecretName and resolves the API key via Get-Secret' {
+        function Get-Secret {
+            param(
+                [string] $Name,
+                [string] $Vault
+            )
+
+            $script:LastVaultName = $Vault
+            if ($Name -ne 'mailgun-key') {
+                throw "Unexpected secret name: $Name"
+            }
+
+            'mailgun-secret-from-vault'
+        }
+
+        try {
+            $credential = ConvertTo-MailgunCredential -SecretName 'mailgun-key' -VaultName 'LocalVault'
+
+            $credential.GetNetworkCredential().Password | Should -Be 'mailgun-secret-from-vault'
+            $script:LastVaultName | Should -Be 'LocalVault'
+        } finally {
+            Remove-Item Function:\Get-Secret -ErrorAction SilentlyContinue
+            Remove-Variable LastVaultName -Scope Script -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/Tests/ConvertTo-OAuth2Credential.Tests.ps1
+++ b/Tests/ConvertTo-OAuth2Credential.Tests.ps1
@@ -1,0 +1,37 @@
+Describe 'ConvertTo-OAuth2Credential cmdlet' {
+    It 'accepts TokenSecureString and returns a PSCredential' {
+        $token = ConvertTo-SecureString 'tok-secure' -AsPlainText -Force
+
+        $credential = ConvertTo-OAuth2Credential -UserName 'user@gmail.com' -TokenSecureString $token
+
+        $credential | Should -BeOfType ([pscredential])
+        $credential.UserName | Should -Be 'user@gmail.com'
+        $credential.GetNetworkCredential().Password | Should -Be 'tok-secure'
+    }
+
+    It 'accepts SecretName and resolves the token via Get-Secret' {
+        function Get-Secret {
+            param(
+                [string] $Name,
+                [string] $Vault
+            )
+
+            $script:LastVaultName = $Vault
+            if ($Name -ne 'oauth-token') {
+                throw "Unexpected secret name: $Name"
+            }
+
+            'tok-from-vault'
+        }
+
+        try {
+            $credential = ConvertTo-OAuth2Credential -UserName 'user@gmail.com' -SecretName 'oauth-token' -VaultName 'LocalVault'
+
+            $credential.GetNetworkCredential().Password | Should -Be 'tok-from-vault'
+            $script:LastVaultName | Should -Be 'LocalVault'
+        } finally {
+            Remove-Item Function:\Get-Secret -ErrorAction SilentlyContinue
+            Remove-Variable LastVaultName -Scope Script -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/Tests/ConvertTo-SendGridCredential.Tests.ps1
+++ b/Tests/ConvertTo-SendGridCredential.Tests.ps1
@@ -1,0 +1,37 @@
+Describe 'ConvertTo-SendGridCredential cmdlet' {
+    It 'accepts ApiKeySecureString and returns a PSCredential' {
+        $secret = ConvertTo-SecureString 'sendgrid-secret' -AsPlainText -Force
+
+        $credential = ConvertTo-SendGridCredential -ApiKeySecureString $secret
+
+        $credential | Should -BeOfType ([pscredential])
+        $credential.UserName | Should -Be 'SendGrid'
+        $credential.GetNetworkCredential().Password | Should -Be 'sendgrid-secret'
+    }
+
+    It 'accepts SecretName and resolves the API key via Get-Secret' {
+        function Get-Secret {
+            param(
+                [string] $Name,
+                [string] $Vault
+            )
+
+            $script:LastVaultName = $Vault
+            if ($Name -ne 'sendgrid-key') {
+                throw "Unexpected secret name: $Name"
+            }
+
+            'sendgrid-secret-from-vault'
+        }
+
+        try {
+            $credential = ConvertTo-SendGridCredential -SecretName 'sendgrid-key' -VaultName 'LocalVault'
+
+            $credential.GetNetworkCredential().Password | Should -Be 'sendgrid-secret-from-vault'
+            $script:LastVaultName | Should -Be 'LocalVault'
+        } finally {
+            Remove-Item Function:\Get-Secret -ErrorAction SilentlyContinue
+            Remove-Variable LastVaultName -Scope Script -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/Tests/Pop3Connector.Dispose.Tests.ps1
+++ b/Tests/Pop3Connector.Dispose.Tests.ps1
@@ -1,13 +1,16 @@
 Describe 'Pop3Connector disposal' {
     BeforeAll {
         $refs = @(
+            [Mailozaurr.Pop3Connector].Assembly.Location,
             [MailKit.Net.Pop3.Pop3Client].Assembly.Location,
             [MailKit.Security.SecureSocketOptions].Assembly.Location
         )
     }
 
     It 'Disposes client after failed connect' {
-        Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+        if (-not ('FailingPop3Client' -as [type])) {
+            Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+using Mailozaurr;
 using MailKit.Net.Pop3;
 using MailKit.Security;
 using System.Threading;
@@ -24,10 +27,17 @@ public class FailingPop3Client : Pop3Client {
         base.Dispose(disposing);
     }
 }
+public static class FailingPop3ClientFactory {
+    public static Pop3Client Client;
+    public static Pop3Client Create() => Client;
+    public static void Install() => Pop3Connector.ClientFactory = Create;
+}
 "@
+        }
 
         $fake = [FailingPop3Client]::new()
-        [Mailozaurr.Pop3Connector]::ClientFactory = { $fake }
+        [FailingPop3ClientFactory]::Client = $fake
+        [FailingPop3ClientFactory]::Install()
 
         try {
             [Mailozaurr.Pop3Connector]::ConnectAsync('h', 995, [MailKit.Security.SecureSocketOptions]::SslOnConnect, 1000, $false, $false, { param($c) [Task]::CompletedTask }, 0, 0, 1.0).GetAwaiter().GetResult()
@@ -36,11 +46,13 @@ public class FailingPop3Client : Pop3Client {
 
         $fake.Disposed | Should -BeTrue
 
-        [Mailozaurr.Pop3Connector]::ClientFactory = { [MailKit.Net.Pop3.Pop3Client]::new() }
+        [Mailozaurr.Pop3Connector]::ResetClientFactory()
     }
 
     It 'Disposes client even when DisconnectAsync throws' {
-        Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+        if (-not ('ThrowingDisconnectPop3Client' -as [type])) {
+            Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+using Mailozaurr;
 using MailKit.Net.Pop3;
 using MailKit.Security;
 using System.Threading;
@@ -62,10 +74,17 @@ public class ThrowingDisconnectPop3Client : Pop3Client {
         base.Dispose(disposing);
     }
 }
+public static class ThrowingDisconnectPop3ClientFactory {
+    public static Pop3Client Client;
+    public static Pop3Client Create() => Client;
+    public static void Install() => Pop3Connector.ClientFactory = Create;
+}
 "@
+        }
 
         $fake = [ThrowingDisconnectPop3Client]::new()
-        [Mailozaurr.Pop3Connector]::ClientFactory = { $fake }
+        [ThrowingDisconnectPop3ClientFactory]::Client = $fake
+        [ThrowingDisconnectPop3ClientFactory]::Install()
 
         try {
             [Mailozaurr.Pop3Connector]::ConnectAsync('h', 995, [MailKit.Security.SecureSocketOptions]::SslOnConnect, 1000, $false, $false, { param($c) [Task]::CompletedTask }, 0, 0, 1.0).GetAwaiter().GetResult()
@@ -75,7 +94,6 @@ public class ThrowingDisconnectPop3Client : Pop3Client {
         $fake.DisconnectCalled | Should -BeTrue
         $fake.Disposed | Should -BeTrue
 
-        [Mailozaurr.Pop3Connector]::ClientFactory = { [MailKit.Net.Pop3.Pop3Client]::new() }
+        [Mailozaurr.Pop3Connector]::ResetClientFactory()
     }
 }
-

--- a/Tests/Save-POP3Message.Tests.ps1
+++ b/Tests/Save-POP3Message.Tests.ps1
@@ -1,13 +1,16 @@
 Describe 'Save-POP3Message' {
     It 'Creates directory when saving message' {
-        $csc = Get-ChildItem "$HOME/.dotnet/sdk/*/Roslyn/bincore/csc.dll" | Sort-Object FullName -Descending | Select-Object -First 1
-        $csPath = Join-Path $TestDrive 'FakePop3Client.cs'
-        @"
+        $refs = @(
+            [MailKit.Net.Pop3.Pop3Client].Assembly.Location,
+            [MimeKit.MimeMessage].Assembly.Location
+        )
+        if (-not ('FakePop3MessageClient' -as [type])) {
+            Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
 using MailKit.Net.Pop3;
 using MimeKit;
-public class FakePop3Client : Pop3Client {
+public class FakePop3MessageClient : Pop3Client {
     private readonly MimeMessage _message;
-    public FakePop3Client() {
+    public FakePop3MessageClient() {
         _message = new MimeMessage();
         _message.From.Add(new MailboxAddress("a", "a@b.com"));
         _message.To.Add(new MailboxAddress("b", "b@c.com"));
@@ -15,37 +18,32 @@ public class FakePop3Client : Pop3Client {
         _message.Body = new TextPart("plain") { Text = "body" };
     }
     public override int Count => 1;
-    public override MimeMessage GetMessage(int index, System.Threading.CancellationToken cancellationToken = default, MailKit.ITransferProgress? progress = null) {
+    public override MimeMessage GetMessage(int index, System.Threading.CancellationToken cancellationToken = default, MailKit.ITransferProgress progress = null) {
         return _message;
     }
 }
-"@ | Set-Content $csPath
-        $dllPath = Join-Path $TestDrive 'FakePop3Client.dll'
-        $refs = @(
-            "$HOME/.nuget/packages/mailkit/4.12.1/lib/netstandard2.0/MailKit.dll",
-            "$HOME/.nuget/packages/mimekit/4.12.0/lib/netstandard2.0/MimeKit.dll",
-            "$HOME/.dotnet/packs/NETStandard.Library.Ref/2.1.0/ref/netstandard2.1/netstandard.dll"
-        )
-        $refArgs = $refs | ForEach-Object { "-r:" + $_ }
-        & dotnet $csc.FullName $csPath -target:library -out:$dllPath $refArgs | Out-Null
-        Add-Type -Path $dllPath
+"@
+        }
 
         $info = [Mailozaurr.PowerShell.PopConnectionInfo]::new()
-        $info.Data = [FakePop3Client]::new()
+        $info.Data = [FakePop3MessageClient]::new()
         $filePath = Join-Path $TestDrive 'subdir/message.eml'
         Save-POP3Message -Client $info -Index 0 -Path $filePath
         Test-Path $filePath | Should -Be $true
     }
 
     It 'Cleans up temp file on conversion failure' {
-        $csc = Get-ChildItem "$HOME/.dotnet/sdk/*/Roslyn/bincore/csc.dll" | Sort-Object FullName -Descending | Select-Object -First 1
-        $csPath = Join-Path $TestDrive 'FakePop3Client.cs'
-        @"
+        $refs = @(
+            [MailKit.Net.Pop3.Pop3Client].Assembly.Location,
+            [MimeKit.MimeMessage].Assembly.Location
+        )
+        if (-not ('FakePop3MessageClient' -as [type])) {
+            Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
 using MailKit.Net.Pop3;
 using MimeKit;
-public class FakePop3Client : Pop3Client {
+public class FakePop3MessageClient : Pop3Client {
     private readonly MimeMessage _message;
-    public FakePop3Client() {
+    public FakePop3MessageClient() {
         _message = new MimeMessage();
         _message.From.Add(new MailboxAddress("a", "a@b.com"));
         _message.To.Add(new MailboxAddress("b", "b@c.com"));
@@ -53,23 +51,15 @@ public class FakePop3Client : Pop3Client {
         _message.Body = new TextPart("plain") { Text = "body" };
     }
     public override int Count => 1;
-    public override MimeMessage GetMessage(int index, System.Threading.CancellationToken cancellationToken = default, MailKit.ITransferProgress? progress = null) {
+    public override MimeMessage GetMessage(int index, System.Threading.CancellationToken cancellationToken = default, MailKit.ITransferProgress progress = null) {
         return _message;
     }
 }
-"@ | Set-Content $csPath
-        $dllPath = Join-Path $TestDrive 'FakePop3Client.dll'
-        $refs = @(
-            "$HOME/.nuget/packages/mailkit/4.12.1/lib/netstandard2.0/MailKit.dll",
-            "$HOME/.nuget/packages/mimekit/4.12.0/lib/netstandard2.0/MimeKit.dll",
-            "$HOME/.dotnet/packs/NETStandard.Library.Ref/2.1.0/ref/netstandard2.1/netstandard.dll"
-        )
-        $refArgs = $refs | ForEach-Object { "-r:" + $_ }
-        & dotnet $csc.FullName $csPath -target:library -out:$dllPath $refArgs | Out-Null
-        Add-Type -Path $dllPath
+"@
+        }
 
         $info = [Mailozaurr.PowerShell.PopConnectionInfo]::new()
-        $info.Data = [FakePop3Client]::new()
+        $info.Data = [FakePop3MessageClient]::new()
 
         $tempDir = Join-Path $TestDrive 'tmp'
         [System.IO.Directory]::CreateDirectory($tempDir) | Out-Null

--- a/Tests/Send-EmailMessage.LoggerScope.Tests.ps1
+++ b/Tests/Send-EmailMessage.LoggerScope.Tests.ps1
@@ -3,7 +3,7 @@ Import-Module (Resolve-Path "$PSScriptRoot/../Mailozaurr.psd1") -Force
 Describe 'Send-EmailMessage - Logger scope' {
     It 'restores previous logger after execution' {
         $original = [Mailozaurr.LoggingMessages]::Logger
-        Send-EmailMessage -From 'from@example.com' -To 'to@example.com' -Server 'smtp.example.com' \
+        Send-EmailMessage -From 'from@example.com' -To 'to@example.com' -Server 'smtp.example.com' `
             -Subject 'Test' -Text 'Body' -Port 25 -WhatIf
         [Mailozaurr.LoggingMessages]::Logger | Should -Be $original
     }

--- a/Tests/Send-EmailMessage.SentLogPath.Tests.ps1
+++ b/Tests/Send-EmailMessage.SentLogPath.Tests.ps1
@@ -2,11 +2,12 @@ Describe 'Send-EmailMessage - SentLogPath OptIn' {
     BeforeAll {
         if (-not ('FakeClientSentLogPs' -as [type])) {
             $refs = @(
+                [Mailozaurr.Smtp].Assembly.Location,
                 [Mailozaurr.ClientSmtp].Assembly.Location,
                 [MailKit.Security.SecureSocketOptions].Assembly.Location,
                 [MimeKit.MimeMessage].Assembly.Location
             )
-            Add-Type -ReferencedAssemblies $refs -TypeDefinition @"
+            Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
 using Mailozaurr;
 using MailKit;
 using MailKit.Security;
@@ -38,6 +39,10 @@ public class FakeClientSentLogPs : ClientSmtp {
         return Task.FromResult(message.MessageId);
     }
 }
+public static class FakeClientSentLogPsFactory {
+    public static ClientSmtp Create(ProtocolLogger logger) => new FakeClientSentLogPs();
+    public static void Install() => Smtp.ClientFactory = Create;
+}
 "@
         }
     }
@@ -53,7 +58,7 @@ public class FakeClientSentLogPs : ClientSmtp {
             $env:TMP = $tempDir
 
             [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
-            [Mailozaurr.Smtp]::ClientFactory = { [FakeClientSentLogPs]::new() }
+            [FakeClientSentLogPsFactory]::Install()
 
             $result = Send-EmailMessage -From 'from@example.com' -To 'to@example.com' -Server 'smtp.example.com' -Port 25 -Subject 'Subject' -Text 'Body'
 
@@ -61,7 +66,7 @@ public class FakeClientSentLogPs : ClientSmtp {
             $defaultSentLogPath = Join-Path $tempDir 'Mailozaurr\sentlog.json'
             (Test-Path $defaultSentLogPath) | Should -BeFalse
         } finally {
-            [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
+            [Mailozaurr.Smtp]::ResetClientFactory()
             [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
             $env:TEMP = $oldTemp
             $env:TMP = $oldTmp
@@ -79,7 +84,7 @@ public class FakeClientSentLogPs : ClientSmtp {
             $env:TMP = $tempDir
 
             [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
-            [Mailozaurr.Smtp]::ClientFactory = { [FakeClientSentLogPs]::new() }
+            [FakeClientSentLogPsFactory]::Install()
 
             $sentLogPath = Join-Path $TestDrive 'sent\sentlog.json'
             $result = Send-EmailMessage -From 'from@example.com' -To 'to@example.com' -Server 'smtp.example.com' -Port 25 -Subject 'Subject' -Text 'Body' -SentLogPath $sentLogPath
@@ -90,7 +95,7 @@ public class FakeClientSentLogPs : ClientSmtp {
             $records = Get-Content -Path $sentLogPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
             $records.Count | Should -BeGreaterThan 0
         } finally {
-            [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
+            [Mailozaurr.Smtp]::ResetClientFactory()
             [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
             $env:TEMP = $oldTemp
             $env:TMP = $oldTmp

--- a/Tests/Send-EmailMessageConnectionPool.Tests.ps1
+++ b/Tests/Send-EmailMessageConnectionPool.Tests.ps1
@@ -1,15 +1,21 @@
 Describe 'Send-EmailMessage connection pool' {
     It 'Reuses connection when pool enabled' {
         $refs = @(
+            [Mailozaurr.Smtp].Assembly.Location,
             [Mailozaurr.ClientSmtp].Assembly.Location,
+            [MimeKit.MimeMessage].Assembly.Location,
             [MailKit.Security.SecureSocketOptions].Assembly.Location
         )
-        Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+        if (-not ('FakeClientPsPool' -as [type])) {
+            Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
 using Mailozaurr;
+using MailKit;
 using MailKit.Security;
+using MimeKit;
 using System.Threading;
+using System.Threading.Tasks;
 public class FakeClientPs : ClientSmtp {
-    public int ConnectCalls;
+    public static int ConnectCalls;
     private bool _connected;
     public override bool IsConnected => _connected;
     public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {
@@ -19,22 +25,34 @@ public class FakeClientPs : ClientSmtp {
     public override void Disconnect(bool quit, CancellationToken cancellationToken = default) {
         _connected = false;
     }
+    public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken, ITransferProgress progress) {
+        message.MessageId = message.MessageId ?? "fake-" + ConnectCalls.ToString();
+        return Task.FromResult(message.MessageId);
+    }
+}
+public static class FakeClientPsPool {
+    public static ClientSmtp Create(ProtocolLogger logger) => new FakeClientPs();
+    public static void Install() => Smtp.ClientFactory = Create;
+    public static void Reset() => FakeClientPs.ConnectCalls = 0;
 }
 "@
+        }
 
-        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($true)
-        [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
-        $fake = [FakeClientPs]::new()
-        [Mailozaurr.Smtp]::ClientFactory = { $fake }
+        try {
+            [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($false)
+            [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
+            [FakeClientPsPool]::Reset()
+            [FakeClientPsPool]::Install()
 
-        $params = @{ From = 'a@b.com'; To = 'c@d.com'; Server = 'h'; Subject = 't'; Text = 'b'; WhatIf = $true; UseConnectionPool = $true }
-        Send-EmailMessage @params | Out-Null
-        Send-EmailMessage @params | Out-Null
+            $params = @{ From = 'a@b.com'; To = 'c@d.com'; Server = 'h'; Subject = 't'; Text = 'b'; UseConnectionPool = $true }
+            Send-EmailMessage @params | Out-Null
+            Send-EmailMessage @params | Out-Null
 
-        $fake.ConnectCalls | Should -Be 1
-
-        [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
-        [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
-        [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($false)
+            [FakeClientPs]::ConnectCalls | Should -Be 1
+        } finally {
+            [Mailozaurr.Smtp]::ResetClientFactory()
+            [Mailozaurr.SmtpConnectionPool]::ClearConnectionPool()
+            [Mailozaurr.SmtpConnectionPool]::SetPoolingEnabled($false)
+        }
     }
 }

--- a/Tests/Test-MimeMessageSignature.Tests.ps1
+++ b/Tests/Test-MimeMessageSignature.Tests.ps1
@@ -11,7 +11,7 @@ Describe 'Test-MimeMessageSignature' {
         $pub = Join-Path $base 'Examples/PGPKeys/mimekit.gpg.pub'
         $sec = Join-Path $base 'Examples/PGPKeys/mimekit.gpg.sec'
         $smtp = [Mailozaurr.Smtp]::new()
-        $smtp.From = 'a@b.com'
+        $smtp.From = 'mimekit@example.com'
         $smtp.To = @('b@c.com')
         $smtp.Subject = 't'
         $smtp.TextBody = 'body'
@@ -23,10 +23,7 @@ Describe 'Test-MimeMessageSignature' {
     }
 
     It 'Verifies SMIME signature' -Skip:(-not $IsWindows) {
-        $rsa = [System.Security.Cryptography.RSA]::Create(2048)
-        $req = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new('cn=test',$rsa,[System.Security.Cryptography.HashAlgorithmName]::SHA256,[System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
-        $cert = $req.CreateSelfSigned([System.DateTimeOffset]::Now.AddDays(-1),[System.DateTimeOffset]::Now.AddDays(1))
-        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx))
+        $cert = [Mailozaurr.TemporarySmimeCertificate]::CreateSelfSigned('CN=test@example.com')
         $smtp = [Mailozaurr.Smtp]::new()
         $smtp.From = 'x@y.com'
         $smtp.To = @('z@a.com')

--- a/Tests/Test-SmtpConnection.Tests.ps1
+++ b/Tests/Test-SmtpConnection.Tests.ps1
@@ -1,26 +1,37 @@
 Describe 'Test-SmtpConnection' {
     It 'Returns capabilities object' {
         $refs = @(
+            [Mailozaurr.Smtp].Assembly.Location,
             [Mailozaurr.ClientSmtp].Assembly.Location,
             [MailKit.Security.SecureSocketOptions].Assembly.Location
         )
-        Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
+        if (-not ('FakeClientPs3' -as [type])) {
+            Add-Type -ReferencedAssemblies $refs -CompilerOptions '/nowarn:1701,1702' -TypeDefinition @"
 using Mailozaurr;
 using MailKit;
+using MailKit.Net.Smtp;
 using MailKit.Security;
 using System.Threading;
 public class FakeClientPs3 : ClientSmtp {
     public override bool IsConnected => true;
-    public new SmtpCapabilities Capabilities => SmtpCapabilities.Pipelining;
+    public override SmtpCapabilities GetCapabilitiesSnapshot() => SmtpCapabilities.Pipelining;
     public override void Connect(string host, int port, SecureSocketOptions options, CancellationToken cancellationToken = default) {}
     public override void Disconnect(bool quit, CancellationToken cancellationToken = default) {}
     public override void NoOp(CancellationToken cancellationToken = default) {}
 }
+public static class FakeClientPs3Factory {
+    public static ClientSmtp Create(ProtocolLogger logger) => new FakeClientPs3();
+    public static void Install() => Smtp.ClientFactory = Create;
+}
 "@
-        [Mailozaurr.Smtp]::ClientFactory = { [FakeClientPs3]::new() }
-        $result = Test-SmtpConnection -Server 'h'
-        $result | Should -BeOfType 'Mailozaurr.SmtpConnectionInfo'
-        $result.Capabilities | Should -Match 'Pipelining'
-        [Mailozaurr.Smtp]::ClientFactory = { [Mailozaurr.ClientSmtp]::new() }
+        }
+        try {
+            [FakeClientPs3Factory]::Install()
+            $result = Test-SmtpConnection -Server 'h'
+            $result | Should -BeOfType 'Mailozaurr.SmtpConnectionInfo'
+            $result.Capabilities | Should -Match 'Pipelining'
+        } finally {
+            [Mailozaurr.Smtp]::ResetClientFactory()
+        }
     }
 }

--- a/Tests/Unprotect-MimeMessage.Tests.ps1
+++ b/Tests/Unprotect-MimeMessage.Tests.ps1
@@ -23,17 +23,13 @@ Describe 'Unprotect-MimeMessage' {
     }
 
     It 'Decrypts SMIME message' -Skip:(-not $IsWindows) {
-        $rsa = [System.Security.Cryptography.RSA]::Create(2048)
-        $req = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new('cn=test',$rsa,[System.Security.Cryptography.HashAlgorithmName]::SHA256,[System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
-        $cert = $req.CreateSelfSigned([System.DateTimeOffset]::Now.AddDays(-1),[System.DateTimeOffset]::Now.AddDays(1))
-        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx))
+        $cert = [Mailozaurr.TemporarySmimeCertificate]::CreateSelfSigned('CN=test@example.com')
         $smtp = [Mailozaurr.Smtp]::new()
         $smtp.From = 'x@y.com'
         $smtp.To = @('z@a.com')
         $smtp.Subject = 'enc'
         $smtp.TextBody = 'data'
         $smtp.CreateMessage()
-        $smtp.Sign($cert) | Out-Null
         $smtp.Encrypt($cert) | Out-Null
         $msg = $smtp.Message
         $out = $msg | Unprotect-MimeMessage -Certificate $cert


### PR DESCRIPTION
## Summary
- harden secret handling across the application, CLI, MCP, and PowerShell surfaces
- improve SMTP pooling, secret-store safety, auth flow handling, and PowerShell test stability
- update PowerShell help, README guidance, and example scripts to promote SecureString and vault-backed usage

## What changed
- added shared application-level secret reference resolution and wired it through bootstrap, auth, and secret services
- expanded CLI and MCP support for safer secret input and reference-based secret reuse
- added SecureString and vault-backed secret support across Graph, Gmail, SendGrid, and Mailgun PowerShell cmdlets
- fixed SMTP pooled client disposal, secret-store replacement semantics, and several PowerShell test and mocking issues
- refreshed docs and examples so secure and vault-based flows are the default guidance

## Validation
- `dotnet test Sources/Mailozaurr.sln --nologo`
- `./Mailozaurr.Tests.ps1`
