### PR TITLE
Add cmdlet-first MIME and IMAP helper surface

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -95,18 +95,6 @@ Build-Module -ModuleName 'Mailozaurr' {
             'Mailozaurr'
             'Mailozaurr.Msg'
         )
-        NETAssemblyTypeAccelerators          = @(
-            'MailKit.Net.Pop3.Pop3Client'
-            'MailKit.Search.SearchQuery'
-            'MailKit.Security.SecureSocketOptions'
-            'MailKit.UniqueId'
-            'MimeKit.BodyBuilder'
-            'MimeKit.MailboxAddress'
-            'MimeKit.MimeContent'
-            'MimeKit.MimeMessage'
-            'MimeKit.MimePart'
-            'MimeKit.TextPart'
-        )
         #NETMergeLibraryDebugging          = $true
         DotSourceLibraries                   = $true
         DotSourceClasses                     = $true

--- a/Examples/Example-RemoveMessageAttachment.ps1
+++ b/Examples/Example-RemoveMessageAttachment.ps1
@@ -1,19 +1,12 @@
 Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
 # Create a MIME message and strip attachments before forwarding
-$builder = [MimeKit.BodyBuilder]::new()
-$builder.TextBody = 'Forwarding without attachments'
 $path = Join-Path $PSScriptRoot 'sample.txt'
 'content' | Set-Content -Path $path
-$builder.Attachments.Add($path) | Out-Null
-$msg = [MimeKit.MimeMessage]::new()
-$msg.From.Add([MimeKit.MailboxAddress]::new('Sender','sender@example.com'))
-$msg.To.Add([MimeKit.MailboxAddress]::new('Recipient','recipient@example.com'))
-$msg.Subject = 'Sample'
-$msg.Body = $builder.ToMessageBody()
+$msg = New-MimeMessage -From 'Sender <sender@example.com>' -To 'Recipient <recipient@example.com>' -Subject 'Sample' -TextBody 'Forwarding without attachments' -AttachmentPath $path
 
 $msg = Remove-IMAPMessageAttachment -Message $msg
-Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' -Subject $msg.Subject -Body $builder.TextBody -Server 'smtp.example.com' -Port 25 -Message $msg -WhatIf
+Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' -Subject $msg.Subject -Body 'Forwarding without attachments' -Server 'smtp.example.com' -Port 25 -Message $msg -WhatIf
 
 # For Graph messages
 $file = Join-Path $PSScriptRoot 'sample2.txt'
@@ -26,6 +19,5 @@ $graphMsg = Remove-GraphMessageAttachment -Message $graphMsg
 # Forward $graphMsg using your preferred method
 
 # For POP3 messages (after retrieval)
-$popMsg = [MimeKit.MimeMessage]::new()
-$popMsg.Body = $builder.ToMessageBody()
+$popMsg = New-MimeMessage -TextBody 'Forwarding without attachments' -AttachmentPath $path
 $popMsg = Remove-POP3MessageAttachment -Message $popMsg

--- a/Examples/Example-SendEmail-Attachments.ps1
+++ b/Examples/Example-SendEmail-Attachments.ps1
@@ -2,12 +2,9 @@ Import-Module $PSScriptRoot\..\Mailozaurr.psd1 -Force
 
 # Custom attachment built from memory
 $bytes = [System.Text.Encoding]::UTF8.GetBytes('Hello from memory')
-$memoryStream = [System.IO.MemoryStream]::new($bytes)
-$mimePart = [MimeKit.MimePart]::new('text/plain')
-$mimePart.Content = [MimeKit.MimeContent]::new($memoryStream)
-$mimePart.FileName = 'Memory.txt'
+$attachment = New-EmailAttachment -Bytes $bytes -FileName 'Memory.txt' -ContentType 'text/plain'
 
 Send-EmailMessage -From 'sender@example.com' -To 'recipient@example.com' \
     -Server 'smtp.example.com' -Port 25 -Subject 'Attachment Demo' -Body 'Check attachments' \
-    -Attachment 'C:\\Temp\\report.pdf', $mimePart \
+    -Attachment 'C:\\Temp\\report.pdf', $attachment \
     -InlineAttachment 'C:\\Temp\\logo.png' -WhatIf -Verbose

--- a/Examples/Example-WaitImapMessageSearchQuery.ps1
+++ b/Examples/Example-WaitImapMessageSearchQuery.ps1
@@ -4,7 +4,8 @@ $credential = Get-Credential
 $client = Connect-IMAP -Server 'imap.example.com' -Credential $credential
 
 Write-Host 'Waiting for new IMAP messages from alice@example.com.'
-Wait-IMAPMessage -Client $client -SearchQuery ([MailKit.Search.SearchQuery]::FromContains('alice@example.com')) -StopOnMatch -TimeoutSeconds 600 -Action {
+$query = New-IMAPSearchQuery -FromContains 'alice@example.com'
+Wait-IMAPMessage -Client $client -SearchQuery $query -StopOnMatch -TimeoutSeconds 600 -Action {
     param($msg)
     Write-Host "New IMAP message from Alice: $($msg.Message.Subject)"
 }

--- a/Sources/Mailozaurr.PowerShell/CmdletGetMimeMessageContent.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletGetMimeMessageContent.cs
@@ -17,15 +17,7 @@ public sealed class CmdletGetMimeMessageContent : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (InputObject == null) return;
-        MimeMessage? message = InputObject switch {
-            MimeMessage m => m,
-            ImapMessageInfo info => info.Raw.Message,
-            ImapEmailMessage imap => imap.Message,
-            Pop3MessageInfo pinfo => pinfo.Raw.Message,
-            Pop3EmailMessage pop => pop.Message,
-            GraphEmailMessage g => g.Message,
-            _ => null
-        };
+        var message = PowerShellMimeMessageResolver.Resolve(InputObject);
         if (message != null) {
             WriteObject(new MimeMessageContent(message));
         }

--- a/Sources/Mailozaurr.PowerShell/CmdletNewEmailAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewEmailAttachment.cs
@@ -1,0 +1,82 @@
+using Mailozaurr.Definitions;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// Creates an attachment descriptor for Mailozaurr send cmdlets.
+/// </summary>
+[Cmdlet(VerbsCommon.New, "EmailAttachment", DefaultParameterSetName = PathParameterSet)]
+[OutputType(typeof(AttachmentDescriptor))]
+public sealed class CmdletNewEmailAttachment : PSCmdlet {
+    private const string PathParameterSet = "Path";
+    private const string BytesParameterSet = "Bytes";
+    private const string TextParameterSet = "Text";
+    private const string StreamParameterSet = "Stream";
+
+    /// <summary>File path used as attachment content.</summary>
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = PathParameterSet)]
+    public string? Path { get; set; }
+
+    /// <summary>Attachment content as bytes.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = BytesParameterSet)]
+    public byte[]? Bytes { get; set; }
+
+    /// <summary>Attachment content as text.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = TextParameterSet)]
+    public string? Text { get; set; }
+
+    /// <summary>Attachment content as a readable stream.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = StreamParameterSet)]
+    public Stream? Stream { get; set; }
+
+    /// <summary>File name to use for non-path attachment content.</summary>
+    [Parameter(ParameterSetName = BytesParameterSet)]
+    [Parameter(ParameterSetName = TextParameterSet)]
+    [Parameter(ParameterSetName = StreamParameterSet)]
+    public string? FileName { get; set; }
+
+    /// <summary>MIME content type for the attachment.</summary>
+    [Parameter]
+    public string? ContentType { get; set; }
+
+    /// <summary>Content id used when the attachment is sent inline.</summary>
+    [Parameter]
+    public string? ContentId { get; set; }
+
+    /// <summary>Text encoding used with Text content. Defaults to UTF-8.</summary>
+    [Parameter(ParameterSetName = TextParameterSet)]
+    public Encoding? Encoding { get; set; }
+
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        AttachmentDescriptor descriptor = ParameterSetName switch {
+            PathParameterSet => new FileAttachmentDescriptor(Path!),
+            BytesParameterSet => new ByteArrayAttachmentDescriptor(Bytes!, RequireFileName()),
+            TextParameterSet => new ByteArrayAttachmentDescriptor((Encoding ?? Encoding.UTF8).GetBytes(Text!), RequireFileName()),
+            StreamParameterSet => new StreamAttachmentDescriptor(Stream!, RequireFileName()),
+            _ => throw new InvalidOperationException($"Unsupported parameter set '{ParameterSetName}'.")
+        };
+
+        if (!string.IsNullOrWhiteSpace(ContentType)) {
+            descriptor.ContentType = ContentType;
+        }
+
+        if (!string.IsNullOrWhiteSpace(ContentId)) {
+            descriptor.ContentId = ContentId;
+        }
+
+        WriteObject(descriptor);
+    }
+
+    private string RequireFileName() {
+        if (string.IsNullOrWhiteSpace(FileName)) {
+            ThrowTerminatingError(new ErrorRecord(
+                new PSArgumentException("FileName is required for in-memory attachment content."),
+                "MissingFileName",
+                ErrorCategory.InvalidArgument,
+                null));
+        }
+
+        return FileName!;
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletNewIMAPSearchQuery.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewIMAPSearchQuery.cs
@@ -1,0 +1,146 @@
+using MailKit.Search;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// Creates a Mailozaurr IMAP search query without requiring callers to construct MailKit types directly.
+/// </summary>
+[Cmdlet(VerbsCommon.New, "IMAPSearchQuery")]
+[OutputType(typeof(SearchQuery))]
+public sealed class CmdletNewIMAPSearchQuery : PSCmdlet {
+    /// <summary>Filters messages by subject text.</summary>
+    [Parameter]
+    public string? Subject { get; set; }
+
+    /// <summary>Filters messages by sender text.</summary>
+    [Parameter]
+    public string? FromContains { get; set; }
+
+    /// <summary>Filters messages by recipient text.</summary>
+    [Parameter]
+    public string? ToContains { get; set; }
+
+    /// <summary>Filters messages by body text.</summary>
+    [Parameter]
+    public string? BodyContains { get; set; }
+
+    /// <summary>Filters messages where any searchable message content contains this text.</summary>
+    [Parameter]
+    public string[]? MessageContains { get; set; }
+
+    /// <summary>Header name to search.</summary>
+    [Parameter]
+    public string? HeaderName { get; set; }
+
+    /// <summary>Header value to search.</summary>
+    [Parameter]
+    public string? HeaderValue { get; set; }
+
+    /// <summary>Only messages delivered after this date are matched.</summary>
+    [Parameter]
+    public DateTime? Since { get; set; }
+
+    /// <summary>Only messages delivered before this date are matched.</summary>
+    [Parameter]
+    public DateTime? Before { get; set; }
+
+    /// <summary>Only unread messages are matched.</summary>
+    [Parameter]
+    public SwitchParameter Unseen { get; set; }
+
+    /// <summary>Only read messages are matched.</summary>
+    [Parameter]
+    public SwitchParameter Seen { get; set; }
+
+    /// <summary>Only answered messages are matched.</summary>
+    [Parameter]
+    public SwitchParameter Answered { get; set; }
+
+    /// <summary>Only unanswered messages are matched.</summary>
+    [Parameter]
+    public SwitchParameter Unanswered { get; set; }
+
+    /// <summary>Only flagged messages are matched.</summary>
+    [Parameter]
+    public SwitchParameter Flagged { get; set; }
+
+    /// <summary>Only unflagged messages are matched.</summary>
+    [Parameter]
+    public SwitchParameter Unflagged { get; set; }
+
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        SearchQuery query = SearchQuery.All;
+
+        if (!string.IsNullOrWhiteSpace(Subject)) {
+            query = query.And(SearchQuery.SubjectContains(Subject!));
+        }
+
+        if (!string.IsNullOrWhiteSpace(FromContains)) {
+            query = query.And(SearchQuery.FromContains(FromContains!));
+        }
+
+        if (!string.IsNullOrWhiteSpace(ToContains)) {
+            query = query.And(SearchQuery.ToContains(ToContains!));
+        }
+
+        if (!string.IsNullOrWhiteSpace(BodyContains)) {
+            query = query.And(SearchQuery.BodyContains(BodyContains!));
+        }
+
+        if (Since.HasValue) {
+            query = query.And(SearchQuery.DeliveredAfter(Since.Value));
+        }
+
+        if (Before.HasValue) {
+            query = query.And(SearchQuery.DeliveredBefore(Before.Value));
+        }
+
+        if (Unseen.IsPresent) {
+            query = query.And(SearchQuery.NotSeen);
+        }
+
+        if (Seen.IsPresent) {
+            query = query.And(SearchQuery.Seen);
+        }
+
+        if (Answered.IsPresent) {
+            query = query.And(SearchQuery.Answered);
+        }
+
+        if (Unanswered.IsPresent) {
+            query = query.And(SearchQuery.NotAnswered);
+        }
+
+        if (Flagged.IsPresent) {
+            query = query.And(SearchQuery.Flagged);
+        }
+
+        if (Unflagged.IsPresent) {
+            query = query.And(SearchQuery.NotFlagged);
+        }
+
+        if (!string.IsNullOrWhiteSpace(HeaderName) || !string.IsNullOrWhiteSpace(HeaderValue)) {
+            if (string.IsNullOrWhiteSpace(HeaderName) || string.IsNullOrWhiteSpace(HeaderValue)) {
+                ThrowTerminatingError(new ErrorRecord(
+                    new PSArgumentException("HeaderName and HeaderValue must be provided together."),
+                    "IncompleteHeaderFilter",
+                    ErrorCategory.InvalidArgument,
+                    null));
+                return;
+            }
+
+            query = query.And(SearchQuery.HeaderContains(HeaderName!, HeaderValue!));
+        }
+
+        if (MessageContains != null) {
+            foreach (var value in MessageContains) {
+                if (!string.IsNullOrWhiteSpace(value)) {
+                    query = query.And(SearchQuery.MessageContains(value));
+                }
+            }
+        }
+
+        WriteObject(query);
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletNewMimeMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletNewMimeMessage.cs
@@ -1,0 +1,101 @@
+using MimeKit;
+
+namespace Mailozaurr.PowerShell;
+
+/// <summary>
+/// Creates a MIME message without requiring callers to construct MimeKit types directly.
+/// </summary>
+[Cmdlet(VerbsCommon.New, "MimeMessage")]
+[OutputType(typeof(MimeMessage))]
+public sealed class CmdletNewMimeMessage : PSCmdlet {
+    /// <summary>Sender address.</summary>
+    [Parameter]
+    public string? From { get; set; }
+
+    /// <summary>Recipient addresses.</summary>
+    [Parameter]
+    public string[]? To { get; set; }
+
+    /// <summary>Carbon-copy recipient addresses.</summary>
+    [Parameter]
+    public string[]? Cc { get; set; }
+
+    /// <summary>Blind-carbon-copy recipient addresses.</summary>
+    [Parameter]
+    public string[]? Bcc { get; set; }
+
+    /// <summary>Message subject.</summary>
+    [Parameter]
+    public string? Subject { get; set; }
+
+    /// <summary>Plain-text message body.</summary>
+    [Parameter]
+    public string? TextBody { get; set; }
+
+    /// <summary>HTML message body.</summary>
+    [Parameter]
+    public string? HtmlBody { get; set; }
+
+    /// <summary>File attachments to add to the message.</summary>
+    [Parameter]
+    public string[]? AttachmentPath { get; set; }
+
+    /// <summary>Additional message headers.</summary>
+    [Parameter]
+    public Hashtable? Header { get; set; }
+
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        var message = new MimeMessage();
+        AddAddress(message.From, From);
+        AddAddresses(message.To, To);
+        AddAddresses(message.Cc, Cc);
+        AddAddresses(message.Bcc, Bcc);
+
+        if (!string.IsNullOrWhiteSpace(Subject)) {
+            message.Subject = Subject!;
+        }
+
+        if (Header != null) {
+            foreach (DictionaryEntry entry in Header) {
+                var name = entry.Key?.ToString();
+                var value = entry.Value?.ToString();
+                if (!string.IsNullOrWhiteSpace(name) && value != null) {
+                    message.Headers[name!] = value;
+                }
+            }
+        }
+
+        var builder = new BodyBuilder {
+            TextBody = TextBody,
+            HtmlBody = HtmlBody
+        };
+
+        if (AttachmentPath != null) {
+            foreach (var path in AttachmentPath) {
+                if (!string.IsNullOrWhiteSpace(path)) {
+                    builder.Attachments.Add(path);
+                }
+            }
+        }
+
+        message.Body = builder.ToMessageBody();
+        WriteObject(message);
+    }
+
+    private static void AddAddress(InternetAddressList list, string? address) {
+        if (!string.IsNullOrWhiteSpace(address)) {
+            list.Add(MailboxAddress.Parse(address!));
+        }
+    }
+
+    private static void AddAddresses(InternetAddressList list, string[]? addresses) {
+        if (addresses == null) {
+            return;
+        }
+
+        foreach (var address in addresses) {
+            AddAddress(list, address);
+        }
+    }
+}

--- a/Sources/Mailozaurr.PowerShell/CmdletRemoveIMAPMessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemoveIMAPMessageAttachment.cs
@@ -13,20 +13,23 @@ public sealed class CmdletRemoveIMAPMessageAttachment : PSCmdlet {
     /// MIME message to process.
     /// </summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
+    [Alias("Message")]
     [ValidateNotNull]
-    public MimeMessage? Message { get; set; }
+    public object? InputObject { get; set; }
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (Message == null) {
+        var message = PowerShellMimeMessageResolver.Resolve(InputObject);
+        if (message == null) {
+            WriteObject(InputObject);
             return;
         }
         if (!ShouldProcess("MimeMessage", "Removing attachments")) {
-            WriteObject(Message);
+            WriteObject(message);
             return;
         }
-        RemoveMimeAttachments(Message.Body);
-        WriteObject(Message);
+        RemoveMimeAttachments(message.Body);
+        WriteObject(message);
     }
 
     private static void RemoveMimeAttachments(MimeEntity? entity) {

--- a/Sources/Mailozaurr.PowerShell/CmdletRemovePOP3MessageAttachment.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletRemovePOP3MessageAttachment.cs
@@ -13,20 +13,23 @@ public sealed class CmdletRemovePOP3MessageAttachment : PSCmdlet {
     /// MIME message to process.
     /// </summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
+    [Alias("Message")]
     [ValidateNotNull]
-    public MimeMessage? Message { get; set; }
+    public object? InputObject { get; set; }
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (Message == null) {
+        var message = PowerShellMimeMessageResolver.Resolve(InputObject);
+        if (message == null) {
+            WriteObject(InputObject);
             return;
         }
         if (!ShouldProcess("MimeMessage", "Removing attachments")) {
-            WriteObject(Message);
+            WriteObject(message);
             return;
         }
-        RemoveMimeAttachments(Message.Body);
-        WriteObject(Message);
+        RemoveMimeAttachments(message.Body);
+        WriteObject(message);
     }
 
     private static void RemoveMimeAttachments(MimeEntity? entity) {

--- a/Sources/Mailozaurr.PowerShell/CmdletSaveMimeMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSaveMimeMessage.cs
@@ -20,15 +20,7 @@ public sealed class CmdletSaveMimeMessage : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (InputObject == null || string.IsNullOrEmpty(Path)) return;
-        MimeMessage? message = InputObject switch {
-            MimeMessage m => m,
-            ImapMessageInfo info => info.Raw.Message,
-            ImapEmailMessage imap => imap.Message,
-            Pop3MessageInfo pinfo => pinfo.Raw.Message,
-            Pop3EmailMessage pop => pop.Message,
-            GraphEmailMessage g => g.Message,
-            _ => null
-        };
+        var message = PowerShellMimeMessageResolver.Resolve(InputObject);
         if (message == null) return;
 
         var resolved = System.IO.Path.GetFullPath(Path);

--- a/Sources/Mailozaurr.PowerShell/CmdletTestMimeMessageSignature.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletTestMimeMessageSignature.cs
@@ -12,8 +12,9 @@ namespace Mailozaurr.PowerShell;
 public sealed class CmdletTestMimeMessageSignature : PSCmdlet {
     /// <summary>Message to verify.</summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
+    [Alias("Message")]
     [ValidateNotNull]
-    public MimeMessage? Message { get; set; }
+    public object? InputObject { get; set; }
 
     /// <summary>Public key for PGP signature verification.</summary>
     [Parameter(ParameterSetName = "Pgp")]
@@ -25,12 +26,13 @@ public sealed class CmdletTestMimeMessageSignature : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (Message == null) { WriteObject(false); return; }
+        var message = PowerShellMimeMessageResolver.Resolve(InputObject);
+        if (message == null) { WriteObject(false); return; }
 
-        var enc = MimeKitUtils.GetEncryption(Message);
+        var enc = MimeKitUtils.GetEncryption(message);
         bool result = enc switch {
-            EmailEncryption.PgpSigned => MimeKitUtils.VerifyPgpSignature(Message, PublicKeyPath!),
-            EmailEncryption.SmimeSigned => MimeKitUtils.VerifySmimeSignature(Message, Certificate!),
+            EmailEncryption.PgpSigned => MimeKitUtils.VerifyPgpSignature(message, PublicKeyPath!),
+            EmailEncryption.SmimeSigned => MimeKitUtils.VerifySmimeSignature(message, Certificate!),
             _ => false
         };
         WriteObject(result);

--- a/Sources/Mailozaurr.PowerShell/CmdletUnprotectMimeMessage.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletUnprotectMimeMessage.cs
@@ -29,17 +29,7 @@ public sealed class CmdletUnprotectMimeMessage : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        var input = InputObject is PSObject psObject ? psObject.BaseObject : InputObject;
-
-        MimeMessage? message = input switch {
-            MimeMessage m => m,
-            ImapMessageInfo info => info.Raw.Message,
-            ImapEmailMessage imap => imap.Message,
-            Pop3MessageInfo pinfo => pinfo.Raw.Message,
-            Pop3EmailMessage pop => pop.Message,
-            GraphEmailMessage g => g.Message,
-            _ => null
-        };
+        var message = PowerShellMimeMessageResolver.Resolve(InputObject);
 
         if (message == null) {
             WriteObject(InputObject);

--- a/Sources/Mailozaurr.PowerShell/PowerShellMimeMessageResolver.cs
+++ b/Sources/Mailozaurr.PowerShell/PowerShellMimeMessageResolver.cs
@@ -1,0 +1,19 @@
+using MimeKit;
+
+namespace Mailozaurr.PowerShell;
+
+internal static class PowerShellMimeMessageResolver {
+    public static MimeMessage? Resolve(object? input) {
+        input = input is PSObject psObject ? psObject.BaseObject : input;
+
+        return input switch {
+            MimeMessage message => message,
+            ImapMessageInfo info => info.Raw.Message,
+            ImapEmailMessage imap => imap.Message,
+            Pop3MessageInfo info => info.Raw.Message,
+            Pop3EmailMessage pop => pop.Message,
+            GraphEmailMessage graph => graph.Message,
+            _ => null
+        };
+    }
+}

--- a/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Tests.ps1
@@ -24,9 +24,10 @@ Import-Module Mailozaurr -Force
 `$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
 `$smtpAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([Mailozaurr.Smtp].Assembly)
 `$msgAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([Mailozaurr.EmailMessage].Assembly)
-`$mimeAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([MimeKit.MimeMessage].Assembly)
-`$mailKitAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([MailKit.UniqueId].Assembly)
-`$message = [MimeKit.MimeMessage]::new()
+`$message = New-MimeMessage -From 'Sender <sender@example.com>' -To 'Recipient <recipient@example.com>' -Subject 'ALC' -TextBody 'Body'
+`$query = New-IMAPSearchQuery -FromContains 'sender@example.com'
+`$mimeAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$message.GetType().Assembly)
+`$mailKitAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$query.GetType().Assembly)
 `$smtp = [Mailozaurr.Smtp]::new()
 
 [pscustomobject]@{
@@ -45,9 +46,9 @@ Import-Module Mailozaurr -Force
     MimeMessageType = `$message.GetType().FullName
     MimeMessageALC = `$mimeAlc.Name
     MimeMessageALCIsDefault = [object]::ReferenceEquals(`$mimeAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
-    MailKitUniqueIdType = [MailKit.UniqueId].FullName
-    MailKitUniqueIdALC = `$mailKitAlc.Name
-    MailKitUniqueIdALCIsDefault = [object]::ReferenceEquals(`$mailKitAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    SearchQueryType = `$query.GetType().FullName
+    SearchQueryALC = `$mailKitAlc.Name
+    SearchQueryALCIsDefault = [object]::ReferenceEquals(`$mailKitAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
     SmtpCreated = `$null -ne `$smtp
 } | ConvertTo-Json -Compress
 "@
@@ -74,9 +75,9 @@ Import-Module Mailozaurr -Force
         $result.MimeMessageType | Should -Be 'MimeKit.MimeMessage'
         $result.MimeMessageALC | Should -Be 'Mailozaurr'
         $result.MimeMessageALCIsDefault | Should -BeFalse
-        $result.MailKitUniqueIdType | Should -Be 'MailKit.UniqueId'
-        $result.MailKitUniqueIdALC | Should -Be 'Mailozaurr'
-        $result.MailKitUniqueIdALCIsDefault | Should -BeFalse
+        $result.SearchQueryType | Should -BeLike 'MailKit.Search.*SearchQuery'
+        $result.SearchQueryALC | Should -Be 'Mailozaurr'
+        $result.SearchQueryALCIsDefault | Should -BeFalse
         $result.SmtpCreated | Should -BeTrue
     }
 }


### PR DESCRIPTION
## Summary
- add cmdlet-first helpers for IMAP search queries, MIME message creation, and in-memory/file email attachments
- make MIME-related cmdlets accept Mailozaurr wrapper objects instead of requiring direct MimeKit input
- remove explicit MailKit/MimeKit dependency type accelerator exposure from the module build configuration and update examples to use the cmdlet surface

## Validation
- dotnet build .\Sources\Mailozaurr.PowerShell\Mailozaurr.PowerShell.csproj -c Release --nologo
- dotnet test .\Sources\Mailozaurr.Tests\Mailozaurr.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~ImapMailboxSearchQueryBuilderTests" --nologo
- direct pwsh import smoke for New-IMAPSearchQuery, New-MimeMessage, New-EmailAttachment, wrapper-aware MIME cmdlets
- git diff --check