### PR TITLE
Fix SMTP attachment transfer encoding

### DIFF
--- a/Sources/Mailozaurr.Application/Mailozaurr.Application.csproj
+++ b/Sources/Mailozaurr.Application/Mailozaurr.Application.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="System.Text.Json" Version="10.0.3" />
+        <PackageReference Include="System.Text.Json" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/Mailozaurr.Cli/Mailozaurr.Cli.csproj
+++ b/Sources/Mailozaurr.Cli/Mailozaurr.Cli.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-      <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+      <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
     </ItemGroup>
 </Project>

--- a/Sources/Mailozaurr.Msg/Mailozaurr.Msg.csproj
+++ b/Sources/Mailozaurr.Msg/Mailozaurr.Msg.csproj
@@ -25,8 +25,9 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Mailozaurr\Mailozaurr.csproj" />
-        <PackageReference Include="MsgKit" Version="3.0.3" />
-        <PackageReference Include="MsgReader" Version="6.0.9" />
+        <PackageReference Include="MsgKit" Version="3.0.4" />
+        <PackageReference Include="MsgReader" Version="6.0.11" />
+        <PackageReference Include="OpenMcdf" Version="3.1.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/Mailozaurr.Tests/EmailMessageConversionTests.cs
+++ b/Sources/Mailozaurr.Tests/EmailMessageConversionTests.cs
@@ -58,8 +58,12 @@ public class EmailMessageConversionTests {
         var msgPath = Path.Combine(msgDir, "sample.msg");
 
         var outputDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Assert.Throws<NotImplementedException>(() => EmailMessage.ConvertMsgToEml(new[] { msgPath }, outputDir, true).ToList());
+        var results = EmailMessage.ConvertMsgToEml(new[] { msgPath }, outputDir, true).ToList();
+
+        Assert.Single(results);
+        Assert.True(results[0].Status);
         Assert.True(Directory.Exists(outputDir));
+        Assert.True(File.Exists(Path.Combine(outputDir, "sample.eml")));
 
 
         Directory.Delete(tmpDir, true);

--- a/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
+++ b/Sources/Mailozaurr.Tests/Mailozaurr.Tests.csproj
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="coverlet.collector" Version="10.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
         <PackageReference Include="xunit" Version="2.9.3" />

--- a/Sources/Mailozaurr.Tests/OAuthCacheTestHelper.cs
+++ b/Sources/Mailozaurr.Tests/OAuthCacheTestHelper.cs
@@ -32,4 +32,19 @@ internal static class OAuthCacheTestHelper {
             }
         }
     }
+
+    internal static string ReadOAuthCacheFileText() {
+        var path = GetOAuthCacheFilePath();
+        for (var attempt = 0; ; attempt++) {
+            try {
+                using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                using var reader = new StreamReader(stream);
+                return reader.ReadToEnd();
+            } catch (IOException) when (attempt < 4) {
+                Thread.Sleep(25 * (attempt + 1));
+            } catch (UnauthorizedAccessException) when (attempt < 4) {
+                Thread.Sleep(25 * (attempt + 1));
+            }
+        }
+    }
 }

--- a/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
@@ -32,7 +32,7 @@ public sealed class OAuthTokenCacheProtectionTests {
         var path = OAuthCacheTestHelper.GetOAuthCacheFilePath();
         Assert.True(File.Exists(path));
 
-        var json = File.ReadAllText(path);
+        var json = OAuthCacheTestHelper.ReadOAuthCacheFileText();
         Assert.DoesNotContain("access-token-value", json, StringComparison.Ordinal);
         Assert.DoesNotContain("refresh-token-value", json, StringComparison.Ordinal);
         Assert.DoesNotContain("client-secret-value", json, StringComparison.Ordinal);
@@ -136,7 +136,7 @@ public sealed class OAuthTokenCacheProtectionTests {
         Assert.Equal(credential.UserName, loaded!.UserName);
         Assert.Equal(credential.AccessToken, loaded.AccessToken);
 
-        var json = File.ReadAllText(path);
+        var json = OAuthCacheTestHelper.ReadOAuthCacheFileText();
         Assert.DoesNotContain("{broken", json, StringComparison.Ordinal);
     }
 

--- a/Sources/Mailozaurr.Tests/SmtpAttachmentTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAttachmentTests.cs
@@ -96,4 +96,74 @@ public class SmtpAttachmentTests
         content.DecodeTo(extracted);
         Assert.Equal(data, extracted.ToArray());
     }
+
+    [Fact]
+    public void CreateMessage_BinaryAttachment_UsesBase64EncodingToAvoidBareLineFeeds()
+    {
+        var data = new byte[] { 0x50, 0x4b, 0x03, 0x04, 0x0a, 0xff, 0x00, 0x0a, 0x7f };
+        var descriptor = new ByteArrayAttachmentDescriptor(data, "document.docx")
+        {
+            ContentType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        };
+
+        var smtp = new Smtp
+        {
+            From = "a@b.com",
+            To = new object[] { "c@d.com" },
+            Subject = "test",
+            TextBody = "body",
+            Attachments = new List<AttachmentDescriptor> { descriptor },
+        };
+
+        smtp.CreateMessage();
+
+        var multipart = Assert.IsType<Multipart>(smtp.Message.Body);
+        var part = Assert.Single(multipart.OfType<MimePart>(), p => p.IsAttachment);
+        Assert.Equal(ContentEncoding.Base64, part.ContentTransferEncoding);
+
+        var options = FormatOptions.Default.Clone();
+        options.NewLineFormat = NewLineFormat.Dos;
+        using var serialized = new MemoryStream();
+        smtp.Message.WriteTo(options, serialized);
+
+        Assert.False(ContainsBareLineFeed(serialized.ToArray()));
+    }
+
+    [Fact]
+    public void CreateMessage_ExplicitTransferEncoding_IsRespected()
+    {
+        var descriptor = new ByteArrayAttachmentDescriptor(Encoding.UTF8.GetBytes("hello world"), "greeting.txt")
+        {
+            ContentType = "text/plain",
+            TransferEncoding = ContentEncoding.QuotedPrintable,
+        };
+
+        var smtp = new Smtp
+        {
+            From = "a@b.com",
+            To = new object[] { "c@d.com" },
+            Subject = "test",
+            TextBody = "body",
+            Attachments = new List<AttachmentDescriptor> { descriptor },
+        };
+
+        smtp.CreateMessage();
+
+        var multipart = Assert.IsType<Multipart>(smtp.Message.Body);
+        var part = Assert.Single(multipart.OfType<MimePart>(), p => p.IsAttachment);
+        Assert.Equal(ContentEncoding.QuotedPrintable, part.ContentTransferEncoding);
+    }
+
+    private static bool ContainsBareLineFeed(byte[] bytes)
+    {
+        for (var index = 0; index < bytes.Length; index++)
+        {
+            if (bytes[index] == 0x0a && (index == 0 || bytes[index - 1] != 0x0d))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/Sources/Mailozaurr/Definitions/AttachmentDescriptor.cs
+++ b/Sources/Mailozaurr/Definitions/AttachmentDescriptor.cs
@@ -66,6 +66,7 @@ public abstract class AttachmentDescriptor
         {
             Content = new MimeContent(stream),
             FileName = FileName,
+            ContentTransferEncoding = TransferEncoding.GetValueOrDefault(ContentEncoding.Base64),
         };
 
         var disposition = ContentDisposition ?? new ContentDisposition(
@@ -91,11 +92,6 @@ public abstract class AttachmentDescriptor
         if (!string.IsNullOrWhiteSpace(ContentDescription))
         {
             part.ContentDescription = ContentDescription;
-        }
-
-        if (TransferEncoding.HasValue)
-        {
-            part.ContentTransferEncoding = TransferEncoding.Value;
         }
 
         if (Headers != null)

--- a/Sources/Mailozaurr/Mailozaurr.csproj
+++ b/Sources/Mailozaurr/Mailozaurr.csproj
@@ -31,24 +31,24 @@
     <ItemGroup>
 
         <PackageReference Include="EmailValidation" Version="1.3.0" />
-        <PackageReference Include="Google.Apis.Auth" Version="1.73.0" />
+        <PackageReference Include="Google.Apis.Auth" Version="1.74.0" />
         <PackageReference Include="MailKit" Version="4.16.0" />
         <PackageReference Include="MimeKit" Version="4.16.0" />
-        <PackageReference Include="Microsoft.Identity.Client" Version="4.82.1" />
+        <PackageReference Include="Microsoft.Identity.Client" Version="4.84.1" />
         <PackageReference Include="NSspi" Version="0.3.1" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-        <PackageReference Include="System.Data.SQLite" Version="2.0.2" />
-        <PackageReference Include="System.Text.Json" Version="10.0.3" />
+        <PackageReference Include="System.Data.SQLite" Version="2.0.3" />
+        <PackageReference Include="System.Text.Json" Version="10.0.8" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="System.Text.Json" Version="10.0.3" />
+        <PackageReference Include="System.Text.Json" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net8.0' ">
-        <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.3" />
+        <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -258,7 +258,8 @@ public partial class ClientSmtp : SmtpClient {
                     Content = new MimeContent(ms),
                     FileName = img.ContentId,
                     ContentId = img.ContentId,
-                    ContentDisposition = new ContentDisposition(ContentDisposition.Inline)
+                    ContentDisposition = new ContentDisposition(ContentDisposition.Inline),
+                    ContentTransferEncoding = ContentEncoding.Base64
                 };
                 bodyBuilder.LinkedResources.Add(part);
             }


### PR DESCRIPTION
## Summary
- default SMTP attachment descriptors to Base64 transfer encoding to prevent binary payload bytes from being emitted as bare LF in SMTP DATA
- keep explicit caller-provided attachment transfer encodings respected
- also Base64-encode auto-embedded remote image MIME parts
- bump current direct NuGet dependencies across runtime/test projects, including the MSG stack and an explicit OpenMcdf override to clear the transitive advisory
- update the MSG-to-EML conversion test for the newer MsgReader behavior, which now completes successfully instead of throwing NotImplementedException

Fixes #608.

## Dependency audit
- `dotnet list Sources\Mailozaurr.sln package --outdated` reports no outdated packages
- `dotnet list Sources\Mailozaurr.sln package --vulnerable --include-transitive` reports no vulnerable packages
- `dotnet list Sources\Mailozaurr.sln package --deprecated` reports only `xunit` v2 as legacy in the test project; this PR intentionally leaves the xUnit v3 migration out of scope

## Validation
- `dotnet test Sources\Mailozaurr.Tests\Mailozaurr.Tests.csproj -f net8.0`
- `dotnet test Sources\Mailozaurr.Tests\Mailozaurr.Tests.csproj -f net472`
- `git diff --check`