### PR TITLE
Improve AOT compatibility

### DIFF
--- a/Sources/Mailozaurr.Application/ApplicationJsonContext.cs
+++ b/Sources/Mailozaurr.Application/ApplicationJsonContext.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+
+namespace Mailozaurr.Application;
+
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true, WriteIndented = true)]
+[JsonSerializable(typeof(MailDraft))]
+[JsonSerializable(typeof(MessageActionExecutionPlan))]
+[JsonSerializable(typeof(IReadOnlyList<MessageActionExecutionPlan>), TypeInfoPropertyName = "MessageActionExecutionPlanList")]
+[JsonSerializable(typeof(MailDraftStoreDocument))]
+[JsonSerializable(typeof(MailMessageActionPlanBatchStoreDocument))]
+[JsonSerializable(typeof(MailProfileStoreDocument))]
+[JsonSerializable(typeof(MailSecretStoreDocument))]
+internal partial class ApplicationJsonContext : JsonSerializerContext;
+
+internal sealed class MailDraftStoreDocument {
+    public int Version { get; set; } = 1;
+
+    public List<MailDraft> Drafts { get; set; } = new();
+}
+
+internal sealed class MailMessageActionPlanBatchStoreDocument {
+    public int Version { get; set; } = 1;
+
+    public List<MailMessageActionPlanBatch> Batches { get; set; } = new();
+}
+
+internal sealed class MailProfileStoreDocument {
+    public int Version { get; set; } = 1;
+
+    public List<MailProfile> Profiles { get; set; } = new();
+}
+
+internal sealed class MailSecretStoreDocument {
+    public int Version { get; set; } = 1;
+
+    public Dictionary<string, string> Secrets { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/Sources/Mailozaurr.Application/FileMailDraftStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailDraftStore.cs
@@ -8,11 +8,6 @@ namespace Mailozaurr.Application;
 public sealed class FileMailDraftStore : IMailDraftStore {
     private readonly string _filePath;
     private readonly SemaphoreSlim _gate = new(1, 1);
-    private static readonly JsonSerializerOptions SerializerOptions = new() {
-        PropertyNameCaseInsensitive = true,
-        WriteIndented = true
-    };
-
     /// <summary>
     /// Creates a new store using the provided options.
     /// </summary>
@@ -114,7 +109,7 @@ public sealed class FileMailDraftStore : IMailDraftStore {
         }
 
         using (var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
-            var document = await JsonSerializer.DeserializeAsync<MailDraftStoreDocument>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            var document = await JsonSerializer.DeserializeAsync(stream, ApplicationJsonContext.Default.MailDraftStoreDocument, cancellationToken).ConfigureAwait(false);
             return document ?? new MailDraftStoreDocument();
         }
     }
@@ -130,7 +125,7 @@ public sealed class FileMailDraftStore : IMailDraftStore {
         var tempPath = Path.Combine(directory, Path.GetRandomFileName());
         try {
             using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                await JsonSerializer.SerializeAsync(stream, document, SerializerOptions, cancellationToken).ConfigureAwait(false);
+                await JsonSerializer.SerializeAsync(stream, document, ApplicationJsonContext.Default.MailDraftStoreDocument, cancellationToken).ConfigureAwait(false);
                 await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
 
@@ -200,9 +195,4 @@ public sealed class FileMailDraftStore : IMailDraftStore {
         ContentId = attachment.ContentId
     };
 
-    private sealed class MailDraftStoreDocument {
-        public int Version { get; set; } = 1;
-
-        public List<MailDraft> Drafts { get; set; } = new();
-    }
 }

--- a/Sources/Mailozaurr.Application/FileMailMessageActionPlanBatchStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailMessageActionPlanBatchStore.cs
@@ -8,11 +8,6 @@ namespace Mailozaurr.Application;
 public sealed class FileMailMessageActionPlanBatchStore : IMailMessageActionPlanBatchStore {
     private readonly string _filePath;
     private readonly SemaphoreSlim _gate = new(1, 1);
-    private static readonly JsonSerializerOptions SerializerOptions = new() {
-        PropertyNameCaseInsensitive = true,
-        WriteIndented = true
-    };
-
     /// <summary>
     /// Creates a new store using the provided options.
     /// </summary>
@@ -114,7 +109,7 @@ public sealed class FileMailMessageActionPlanBatchStore : IMailMessageActionPlan
         }
 
         using (var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
-            var document = await JsonSerializer.DeserializeAsync<MailMessageActionPlanBatchStoreDocument>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            var document = await JsonSerializer.DeserializeAsync(stream, ApplicationJsonContext.Default.MailMessageActionPlanBatchStoreDocument, cancellationToken).ConfigureAwait(false);
             return document ?? new MailMessageActionPlanBatchStoreDocument();
         }
     }
@@ -130,7 +125,7 @@ public sealed class FileMailMessageActionPlanBatchStore : IMailMessageActionPlan
         var tempPath = Path.Combine(directory, Path.GetRandomFileName());
         try {
             using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                await JsonSerializer.SerializeAsync(stream, document, SerializerOptions, cancellationToken).ConfigureAwait(false);
+                await JsonSerializer.SerializeAsync(stream, document, ApplicationJsonContext.Default.MailMessageActionPlanBatchStoreDocument, cancellationToken).ConfigureAwait(false);
                 await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
 
@@ -208,9 +203,4 @@ public sealed class FileMailMessageActionPlanBatchStore : IMailMessageActionPlan
         Warnings = plan.Warnings.ToList()
     };
 
-    private sealed class MailMessageActionPlanBatchStoreDocument {
-        public int Version { get; set; } = 1;
-
-        public List<MailMessageActionPlanBatch> Batches { get; set; } = new();
-    }
 }

--- a/Sources/Mailozaurr.Application/FileMailProfileStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailProfileStore.cs
@@ -8,11 +8,6 @@ namespace Mailozaurr.Application;
 public sealed class FileMailProfileStore : IMailProfileStore {
     private readonly string _filePath;
     private readonly SemaphoreSlim _gate = new(1, 1);
-    private static readonly JsonSerializerOptions SerializerOptions = new() {
-        PropertyNameCaseInsensitive = true,
-        WriteIndented = true
-    };
-
     /// <summary>
     /// Creates a new store using the provided options.
     /// </summary>
@@ -109,7 +104,7 @@ public sealed class FileMailProfileStore : IMailProfileStore {
         }
 
         using (var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
-            var document = await JsonSerializer.DeserializeAsync<MailProfileStoreDocument>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            var document = await JsonSerializer.DeserializeAsync(stream, ApplicationJsonContext.Default.MailProfileStoreDocument, cancellationToken).ConfigureAwait(false);
             return document ?? new MailProfileStoreDocument();
         }
     }
@@ -125,7 +120,7 @@ public sealed class FileMailProfileStore : IMailProfileStore {
         var tempPath = Path.Combine(directory, Path.GetRandomFileName());
         try {
             using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                await JsonSerializer.SerializeAsync(stream, document, SerializerOptions, cancellationToken).ConfigureAwait(false);
+                await JsonSerializer.SerializeAsync(stream, document, ApplicationJsonContext.Default.MailProfileStoreDocument, cancellationToken).ConfigureAwait(false);
                 await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
 
@@ -173,9 +168,4 @@ public sealed class FileMailProfileStore : IMailProfileStore {
             : new ProfileCapabilities(profile.Capabilities.Kind, profile.Capabilities.Capabilities)
     };
 
-    private sealed class MailProfileStoreDocument {
-        public int Version { get; set; } = 1;
-
-        public List<MailProfile> Profiles { get; set; } = new();
-    }
 }

--- a/Sources/Mailozaurr.Application/FileMailSecretStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailSecretStore.cs
@@ -9,11 +9,6 @@ public sealed class FileMailSecretStore : IMailSecretStore {
     private readonly string _filePath;
     private readonly ICredentialProtector _protector;
     private readonly SemaphoreSlim _gate = new(1, 1);
-    private static readonly JsonSerializerOptions SerializerOptions = new() {
-        PropertyNameCaseInsensitive = true,
-        WriteIndented = true
-    };
-
     /// <summary>
     /// Creates a new store using the default credential protector.
     /// </summary>
@@ -91,7 +86,7 @@ public sealed class FileMailSecretStore : IMailSecretStore {
         }
 
         using (var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
-            var document = await JsonSerializer.DeserializeAsync<MailSecretStoreDocument>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            var document = await JsonSerializer.DeserializeAsync(stream, ApplicationJsonContext.Default.MailSecretStoreDocument, cancellationToken).ConfigureAwait(false);
             return document ?? new MailSecretStoreDocument();
         }
     }
@@ -108,7 +103,7 @@ public sealed class FileMailSecretStore : IMailSecretStore {
         var backupPath = Path.Combine(directory, Path.GetRandomFileName());
         try {
             using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                await JsonSerializer.SerializeAsync(stream, document, SerializerOptions, cancellationToken).ConfigureAwait(false);
+                await JsonSerializer.SerializeAsync(stream, document, ApplicationJsonContext.Default.MailSecretStoreDocument, cancellationToken).ConfigureAwait(false);
                 await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
 
@@ -142,9 +137,4 @@ public sealed class FileMailSecretStore : IMailSecretStore {
         }
     }
 
-    private sealed class MailSecretStoreDocument {
-        public int Version { get; set; } = 1;
-
-        public Dictionary<string, string> Secrets { get; set; } = new(StringComparer.OrdinalIgnoreCase);
-    }
 }

--- a/Sources/Mailozaurr.Application/JsonMailDraftExchangeService.cs
+++ b/Sources/Mailozaurr.Application/JsonMailDraftExchangeService.cs
@@ -6,11 +6,6 @@ namespace Mailozaurr.Application;
 /// Imports and exports drafts as JSON documents.
 /// </summary>
 public sealed class JsonMailDraftExchangeService : IMailDraftExchangeService {
-    private static readonly JsonSerializerOptions SerializerOptions = new() {
-        PropertyNameCaseInsensitive = true,
-        WriteIndented = true
-    };
-
     /// <inheritdoc />
     public async Task<MailDraft> LoadAsync(string path, CancellationToken cancellationToken = default) {
         if (string.IsNullOrWhiteSpace(path)) {
@@ -19,7 +14,7 @@ public sealed class JsonMailDraftExchangeService : IMailDraftExchangeService {
 
         var fullPath = Path.GetFullPath(path);
         using var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        var draft = await JsonSerializer.DeserializeAsync<MailDraft>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        var draft = await JsonSerializer.DeserializeAsync(stream, ApplicationJsonContext.Default.MailDraft, cancellationToken).ConfigureAwait(false);
         if (draft == null) {
             throw new InvalidDataException($"Draft file '{fullPath}' did not contain a valid draft document.");
         }
@@ -43,7 +38,7 @@ public sealed class JsonMailDraftExchangeService : IMailDraftExchangeService {
         }
 
         using var stream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None);
-        await JsonSerializer.SerializeAsync(stream, draft, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        await JsonSerializer.SerializeAsync(stream, draft, ApplicationJsonContext.Default.MailDraft, cancellationToken).ConfigureAwait(false);
         await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/Sources/Mailozaurr.Application/JsonMailMessageActionPlanExchangeService.cs
+++ b/Sources/Mailozaurr.Application/JsonMailMessageActionPlanExchangeService.cs
@@ -6,11 +6,6 @@ namespace Mailozaurr.Application;
 /// Imports and exports normalized message action plans as JSON documents.
 /// </summary>
 public sealed class JsonMailMessageActionPlanExchangeService : IMailMessageActionPlanExchangeService {
-    private static readonly JsonSerializerOptions SerializerOptions = new() {
-        PropertyNameCaseInsensitive = true,
-        WriteIndented = true
-    };
-
     /// <inheritdoc />
     public async Task<MessageActionExecutionPlan> LoadAsync(string path, CancellationToken cancellationToken = default) {
         if (string.IsNullOrWhiteSpace(path)) {
@@ -19,7 +14,7 @@ public sealed class JsonMailMessageActionPlanExchangeService : IMailMessageActio
 
         var fullPath = Path.GetFullPath(path);
         using var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        var plan = await JsonSerializer.DeserializeAsync<MessageActionExecutionPlan>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        var plan = await JsonSerializer.DeserializeAsync(stream, ApplicationJsonContext.Default.MessageActionExecutionPlan, cancellationToken).ConfigureAwait(false);
         if (plan == null) {
             throw new InvalidDataException($"Action plan file '{fullPath}' did not contain a valid action plan document.");
         }
@@ -43,7 +38,7 @@ public sealed class JsonMailMessageActionPlanExchangeService : IMailMessageActio
         }
 
         using var stream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None);
-        await JsonSerializer.SerializeAsync(stream, plan, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        await JsonSerializer.SerializeAsync(stream, plan, ApplicationJsonContext.Default.MessageActionExecutionPlan, cancellationToken).ConfigureAwait(false);
         await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -55,7 +50,7 @@ public sealed class JsonMailMessageActionPlanExchangeService : IMailMessageActio
 
         var fullPath = Path.GetFullPath(path);
         using var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        var plans = await JsonSerializer.DeserializeAsync<List<MessageActionExecutionPlan>>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        var plans = await JsonSerializer.DeserializeAsync(stream, ApplicationJsonContext.Default.MessageActionExecutionPlanList, cancellationToken).ConfigureAwait(false);
         if (plans == null) {
             throw new InvalidDataException($"Action plan batch file '{fullPath}' did not contain a valid action plan array.");
         }
@@ -79,7 +74,7 @@ public sealed class JsonMailMessageActionPlanExchangeService : IMailMessageActio
         }
 
         using var stream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None);
-        await JsonSerializer.SerializeAsync(stream, plans, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        await JsonSerializer.SerializeAsync(stream, plans, ApplicationJsonContext.Default.MessageActionExecutionPlanList, cancellationToken).ConfigureAwait(false);
         await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/Sources/Mailozaurr.Application/Mailozaurr.Application.csproj
+++ b/Sources/Mailozaurr.Application/Mailozaurr.Application.csproj
@@ -12,6 +12,10 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+        <IsAotCompatible>true</IsAotCompatible>
+    </PropertyGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\Mailozaurr\Mailozaurr.csproj" />
     </ItemGroup>

--- a/Sources/Mailozaurr.Cli/CliJsonContext.cs
+++ b/Sources/Mailozaurr.Cli/CliJsonContext.cs
@@ -1,0 +1,76 @@
+using System.Text.Json.Serialization;
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Cli;
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(CliErrorEnvelope))]
+[JsonSerializable(typeof(CliError))]
+[JsonSerializable(typeof(OperationResult))]
+[JsonSerializable(typeof(MailProfileAuthenticationResult))]
+[JsonSerializable(typeof(MailProfileAuthStatus))]
+[JsonSerializable(typeof(MailProfileConnectionTestResult))]
+[JsonSerializable(typeof(MailProfileOverviewCompact))]
+[JsonSerializable(typeof(MailProfileOverview))]
+[JsonSerializable(typeof(MailProfile))]
+[JsonSerializable(typeof(ProfileCapabilities))]
+[JsonSerializable(typeof(MailProfileValidationResult))]
+[JsonSerializable(typeof(FolderRefCompact))]
+[JsonSerializable(typeof(FolderRef))]
+[JsonSerializable(typeof(MailFolderAliasSummary))]
+[JsonSerializable(typeof(MailFolderTargetResolution))]
+[JsonSerializable(typeof(MailMessageActionPlanBatchSummary))]
+[JsonSerializable(typeof(MailMessageActionPlanBatchCompact))]
+[JsonSerializable(typeof(MailMessageActionPlanBatch))]
+[JsonSerializable(typeof(MailMessageActionPlanBatchTransformPreview))]
+[JsonSerializable(typeof(MoveMessagesPreview))]
+[JsonSerializable(typeof(StandardMessageActionsPreview))]
+[JsonSerializable(typeof(CommonMessageActionsPreview))]
+[JsonSerializable(typeof(MessageActionExecutionPlan))]
+[JsonSerializable(typeof(MessageActionBatchExecutionResult))]
+[JsonSerializable(typeof(DeleteMessagesPreview))]
+[JsonSerializable(typeof(MessageStateChangePreview))]
+[JsonSerializable(typeof(MessageActionResult))]
+[JsonSerializable(typeof(MessageSummaryCompact))]
+[JsonSerializable(typeof(MessageSummary))]
+[JsonSerializable(typeof(MessageDetailCompact))]
+[JsonSerializable(typeof(MessageDetail))]
+[JsonSerializable(typeof(AttachmentSummary))]
+[JsonSerializable(typeof(SavedAttachmentResult))]
+[JsonSerializable(typeof(SaveAttachmentsResult))]
+[JsonSerializable(typeof(SaveAttachmentsManyResult))]
+[JsonSerializable(typeof(MailDraftCompact))]
+[JsonSerializable(typeof(MailDraft))]
+[JsonSerializable(typeof(QueuedMessageCompact))]
+[JsonSerializable(typeof(QueuedMessageSummary))]
+[JsonSerializable(typeof(QueueProcessResult))]
+[JsonSerializable(typeof(SendResult))]
+[JsonSerializable(typeof(IReadOnlyList<MailProfileOverviewCompact>), TypeInfoPropertyName = "MailProfileOverviewCompactList")]
+[JsonSerializable(typeof(IReadOnlyList<MailProfileOverview>), TypeInfoPropertyName = "MailProfileOverviewList")]
+[JsonSerializable(typeof(IReadOnlyList<MailProfile>), TypeInfoPropertyName = "MailProfileList")]
+[JsonSerializable(typeof(IReadOnlyList<FolderRefCompact>), TypeInfoPropertyName = "FolderRefCompactList")]
+[JsonSerializable(typeof(IReadOnlyList<FolderRef>), TypeInfoPropertyName = "FolderRefList")]
+[JsonSerializable(typeof(IReadOnlyList<MailFolderAliasSummary>), TypeInfoPropertyName = "MailFolderAliasSummaryList")]
+[JsonSerializable(typeof(IReadOnlyList<MailMessageActionPlanBatchSummary>), TypeInfoPropertyName = "MailMessageActionPlanBatchSummaryList")]
+[JsonSerializable(typeof(IReadOnlyList<MailMessageActionPlanBatchCompact>), TypeInfoPropertyName = "MailMessageActionPlanBatchCompactList")]
+[JsonSerializable(typeof(IReadOnlyList<MailMessageActionPlanBatch>), TypeInfoPropertyName = "MailMessageActionPlanBatchList")]
+[JsonSerializable(typeof(IReadOnlyList<MessageSummaryCompact>), TypeInfoPropertyName = "MessageSummaryCompactList")]
+[JsonSerializable(typeof(IReadOnlyList<MessageSummary>), TypeInfoPropertyName = "MessageSummaryList")]
+[JsonSerializable(typeof(IReadOnlyList<MessageDetailCompact>), TypeInfoPropertyName = "MessageDetailCompactList")]
+[JsonSerializable(typeof(IReadOnlyList<MessageDetail>), TypeInfoPropertyName = "MessageDetailList")]
+[JsonSerializable(typeof(IReadOnlyList<AttachmentSummary>), TypeInfoPropertyName = "AttachmentSummaryList")]
+[JsonSerializable(typeof(IReadOnlyList<MailDraftCompact>), TypeInfoPropertyName = "MailDraftCompactList")]
+[JsonSerializable(typeof(IReadOnlyList<MailDraft>), TypeInfoPropertyName = "MailDraftList")]
+[JsonSerializable(typeof(IReadOnlyList<QueuedMessageCompact>), TypeInfoPropertyName = "QueuedMessageCompactList")]
+[JsonSerializable(typeof(IReadOnlyList<QueuedMessageSummary>), TypeInfoPropertyName = "QueuedMessageSummaryList")]
+internal partial class CliJsonContext : JsonSerializerContext;
+
+internal sealed class CliErrorEnvelope {
+    public required CliError Error { get; init; }
+}
+
+internal sealed class CliError {
+    public required string Type { get; init; }
+
+    public required string Message { get; init; }
+}

--- a/Sources/Mailozaurr.Cli/CliRunner.cs
+++ b/Sources/Mailozaurr.Cli/CliRunner.cs
@@ -1,15 +1,12 @@
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using Mailozaurr.Application;
 using Mailozaurr.Cli.Mcp;
 
 namespace Mailozaurr.Cli;
 
 public static class CliRunner {
-    private static readonly JsonSerializerOptions JsonOptions = new() {
-        WriteIndented = true
-    };
-
     public static async Task<int> RunAsync(
         string[] args,
         TextWriter output,
@@ -1250,7 +1247,7 @@ public static class CliRunner {
         bool json,
         Func<T, string> formatter) {
         if (json) {
-            await output.WriteLineAsync(JsonSerializer.Serialize(value, JsonOptions)).ConfigureAwait(false);
+            await output.WriteLineAsync(SerializeJson(value)).ConfigureAwait(false);
             return;
         }
 
@@ -1263,7 +1260,7 @@ public static class CliRunner {
         bool json,
         Func<T, string> formatter) {
         if (json) {
-            await output.WriteLineAsync(JsonSerializer.Serialize(values, JsonOptions)).ConfigureAwait(false);
+            await output.WriteLineAsync(SerializeJson<IReadOnlyList<T>>(values)).ConfigureAwait(false);
             return;
         }
 
@@ -1323,11 +1320,17 @@ public static class CliRunner {
                     Message = exception.Message
                 }
             };
-            await error.WriteLineAsync(JsonSerializer.Serialize(payload, JsonOptions)).ConfigureAwait(false);
+            await error.WriteLineAsync(SerializeJson(payload)).ConfigureAwait(false);
             return;
         }
 
         await error.WriteLineAsync(exception.Message).ConfigureAwait(false);
+    }
+
+    private static string SerializeJson<T>(T value) {
+        var typeInfo = CliJsonContext.Default.GetTypeInfo(typeof(T)) ??
+            throw new InvalidOperationException($"JSON output for '{typeof(T).FullName}' is not registered.");
+        return JsonSerializer.Serialize(value, (JsonTypeInfo)typeInfo);
     }
 
     private static void WriteHelp(TextWriter output) {
@@ -1460,13 +1463,4 @@ public static class CliRunner {
         throw new InvalidOperationException($"Unsupported profile overview sort '{rawSort}'.");
     }
 
-    private sealed class CliErrorEnvelope {
-        public required CliError Error { get; init; }
-    }
-
-    private sealed class CliError {
-        public required string Type { get; init; }
-
-        public required string Message { get; init; }
-    }
 }

--- a/Sources/Mailozaurr.Cli/Mailozaurr.Cli.csproj
+++ b/Sources/Mailozaurr.Cli/Mailozaurr.Cli.csproj
@@ -7,6 +7,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Sources/Mailozaurr.Cli/Mcp/McpServerHost.cs
+++ b/Sources/Mailozaurr.Cli/Mcp/McpServerHost.cs
@@ -13,7 +13,7 @@ internal static class McpServerHost {
         builder.Services
             .AddMcpServer()
             .WithStdioServerTransport()
-            .WithToolsFromAssembly(typeof(MailMcpTools).Assembly);
+            .WithTools<MailMcpTools>();
 
         using var host = builder.Build();
         await host.RunAsync(cancellationToken).ConfigureAwait(false);

--- a/Sources/Mailozaurr/Mailozaurr.csproj
+++ b/Sources/Mailozaurr/Mailozaurr.csproj
@@ -23,6 +23,10 @@
             Windows;MacOS;Linux;Mail;Email;MX;SPF;DMARC;DKIM;GraphApi;SendGrid;Graph;IMAP;POP3</PackageTags>
     </PropertyGroup>
 
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+        <IsAotCompatible>true</IsAotCompatible>
+    </PropertyGroup>
+
     <!-- Include referenced assemblies alongside output -->
     <PropertyGroup>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
## Summary
- enable AOT compatibility analyzers for the net8.0 core, application, and CLI projects
- replace first-party JSON serialization paths with source-generated System.Text.Json contexts
- switch MCP tool registration from assembly scanning to generic registration for Native AOT friendliness

## Notes
The strict native AOT CLI publish now succeeds and produces a native executable. Dependency/runtime warnings remain from the Google/Newtonsoft/System.Data side of the graph, which is expected until we decide whether to split optional provider-specific pieces into smaller packages.

## Validation
- dotnet build Sources\Mailozaurr.sln -c Release
- dotnet test Sources\Mailozaurr.Tests\Mailozaurr.Tests.csproj -c Release -f net8.0
- dotnet publish Sources\Mailozaurr.Cli\Mailozaurr.Cli.csproj -c Release -f net8.0 -r win-x64 -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0 -p:PublishAot=true -p:SelfContained=true -p:InvariantGlobalization=true -v:minimal
- native CLI smoke: Mailozaurr.Cli.exe --profiles-dir <temp> profile list --json
- git diff --cached --check
