### PR TITLE
Fix OAuth O365 interactive login fallback

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -71,7 +71,7 @@ Build-Module -ModuleName 'Mailozaurr' {
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
 
     New-ConfigurationImportModule -ImportSelf #-ImportRequiredModules
 

--- a/Examples/Example-SendEmail-OAuthO365.ps1
+++ b/Examples/Example-SendEmail-OAuthO365.ps1
@@ -1,11 +1,13 @@
 Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
-$ClientID = '4c1197dd-53'
-$TenantID = 'ceb371f6-87'
+$Login = 'sender@example.com'
+$ClientID = '00000000-0000-0000-0000-000000000000'
+$TenantID = '00000000-0000-0000-0000-000000000000'
+$Text = 'Hello from Mailozaurr using Office 365 OAuth2.'
+$Body = '<p>Hello from Mailozaurr using Office 365 OAuth2.</p>'
 
-$CredentialOAuth2 = Connect-OAuthO365 -ClientID $ClientID -TenantID $TenantID
+$CredentialOAuth2 = Connect-OAuthO365 -Login $Login -ClientID $ClientID -TenantID $TenantID
 
-Send-EmailMessage -From @{ Name = 'Przemysław Kłys'; Email = 'test@evotec.pl' } -To 'test@evotec.pl' `
+Send-EmailMessage -From @{ Name = 'Sender'; Email = $Login } -To 'recipient@example.com' `
     -Server 'smtp.office365.com' -HTML $Body -Text $Text -DeliveryNotificationOption OnSuccess -Priority High `
-    -Subject 'This is another test email' -SecureSocketOptions Auto -Credential $CredentialOAuth2 -OAuth2
-
+    -Subject 'OAuth2 test email' -SecureSocketOptions Auto -Credential $CredentialOAuth2 -OAuth2

--- a/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthHelpers.cs
@@ -113,18 +113,14 @@ public static class OAuthHelpers {
         } else {
             account = accounts.FirstOrDefault();
         }
-        try {
-            if (account != null) {
+        if (account != null) {
+            try {
                 result = await app.AcquireTokenSilent(scopes, account).ExecuteAsync();
-            } else {
-                throw new MsalUiRequiredException("", "no_account");
+            } catch (MsalUiRequiredException) {
+                result = await AcquireO365TokenInteractivePromptAsync(app, login, scopes).ConfigureAwait(false);
             }
-        } catch (MsalUiRequiredException) {
-            var builder = app.AcquireTokenInteractive(scopes);
-            if (!string.IsNullOrWhiteSpace(login)) {
-                builder = builder.WithLoginHint(login);
-            }
-            result = await builder.ExecuteAsync();
+        } else {
+            result = await AcquireO365TokenInteractivePromptAsync(app, login, scopes).ConfigureAwait(false);
         }
         var cred = new OAuthCredential {
             UserName = result.Account.Username,
@@ -134,6 +130,18 @@ public static class OAuthHelpers {
         };
         await PersistO365CredentialAsync(cred, clientId, tenantId, redirectUri, scopes).ConfigureAwait(false);
         return cred;
+    }
+
+    private static Task<AuthenticationResult> AcquireO365TokenInteractivePromptAsync(
+        IPublicClientApplication app,
+        string? login,
+        IEnumerable<string> scopes) {
+        var builder = app.AcquireTokenInteractive(scopes);
+        if (!string.IsNullOrWhiteSpace(login)) {
+            builder = builder.WithLoginHint(login);
+        }
+
+        return builder.ExecuteAsync();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Fix Connect-OAuthO365 when no cached account exists by entering interactive auth directly instead of constructing an MSAL exception with an empty error code
- Refresh the Office 365 OAuth example with realistic placeholders, Login usage, and defined message body values

Fixes #613

## Tests
- dotnet build .\Sources\Mailozaurr.PowerShell\Mailozaurr.PowerShell.csproj -c Release -f net8.0 --no-restore -m:1 /nr:false
- dotnet test .\Sources\Mailozaurr.Tests\Mailozaurr.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~OAuthHelpersCachedTokenTests|FullyQualifiedName~OAuthHelpersGoogleCachedTokenTests"
- dotnet test .\Sources\Mailozaurr.Tests\Mailozaurr.Tests.csproj -c Release -f net8.0 --no-build