### PR TITLE
Fix MgGraphRequest large attachment uploads

### DIFF
--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Process.cs
@@ -406,19 +406,28 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         }
         if (graph.IsLargerAttachment) {
             var json = graph.CreateDraftForMg();
-            var draftMessageId = InvokeMgGraphRequestPOST1($"v1.0/users/{graph.From}/mailfolders/drafts/messages", EmailAction.SendDraftMessage, json, graph.SentFrom, graph.SentTo, graph.Stopwatch.Elapsed);
+            var draftMessageId = InvokeMgGraphRequestPOST1($"v1.0/users/{graph.SentFrom}/mailfolders/drafts/messages", EmailAction.SendDraftMessage, json, graph.SentFrom, graph.SentTo, graph.Stopwatch.Elapsed);
+            if (draftMessageId == string.Empty) {
+                LogEmitter.EmitLogs(graph.LogCollector, this);
+                return;
+            }
             await graph.PrepareAttachments();
             foreach (var attachment in graph.AttachmentsPlaceHolders) {
-                var uploadUrl = InvokeMgGraphRequestPOST(attachment.Json, EmailAction.Send, attachment.Json, graph.SentFrom, graph.SentTo, graph.Stopwatch.Elapsed);
+                var uploadSessionUri = GraphDraftMessageUris.CreateUploadSession(graph.SentFrom, draftMessageId);
+                var uploadUrl = InvokeMgGraphRequestPOST(uploadSessionUri, EmailAction.SendAttachment, attachment.Json, graph.SentFrom, graph.SentTo, graph.Stopwatch.Elapsed);
                 if (uploadUrl != string.Empty) {
-                    await InvokeMgGraphRequestPUT(uploadUrl, EmailAction.SendAttachment, attachment, graph.SentFrom, graph.SentTo, graph.Stopwatch.Elapsed);
+                    var uploaded = await InvokeMgGraphRequestPUT(uploadUrl, EmailAction.SendAttachment, attachment, graph.SentFrom, graph.SentTo, graph.Stopwatch.Elapsed);
+                    if (!uploaded) {
+                        LogEmitter.EmitLogs(graph.LogCollector, this);
+                        return;
+                    }
                 } else {
-                    graph.LogCollector.LogVerbose("PlaceHolders not working?");
+                    graph.LogCollector.LogWarning($"Send-EmailMessage - Unable to create Graph upload session for attachment '{attachment.FileName}'. Draft message was not sent.");
+                    LogEmitter.EmitLogs(graph.LogCollector, this);
+                    return;
                 }
             }
-            var sendUri = MicrosoftGraphUtils.BuildGraphUri(
-                GraphEndpoint.V1,
-                $"/users('{graph.SentFrom}')/messages/{draftMessageId}/send");
+            var sendUri = GraphDraftMessageUris.Send(graph.SentFrom, draftMessageId);
             InvokeMgGraphRequest(sendUri, EmailAction.Send, graph.MessageJson, graph.SentFrom, graph.SentTo, graph.Stopwatch.Elapsed);
             LogEmitter.EmitLogs(graph.LogCollector, this);
         } else {
@@ -616,7 +625,7 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         }
     }
 
-    private async Task InvokeMgGraphRequestPUT(string uri, EmailAction action, GraphAttachmentPlaceHolder attachment, string sentFrom, string sentTo, TimeSpan elapsed) {
+    private async Task<bool> InvokeMgGraphRequestPUT(string uri, EmailAction action, GraphAttachmentPlaceHolder attachment, string sentFrom, string sentTo, TimeSpan elapsed) {
         foreach (var body in attachment.Content) {
             var parameters = new Hashtable {
                 { "Method", "PUT" },
@@ -647,9 +656,12 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
                         };
                         WriteObject(result);
                     }
+                    return false;
                 }
             }
         }
+
+        return true;
     }
 
 
@@ -667,15 +679,8 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             try {
                 var results = powerShell.Invoke();
                 if (results.Count > 0) {
-                    // Assuming the first result contains the property you're interested in
-                    var result = results[0];
-                    if (result.BaseObject is IDictionary dictionary) {
-                        var uploadUrl = dictionary["uploadUrl"]?.ToString();
-                        if (!string.IsNullOrEmpty(uploadUrl)) {
-                            return uploadUrl!;
-                        }
-                        // Handle the case where the property is not present
-                        throw new InvalidOperationException("The result does not contain an 'uploadUrl' property.");
+                    if (TryGetPowerShellResultValue(results[0], "uploadUrl", out var uploadUrl)) {
+                        return uploadUrl;
                     }
                     throw new InvalidOperationException("The result does not contain an 'uploadUrl' property.");
                 } else {
@@ -712,15 +717,8 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
             try {
                 var results = powerShell.Invoke();
                 if (results.Count > 0) {
-                    // Assuming the first result contains the property you're interested in
-                    var result = results[0];
-                    if (result.BaseObject is IDictionary dictionary) {
-                        var id = dictionary["id"]?.ToString();
-                        if (!string.IsNullOrEmpty(id)) {
-                            return id!;
-                        }
-                        // Handle the case where the property is not present
-                        throw new InvalidOperationException("The result does not contain an 'id' property.");
+                    if (TryGetPowerShellResultValue(results[0], "id", out var id)) {
+                        return id;
                     }
                     throw new InvalidOperationException("The result does not contain an 'id' property.");
                 } else {
@@ -742,6 +740,17 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet
         }
 
         return "";
+    }
+
+    private static bool TryGetPowerShellResultValue(PSObject result, string propertyName, out string value) {
+        value = string.Empty;
+        if (result.BaseObject is IDictionary dictionary) {
+            value = dictionary[propertyName]?.ToString() ?? string.Empty;
+        } else {
+            value = result.Properties[propertyName]?.Value?.ToString() ?? string.Empty;
+        }
+
+        return !string.IsNullOrEmpty(value);
     }
 
     private static List<AttachmentDescriptor>? ConvertToAttachmentDescriptors(object[]? attachments) {

--- a/Sources/Mailozaurr.Tests/GraphDraftTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphDraftTests.cs
@@ -49,6 +49,28 @@ public class GraphDraftTests
     }
 
     [Fact]
+    public async Task PrepareAttachments_FileInfo_CreatePlaceholders()
+    {
+        string tmp = Path.GetTempFileName();
+        File.WriteAllBytes(tmp, new byte[4_100_000]);
+        using var graph = new Graph { Attachments = new object[] { new FileInfo(tmp) } };
+
+        try
+        {
+            graph.CreateAttachments();
+            await graph.PrepareAttachments();
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
+
+        Assert.True(graph.IsLargerAttachment);
+        var placeholder = Assert.Single(graph.AttachmentsPlaceHolders);
+        Assert.Equal(Path.GetFileName(tmp), placeholder.FileName);
+    }
+
+    [Fact]
     public async Task CreateGraphAttachment_MissingFile_ThrowsAndLogsWarning()
     {
         string missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
@@ -126,5 +148,21 @@ public class GraphDraftTests
 
         string json = graph.CreateDraftForMg();
         Assert.Contains("\"importance\":\"low\"", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DraftMessageUris_BuildUploadSessionUri()
+    {
+        string uri = GraphDraftMessageUris.CreateUploadSession("from@example.com", "draft-id");
+
+        Assert.Equal("https://graph.microsoft.com/v1.0/users('from@example.com')/messages/draft-id/attachments/createUploadSession", uri);
+    }
+
+    [Fact]
+    public void DraftMessageUris_BuildSendUri()
+    {
+        string uri = GraphDraftMessageUris.Send("from@example.com", "draft-id");
+
+        Assert.Equal("https://graph.microsoft.com/v1.0/users('from@example.com')/messages/draft-id/send", uri);
     }
 }

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -343,7 +343,11 @@ namespace Mailozaurr;
 
             // First pass: compute total size without loading file contents.
             foreach (var item in Attachments) {
-                if (item is string path) {
+                if (item is GraphAttachment ga) {
+                    ConvertedAttachments.Add(ga);
+                    var size = EstimateAttachmentSize(ga);
+                    inMemoryTotalBytes += size;
+                } else if (TryGetAttachmentPath(item, out var path)) {
                     if (!File.Exists(path)) {
                         LogMissingAttachmentWarning(path);
                         continue;
@@ -356,10 +360,6 @@ namespace Mailozaurr;
                     } catch (Exception ex) {
                         LogCollector.LogError($"Send-EmailMessage - Failed to read attachment '{path}': {ex.Message}");
                     }
-                } else if (item is GraphAttachment ga) {
-                    ConvertedAttachments.Add(ga);
-                    var size = EstimateAttachmentSize(ga);
-                    inMemoryTotalBytes += size;
                 }
             }
 
@@ -376,6 +376,31 @@ namespace Mailozaurr;
 
             if (_inlineAttachmentSizeBytes > GraphPayloadLimitBytes) {
                 LogCollector.LogWarning("Send-EmailMessage - Large in-memory attachments detected. Consider using file paths for large attachments to enable upload sessions.");
+            }
+        }
+    }
+
+    private static bool TryGetAttachmentPath(object? item, out string path) {
+        path = item switch {
+            string value => value,
+            FileInfo fileInfo => fileInfo.FullName,
+            _ => item?.ToString() ?? string.Empty
+        };
+
+        return !string.IsNullOrWhiteSpace(path);
+    }
+
+    private IEnumerable<string> EnumerateAttachmentPaths() {
+        if (Attachments == null || Attachments.Length == 0) {
+            yield break;
+        }
+
+        foreach (var item in Attachments) {
+            if (item is GraphAttachment) {
+                continue;
+            }
+            if (TryGetAttachmentPath(item, out var path)) {
+                yield return path;
             }
         }
     }
@@ -953,9 +978,7 @@ namespace Mailozaurr;
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The upload session URL.</returns>
         public async Task<string> CreateUploadSession(GraphMessage draftMessage, string attachmentItemJson, CancellationToken cancellationToken = default) {
-        var uploadSessionUrl = MicrosoftGraphUtils.BuildGraphUri(
-            GraphEndpoint.V1,
-            $"/users('{SentFrom}')/messages/{draftMessage.Id}/attachments/createUploadSession");
+        var uploadSessionUrl = GraphDraftMessageUris.CreateUploadSession(SentFrom, draftMessage.Id!);
         using var request = new HttpRequestMessage(HttpMethod.Post, uploadSessionUrl) {
             Content = new StringContent(attachmentItemJson, Encoding.UTF8, "application/json")
         };
@@ -1042,13 +1065,11 @@ namespace Mailozaurr;
         /// <param name="draftMessage">The draft message to attach the files to.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         public async Task UploadAttachmentsAsync(GraphMessage draftMessage, CancellationToken cancellationToken = default) {
-        if (Attachments != null && Attachments.Length > 0) {
-            foreach (var path in Attachments.OfType<string>()) {
-                try {
-                    await UploadAttachmentWithRetryAsync(draftMessage, path, cancellationToken);
-                } catch (FileNotFoundException) {
-                    // Already logged by CreateGraphAttachment.
-                }
+        foreach (var path in EnumerateAttachmentPaths()) {
+            try {
+                await UploadAttachmentWithRetryAsync(draftMessage, path, cancellationToken);
+            } catch (FileNotFoundException) {
+                // Already logged by CreateGraphAttachment.
             }
         }
     }
@@ -1058,14 +1079,12 @@ namespace Mailozaurr;
         /// </summary>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         public async Task PrepareAttachments(CancellationToken cancellationToken = default) {
-        if (Attachments != null && Attachments.Length > 0) {
-            foreach (var path in Attachments.OfType<string>()) {
-                try {
-                    var attachmentItemJson = await CreateGraphAttachment(path, cancellationToken);
-                    AttachmentsPlaceHolders.Add(attachmentItemJson);
-                } catch (FileNotFoundException) {
-                    // Already logged by CreateGraphAttachment.
-                }
+        foreach (var path in EnumerateAttachmentPaths()) {
+            try {
+                var attachmentItemJson = await CreateGraphAttachment(path, cancellationToken);
+                AttachmentsPlaceHolders.Add(attachmentItemJson);
+            } catch (FileNotFoundException) {
+                // Already logged by CreateGraphAttachment.
             }
         }
     }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphDraftMessageUris.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphDraftMessageUris.cs
@@ -1,0 +1,38 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Builds Microsoft Graph draft-message action URIs used by large attachment sends.
+/// </summary>
+public static class GraphDraftMessageUris {
+    /// <summary>
+    /// Builds the URI used to create an upload session for a draft message attachment.
+    /// </summary>
+    /// <param name="userPrincipalName">Mailbox user principal name or SMTP address.</param>
+    /// <param name="draftMessageId">Graph draft message identifier.</param>
+    /// <returns>The absolute Microsoft Graph upload-session URI.</returns>
+    public static string CreateUploadSession(string userPrincipalName, string draftMessageId) =>
+        BuildDraftActionUri(userPrincipalName, draftMessageId, "attachments/createUploadSession");
+
+    /// <summary>
+    /// Builds the URI used to send an existing draft message.
+    /// </summary>
+    /// <param name="userPrincipalName">Mailbox user principal name or SMTP address.</param>
+    /// <param name="draftMessageId">Graph draft message identifier.</param>
+    /// <returns>The absolute Microsoft Graph draft-send URI.</returns>
+    public static string Send(string userPrincipalName, string draftMessageId) =>
+        BuildDraftActionUri(userPrincipalName, draftMessageId, "send");
+
+    private static string BuildDraftActionUri(string userPrincipalName, string draftMessageId, string actionPath) {
+        if (string.IsNullOrWhiteSpace(userPrincipalName)) {
+            throw new ArgumentException("User principal name must be provided.", nameof(userPrincipalName));
+        }
+        if (string.IsNullOrWhiteSpace(draftMessageId)) {
+            throw new ArgumentException("Draft message id must be provided.", nameof(draftMessageId));
+        }
+
+        var escapedUser = userPrincipalName.Replace("'", "''");
+        return MicrosoftGraphUtils.BuildGraphUri(
+            GraphEndpoint.V1,
+            $"/users('{escapedUser}')/messages/{draftMessageId}/{actionPath}");
+    }
+}

--- a/Tests/Send-EmailMessage.MgGraphRequest.Tests.ps1
+++ b/Tests/Send-EmailMessage.MgGraphRequest.Tests.ps1
@@ -1,0 +1,53 @@
+$env:MAILOZAURR_DEVELOPMENT = '1'
+Import-Module (Resolve-Path "$PSScriptRoot/../Mailozaurr.psd1") -Force
+
+Describe 'Send-EmailMessage - MgGraphRequest attachments' {
+    It 'Uploads large attachments to the draft before sending' {
+        $script:mgGraphRequestCalls = [System.Collections.Generic.List[object]]::new()
+
+        function global:Invoke-MgGraphRequest {
+            param(
+                [string] $Method,
+                [string] $Uri,
+                [string] $ContentType,
+                [object] $Body,
+                [hashtable] $Headers
+            )
+
+            $script:mgGraphRequestCalls.Add([pscustomobject] @{
+                    Method      = $Method
+                    Uri         = $Uri
+                    ContentType = $ContentType
+                    Body        = $Body
+                    Headers     = $Headers
+                })
+
+            if ($Method -eq 'POST' -and $Uri -like '*/mailfolders/drafts/messages') {
+                return @{ id = 'draft-id' }
+            }
+            if ($Method -eq 'POST' -and $Uri -like '*/attachments/createUploadSession') {
+                return @{ uploadUrl = 'https://upload.example/session' }
+            }
+            if ($Method -eq 'POST' -and $Uri -like '*/messages/draft-id/send') {
+                return @{}
+            }
+        }
+
+        $file = Join-Path $TestDrive 'large.bin'
+        [System.IO.File]::WriteAllBytes($file, (New-Object byte[] 4000001))
+
+        try {
+            Send-EmailMessage -From 'from@example.com' -To 'to@example.com' -Subject 's' -Body 'b' -MgGraphRequest -Attachment $file -Confirm:$false | Out-Null
+        } finally {
+            Remove-Item -Path function:global:Invoke-MgGraphRequest -ErrorAction SilentlyContinue
+        }
+
+        $script:mgGraphRequestCalls.Count | Should -Be 4
+        $script:mgGraphRequestCalls[0].Uri | Should -Be 'v1.0/users/from@example.com/mailfolders/drafts/messages'
+        $script:mgGraphRequestCalls[1].Uri | Should -Be "https://graph.microsoft.com/v1.0/users('from@example.com')/messages/draft-id/attachments/createUploadSession"
+        $script:mgGraphRequestCalls[2].Method | Should -Be 'PUT'
+        $script:mgGraphRequestCalls[2].Uri | Should -Be 'https://upload.example/session'
+        $script:mgGraphRequestCalls[2].Headers['Content-Range'].ToString() | Should -Match '^bytes 0-'
+        $script:mgGraphRequestCalls[3].Uri | Should -Be "https://graph.microsoft.com/v1.0/users('from@example.com')/messages/draft-id/send"
+    }
+}


### PR DESCRIPTION
## Summary
- fix `Send-EmailMessage -MgGraphRequest` large attachment sends to create Graph upload sessions against the draft message
- prevent sending the draft when draft creation or attachment upload fails
- normalize Graph attachment path inputs and add regression coverage for the MgGraphRequest upload sequence

Fixes #616

## Validation
- dotnet test Sources\Mailozaurr.Tests\Mailozaurr.Tests.csproj --no-restore
- pwsh -NoProfile -Command "Invoke-Pester -Script 'Tests\Send-EmailMessage.MgGraphRequest.Tests.ps1' -PassThru"
- git diff --check
