### PR TITLE
Add direct EOP SMTP validation probes

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -260,6 +260,10 @@ jobs:
       - name: Install PowerShell modules
         shell: pwsh
         run: |
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           Install-Module -Name PSPublishModule -Repository PSGallery -Force -Scope CurrentUser -AllowClobber
           Install-Module -Name Pester -Repository PSGallery -Force -Scope CurrentUser -SkipPublisherCheck -AllowClobber
 

--- a/Sources/Mailozaurr.PowerShell/CmdletTestSmtpConnection.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletTestSmtpConnection.cs
@@ -10,39 +10,181 @@ namespace Mailozaurr.PowerShell;
 /// <para type="description">The <c>Test-SmtpConnection</c> cmdlet connects to an
 /// SMTP server and returns information about supported features. It also checks
 /// if the connection remains open after a NOOP command which indicates support
-/// for persistent connections.</para>
+/// for persistent connections. It can also perform an envelope-only recipient
+/// probe or send an explicit validation message for authorized mail-flow testing.</para>
 /// <example>
 ///   <summary>Check capabilities of an SMTP server</summary>
 ///   <code>Test-SmtpConnection -Server "smtp.example.com" -Port 25</code>
 /// </example>
 /// </summary>
-[Cmdlet(VerbsDiagnostic.Test, "SmtpConnection")]
+[Cmdlet(VerbsDiagnostic.Test, "SmtpConnection", DefaultParameterSetName = "Connection", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Medium)]
 public sealed class CmdletTestSmtpConnection : AsyncPSCmdlet {
     /// <summary>
     /// SMTP server hostname to test.
     /// </summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(ParameterSetName = "Connection")]
+    [Parameter(ParameterSetName = "RecipientProbe")]
+    [Parameter(ParameterSetName = "ValidationMessage")]
     public string? Server { get; set; }
+
+    /// <summary>
+    /// External email domain used to infer the direct Exchange Online Protection target.
+    /// </summary>
+    [Parameter(ParameterSetName = "Connection")]
+    [Parameter(ParameterSetName = "RecipientProbe")]
+    [Parameter(ParameterSetName = "ValidationMessage")]
+    public string? Domain { get; set; }
+
+    /// <summary>
+    /// Infers the direct Exchange Online Protection target from the domain instead of requiring -Server.
+    /// </summary>
+    [Parameter(ParameterSetName = "Connection")]
+    [Parameter(ParameterSetName = "RecipientProbe")]
+    [Parameter(ParameterSetName = "ValidationMessage")]
+    public SwitchParameter ExchangeOnlineDirect { get; set; }
 
     /// <summary>
     /// TCP port used for the SMTP connection.
     /// </summary>
-    [Parameter]
+    [Parameter(ParameterSetName = "Connection")]
+    [Parameter(ParameterSetName = "RecipientProbe")]
+    [Parameter(ParameterSetName = "ValidationMessage")]
     public int Port { get; set; } = 587;
 
     /// <summary>
     /// Indicates whether to test SSL connectivity.
     /// </summary>
-    [Parameter]
+    [Parameter(ParameterSetName = "Connection")]
+    [Parameter(ParameterSetName = "RecipientProbe")]
+    [Parameter(ParameterSetName = "ValidationMessage")]
     public SwitchParameter UseSsl { get; set; }
+
+    /// <summary>
+    /// Optional recipient address to validate with RCPT TO without sending message DATA.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "RecipientProbe")]
+    [Parameter(Mandatory = true, ParameterSetName = "ValidationMessage")]
+    public string? Recipient { get; set; }
+
+    /// <summary>
+    /// Envelope sender address used with MAIL FROM during recipient probing.
+    /// </summary>
+    [Parameter(ParameterSetName = "RecipientProbe")]
+    [Parameter(ParameterSetName = "ValidationMessage")]
+    public string Sender { get; set; } = "probe@example.com";
+
+    /// <summary>
+    /// EHLO/HELO hostname used during recipient probing.
+    /// </summary>
+    [Parameter(ParameterSetName = "RecipientProbe")]
+    [Parameter(ParameterSetName = "ValidationMessage")]
+    public string HeloHost { get; set; } = "localhost";
+
+    /// <summary>
+    /// Sends a neutral validation message after the connection and recipient probe.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "ValidationMessage")]
+    public SwitchParameter SendValidationMessage { get; set; }
+
+    /// <summary>
+    /// Explicit acknowledgement that the validation mode sends an email message.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "ValidationMessage")]
+    public SwitchParameter IUnderstandThisSendsEmail { get; set; }
+
+    /// <summary>
+    /// Optional validation test identifier used in the subject, body, and custom header.
+    /// </summary>
+    [Parameter(ParameterSetName = "ValidationMessage")]
+    public string? TestId { get; set; }
+
+    /// <summary>
+    /// Optional subject used for the validation message.
+    /// </summary>
+    [Parameter(ParameterSetName = "ValidationMessage")]
+    public string? ValidationSubject { get; set; }
+
+    /// <summary>
+    /// Optional plain-text body used for the validation message.
+    /// </summary>
+    [Parameter(ParameterSetName = "ValidationMessage")]
+    public string? ValidationBody { get; set; }
+
+    /// <summary>
+    /// Marks the validation message as high priority.
+    /// </summary>
+    [Parameter(ParameterSetName = "ValidationMessage")]
+    public SwitchParameter HighPriority { get; set; }
 
     /// <summary>
     /// Tests the SMTP server connection and outputs capability information.
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     protected override Task ProcessRecordAsync() {
-        var info = Smtp.TestConnection(Server!, Port, SecureSocketOptions.Auto, UseSsl.IsPresent);
+        var effectiveServer = ResolveServer();
+        var effectivePort = ExchangeOnlineDirect.IsPresent && !MyInvocation.BoundParameters.ContainsKey(nameof(Port))
+            ? 25
+            : Port;
+
+        SmtpValidationMessageRequest? validationMessage = null;
+        if (SendValidationMessage.IsPresent) {
+            if (!IUnderstandThisSendsEmail.IsPresent) {
+                ThrowTerminatingError(new ErrorRecord(
+                    new InvalidOperationException("Validation message mode sends a real email. Supply -IUnderstandThisSendsEmail to continue."),
+                    "ValidationSendConfirmationRequired",
+                    ErrorCategory.InvalidOperation,
+                    Recipient));
+            }
+
+            if (!ShouldProcess(Recipient!, "Sending SMTP validation message")) {
+                return Task.CompletedTask;
+            }
+
+            validationMessage = new SmtpValidationMessageRequest {
+                Sender = Sender,
+                Recipient = Recipient!,
+                HeloHost = HeloHost,
+                TestId = TestId,
+                Subject = ValidationSubject,
+                Body = ValidationBody,
+                HighPriority = HighPriority.IsPresent
+            };
+        }
+
+        var info = Smtp.TestConnection(effectiveServer, effectivePort, SecureSocketOptions.Auto, UseSsl.IsPresent, Recipient, Sender, HeloHost, validationMessage);
         WriteObject(info);
         return Task.CompletedTask;
+    }
+
+    private string ResolveServer() {
+        if (!ExchangeOnlineDirect.IsPresent) {
+            if (string.IsNullOrWhiteSpace(Server)) {
+                ThrowTerminatingError(new ErrorRecord(
+                    new ArgumentException("Server is required unless -ExchangeOnlineDirect is used."),
+                    "SmtpServerRequired",
+                    ErrorCategory.InvalidArgument,
+                    Server));
+            }
+
+            return Server!.Trim();
+        }
+
+        var domain = Domain;
+        if (string.IsNullOrWhiteSpace(domain) && !string.IsNullOrWhiteSpace(Recipient)) {
+            var atIndex = Recipient!.LastIndexOf('@');
+            if (atIndex >= 0 && atIndex < Recipient.Length - 1) {
+                domain = Recipient.Substring(atIndex + 1);
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(domain)) {
+            ThrowTerminatingError(new ErrorRecord(
+                new ArgumentException("Domain is required for -ExchangeOnlineDirect when it cannot be inferred from -Recipient."),
+                "ExchangeOnlineDirectDomainRequired",
+                ErrorCategory.InvalidArgument,
+                Domain));
+        }
+
+        return Smtp.GetExchangeOnlineProtectionHost(domain!);
     }
 }

--- a/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
+++ b/Sources/Mailozaurr.Tests/SearchNonDeliveryReportsTests.cs
@@ -357,15 +357,15 @@ public class SearchNonDeliveryReportsTests {
 
     [Fact]
     public async Task SearchNonDeliveryReportsAsync_Graph_PropagatesCancellationToMessageListing() {
-        var handler = new CancelDuringGraphListHandler();
+        using var cts = new CancellationTokenSource();
+        var handler = new CancelDuringGraphListHandler(cts);
         var field = typeof(MicrosoftGraphUtils).GetField("HttpClient", BindingFlags.NonPublic | BindingFlags.Static)!;
         var client = (HttpClient)field.GetValue(null)!;
         var handlerField = GetHandlerField();
         var original = (HttpMessageHandler)handlerField.GetValue(client)!;
         handlerField.SetValue(client, handler);
         try {
-            var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
-            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+            var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", AccessToken = "token" };
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
                 MailboxSearcher.SearchNonDeliveryReportsAsync(
@@ -499,6 +499,12 @@ public class SearchNonDeliveryReportsTests {
     }
 
     private sealed class CancelDuringGraphListHandler : HttpMessageHandler {
+        private readonly CancellationTokenSource _cancellationTokenSource;
+
+        public CancelDuringGraphListHandler(CancellationTokenSource cancellationTokenSource) {
+            _cancellationTokenSource = cancellationTokenSource;
+        }
+
         public bool ListRequestCanceled { get; private set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
@@ -510,7 +516,8 @@ public class SearchNonDeliveryReportsTests {
 
             if (uri.AbsolutePath.EndsWith("/messages", StringComparison.Ordinal)) {
                 try {
-                    await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken).ConfigureAwait(false);
+                    _cancellationTokenSource.Cancel();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
                 } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
                     ListRequestCanceled = true;
                     throw;

--- a/Sources/Mailozaurr.Tests/SmtpRecipientProbeTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpRecipientProbeTests.cs
@@ -99,6 +99,72 @@ public class SmtpRecipientProbeTests {
     }
 
     [Fact]
+    public async Task TestRecipient_FallsBackToHeloWhenEhloIsRejected() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        try {
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var commands = new List<string>();
+
+            var serverTask = Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: false);
+                using var writer = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: false) {
+                    AutoFlush = true,
+                    NewLine = "\r\n"
+                };
+
+                await writer.WriteLineAsync("220 local.test SMTP");
+                while (true) {
+                    var command = await reader.ReadLineAsync();
+                    if (command == null) {
+                        break;
+                    }
+
+                    commands.Add(command);
+                    if (command.StartsWith("EHLO ", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("500 5.5.1 EHLO not supported");
+                    } else if (command.StartsWith("HELO ", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("250 local.test");
+                    } else if (command.StartsWith("MAIL FROM:", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("250 2.1.0 Sender OK");
+                    } else if (command.StartsWith("RCPT TO:", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("250 2.1.5 Recipient OK");
+                    } else if (command.Equals("RSET", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("250 2.0.0 Reset OK");
+                    } else if (command.Equals("QUIT", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("221 2.0.0 Bye");
+                        break;
+                    } else if (command.Equals("DATA", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("554 DATA is not expected in recipient probe");
+                    }
+                }
+            });
+
+            var result = Smtp.TestRecipient(
+                "127.0.0.1",
+                port,
+                "recipient@example.com",
+                "sender@example.com",
+                "probe.local",
+                SecureSocketOptions.None);
+
+            await serverTask;
+
+            Assert.True(result.Accepted);
+            Assert.Equal(250, result.MailFromStatusCode);
+            Assert.Equal(250, result.RecipientStatusCode);
+            Assert.False(result.StartTlsUsed);
+            Assert.Contains(commands, command => command.StartsWith("EHLO probe.local", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(commands, command => command.StartsWith("HELO probe.local", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(commands, command => command.Equals("DATA", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
     public async Task SendValidationMessage_SendsDataAndReturnsCorrelationFields() {
         var listener = new TcpListener(IPAddress.Loopback, 0);
         try {

--- a/Sources/Mailozaurr.Tests/SmtpRecipientProbeTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpRecipientProbeTests.cs
@@ -16,6 +16,23 @@ public class SmtpRecipientProbeTests {
         Assert.Equal(expectedHost, host);
     }
 
+    [Theory]
+    [InlineData("recipient@example.com\r\nDATA", "sender@example.com", "probe.local", "recipient must not contain CR or LF characters.")]
+    [InlineData("recipient@example.com", "sender@example.com\r\nDATA", "probe.local", "sender must not contain CR or LF characters.")]
+    [InlineData("recipient@example.com", "sender@example.com", "probe.local\r\nDATA", "heloHost must not contain CR or LF characters.")]
+    public void TestRecipient_RejectsCommandInjectionInput(string recipient, string sender, string heloHost, string expectedError) {
+        var result = Smtp.TestRecipient(
+            "127.0.0.1",
+            25,
+            recipient,
+            sender,
+            heloHost,
+            SecureSocketOptions.None);
+
+        Assert.False(result.Accepted);
+        Assert.Equal(expectedError, result.Error);
+    }
+
     [Fact]
     public async Task TestRecipient_StopsBeforeDataAndReportsAccepted() {
         var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/Sources/Mailozaurr.Tests/SmtpRecipientProbeTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpRecipientProbeTests.cs
@@ -1,0 +1,160 @@
+using MailKit.Security;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace Mailozaurr.Tests;
+
+public class SmtpRecipientProbeTests {
+    [Theory]
+    [InlineData("example.com", "example-com.mail.protection.outlook.com")]
+    [InlineData("Example.COM.", "example-com.mail.protection.outlook.com")]
+    [InlineData("mail.example.com", "mail-example-com.mail.protection.outlook.com")]
+    public void GetExchangeOnlineProtectionHost_BuildsDirectTarget(string domain, string expectedHost) {
+        var host = Smtp.GetExchangeOnlineProtectionHost(domain);
+
+        Assert.Equal(expectedHost, host);
+    }
+
+    [Fact]
+    public async Task TestRecipient_StopsBeforeDataAndReportsAccepted() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        try {
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var commands = new List<string>();
+
+            var serverTask = Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: false);
+                using var writer = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: false) {
+                    AutoFlush = true,
+                    NewLine = "\r\n"
+                };
+
+                await writer.WriteLineAsync("220 local.test ESMTP");
+                while (true) {
+                    var command = await reader.ReadLineAsync();
+                    if (command == null) {
+                        break;
+                    }
+
+                    commands.Add(command);
+                    if (command.StartsWith("EHLO ", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("250-local.test");
+                        await writer.WriteLineAsync("250 SIZE 1000000");
+                    } else if (command.StartsWith("MAIL FROM:", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("250 2.1.0 Sender OK");
+                    } else if (command.StartsWith("RCPT TO:", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("250 2.1.5 Recipient OK");
+                    } else if (command.Equals("RSET", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("250 2.0.0 Reset OK");
+                    } else if (command.Equals("QUIT", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("221 2.0.0 Bye");
+                        break;
+                    } else if (command.Equals("DATA", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("554 DATA is not expected in recipient probe");
+                    }
+                }
+            });
+
+            var result = Smtp.TestRecipient(
+                "127.0.0.1",
+                port,
+                "recipient@example.com",
+                "sender@example.com",
+                "probe.local",
+                SecureSocketOptions.None);
+
+            await serverTask;
+
+            Assert.True(result.Accepted);
+            Assert.Equal(250, result.MailFromStatusCode);
+            Assert.Equal(250, result.RecipientStatusCode);
+            Assert.False(result.StartTlsUsed);
+            Assert.Contains(commands, command => command.StartsWith("MAIL FROM:<sender@example.com>", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(commands, command => command.StartsWith("RCPT TO:<recipient@example.com>", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(commands, command => command.Equals("DATA", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task SendValidationMessage_SendsDataAndReturnsCorrelationFields() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        try {
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var commands = new List<string>();
+            var dataLines = new List<string>();
+
+            var serverTask = Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: false);
+                using var writer = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: false) {
+                    AutoFlush = true,
+                    NewLine = "\r\n"
+                };
+
+                await writer.WriteLineAsync("220 local.test ESMTP");
+                while (true) {
+                    var command = await reader.ReadLineAsync();
+                    if (command == null) {
+                        break;
+                    }
+
+                    commands.Add(command);
+                    if (command.StartsWith("EHLO ", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("250-local.test");
+                        await writer.WriteLineAsync("250 SIZE 1000000");
+                    } else if (command.StartsWith("MAIL FROM:", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("250 2.1.0 Sender OK");
+                    } else if (command.StartsWith("RCPT TO:", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("250 2.1.5 Recipient OK");
+                    } else if (command.Equals("DATA", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("354 End data with <CR><LF>.<CR><LF>");
+                        while (true) {
+                            var dataLine = await reader.ReadLineAsync();
+                            if (dataLine == null || dataLine == ".") {
+                                break;
+                            }
+
+                            dataLines.Add(dataLine);
+                        }
+
+                        await writer.WriteLineAsync("250 2.0.0 Queued");
+                    } else if (command.Equals("QUIT", StringComparison.OrdinalIgnoreCase)) {
+                        await writer.WriteLineAsync("221 2.0.0 Bye");
+                        break;
+                    }
+                }
+            });
+
+            var result = Smtp.SendValidationMessage(
+                "127.0.0.1",
+                port,
+                new SmtpValidationMessageRequest {
+                    Sender = "sender@example.com",
+                    Recipient = "recipient@example.com",
+                    HeloHost = "probe.local",
+                    TestId = "DD-Test-123"
+                },
+                SecureSocketOptions.None);
+
+            await serverTask;
+
+            Assert.True(result.Sent);
+            Assert.Equal("DD-Test-123", result.TestId);
+            Assert.Equal("Authorized SMTP validation DD-Test-123", result.Subject);
+            Assert.False(string.IsNullOrWhiteSpace(result.MessageId));
+            Assert.Contains(commands, command => command.Equals("DATA", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(dataLines, line => line.Contains("X-Mailozaurr-Validation-TestId: DD-Test-123", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(dataLines, line => line.Contains("TestId: DD-Test-123", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            listener.Stop();
+        }
+    }
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.ExchangeOnline.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.ExchangeOnline.cs
@@ -1,0 +1,25 @@
+using System.Globalization;
+
+namespace Mailozaurr;
+
+public partial class Smtp {
+    /// <summary>
+    /// Builds the direct Exchange Online Protection host name commonly used for an accepted domain.
+    /// </summary>
+    /// <param name="domain">Accepted email domain, for example <c>example.com</c>.</param>
+    /// <returns>The inferred Exchange Online Protection host name.</returns>
+    public static string GetExchangeOnlineProtectionHost(string domain) {
+        if (string.IsNullOrWhiteSpace(domain)) {
+            throw new ArgumentException("Domain is required.", nameof(domain));
+        }
+
+        var normalized = domain.Trim().TrimEnd('.').ToLowerInvariant();
+        if (normalized.Length == 0) {
+            throw new ArgumentException("Domain is required.", nameof(domain));
+        }
+
+        var idn = new IdnMapping();
+        var asciiDomain = idn.GetAscii(normalized);
+        return asciiDomain.Replace('.', '-') + ".mail.protection.outlook.com";
+    }
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.RecipientProbe.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.RecipientProbe.cs
@@ -40,6 +40,13 @@ public partial class Smtp {
             heloHost = "localhost";
         }
 
+        var commandValueError = ValidateSmtpCommandValue(nameof(heloHost), heloHost)
+            ?? ValidateSmtpCommandValue(nameof(sender), sender)
+            ?? ValidateSmtpCommandValue(nameof(recipient), recipient);
+        if (commandValueError != null) {
+            return new SmtpRecipientProbeInfo(server, port, heloHost, sender, recipient, null, false, null, null, null, null, false, commandValueError);
+        }
+
         string? banner = null;
         string? mailFromResponse = null;
         string? recipientResponse = null;
@@ -49,7 +56,14 @@ public partial class Smtp {
             using var tcpClient = new TcpClient();
             tcpClient.ReceiveTimeout = RecipientProbeTimeoutMilliseconds;
             tcpClient.SendTimeout = RecipientProbeTimeoutMilliseconds;
-            tcpClient.Connect(server, port);
+            var connectTask = tcpClient.ConnectAsync(server, port);
+            if (!connectTask.Wait(RecipientProbeTimeoutMilliseconds)) {
+                return new SmtpRecipientProbeInfo(server, port, heloHost, sender, recipient, null, false, null, null, null, null, false, "Connection timed out after " + RecipientProbeTimeoutMilliseconds + " ms.");
+            }
+
+            if (connectTask.IsFaulted) {
+                throw connectTask.Exception?.GetBaseException() ?? new SocketException();
+            }
 
             Stream stream = tcpClient.GetStream();
             var effectiveOptions = secureSocketOptions;
@@ -155,6 +169,16 @@ public partial class Smtp {
 
     private static void WriteSmtpCommand(StreamWriter writer, string command) {
         writer.WriteLine(command);
+    }
+
+    private static string? ValidateSmtpCommandValue(string name, string value) {
+        foreach (var character in value) {
+            if (character == '\r' || character == '\n') {
+                return name + " must not contain CR or LF characters.";
+            }
+        }
+
+        return null;
     }
 
     private static string? ReadSmtpResponse(StreamReader reader) {

--- a/Sources/Mailozaurr/Smtp/Smtp.RecipientProbe.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.RecipientProbe.cs
@@ -84,10 +84,11 @@ public partial class Smtp {
             };
 
             banner = ReadSmtpResponse(reader);
-            WriteSmtpCommand(writer, "EHLO " + heloHost);
-            var ehloResponse = ReadSmtpResponse(reader);
+            if (!TryGreetSmtpServer(writer, reader, heloHost, out var greetingResponse)) {
+                return new SmtpRecipientProbeInfo(server, port, heloHost, sender, recipient, banner, false, null, null, null, null, false, greetingResponse);
+            }
 
-            if (!startTlsUsed && ShouldUseStartTls(effectiveOptions, ehloResponse)) {
+            if (!startTlsUsed && ShouldUseStartTls(effectiveOptions, greetingResponse)) {
                 WriteSmtpCommand(writer, "STARTTLS");
                 var startTlsResponse = ReadSmtpResponse(reader);
                 var startTlsCode = ParseSmtpStatusCode(startTlsResponse);
@@ -103,8 +104,10 @@ public partial class Smtp {
                     NewLine = "\r\n"
                 };
 
-                WriteSmtpCommand(tlsWriter, "EHLO " + heloHost);
-                _ = ReadSmtpResponse(tlsReader);
+                if (!TryGreetSmtpServer(tlsWriter, tlsReader, heloHost, out var tlsGreetingResponse)) {
+                    return new SmtpRecipientProbeInfo(server, port, heloHost, sender, recipient, banner, true, null, null, null, null, false, tlsGreetingResponse);
+                }
+
                 return ProbeRecipientEnvelope(server, port, heloHost, sender, recipient, banner, startTlsUsed, tlsReader, tlsWriter);
             }
 
@@ -116,6 +119,19 @@ public partial class Smtp {
         } catch (Exception ex) {
             return new SmtpRecipientProbeInfo(server, port, heloHost, sender, recipient, banner, startTlsUsed, ParseSmtpStatusCode(mailFromResponse), mailFromResponse, ParseSmtpStatusCode(recipientResponse), recipientResponse, false, ex.Message);
         }
+    }
+
+    private static bool TryGreetSmtpServer(StreamWriter writer, StreamReader reader, string heloHost, out string? response) {
+        WriteSmtpCommand(writer, "EHLO " + heloHost);
+        response = ReadSmtpResponse(reader);
+        var statusCode = ParseSmtpStatusCode(response);
+        if (statusCode is >= 500 and < 600) {
+            WriteSmtpCommand(writer, "HELO " + heloHost);
+            response = ReadSmtpResponse(reader);
+            statusCode = ParseSmtpStatusCode(response);
+        }
+
+        return statusCode is >= 200 and < 400;
     }
 
     private static SmtpRecipientProbeInfo ProbeRecipientEnvelope(

--- a/Sources/Mailozaurr/Smtp/Smtp.RecipientProbe.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.RecipientProbe.cs
@@ -1,0 +1,191 @@
+using System.Net.Security;
+using System.Net.Sockets;
+
+namespace Mailozaurr;
+
+public partial class Smtp {
+    private const int RecipientProbeTimeoutMilliseconds = 10000;
+
+    /// <summary>
+    /// Tests whether an SMTP server accepts a recipient at envelope stage without sending message DATA.
+    /// </summary>
+    /// <param name="server">SMTP server name.</param>
+    /// <param name="port">Port number.</param>
+    /// <param name="recipient">Recipient address used in RCPT TO.</param>
+    /// <param name="sender">Envelope sender address used in MAIL FROM.</param>
+    /// <param name="heloHost">EHLO/HELO name sent by the probe.</param>
+    /// <param name="secureSocketOptions">Controls SSL/TLS usage.</param>
+    /// <param name="useSsl">Compatibility flag overriding <paramref name="secureSocketOptions"/> when set.</param>
+    public static SmtpRecipientProbeInfo TestRecipient(
+        string server,
+        int port,
+        string recipient,
+        string sender = "probe@example.com",
+        string heloHost = "localhost",
+        SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto,
+        bool useSsl = false) {
+        if (!SmtpValidation.TryValidateServer(server, port, out var validationError)) {
+            return new SmtpRecipientProbeInfo(server ?? string.Empty, port, heloHost, sender, recipient, null, false, null, null, null, null, false, validationError);
+        }
+
+        if (string.IsNullOrWhiteSpace(recipient)) {
+            return new SmtpRecipientProbeInfo(server, port, heloHost, sender, recipient ?? string.Empty, null, false, null, null, null, null, false, "Recipient address is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(sender)) {
+            return new SmtpRecipientProbeInfo(server, port, heloHost, sender ?? string.Empty, recipient, null, false, null, null, null, null, false, "Sender address is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(heloHost)) {
+            heloHost = "localhost";
+        }
+
+        string? banner = null;
+        string? mailFromResponse = null;
+        string? recipientResponse = null;
+        var startTlsUsed = false;
+
+        try {
+            using var tcpClient = new TcpClient();
+            tcpClient.ReceiveTimeout = RecipientProbeTimeoutMilliseconds;
+            tcpClient.SendTimeout = RecipientProbeTimeoutMilliseconds;
+            tcpClient.Connect(server, port);
+
+            Stream stream = tcpClient.GetStream();
+            var effectiveOptions = secureSocketOptions;
+            if (useSsl && effectiveOptions == SecureSocketOptions.Auto) {
+                effectiveOptions = SecureSocketOptions.StartTls;
+            }
+
+            if (effectiveOptions == SecureSocketOptions.SslOnConnect
+                || (effectiveOptions == SecureSocketOptions.Auto && port == 465)) {
+                stream = CreateAuthenticatedSslStream(stream, server);
+                startTlsUsed = true;
+            }
+
+            using var reader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: false);
+            using var writer = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: false) {
+                AutoFlush = true,
+                NewLine = "\r\n"
+            };
+
+            banner = ReadSmtpResponse(reader);
+            WriteSmtpCommand(writer, "EHLO " + heloHost);
+            var ehloResponse = ReadSmtpResponse(reader);
+
+            if (!startTlsUsed && ShouldUseStartTls(effectiveOptions, ehloResponse)) {
+                WriteSmtpCommand(writer, "STARTTLS");
+                var startTlsResponse = ReadSmtpResponse(reader);
+                var startTlsCode = ParseSmtpStatusCode(startTlsResponse);
+                if (startTlsCode is < 200 or >= 400) {
+                    return new SmtpRecipientProbeInfo(server, port, heloHost, sender, recipient, banner, false, null, null, null, null, false, startTlsResponse);
+                }
+
+                stream = CreateAuthenticatedSslStream(stream, server);
+                startTlsUsed = true;
+                using var tlsReader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: false);
+                using var tlsWriter = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: false) {
+                    AutoFlush = true,
+                    NewLine = "\r\n"
+                };
+
+                WriteSmtpCommand(tlsWriter, "EHLO " + heloHost);
+                _ = ReadSmtpResponse(tlsReader);
+                return ProbeRecipientEnvelope(server, port, heloHost, sender, recipient, banner, startTlsUsed, tlsReader, tlsWriter);
+            }
+
+            if (!startTlsUsed && effectiveOptions == SecureSocketOptions.StartTls) {
+                return new SmtpRecipientProbeInfo(server, port, heloHost, sender, recipient, banner, false, null, null, null, null, false, "STARTTLS was required but not advertised.");
+            }
+
+            return ProbeRecipientEnvelope(server, port, heloHost, sender, recipient, banner, startTlsUsed, reader, writer);
+        } catch (Exception ex) {
+            return new SmtpRecipientProbeInfo(server, port, heloHost, sender, recipient, banner, startTlsUsed, ParseSmtpStatusCode(mailFromResponse), mailFromResponse, ParseSmtpStatusCode(recipientResponse), recipientResponse, false, ex.Message);
+        }
+    }
+
+    private static SmtpRecipientProbeInfo ProbeRecipientEnvelope(
+        string server,
+        int port,
+        string heloHost,
+        string sender,
+        string recipient,
+        string? banner,
+        bool startTlsUsed,
+        StreamReader reader,
+        StreamWriter writer) {
+        WriteSmtpCommand(writer, "MAIL FROM:<" + sender + ">");
+        var mailFromResponse = ReadSmtpResponse(reader);
+        var mailFromCode = ParseSmtpStatusCode(mailFromResponse);
+
+        WriteSmtpCommand(writer, "RCPT TO:<" + recipient + ">");
+        var recipientResponse = ReadSmtpResponse(reader);
+        var recipientCode = ParseSmtpStatusCode(recipientResponse);
+
+        try {
+            WriteSmtpCommand(writer, "RSET");
+            _ = ReadSmtpResponse(reader);
+            WriteSmtpCommand(writer, "QUIT");
+            _ = ReadSmtpResponse(reader);
+        } catch (IOException) {
+            // The probe result is already known; best-effort cleanup should not hide it.
+        }
+
+        var accepted = mailFromCode is >= 200 and < 300
+            && (recipientCode is >= 200 and < 300 || recipientCode == 251 || recipientCode == 252);
+
+        return new SmtpRecipientProbeInfo(server, port, heloHost, sender, recipient, banner, startTlsUsed, mailFromCode, mailFromResponse, recipientCode, recipientResponse, accepted, null);
+    }
+
+    private static SslStream CreateAuthenticatedSslStream(Stream stream, string server) {
+        var sslStream = new SslStream(stream, false);
+        sslStream.AuthenticateAsClient(server);
+        return sslStream;
+    }
+
+    private static bool ShouldUseStartTls(SecureSocketOptions options, string? ehloResponse) {
+        if (options != SecureSocketOptions.Auto
+            && options != SecureSocketOptions.StartTls
+            && options != SecureSocketOptions.StartTlsWhenAvailable) {
+            return false;
+        }
+
+        return ehloResponse?.IndexOf("STARTTLS", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static void WriteSmtpCommand(StreamWriter writer, string command) {
+        writer.WriteLine(command);
+    }
+
+    private static string? ReadSmtpResponse(StreamReader reader) {
+        var lines = new List<string>();
+        var line = reader.ReadLine();
+        if (line == null) {
+            return null;
+        }
+
+        lines.Add(line);
+        var code = line.Length >= 3 ? line.Substring(0, 3) : string.Empty;
+        while (line.Length >= 4 && line[3] == '-') {
+            line = reader.ReadLine();
+            if (line == null) {
+                break;
+            }
+
+            lines.Add(line);
+            if (line.StartsWith(code + " ", StringComparison.Ordinal)) {
+                break;
+            }
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static int? ParseSmtpStatusCode(string? response) {
+        if (response != null && response.Length >= 3 && int.TryParse(response.Substring(0, 3), out var code)) {
+            return code;
+        }
+
+        return null;
+    }
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.ValidationMessage.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.ValidationMessage.cs
@@ -1,0 +1,78 @@
+using MimeKit.Utils;
+using System.Globalization;
+using System.Threading;
+
+namespace Mailozaurr;
+
+public partial class Smtp {
+    /// <summary>
+    /// Sends a neutral validation message through the specified SMTP server.
+    /// </summary>
+    /// <param name="server">SMTP server name.</param>
+    /// <param name="port">SMTP server port.</param>
+    /// <param name="request">Validation message settings.</param>
+    /// <param name="secureSocketOptions">Controls SSL/TLS usage.</param>
+    /// <param name="useSsl">Compatibility flag overriding <paramref name="secureSocketOptions"/> when set.</param>
+    public static SmtpValidationMessageInfo SendValidationMessage(
+        string server,
+        int port,
+        SmtpValidationMessageRequest request,
+        SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto,
+        bool useSsl = false) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var testId = string.IsNullOrWhiteSpace(request.TestId)
+            ? "Mailozaurr-SmtpValidation-" + DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture)
+            : request.TestId!.Trim();
+        var sender = request.Sender?.Trim() ?? string.Empty;
+        var recipient = request.Recipient?.Trim() ?? string.Empty;
+        var heloHost = string.IsNullOrWhiteSpace(request.HeloHost) ? "localhost" : request.HeloHost.Trim();
+        var subject = string.IsNullOrWhiteSpace(request.Subject)
+            ? "Authorized SMTP validation " + testId
+            : request.Subject!.Trim();
+        var body = string.IsNullOrWhiteSpace(request.Body)
+            ? BuildDefaultValidationBody(testId, sender, recipient, server, port)
+            : request.Body!;
+
+        var smtp = new Smtp();
+        var messageId = MimeUtils.GenerateMessageId(server);
+        SmtpResult result;
+        try {
+            smtp.LocalDomain = heloHost;
+            smtp.UseConnectionPool = false;
+            smtp.From = sender;
+            smtp.To = new object[] { recipient };
+            smtp.Subject = subject;
+            smtp.TextBody = body;
+            smtp.Priority = request.HighPriority ? MessagePriority.High : MessagePriority.Normal;
+            smtp.Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                ["X-Mailozaurr-Validation-TestId"] = testId,
+                ["X-Auto-Response-Suppress"] = "All"
+            };
+
+            result = smtp.Connect(server, port, secureSocketOptions, useSsl);
+            if (result.Status) {
+                smtp.CreateMessage(CancellationToken.None);
+                smtp.Message.MessageId = messageId;
+                result = smtp.Send();
+            }
+        } finally {
+            smtp.Dispose();
+        }
+
+        result.MessageId ??= messageId;
+        return new SmtpValidationMessageInfo(server, port, testId, sender, recipient, heloHost, subject, result.MessageId, result);
+    }
+
+    private static string BuildDefaultValidationBody(string testId, string sender, string recipient, string server, int port) {
+        return "Authorized SMTP mail-flow validation test." + Environment.NewLine +
+            "TestId: " + testId + Environment.NewLine +
+            "Header From and recipient are intentionally set to validate SPF/DKIM/DMARC and gateway handling." + Environment.NewLine +
+            "From: " + sender + Environment.NewLine +
+            "To: " + recipient + Environment.NewLine +
+            "Direct target: " + server + ":" + port.ToString(CultureInfo.InvariantCulture) + Environment.NewLine +
+            "No action is required by the recipient.";
+    }
+}

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -342,6 +342,50 @@ public partial class Smtp {
     /// <param name="secureSocketOptions">Controls SSL/TLS usage.</param>
     /// <param name="useSsl">Compatibility flag overriding <paramref name="secureSocketOptions"/> when set.</param>
     public static SmtpConnectionInfo TestConnection(string server, int port, SecureSocketOptions secureSocketOptions = SecureSocketOptions.Auto, bool useSsl = false) {
+        return TestConnection(server, port, secureSocketOptions, useSsl, null, "probe@example.com", "localhost");
+    }
+
+    /// <summary>
+    /// Connects to the specified SMTP server and optionally tests recipient acceptance before DATA.
+    /// </summary>
+    /// <param name="server">SMTP server name.</param>
+    /// <param name="port">Port number.</param>
+    /// <param name="secureSocketOptions">Controls SSL/TLS usage.</param>
+    /// <param name="useSsl">Compatibility flag overriding <paramref name="secureSocketOptions"/> when set.</param>
+    /// <param name="recipient">Optional recipient address used in RCPT TO.</param>
+    /// <param name="sender">Envelope sender address used in MAIL FROM when <paramref name="recipient"/> is supplied.</param>
+    /// <param name="heloHost">EHLO/HELO name sent during the recipient probe.</param>
+    public static SmtpConnectionInfo TestConnection(
+        string server,
+        int port,
+        SecureSocketOptions secureSocketOptions,
+        bool useSsl,
+        string? recipient,
+        string sender = "probe@example.com",
+        string heloHost = "localhost") {
+        return TestConnection(server, port, secureSocketOptions, useSsl, recipient, sender, heloHost, null);
+    }
+
+    /// <summary>
+    /// Connects to the specified SMTP server and optionally tests recipient acceptance or sends a validation message.
+    /// </summary>
+    /// <param name="server">SMTP server name.</param>
+    /// <param name="port">Port number.</param>
+    /// <param name="secureSocketOptions">Controls SSL/TLS usage.</param>
+    /// <param name="useSsl">Compatibility flag overriding <paramref name="secureSocketOptions"/> when set.</param>
+    /// <param name="recipient">Optional recipient address used in RCPT TO.</param>
+    /// <param name="sender">Envelope sender address used in MAIL FROM when <paramref name="recipient"/> is supplied.</param>
+    /// <param name="heloHost">EHLO/HELO name sent during the recipient probe.</param>
+    /// <param name="validationMessage">Optional validation message request.</param>
+    public static SmtpConnectionInfo TestConnection(
+        string server,
+        int port,
+        SecureSocketOptions secureSocketOptions,
+        bool useSsl,
+        string? recipient,
+        string sender,
+        string heloHost,
+        SmtpValidationMessageRequest? validationMessage) {
         var logging = new LoggingConfigurator();
         logging.ConfigureLogging(null, false, true, false, false);
 
@@ -376,10 +420,21 @@ public partial class Smtp {
             persistent = false;
         }
 
-        var info = new SmtpConnectionInfo(server, port, banner, software, smtp.Client.GetCapabilitiesSnapshot(), persistent);
+        var capabilities = smtp.Client.GetCapabilitiesSnapshot();
         smtp.Disconnect();
         smtp.Dispose();
-        return info;
+
+        SmtpRecipientProbeInfo? recipientProbe = null;
+        if (!string.IsNullOrWhiteSpace(recipient)) {
+            recipientProbe = TestRecipient(server, port, recipient!, sender, heloHost, secureSocketOptions, useSsl);
+        }
+
+        SmtpValidationMessageInfo? validationMessageInfo = null;
+        if (validationMessage != null) {
+            validationMessageInfo = SendValidationMessage(server, port, validationMessage, secureSocketOptions, useSsl);
+        }
+
+        return new SmtpConnectionInfo(server, port, banner, software, capabilities, persistent, recipientProbe, validationMessageInfo);
     }
 
     /// <summary>

--- a/Sources/Mailozaurr/Smtp/SmtpConnectionInfo.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpConnectionInfo.cs
@@ -18,6 +18,10 @@ public sealed class SmtpConnectionInfo {
     public SmtpCapabilities Capabilities { get; }
     /// <summary>Indicates whether the server kept the connection open after a NOOP.</summary>
     public bool Persistent { get; }
+    /// <summary>Optional recipient probe result when RCPT validation was requested.</summary>
+    public SmtpRecipientProbeInfo? RecipientProbe { get; }
+    /// <summary>Optional validation message result when a deliberate test send was requested.</summary>
+    public SmtpValidationMessageInfo? ValidationMessage { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SmtpConnectionInfo"/> class.
@@ -29,5 +33,32 @@ public sealed class SmtpConnectionInfo {
         Software = software;
         Capabilities = capabilities;
         Persistent = persistent;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmtpConnectionInfo"/> class.
+    /// </summary>
+    public SmtpConnectionInfo(string server, int port, string? banner, string? software, SmtpCapabilities capabilities, bool persistent, SmtpRecipientProbeInfo? recipientProbe) {
+        Server = server;
+        Port = port;
+        Banner = banner;
+        Software = software;
+        Capabilities = capabilities;
+        Persistent = persistent;
+        RecipientProbe = recipientProbe;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmtpConnectionInfo"/> class.
+    /// </summary>
+    public SmtpConnectionInfo(string server, int port, string? banner, string? software, SmtpCapabilities capabilities, bool persistent, SmtpRecipientProbeInfo? recipientProbe, SmtpValidationMessageInfo? validationMessage) {
+        Server = server;
+        Port = port;
+        Banner = banner;
+        Software = software;
+        Capabilities = capabilities;
+        Persistent = persistent;
+        RecipientProbe = recipientProbe;
+        ValidationMessage = validationMessage;
     }
 }

--- a/Sources/Mailozaurr/Smtp/SmtpRecipientProbeInfo.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpRecipientProbeInfo.cs
@@ -1,0 +1,65 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents the result of an SMTP envelope recipient probe that stops before DATA.
+/// </summary>
+public sealed class SmtpRecipientProbeInfo {
+    /// <summary>SMTP server that was tested.</summary>
+    public string Server { get; }
+    /// <summary>TCP port used during the probe.</summary>
+    public int Port { get; }
+    /// <summary>EHLO/HELO name sent by the probe.</summary>
+    public string HeloHost { get; }
+    /// <summary>Envelope sender used in the MAIL FROM command.</summary>
+    public string Sender { get; }
+    /// <summary>Recipient tested with the RCPT TO command.</summary>
+    public string Recipient { get; }
+    /// <summary>Initial SMTP banner returned by the server.</summary>
+    public string? Banner { get; }
+    /// <summary>Indicates whether STARTTLS was negotiated before the envelope probe.</summary>
+    public bool StartTlsUsed { get; }
+    /// <summary>Status code returned for MAIL FROM.</summary>
+    public int? MailFromStatusCode { get; }
+    /// <summary>Response returned for MAIL FROM.</summary>
+    public string? MailFromResponse { get; }
+    /// <summary>Status code returned for RCPT TO.</summary>
+    public int? RecipientStatusCode { get; }
+    /// <summary>Response returned for RCPT TO.</summary>
+    public string? RecipientResponse { get; }
+    /// <summary>Indicates whether the server accepted the tested recipient at SMTP envelope stage.</summary>
+    public bool Accepted { get; }
+    /// <summary>Error captured when the probe could not complete.</summary>
+    public string? Error { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmtpRecipientProbeInfo"/> class.
+    /// </summary>
+    public SmtpRecipientProbeInfo(
+        string server,
+        int port,
+        string heloHost,
+        string sender,
+        string recipient,
+        string? banner,
+        bool startTlsUsed,
+        int? mailFromStatusCode,
+        string? mailFromResponse,
+        int? recipientStatusCode,
+        string? recipientResponse,
+        bool accepted,
+        string? error) {
+        Server = server;
+        Port = port;
+        HeloHost = heloHost;
+        Sender = sender;
+        Recipient = recipient;
+        Banner = banner;
+        StartTlsUsed = startTlsUsed;
+        MailFromStatusCode = mailFromStatusCode;
+        MailFromResponse = mailFromResponse;
+        RecipientStatusCode = recipientStatusCode;
+        RecipientResponse = recipientResponse;
+        Accepted = accepted;
+        Error = error;
+    }
+}

--- a/Sources/Mailozaurr/Smtp/SmtpValidationMessageInfo.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpValidationMessageInfo.cs
@@ -1,0 +1,53 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Represents the outcome of a deliberate SMTP validation message send.
+/// </summary>
+public sealed class SmtpValidationMessageInfo {
+    /// <summary>SMTP server used for the validation send.</summary>
+    public string Server { get; }
+    /// <summary>TCP port used for the validation send.</summary>
+    public int Port { get; }
+    /// <summary>Generated or supplied validation identifier.</summary>
+    public string TestId { get; }
+    /// <summary>Envelope and header sender used for the validation message.</summary>
+    public string Sender { get; }
+    /// <summary>Recipient used for the validation message.</summary>
+    public string Recipient { get; }
+    /// <summary>EHLO/HELO name used by the SMTP client.</summary>
+    public string HeloHost { get; }
+    /// <summary>Subject used for the validation message.</summary>
+    public string Subject { get; }
+    /// <summary>Message-ID used for the validation message.</summary>
+    public string? MessageId { get; }
+    /// <summary>Underlying SMTP send result.</summary>
+    public SmtpResult Result { get; }
+    /// <summary>Indicates whether the validation message was accepted by the SMTP server.</summary>
+    public bool Sent => Result.Status;
+    /// <summary>Error captured when the validation send failed.</summary>
+    public string? Error => Result.Error;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmtpValidationMessageInfo"/> class.
+    /// </summary>
+    public SmtpValidationMessageInfo(
+        string server,
+        int port,
+        string testId,
+        string sender,
+        string recipient,
+        string heloHost,
+        string subject,
+        string? messageId,
+        SmtpResult result) {
+        Server = server;
+        Port = port;
+        TestId = testId;
+        Sender = sender;
+        Recipient = recipient;
+        HeloHost = heloHost;
+        Subject = subject;
+        MessageId = messageId;
+        Result = result;
+    }
+}

--- a/Sources/Mailozaurr/Smtp/SmtpValidationMessageRequest.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpValidationMessageRequest.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Describes a deliberate SMTP validation message sent during mail-flow diagnostics.
+/// </summary>
+public sealed class SmtpValidationMessageRequest {
+    /// <summary>Envelope and header sender used for the validation message.</summary>
+    public string Sender { get; set; } = "probe@example.com";
+    /// <summary>Recipient that receives the validation message.</summary>
+    public string Recipient { get; set; } = string.Empty;
+    /// <summary>EHLO/HELO name used by the SMTP client.</summary>
+    public string HeloHost { get; set; } = "localhost";
+    /// <summary>Optional stable test identifier. A value is generated when omitted.</summary>
+    public string? TestId { get; set; }
+    /// <summary>Optional validation subject. A neutral subject is generated when omitted.</summary>
+    public string? Subject { get; set; }
+    /// <summary>Optional validation body. A neutral body is generated when omitted.</summary>
+    public string? Body { get; set; }
+    /// <summary>Marks the validation message as high priority.</summary>
+    public bool HighPriority { get; set; }
+}


### PR DESCRIPTION
## Summary
- add recipient-stage SMTP probing that stops before DATA
- add guarded validation-message sending with test IDs and correlation headers
- add Exchange Online direct-target inference via `-ExchangeOnlineDirect` / `-Domain`

## Tests
- `dotnet test Sources\Mailozaurr.Tests\Mailozaurr.Tests.csproj --framework net8.0 --filter FullyQualifiedName~SmtpRecipientProbeTests --no-restore`
- `dotnet test Sources\Mailozaurr.Tests\Mailozaurr.Tests.csproj --framework net472 --filter FullyQualifiedName~SmtpRecipientProbeTests --no-restore`
- PowerShell smoke: imported built module and confirmed `Test-SmtpConnection` exposes `-ExchangeOnlineDirect` and `-Domain`