### PR TITLE
Enable module AssemblyLoadContext packaging

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -275,6 +275,7 @@ jobs:
         shell: pwsh
         env:
           RefreshPSD1Only: 'false'
+          SignModule: 'false'
         run: ./Build/Build-Module.ps1
 
       - name: Run AssemblyLoadContext packaging regression

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -252,3 +252,31 @@ jobs:
           files: '**/coverage.cobertura.xml'
           fail_ci_if_error: false
 
+  test-module-alc:
+    name: 'PowerShell ALC packaging'
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install PowerShell modules
+        shell: pwsh
+        run: |
+          Install-Module -Name PSPublishModule -Repository PSGallery -Force -Scope CurrentUser -AllowClobber
+          Install-Module -Name Pester -Repository PSGallery -Force -Scope CurrentUser -SkipPublisherCheck -AllowClobber
+
+      - name: Build packaged module
+        shell: pwsh
+        env:
+          RefreshPSD1Only: 'false'
+        run: ./Build/Build-Module.ps1
+
+      - name: Run AssemblyLoadContext packaging regression
+        shell: pwsh
+        run: Invoke-Pester -Path ./Tests/AssemblyLoadContext.Tests.ps1 -Output Detailed

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -78,7 +78,7 @@ Build-Module -ModuleName 'Mailozaurr' {
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = $true
+        SignModule                        = if ([string]::IsNullOrWhiteSpace($Env:SignModule)) { $true } else { [bool]::Parse($Env:SignModule) }
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
         CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -89,12 +89,30 @@ Build-Module -ModuleName 'Mailozaurr' {
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net8.0', 'net472'
         NETHandleAssemblyWithSameName     = $true
+        NETAssemblyLoadContext            = $true
+        NETAssemblyTypeAcceleratorMode    = 'Assembly'
+        NETAssemblyTypeAcceleratorAssemblies = @(
+            'Mailozaurr'
+            'Mailozaurr.Msg'
+        )
+        NETAssemblyTypeAccelerators       = @(
+            'MailKit.Net.Pop3.Pop3Client'
+            'MailKit.Search.SearchQuery'
+            'MailKit.Security.SecureSocketOptions'
+            'MailKit.UniqueId'
+            'MimeKit.BodyBuilder'
+            'MimeKit.MailboxAddress'
+            'MimeKit.MimeContent'
+            'MimeKit.MimeMessage'
+            'MimeKit.MimePart'
+            'MimeKit.TextPart'
+        )
         #NETMergeLibraryDebugging          = $true
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
         NETBinaryModuleDocumenation       = $true
-        RefreshPSD1Only                   = $true
+        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $true } else { [bool]::Parse($Env:RefreshPSD1Only) }
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat #-DotSourceLibraries -DotSourceClasses -MergeModuleOnBuild -Enable -SignModule -DeleteTargetModuleBeforeBuild -CertificateThumbprint '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703' -MergeFunctionsFromApprovedModules

--- a/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Tests.ps1
@@ -1,0 +1,80 @@
+Describe 'Packaged AssemblyLoadContext isolation' {
+    It 'loads binary cmdlets and selected public types from the module ALC' {
+        $packagedModuleRoot = Join-Path $PSScriptRoot '..\Artefacts\Modules'
+        $packagedModule = Join-Path $packagedModuleRoot 'Mailozaurr'
+        $packagedLoader = Join-Path $packagedModule 'Lib\Core\Mailozaurr.ModuleLoadContext.dll'
+        if ($PSVersionTable.PSEdition -ne 'Core' -or -not (Test-Path -LiteralPath $packagedLoader)) {
+            Set-ItResult -Skipped -Because 'packaged Core artifact is required'
+            return
+        }
+
+        $moduleRootLiteral = $packagedModuleRoot.Replace("'", "''")
+        $script = @"
+`$ErrorActionPreference = 'Stop'
+`$WarningPreference = 'SilentlyContinue'
+`$moduleRoot = '$moduleRootLiteral'
+`$env:PSModulePath = `$moduleRoot + [IO.Path]::PathSeparator + `$env:PSModulePath
+
+Import-Module Mailozaurr -Force
+
+`$command = Get-Command Send-EmailMessage -Module Mailozaurr -ErrorAction Stop
+`$commandAssembly = `$command.ImplementingType.Assembly
+`$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
+`$smtpAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([Mailozaurr.Smtp].Assembly)
+`$msgAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([Mailozaurr.EmailMessage].Assembly)
+`$mimeAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([MimeKit.MimeMessage].Assembly)
+`$mailKitAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([MailKit.UniqueId].Assembly)
+`$message = [MimeKit.MimeMessage]::new()
+`$smtp = [Mailozaurr.Smtp]::new()
+
+[pscustomobject]@{
+    CommandName = `$command.Name
+    CommandAssembly = `$commandAssembly.GetName().Name
+    CommandAssemblyPath = `$commandAssembly.Location
+    CommandALC = `$commandAlc.Name
+    CommandALCIsDefault = [object]::ReferenceEquals(`$commandAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    SmtpType = [Mailozaurr.Smtp].FullName
+    SmtpALC = `$smtpAlc.Name
+    SmtpALCIsDefault = [object]::ReferenceEquals(`$smtpAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    EmailProviderType = [Mailozaurr.EmailProvider].FullName
+    EmailMessageType = [Mailozaurr.EmailMessage].FullName
+    EmailMessageALC = `$msgAlc.Name
+    EmailMessageALCIsDefault = [object]::ReferenceEquals(`$msgAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    MimeMessageType = `$message.GetType().FullName
+    MimeMessageALC = `$mimeAlc.Name
+    MimeMessageALCIsDefault = [object]::ReferenceEquals(`$mimeAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    MailKitUniqueIdType = [MailKit.UniqueId].FullName
+    MailKitUniqueIdALC = `$mailKitAlc.Name
+    MailKitUniqueIdALCIsDefault = [object]::ReferenceEquals(`$mailKitAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    SmtpCreated = `$null -ne `$smtp
+} | ConvertTo-Json -Compress
+"@
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($script))
+        $output = pwsh -NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded 2>&1
+        $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
+
+        $json = $output | Where-Object { $_ -is [string] -and $_.TrimStart().StartsWith('{') } | Select-Object -Last 1
+        $json | Should -Not -BeNullOrEmpty -Because ($output -join [Environment]::NewLine)
+        $result = $json | ConvertFrom-Json
+
+        $result.CommandName | Should -Be 'Send-EmailMessage'
+        $result.CommandAssembly | Should -Be 'Mailozaurr.PowerShell'
+        $result.CommandAssemblyPath | Should -BeLike '*\Artefacts\Modules\Mailozaurr\Lib\Core\Mailozaurr.PowerShell.dll'
+        $result.CommandALC | Should -Be 'Mailozaurr'
+        $result.CommandALCIsDefault | Should -BeFalse
+        $result.SmtpType | Should -Be 'Mailozaurr.Smtp'
+        $result.SmtpALC | Should -Be 'Mailozaurr'
+        $result.SmtpALCIsDefault | Should -BeFalse
+        $result.EmailProviderType | Should -Be 'Mailozaurr.EmailProvider'
+        $result.EmailMessageType | Should -Be 'Mailozaurr.EmailMessage'
+        $result.EmailMessageALC | Should -Be 'Mailozaurr'
+        $result.EmailMessageALCIsDefault | Should -BeFalse
+        $result.MimeMessageType | Should -Be 'MimeKit.MimeMessage'
+        $result.MimeMessageALC | Should -Be 'Mailozaurr'
+        $result.MimeMessageALCIsDefault | Should -BeFalse
+        $result.MailKitUniqueIdType | Should -Be 'MailKit.UniqueId'
+        $result.MailKitUniqueIdALC | Should -Be 'Mailozaurr'
+        $result.MailKitUniqueIdALCIsDefault | Should -BeFalse
+        $result.SmtpCreated | Should -BeTrue
+    }
+}

--- a/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Tests.ps1
@@ -3,10 +3,12 @@ Describe 'Packaged AssemblyLoadContext isolation' {
         $packagedModuleRoot = Join-Path $PSScriptRoot '..\Artefacts\Modules'
         $packagedModule = Join-Path $packagedModuleRoot 'Mailozaurr'
         $packagedLoader = Join-Path $packagedModule 'Lib\Core\Mailozaurr.ModuleLoadContext.dll'
-        if ($PSVersionTable.PSEdition -ne 'Core' -or -not (Test-Path -LiteralPath $packagedLoader)) {
-            Set-ItResult -Skipped -Because 'packaged Core artifact is required'
+        if ($PSVersionTable.PSEdition -ne 'Core') {
+            Set-ItResult -Skipped -Because 'module-scoped AssemblyLoadContext is PowerShell Core-only'
             return
         }
+
+        Test-Path -LiteralPath $packagedLoader | Should -BeTrue -Because 'Build\Build-Module.ps1 must create the packaged ALC loader before this regression runs'
 
         $moduleRootLiteral = $packagedModuleRoot.Replace("'", "''")
         $script = @"
@@ -59,7 +61,7 @@ Import-Module Mailozaurr -Force
 
         $result.CommandName | Should -Be 'Send-EmailMessage'
         $result.CommandAssembly | Should -Be 'Mailozaurr.PowerShell'
-        $result.CommandAssemblyPath | Should -BeLike '*\Artefacts\Modules\Mailozaurr\Lib\Core\Mailozaurr.PowerShell.dll'
+        ($result.CommandAssemblyPath -replace '\\', '/') | Should -BeLike '*/Artefacts/Modules/Mailozaurr/Lib/Core/Mailozaurr.PowerShell.dll'
         $result.CommandALC | Should -Be 'Mailozaurr'
         $result.CommandALCIsDefault | Should -BeFalse
         $result.SmtpType | Should -Be 'Mailozaurr.Smtp'


### PR DESCRIPTION
## Summary
- Enable PowerForge/PSPublishModule module-scoped AssemblyLoadContext packaging for Mailozaurr Core builds.
- Expose Mailozaurr public object-model assemblies plus selected MimeKit/MailKit compatibility types through type accelerators.
- Add a packaged-module Pester regression that verifies cmdlets and exposed types load from the Mailozaurr ALC instead of the default context.

## Notes
Existing binary cmdlets are re-exported by the PSPublishModule ALC bridge, so this does not add duplicate wrapper cmdlets. The compatibility surface is kept to public Mailozaurr assemblies and the dependency types already used by tests/examples.

## Validation
- `$env:RefreshPSD1Only='false'; .\Build\Build-Module.ps1`
- `Invoke-Pester -Path .\Tests\AssemblyLoadContext.Tests.ps1 -Output Detailed`
- packaged artifact smoke: 64 repository Mailozaurr/MimeKit/MailKit type literals resolve from the packaged module
- `dotnet test Sources\Mailozaurr.Tests\Mailozaurr.Tests.csproj -c Release -f net8.0 --no-restore`
- `git diff --check`