### PR TITLE
Harden JSON storage and add orphan-secret maintenance

### DIFF
--- a/Docs/Configuration-and-Usage.md
+++ b/Docs/Configuration-and-Usage.md
@@ -191,6 +191,22 @@ Main command groups:
 
 Most commands support `--json`, which is the preferred mode for automation.
 
+### Orphaned profile secrets
+
+Inspect the secret store after profiles have been moved, restored, or edited outside the application:
+
+```powershell
+mailozaurr profile inspect-orphan-secrets --json
+```
+
+The report contains structured secret sets whose profile no longer exists. It also lists ambiguous legacy keys separately without exposing their protected values. Cleanup removes only the structured orphan sets; ambiguous legacy keys are retained because Mailozaurr cannot prove where the profile identifier ends and the secret name begins.
+
+The built-in file stores coordinate cleanup with profile writes so a profile created in another process cannot lose its secrets. Applications that replace the stores should implement `IMailProfileMaintenanceCoordinator` together with `IMailProfileSecretMaintenanceStore`, or inject an `IMailProfileSecretMaintenanceService` that provides equivalent coordination.
+
+```powershell
+mailozaurr profile cleanup-orphan-secrets --json
+```
+
 ## Common CLI recipes
 
 ### Generic IMAP profile

--- a/Sources/Mailozaurr.Application/FileMailProfileStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailProfileStore.cs
@@ -3,7 +3,7 @@ namespace Mailozaurr.Application;
 /// <summary>
 /// Stores profiles in a JSON document on disk.
 /// </summary>
-public sealed class FileMailProfileStore : IMailProfileStore {
+public sealed class FileMailProfileStore : IMailProfileStore, IMailProfileMaintenanceCoordinator {
     private readonly JsonFileDocumentStore<MailProfileStoreDocument> _store;
     /// <summary>
     /// Creates a new store using the provided options.
@@ -70,6 +70,21 @@ public sealed class FileMailProfileStore : IMailProfileStore {
 
         return _store.RemoveAsync(document => document.Profiles.RemoveAll(p =>
             string.Equals(p.Id, profileId, StringComparison.OrdinalIgnoreCase)) > 0, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<TResult> ExecuteWithStableProfileIdsAsync<TResult>(
+        Func<IReadOnlyCollection<string>, CancellationToken, Task<TResult>> operation,
+        CancellationToken cancellationToken = default) {
+        if (operation == null) throw new ArgumentNullException(nameof(operation));
+        return _store.ExecuteUnderWriterLockAsync(document => {
+            string[] profileIds = document.Profiles
+                .Where(profile => !string.IsNullOrWhiteSpace(profile.Id))
+                .Select(profile => profile.Id.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            return operation(profileIds, cancellationToken);
+        }, cancellationToken);
     }
 
     private static void ValidateProfile(MailProfile? profile) {

--- a/Sources/Mailozaurr.Application/FileMailSecretStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailSecretStore.cs
@@ -6,7 +6,8 @@ namespace Mailozaurr.Application;
 public sealed class FileMailSecretStore :
     IMailSecretStore,
     IMailProfileSecretContextCleanup,
-    IMailProfileSecretSnapshotStore {
+    IMailProfileSecretSnapshotStore,
+    IMailProfileSecretMaintenanceStore {
     private readonly JsonFileDocumentStore<MailSecretStoreDocument> _store;
     private readonly ICredentialProtector _protector;
     /// <summary>
@@ -199,6 +200,75 @@ public sealed class FileMailSecretStore :
 
             RestoreLegacySecrets(document, fileSnapshot.LegacySecrets);
         }, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<MailProfileSecretMaintenanceResult> InspectOrphanedSecretsAsync(
+        IReadOnlyCollection<string> knownProfileIds,
+        CancellationToken cancellationToken = default) {
+        HashSet<string> knownProfiles = NormalizeKnownProfileIds(knownProfileIds);
+        return _store.ReadAsync(
+            document => InspectOrphanedSecrets(document, knownProfiles, remove: false, out _),
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<MailProfileSecretMaintenanceResult> RemoveOrphanedSecretsAsync(
+        IReadOnlyCollection<string> knownProfileIds,
+        CancellationToken cancellationToken = default) {
+        HashSet<string> knownProfiles = NormalizeKnownProfileIds(knownProfileIds);
+        MailProfileSecretMaintenanceResult? result = null;
+        await _store.RemoveAsync(document => {
+            result = InspectOrphanedSecrets(document, knownProfiles, remove: true, out bool changed);
+            return changed;
+        }, cancellationToken).ConfigureAwait(false);
+        return result!;
+    }
+
+    private static HashSet<string> NormalizeKnownProfileIds(IReadOnlyCollection<string> knownProfileIds) {
+        if (knownProfileIds == null) throw new ArgumentNullException(nameof(knownProfileIds));
+        return new HashSet<string>(
+            knownProfileIds
+                .Where(profileId => !string.IsNullOrWhiteSpace(profileId))
+                .Select(profileId => profileId.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static MailProfileSecretMaintenanceResult InspectOrphanedSecrets(
+        MailSecretStoreDocument document,
+        HashSet<string> knownProfileIds,
+        bool remove,
+        out bool changed) {
+        var result = new MailProfileSecretMaintenanceResult { Succeeded = true };
+        changed = false;
+
+        foreach (string profileId in document.ProfileSecrets.Keys.ToArray()) {
+            if (knownProfileIds.Contains(profileId)) continue;
+
+            Dictionary<string, string>? secrets = document.ProfileSecrets[profileId];
+            if (secrets != null && secrets.Count > 0) {
+                result.OrphanedProfileIds.Add(profileId);
+                if (remove) {
+                    result.RemovedProfileIds.Add(profileId);
+                }
+            }
+            if (remove) {
+                changed = document.ProfileSecrets.Remove(profileId) || changed;
+            }
+        }
+
+        if (document.Secrets != null) {
+            foreach (string legacyKey in document.Secrets.Keys) {
+                if (ResolveLegacyOwner(legacyKey, knownProfileIds) == null) {
+                    result.UnresolvedLegacyKeys.Add(legacyKey);
+                }
+            }
+        }
+
+        result.OrphanedProfileIds.Sort(StringComparer.OrdinalIgnoreCase);
+        result.RemovedProfileIds.Sort(StringComparer.OrdinalIgnoreCase);
+        result.UnresolvedLegacyKeys.Sort(StringComparer.OrdinalIgnoreCase);
+        return result;
     }
 
     private static void NormalizeDocument(MailSecretStoreDocument document) {

--- a/Sources/Mailozaurr.Application/IMailProfileSecretMaintenanceService.cs
+++ b/Sources/Mailozaurr.Application/IMailProfileSecretMaintenanceService.cs
@@ -1,0 +1,16 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Inspects and cleans profile-scoped secrets whose owning profiles no longer exist.
+/// </summary>
+public interface IMailProfileSecretMaintenanceService {
+    /// <summary>Reports profile-scoped secrets whose owning profiles no longer exist.</summary>
+    Task<MailProfileSecretMaintenanceResult> InspectOrphanedSecretsAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes structured orphan secret sets while retaining ambiguous legacy keys for explicit review.
+    /// </summary>
+    Task<MailProfileSecretMaintenanceResult> RemoveOrphanedSecretsAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailProfileStore.cs
+++ b/Sources/Mailozaurr.Application/IMailProfileStore.cs
@@ -16,3 +16,15 @@ public interface IMailProfileStore {
     /// <summary>Removes a profile by identifier.</summary>
     Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Coordinates maintenance that must observe a profile inventory which cannot change during the operation.
+/// </summary>
+public interface IMailProfileMaintenanceCoordinator {
+    /// <summary>
+    /// Invokes an operation while profile saves and removals are blocked, including across processes when the store is shared.
+    /// </summary>
+    Task<TResult> ExecuteWithStableProfileIdsAsync<TResult>(
+        Func<IReadOnlyCollection<string>, CancellationToken, Task<TResult>> operation,
+        CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/IMailSecretStore.cs
+++ b/Sources/Mailozaurr.Application/IMailSecretStore.cs
@@ -58,3 +58,22 @@ public interface IMailProfileSecretSnapshotStore {
         IMailProfileSecretSnapshot snapshot,
         CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Inspects and removes profile-scoped secret sets whose owning profiles no longer exist.
+/// </summary>
+public interface IMailProfileSecretMaintenanceStore {
+    /// <summary>
+    /// Reports structured orphan secret sets and ambiguous legacy keys without decrypting secret values.
+    /// </summary>
+    Task<MailProfileSecretMaintenanceResult> InspectOrphanedSecretsAsync(
+        IReadOnlyCollection<string> knownProfileIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes structured orphan secret sets while retaining ambiguous legacy keys that cannot be assigned safely.
+    /// </summary>
+    Task<MailProfileSecretMaintenanceResult> RemoveOrphanedSecretsAsync(
+        IReadOnlyCollection<string> knownProfileIds,
+        CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr.Application/JsonFileDocumentStore.cs
+++ b/Sources/Mailozaurr.Application/JsonFileDocumentStore.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 
@@ -5,26 +7,34 @@ namespace Mailozaurr.Application;
 
 /// <summary>Coordinates typed whole-document JSON persistence across instances and processes.</summary>
 internal sealed class JsonFileDocumentStore<TDocument> where TDocument : class {
+    private static readonly TimeSpan DefaultLockTimeout = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan LockRetryDelay = TimeSpan.FromMilliseconds(25);
     private readonly string _filePath;
     private readonly string _invalidPathMessage;
     private readonly string _lockPath;
+    private readonly TimeSpan _lockTimeout;
     private readonly JsonTypeInfo<TDocument> _jsonTypeInfo;
     private readonly Func<TDocument> _createDocument;
     private readonly Action<TDocument>? _normalizeDocument;
-    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly SemaphoreSlim _writerGate;
 
     internal JsonFileDocumentStore(
         string filePath,
         string invalidPathMessage,
         JsonTypeInfo<TDocument> jsonTypeInfo,
         Func<TDocument> createDocument,
-        Action<TDocument>? normalizeDocument = null) {
+        Action<TDocument>? normalizeDocument = null,
+        TimeSpan? lockTimeout = null) {
         _filePath = Path.GetFullPath(filePath ?? throw new ArgumentNullException(nameof(filePath)));
         _invalidPathMessage = invalidPathMessage ?? throw new ArgumentNullException(nameof(invalidPathMessage));
         _jsonTypeInfo = jsonTypeInfo ?? throw new ArgumentNullException(nameof(jsonTypeInfo));
         _createDocument = createDocument ?? throw new ArgumentNullException(nameof(createDocument));
         _normalizeDocument = normalizeDocument;
+        _lockTimeout = lockTimeout ?? DefaultLockTimeout;
+        if (_lockTimeout <= TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException(nameof(lockTimeout), "A positive lock timeout is required.");
+        }
+        _writerGate = JsonFileDocumentStoreCoordinator.GetWriterGate(_filePath);
 
         string? directory = Path.GetDirectoryName(_filePath);
         if (string.IsNullOrWhiteSpace(directory)) {
@@ -53,12 +63,20 @@ internal sealed class JsonFileDocumentStore<TDocument> where TDocument : class {
         return ExecuteConditionalUpdateAsync(remove, cancellationToken);
     }
 
+    internal Task<TResult> ExecuteUnderWriterLockAsync<TResult>(
+        Func<TDocument, Task<TResult>> operation,
+        CancellationToken cancellationToken = default) {
+        if (operation == null) throw new ArgumentNullException(nameof(operation));
+        return ExecuteLockedReadAsync(operation, cancellationToken);
+    }
+
     private async Task<bool> ExecuteConditionalUpdateAsync(
         Func<TDocument, bool> update,
         CancellationToken cancellationToken) {
-        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var elapsed = Stopwatch.StartNew();
+        await AcquireWriterGateAsync(elapsed, cancellationToken).ConfigureAwait(false);
         try {
-            using FileStream fileLock = await AcquireFileLockAsync(cancellationToken).ConfigureAwait(false);
+            using FileStream fileLock = await AcquireFileLockAsync(elapsed, cancellationToken).ConfigureAwait(false);
             TDocument document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
             bool changed = update(document);
             if (changed) {
@@ -66,53 +84,86 @@ internal sealed class JsonFileDocumentStore<TDocument> where TDocument : class {
             }
             return changed;
         } finally {
-            _gate.Release();
+            _writerGate.Release();
         }
     }
 
     private async Task<TResult> ExecuteReadAsync<TResult>(
         Func<TDocument, TResult> read,
         CancellationToken cancellationToken) {
-        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        TDocument document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
+        return read(document);
+    }
+
+    private async Task<TResult> ExecuteLockedReadAsync<TResult>(
+        Func<TDocument, Task<TResult>> operation,
+        CancellationToken cancellationToken) {
+        var elapsed = Stopwatch.StartNew();
+        await AcquireWriterGateAsync(elapsed, cancellationToken).ConfigureAwait(false);
         try {
+            using FileStream fileLock = await AcquireFileLockAsync(elapsed, cancellationToken).ConfigureAwait(false);
             TDocument document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
-            return read(document);
+            return await operation(document).ConfigureAwait(false);
         } finally {
-            _gate.Release();
+            _writerGate.Release();
         }
     }
 
     private async Task<TResult> ExecuteUpdateAsync<TResult>(
         Func<TDocument, Task<TResult>> update,
         CancellationToken cancellationToken) {
-        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var elapsed = Stopwatch.StartNew();
+        await AcquireWriterGateAsync(elapsed, cancellationToken).ConfigureAwait(false);
         try {
-            using FileStream fileLock = await AcquireFileLockAsync(cancellationToken).ConfigureAwait(false);
+            using FileStream fileLock = await AcquireFileLockAsync(elapsed, cancellationToken).ConfigureAwait(false);
             TDocument document = await LoadDocumentAsync(cancellationToken).ConfigureAwait(false);
             TResult result = await update(document).ConfigureAwait(false);
             await SaveDocumentAsync(document, cancellationToken).ConfigureAwait(false);
             return result;
         } finally {
-            _gate.Release();
+            _writerGate.Release();
         }
     }
 
-    private async Task<FileStream> AcquireFileLockAsync(CancellationToken cancellationToken) {
+    private async Task AcquireWriterGateAsync(Stopwatch elapsed, CancellationToken cancellationToken) {
+        TimeSpan remaining = GetRemainingLockTime(elapsed, lastError: null);
+        bool acquired = await _writerGate.WaitAsync(remaining, cancellationToken).ConfigureAwait(false);
+        if (!acquired) {
+            throw CreateLockTimeoutException(lastError: null);
+        }
+    }
+
+    private async Task<FileStream> AcquireFileLockAsync(Stopwatch elapsed, CancellationToken cancellationToken) {
         string? lockDirectory = Path.GetDirectoryName(_lockPath);
         if (string.IsNullOrWhiteSpace(lockDirectory)) {
             throw new InvalidOperationException(_invalidPathMessage);
         }
         Directory.CreateDirectory(lockDirectory);
 
+        IOException? lastError = null;
         while (true) {
             cancellationToken.ThrowIfCancellationRequested();
             try {
                 return new FileStream(_lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
-            } catch (IOException) {
-                await Task.Delay(LockRetryDelay, cancellationToken).ConfigureAwait(false);
+            } catch (IOException ex) {
+                lastError = ex;
+                TimeSpan remaining = GetRemainingLockTime(elapsed, lastError);
+                TimeSpan delay = remaining < LockRetryDelay ? remaining : LockRetryDelay;
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
             }
         }
     }
+
+    private TimeSpan GetRemainingLockTime(Stopwatch elapsed, IOException? lastError) {
+        TimeSpan remaining = _lockTimeout - elapsed.Elapsed;
+        if (remaining <= TimeSpan.Zero) {
+            throw CreateLockTimeoutException(lastError);
+        }
+        return remaining;
+    }
+
+    private TimeoutException CreateLockTimeoutException(IOException? lastError) =>
+        new($"Timed out after {_lockTimeout.TotalSeconds:0.###} seconds waiting to update '{_filePath}'.", lastError);
 
     private async Task<TDocument> LoadDocumentAsync(CancellationToken cancellationToken) {
         TDocument document;
@@ -138,4 +189,15 @@ internal sealed class JsonFileDocumentStore<TDocument> where TDocument : class {
             _invalidPathMessage,
             (stream, token) => JsonSerializer.SerializeAsync(stream, document, _jsonTypeInfo, token),
             cancellationToken);
+}
+
+/// <summary>Shares writer gates for canonical document paths across store instances in this process.</summary>
+internal static class JsonFileDocumentStoreCoordinator {
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> WriterGates =
+        new(Path.DirectorySeparatorChar == '\\'
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal);
+
+    internal static SemaphoreSlim GetWriterGate(string canonicalPath) =>
+        WriterGates.GetOrAdd(canonicalPath, static _ => new SemaphoreSlim(1, 1));
 }

--- a/Sources/Mailozaurr.Application/MailApplication.cs
+++ b/Sources/Mailozaurr.Application/MailApplication.cs
@@ -12,6 +12,7 @@ public sealed class MailApplication {
         IMailProfileOverviewService profileOverview,
         IMailProfileConnectionService profileConnections,
         IMailProfileSecretService profileSecrets,
+        IMailProfileSecretMaintenanceService profileSecretMaintenance,
         IMailProfileBootstrapService profileBootstrap,
         IMailProfileAuthService profileAuth,
         IMailFolderAliasService folderAliases,
@@ -36,6 +37,7 @@ public sealed class MailApplication {
         ProfileOverview = profileOverview;
         ProfileConnections = profileConnections;
         ProfileSecrets = profileSecrets;
+        ProfileSecretMaintenance = profileSecretMaintenance;
         ProfileBootstrap = profileBootstrap;
         ProfileAuth = profileAuth;
         FolderAliases = folderAliases;
@@ -75,6 +77,9 @@ public sealed class MailApplication {
 
     /// <summary>Profile secret lifecycle service.</summary>
     public IMailProfileSecretService ProfileSecrets { get; }
+
+    /// <summary>Orphaned profile-secret inspection and cleanup service.</summary>
+    public IMailProfileSecretMaintenanceService ProfileSecretMaintenance { get; }
 
     /// <summary>Higher-level profile bootstrap workflows.</summary>
     public IMailProfileBootstrapService ProfileBootstrap { get; }

--- a/Sources/Mailozaurr.Application/MailApplicationBuilder.cs
+++ b/Sources/Mailozaurr.Application/MailApplicationBuilder.cs
@@ -16,6 +16,7 @@ public sealed class MailApplicationBuilder {
     private IMailProfileOverviewService? _profileOverviewService;
     private IMailProfileConnectionService? _profileConnectionService;
     private IMailProfileSecretService? _profileSecretService;
+    private IMailProfileSecretMaintenanceService? _profileSecretMaintenanceService;
     private IMailProfileBootstrapService? _profileBootstrapService;
     private IMailProfileAuthService? _profileAuthService;
     private IMailFolderAliasService? _folderAliasService;
@@ -102,6 +103,14 @@ public sealed class MailApplicationBuilder {
     /// <summary>Uses an explicit profile secret service.</summary>
     public MailApplicationBuilder UseProfileSecretService(IMailProfileSecretService profileSecretService) {
         _profileSecretService = profileSecretService ?? throw new ArgumentNullException(nameof(profileSecretService));
+        return this;
+    }
+
+    /// <summary>Uses an explicit orphaned profile-secret maintenance service.</summary>
+    public MailApplicationBuilder UseProfileSecretMaintenanceService(
+        IMailProfileSecretMaintenanceService profileSecretMaintenanceService) {
+        _profileSecretMaintenanceService = profileSecretMaintenanceService ??
+            throw new ArgumentNullException(nameof(profileSecretMaintenanceService));
         return this;
     }
 
@@ -262,6 +271,8 @@ public sealed class MailApplicationBuilder {
         var gmailSessionFactory = _gmailSessionFactory ?? new GmailSessionFactory(secretStore);
         var smtpSessionFactory = _smtpSessionFactory ?? new SmtpSessionFactory(secretStore);
         var profileSecretService = _profileSecretService ?? new MailProfileSecretService(profileStore, secretStore);
+        var profileSecretMaintenanceService = _profileSecretMaintenanceService ??
+            new MailProfileSecretMaintenanceService(profileStore, secretStore);
         var draftMimeMessageFactory = _draftMimeMessageFactory ?? new DraftMimeMessageFactory();
         var pendingMessageRepository = _pendingMessageRepository ?? new FilePendingMessageRepository(_options.PendingMessageStore);
 
@@ -335,6 +346,7 @@ public sealed class MailApplicationBuilder {
             profileOverviewService,
             profileConnectionService,
             profileSecretService,
+            profileSecretMaintenanceService,
             profileBootstrapService,
             profileAuthService,
             folderAliasService,

--- a/Sources/Mailozaurr.Application/MailProfileSecretMaintenanceResult.cs
+++ b/Sources/Mailozaurr.Application/MailProfileSecretMaintenanceResult.cs
@@ -1,0 +1,23 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Reports profile-scoped secret sets that no longer have a profile owner and legacy keys that cannot be classified safely.
+/// </summary>
+public sealed class MailProfileSecretMaintenanceResult : OperationResult {
+    /// <summary>Profile identifiers whose structured secret sets had no matching saved profile.</summary>
+    public List<string> OrphanedProfileIds { get; } = new();
+
+    /// <summary>Orphaned profile identifiers whose structured secret sets were removed.</summary>
+    public List<string> RemovedProfileIds { get; } = new();
+
+    /// <summary>
+    /// Ambiguous legacy flat keys that were retained because their profile and secret-name boundary cannot be proven.
+    /// </summary>
+    public List<string> UnresolvedLegacyKeys { get; } = new();
+
+    /// <summary>Whether structured orphan secret sets were found.</summary>
+    public bool HasOrphanedSecrets => OrphanedProfileIds.Count > 0;
+
+    /// <summary>Whether ambiguous legacy keys still require explicit operator review.</summary>
+    public bool HasUnresolvedLegacySecrets => UnresolvedLegacyKeys.Count > 0;
+}

--- a/Sources/Mailozaurr.Application/MailProfileSecretMaintenanceService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileSecretMaintenanceService.cs
@@ -1,0 +1,89 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Coordinates orphan-secret inspection and cleanup against the current profile inventory.
+/// </summary>
+public sealed class MailProfileSecretMaintenanceService : IMailProfileSecretMaintenanceService {
+    private readonly IMailProfileStore _profileStore;
+    private readonly IMailSecretStore _secretStore;
+
+    /// <summary>Creates a maintenance service over the provided profile and secret stores.</summary>
+    public MailProfileSecretMaintenanceService(
+        IMailProfileStore profileStore,
+        IMailSecretStore secretStore) {
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+    }
+
+    /// <inheritdoc />
+    public Task<MailProfileSecretMaintenanceResult> InspectOrphanedSecretsAsync(
+        CancellationToken cancellationToken = default) =>
+        ExecuteAsync(remove: false, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<MailProfileSecretMaintenanceResult> RemoveOrphanedSecretsAsync(
+        CancellationToken cancellationToken = default) =>
+        ExecuteAsync(remove: true, cancellationToken);
+
+    private async Task<MailProfileSecretMaintenanceResult> ExecuteAsync(
+        bool remove,
+        CancellationToken cancellationToken) {
+        if (_secretStore is not IMailProfileSecretMaintenanceStore maintenanceStore) {
+            return new MailProfileSecretMaintenanceResult {
+                Succeeded = false,
+                Code = "secret_maintenance_unavailable",
+                Message = "The configured secret store does not support orphan-secret maintenance."
+            };
+        }
+
+        MailProfileSecretMaintenanceResult result;
+        if (remove) {
+            if (_profileStore is not IMailProfileMaintenanceCoordinator profileCoordinator) {
+                return new MailProfileSecretMaintenanceResult {
+                    Succeeded = false,
+                    Code = "secret_cleanup_coordination_unavailable",
+                    Message = "The configured profile store cannot hold a stable inventory during orphan-secret cleanup. " +
+                              "Inject a custom profile-secret maintenance service for this store."
+                };
+            }
+            result = await profileCoordinator.ExecuteWithStableProfileIdsAsync(
+                (knownProfileIds, operationCancellationToken) => maintenanceStore.RemoveOrphanedSecretsAsync(
+                    knownProfileIds,
+                    operationCancellationToken),
+                cancellationToken).ConfigureAwait(false);
+        } else {
+            string[] knownProfileIds = await GetKnownProfileIdsAsync(cancellationToken).ConfigureAwait(false);
+            result = await maintenanceStore.InspectOrphanedSecretsAsync(knownProfileIds, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (result.Succeeded) {
+            result.Message = remove
+                ? CreateRemovalMessage(result)
+                : CreateInspectionMessage(result);
+        }
+        return result;
+    }
+
+    private async Task<string[]> GetKnownProfileIdsAsync(CancellationToken cancellationToken) {
+        IReadOnlyList<MailProfile> profiles = await _profileStore.GetAllAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return profiles
+            .Where(profile => !string.IsNullOrWhiteSpace(profile.Id))
+            .Select(profile => profile.Id.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string CreateInspectionMessage(MailProfileSecretMaintenanceResult result) {
+        if (!result.HasOrphanedSecrets && !result.HasUnresolvedLegacySecrets) {
+            return "No orphaned profile secrets were found.";
+        }
+        return $"Found {result.OrphanedProfileIds.Count} structured orphan secret set(s) and " +
+               $"{result.UnresolvedLegacyKeys.Count} ambiguous legacy key(s).";
+    }
+
+    private static string CreateRemovalMessage(MailProfileSecretMaintenanceResult result) =>
+        $"Removed {result.RemovedProfileIds.Count} structured orphan secret set(s); " +
+        $"retained {result.UnresolvedLegacyKeys.Count} ambiguous legacy key(s).";
+}

--- a/Sources/Mailozaurr.Application/Mailozaurr.Application.csproj
+++ b/Sources/Mailozaurr.Application/Mailozaurr.Application.csproj
@@ -28,6 +28,12 @@
         <ProjectReference Include="..\Mailozaurr\Mailozaurr.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Mailozaurr.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
         <PackageReference Include="System.Text.Json" Version="10.0.9" />
     </ItemGroup>

--- a/Sources/Mailozaurr.Cli/CliJsonContext.cs
+++ b/Sources/Mailozaurr.Cli/CliJsonContext.cs
@@ -15,6 +15,7 @@ namespace Mailozaurr.Cli;
 [JsonSerializable(typeof(MailProfile))]
 [JsonSerializable(typeof(ProfileCapabilities))]
 [JsonSerializable(typeof(MailProfileValidationResult))]
+[JsonSerializable(typeof(MailProfileSecretMaintenanceResult))]
 [JsonSerializable(typeof(FolderRefCompact))]
 [JsonSerializable(typeof(FolderRef))]
 [JsonSerializable(typeof(MailFolderAliasSummary))]

--- a/Sources/Mailozaurr.Cli/CliRunner.Help.cs
+++ b/Sources/Mailozaurr.Cli/CliRunner.Help.cs
@@ -29,6 +29,8 @@ public static partial class CliRunner {
         output.WriteLine("  profile set-default --profile <id> [--json]");
         output.WriteLine("  profile set-secret --profile <id> --name <secret-name> [--value-env <name>|--value-stdin|--value-ref <profile-id:secret-name>] [--json]");
         output.WriteLine("  profile remove-secret --profile <id> --name <secret-name> [--json]");
+        output.WriteLine("  profile inspect-orphan-secrets [--json]");
+        output.WriteLine("  profile cleanup-orphan-secrets [--json]");
         output.WriteLine("  draft list [--compact] [--json]");
         output.WriteLine("  draft save --file <path> [--draft <id>] [--name <display-name>] [--json]");
         output.WriteLine("  draft save --draft <id> --name <display-name> --profile <id> --to <address> [--to <address>] [--cc <address>] [--bcc <address>] [--reply-to <address>] [--from <address>] [--subject <text>] [--text <text>] [--html <html>] [--attachment <path>] [--header <key=value>] [--json]");

--- a/Sources/Mailozaurr.Cli/CliRunner.Profile.cs
+++ b/Sources/Mailozaurr.Cli/CliRunner.Profile.cs
@@ -14,7 +14,7 @@ public static partial class CliRunner {
         TextWriter error,
         TextReader input) {
         if (parseResult.Positionals.Count < 2) {
-            await error.WriteLineAsync("Missing profile command. Use 'profile list', 'profile create', 'profile graph-bootstrap', 'profile gmail-bootstrap', 'profile graph-login', 'profile gmail-login', 'profile refresh-auth', 'profile auth-status', 'profile test', 'profile summary', 'profile capabilities', 'profile show', 'profile validate', 'profile doctor', 'profile delete', 'profile set-default', 'profile set-secret', or 'profile remove-secret'.").ConfigureAwait(false);
+            await error.WriteLineAsync("Missing profile command. Use 'profile list', 'profile create', 'profile graph-bootstrap', 'profile gmail-bootstrap', 'profile graph-login', 'profile gmail-login', 'profile refresh-auth', 'profile auth-status', 'profile test', 'profile summary', 'profile capabilities', 'profile show', 'profile validate', 'profile doctor', 'profile delete', 'profile set-default', 'profile set-secret', 'profile remove-secret', 'profile inspect-orphan-secrets', or 'profile cleanup-orphan-secrets'.").ConfigureAwait(false);
             return 1;
         }
 
@@ -206,6 +206,24 @@ public static partial class CliRunner {
                     RequireOption(parseResult, "name")).ConfigureAwait(false);
                 await WriteItemAsync(output, removeSecretResult, json, value => value.Message ?? "Secret removed.").ConfigureAwait(false);
                 return removeSecretResult.Succeeded ? 0 : 1;
+            case "inspect-orphan-secrets":
+                var orphanInspection = await application.ProfileSecretMaintenance.InspectOrphanedSecretsAsync()
+                    .ConfigureAwait(false);
+                await WriteItemAsync(
+                    output,
+                    orphanInspection,
+                    json,
+                    value => value.Message ?? "Orphan-secret inspection completed.").ConfigureAwait(false);
+                return orphanInspection.Succeeded ? 0 : 1;
+            case "cleanup-orphan-secrets":
+                var orphanCleanup = await application.ProfileSecretMaintenance.RemoveOrphanedSecretsAsync()
+                    .ConfigureAwait(false);
+                await WriteItemAsync(
+                    output,
+                    orphanCleanup,
+                    json,
+                    value => value.Message ?? "Orphan-secret cleanup completed.").ConfigureAwait(false);
+                return orphanCleanup.Succeeded ? 0 : 1;
             default:
                 await error.WriteLineAsync($"Unknown profile command '{subCommand}'.").ConfigureAwait(false);
                 return 1;

--- a/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.Profiles.cs
+++ b/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.Profiles.cs
@@ -312,4 +312,16 @@ public sealed partial class MailMcpTools {
         [Description("The stable secret name to remove.")] string secretName,
         CancellationToken cancellationToken = default) =>
         _application.ProfileSecrets.RemoveSecretAsync(profileId, secretName, cancellationToken);
+
+    [McpServerTool(ReadOnly = true, Destructive = false, Idempotent = true)]
+    [Description("Reports structured secret sets whose owning Mailozaurr profiles no longer exist, while identifying ambiguous legacy keys without exposing secret values.")]
+    public Task<MailProfileSecretMaintenanceResult> mail_profile_secrets_orphaned_inspect(
+        CancellationToken cancellationToken = default) =>
+        _application.ProfileSecretMaintenance.InspectOrphanedSecretsAsync(cancellationToken);
+
+    [McpServerTool(ReadOnly = false, Destructive = true, Idempotent = true)]
+    [Description("Removes structured orphan secret sets while retaining ambiguous legacy keys that cannot be assigned safely.")]
+    public Task<MailProfileSecretMaintenanceResult> mail_profile_secrets_orphaned_cleanup(
+        CancellationToken cancellationToken = default) =>
+        _application.ProfileSecretMaintenance.RemoveOrphanedSecretsAsync(cancellationToken);
 }

--- a/Sources/Mailozaurr.Tests/ApplicationBuilderTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationBuilderTests.cs
@@ -21,6 +21,8 @@ public sealed class ApplicationBuilderTests {
         Assert.NotNull(app.Profiles);
         Assert.NotNull(app.ProfileOverview);
         Assert.NotNull(app.ProfileConnections);
+        Assert.NotNull(app.ProfileSecrets);
+        Assert.NotNull(app.ProfileSecretMaintenance);
         Assert.NotNull(app.Drafts);
         Assert.NotNull(app.DraftExchange);
         Assert.NotNull(app.ProfileBootstrap);
@@ -284,6 +286,19 @@ public sealed class ApplicationBuilderTests {
         Assert.NotNull(app.Queue);
     }
 
+    [Fact]
+    public void BuildUsesInjectedProfileSecretMaintenanceService() {
+        var maintenanceService = new FakeProfileSecretMaintenanceService();
+        var builder = new MailApplicationBuilder(new MailApplicationOptions {
+            ProfileStore = new MailProfileStoreOptions { DirectoryPath = CreateTemporaryDirectory() },
+            SecretStore = new MailSecretStoreOptions { DirectoryPath = CreateTemporaryDirectory() }
+        }).UseProfileSecretMaintenanceService(maintenanceService);
+
+        MailApplication app = builder.Build();
+
+        Assert.Same(maintenanceService, app.ProfileSecretMaintenance);
+    }
+
     private static string CreateTemporaryDirectory() {
         var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
@@ -413,5 +428,15 @@ public sealed class ApplicationBuilderTests {
 
         public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
+    }
+
+    private sealed class FakeProfileSecretMaintenanceService : IMailProfileSecretMaintenanceService {
+        public Task<MailProfileSecretMaintenanceResult> InspectOrphanedSecretsAsync(
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MailProfileSecretMaintenanceResult { Succeeded = true });
+
+        public Task<MailProfileSecretMaintenanceResult> RemoveOrphanedSecretsAsync(
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MailProfileSecretMaintenanceResult { Succeeded = true });
     }
 }

--- a/Sources/Mailozaurr.Tests/ApplicationJsonFileDocumentStoreTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationJsonFileDocumentStoreTests.cs
@@ -1,0 +1,191 @@
+using Mailozaurr.Application;
+using System.Diagnostics;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationJsonFileDocumentStoreTests {
+    private const string WorkerFileVariable = "MAILOZAURR_JSON_WORKER_FILE";
+    private const string WorkerGateVariable = "MAILOZAURR_JSON_WORKER_GATE";
+    private const string WorkerReadyVariable = "MAILOZAURR_JSON_WORKER_READY";
+    private const string WorkerProfileVariable = "MAILOZAURR_JSON_WORKER_PROFILE";
+
+    [Fact]
+    public async Task WriterLockWaitHasAFiniteTimeout() {
+        string filePath = CreateTemporaryFilePath();
+        string lockDirectory = Path.Combine(Path.GetDirectoryName(filePath)!, ".mailozaurr-locks");
+        string lockPath = Path.Combine(lockDirectory, Path.GetFileName(filePath) + ".lock");
+        Directory.CreateDirectory(lockDirectory);
+        using var heldLock = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+        var store = new JsonFileDocumentStore<MailProfileStoreDocument>(
+            filePath,
+            "Profile store path is invalid.",
+            ApplicationJsonContext.Default.MailProfileStoreDocument,
+            static () => new MailProfileStoreDocument(),
+            lockTimeout: TimeSpan.FromMilliseconds(150));
+
+        TimeoutException exception = await Assert.ThrowsAsync<TimeoutException>(() =>
+            store.UpdateAsync(document => document.Profiles.Add(new MailProfile {
+                Id = "blocked",
+                DisplayName = "Blocked",
+                Kind = MailProfileKind.Imap
+            })));
+
+        Assert.Contains("Timed out", exception.Message, StringComparison.Ordinal);
+        Assert.IsType<IOException>(exception.InnerException);
+    }
+
+#if NET8_0_OR_GREATER
+    [Fact]
+    public async Task IndependentProcessesDoNotLoseConcurrentProfileWrites() {
+        const int workerCount = 8;
+        string root = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        string filePath = Path.Combine(root, "profiles.json");
+        string gatePath = Path.Combine(root, "start.gate");
+        string readyDirectory = Path.Combine(root, "ready");
+        Directory.CreateDirectory(readyDirectory);
+        var workers = new List<WorkerProcess>();
+
+        try {
+            for (var index = 0; index < workerCount; index++) {
+                workers.Add(StartWorker(filePath, gatePath, readyDirectory, $"profile-{index}"));
+            }
+
+            DateTime readyDeadline = DateTime.UtcNow.AddSeconds(20);
+            while (Directory.GetFiles(readyDirectory).Length < workerCount && DateTime.UtcNow < readyDeadline) {
+                await Task.Delay(25);
+            }
+            int readyCount = Directory.GetFiles(readyDirectory).Length;
+            File.WriteAllText(gatePath, "go");
+
+            using var waitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await Task.WhenAll(workers.Select(worker =>
+                worker.Process.WaitForExitAsync(waitTimeout.Token)));
+            string diagnostics = await BuildWorkerDiagnosticsAsync(workers);
+
+            Assert.True(readyCount == workerCount,
+                $"Only {readyCount} of {workerCount} workers reached the contention gate.{Environment.NewLine}{diagnostics}");
+            Assert.True(workers.All(worker => worker.Process.ExitCode == 0), diagnostics);
+
+            IReadOnlyList<MailProfile> profiles = await new FileMailProfileStore(filePath).GetAllAsync();
+            Assert.Equal(workerCount, profiles.Count);
+            Assert.Equal(
+                workerCount,
+                profiles.Select(profile => profile.Id).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        } finally {
+            foreach (WorkerProcess worker in workers) {
+                if (!worker.Process.HasExited) {
+                    worker.Process.Kill(entireProcessTree: true);
+                    worker.Process.WaitForExit(5000);
+                }
+                worker.Process.Dispose();
+            }
+            if (Directory.Exists(root)) {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact(Explicit = true)]
+    public async Task CrossProcessProfileWriteWorker() {
+        string filePath = RequireWorkerVariable(WorkerFileVariable);
+        string gatePath = RequireWorkerVariable(WorkerGateVariable);
+        string readyPath = RequireWorkerVariable(WorkerReadyVariable);
+        string profileId = RequireWorkerVariable(WorkerProfileVariable);
+        File.WriteAllText(readyPath, "ready");
+        await WaitForFileAsync(gatePath, TimeSpan.FromSeconds(20));
+
+        await new FileMailProfileStore(filePath).SaveAsync(new MailProfile {
+            Id = profileId,
+            DisplayName = profileId,
+            Kind = MailProfileKind.Imap
+        });
+    }
+
+    private static WorkerProcess StartWorker(
+        string filePath,
+        string gatePath,
+        string readyDirectory,
+        string profileId) {
+        string testAssemblyPath = typeof(ApplicationJsonFileDocumentStoreTests).Assembly.Location;
+        string dotnetHost = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet";
+        var startInfo = new ProcessStartInfo(dotnetHost) {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add(testAssemblyPath);
+        startInfo.ArgumentList.Add("-noLogo");
+        startInfo.ArgumentList.Add("-noColor");
+        startInfo.ArgumentList.Add("-reporter");
+        startInfo.ArgumentList.Add("silent");
+        startInfo.ArgumentList.Add("-parallel");
+        startInfo.ArgumentList.Add("none");
+        startInfo.ArgumentList.Add("-explicit");
+        startInfo.ArgumentList.Add("only");
+        startInfo.ArgumentList.Add("-method");
+        startInfo.ArgumentList.Add(
+            "Mailozaurr.Tests.ApplicationJsonFileDocumentStoreTests.CrossProcessProfileWriteWorker");
+        startInfo.Environment[WorkerFileVariable] = filePath;
+        startInfo.Environment[WorkerGateVariable] = gatePath;
+        startInfo.Environment[WorkerReadyVariable] = Path.Combine(readyDirectory, profileId + ".ready");
+        startInfo.Environment[WorkerProfileVariable] = profileId;
+
+        Process process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("The cross-process JSON worker could not be started.");
+        return new WorkerProcess(
+            process,
+            process.StandardOutput.ReadToEndAsync(),
+            process.StandardError.ReadToEndAsync());
+    }
+
+    private static async Task<string> BuildWorkerDiagnosticsAsync(IEnumerable<WorkerProcess> workers) {
+        var diagnostics = new List<string>();
+        foreach (WorkerProcess worker in workers) {
+            string output = await worker.StandardOutput;
+            string error = await worker.StandardError;
+            diagnostics.Add(
+                $"pid={worker.Process.Id}; exit={worker.Process.ExitCode}; stdout={output}; stderr={error}");
+        }
+        return string.Join(Environment.NewLine, diagnostics);
+    }
+
+    private static async Task WaitForFileAsync(string path, TimeSpan timeout) {
+        DateTime deadline = DateTime.UtcNow.Add(timeout);
+        while (!File.Exists(path)) {
+            if (DateTime.UtcNow >= deadline) {
+                throw new TimeoutException($"Timed out waiting for cross-process gate '{path}'.");
+            }
+            await Task.Delay(25);
+        }
+    }
+
+    private static string RequireWorkerVariable(string name) {
+        string? value = Environment.GetEnvironmentVariable(name);
+        return string.IsNullOrWhiteSpace(value)
+            ? throw new InvalidOperationException($"Required worker variable '{name}' was not provided.")
+            : value;
+    }
+
+    private sealed class WorkerProcess {
+        internal WorkerProcess(
+            Process process,
+            Task<string> standardOutput,
+            Task<string> standardError) {
+            Process = process;
+            StandardOutput = standardOutput;
+            StandardError = standardError;
+        }
+
+        internal Process Process { get; }
+        internal Task<string> StandardOutput { get; }
+        internal Task<string> StandardError { get; }
+    }
+#endif
+
+    private static string CreateTemporaryFilePath() {
+        string directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, "profiles.json");
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationProfileSecretMaintenanceServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileSecretMaintenanceServiceTests.cs
@@ -1,0 +1,181 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationProfileSecretMaintenanceServiceTests {
+    [Fact]
+    public async Task OrphanMaintenanceUsesTheCurrentProfileInventory() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var secretStore = new FileMailSecretStore(
+            CreateTemporaryFilePath("secrets.json"),
+            new TestCredentialProtector());
+        var service = new MailProfileSecretMaintenanceService(profileStore, secretStore);
+        await profileStore.SaveAsync(new MailProfile {
+            Id = "work",
+            DisplayName = "Work",
+            Kind = MailProfileKind.Imap
+        });
+        await secretStore.SetSecretAsync("work", "password", "work-secret");
+        await secretStore.SetSecretAsync("retired", "password", "retired-secret");
+
+        MailProfileSecretMaintenanceResult inspection = await service.InspectOrphanedSecretsAsync();
+        MailProfileSecretMaintenanceResult cleanup = await service.RemoveOrphanedSecretsAsync();
+
+        Assert.True(inspection.Succeeded);
+        Assert.Equal(new[] { "retired" }, inspection.OrphanedProfileIds);
+        Assert.Equal(new[] { "retired" }, cleanup.RemovedProfileIds);
+        Assert.Equal("work-secret", await secretStore.GetSecretAsync("work", "password"));
+        Assert.Null(await secretStore.GetSecretAsync("retired", "password"));
+    }
+
+    [Fact]
+    public async Task OrphanMaintenanceReportsUnsupportedCustomSecretStores() {
+        var service = new MailProfileSecretMaintenanceService(
+            new FileMailProfileStore(CreateTemporaryFilePath("profiles.json")),
+            new MinimalSecretStore());
+
+        MailProfileSecretMaintenanceResult result = await service.InspectOrphanedSecretsAsync();
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("secret_maintenance_unavailable", result.Code);
+    }
+
+    [Fact]
+    public async Task CleanupRefusesAProfileStoreWithoutStableInventoryCoordination() {
+        var service = new MailProfileSecretMaintenanceService(
+            new MinimalProfileStore(),
+            new FileMailSecretStore(
+                CreateTemporaryFilePath("secrets.json"),
+                new TestCredentialProtector()));
+
+        MailProfileSecretMaintenanceResult result = await service.RemoveOrphanedSecretsAsync();
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("secret_cleanup_coordination_unavailable", result.Code);
+    }
+
+    [Fact]
+    public async Task CleanupHoldsTheProfileInventoryStableUntilSecretRemovalCompletes() {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var secretStore = new BlockingMaintenanceSecretStore();
+        var service = new MailProfileSecretMaintenanceService(profileStore, secretStore);
+
+        Task<MailProfileSecretMaintenanceResult> cleanup = service.RemoveOrphanedSecretsAsync();
+        Task entered = secretStore.Entered;
+        Assert.Same(entered, await Task.WhenAny(entered, Task.Delay(TimeSpan.FromSeconds(5))));
+
+        Task save = profileStore.SaveAsync(new MailProfile {
+            Id = "created-during-cleanup",
+            DisplayName = "Created during cleanup",
+            Kind = MailProfileKind.Imap
+        });
+        try {
+            await Task.Delay(100);
+            Assert.False(save.IsCompleted);
+        } finally {
+            secretStore.Release();
+        }
+
+        await Task.WhenAll(cleanup, save);
+        Assert.NotNull(await profileStore.GetByIdAsync("created-during-cleanup"));
+    }
+
+    private static string CreateTemporaryFilePath(string fileName) {
+        string directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+
+    private sealed class TestCredentialProtector : ICredentialProtector {
+        public string Protect(string value) => Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(value));
+
+        public string Unprotect(string protectedValue) {
+            byte[] decoded = Convert.FromBase64String(protectedValue);
+            return System.Text.Encoding.UTF8.GetString(decoded);
+        }
+    }
+
+    private sealed class MinimalSecretStore : IMailSecretStore {
+        public Task<string?> GetSecretAsync(
+            string profileId,
+            string secretName,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<string?>(null);
+
+        public Task SetSecretAsync(
+            string profileId,
+            string secretName,
+            string secretValue,
+            CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<bool> RemoveSecretAsync(
+            string profileId,
+            string secretName,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+    }
+
+    private sealed class MinimalProfileStore : IMailProfileStore {
+        public Task<IReadOnlyList<MailProfile>> GetAllAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MailProfile>>(Array.Empty<MailProfile>());
+
+        public Task<MailProfile?> GetByIdAsync(
+            string profileId,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<MailProfile?>(null);
+
+        public Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<bool> RemoveAsync(
+            string profileId,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+    }
+
+    private sealed class BlockingMaintenanceSecretStore :
+        IMailSecretStore,
+        IMailProfileSecretMaintenanceStore {
+        private readonly TaskCompletionSource<bool> _entered =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal Task Entered => _entered.Task;
+
+        internal void Release() => _release.TrySetResult(true);
+
+        public Task<string?> GetSecretAsync(
+            string profileId,
+            string secretName,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<string?>(null);
+
+        public Task SetSecretAsync(
+            string profileId,
+            string secretName,
+            string secretValue,
+            CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<bool> RemoveSecretAsync(
+            string profileId,
+            string secretName,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+
+        public Task<MailProfileSecretMaintenanceResult> InspectOrphanedSecretsAsync(
+            IReadOnlyCollection<string> knownProfileIds,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new MailProfileSecretMaintenanceResult { Succeeded = true });
+
+        public async Task<MailProfileSecretMaintenanceResult> RemoveOrphanedSecretsAsync(
+            IReadOnlyCollection<string> knownProfileIds,
+            CancellationToken cancellationToken = default) {
+            _entered.TrySetResult(true);
+            await _release.Task.ConfigureAwait(false);
+            return new MailProfileSecretMaintenanceResult { Succeeded = true };
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationSecretStoreTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationSecretStoreTests.cs
@@ -198,6 +198,38 @@ public sealed class ApplicationSecretStoreTests {
         Assert.Equal("legacy-secret", await store.GetSecretAsync("work", "api::token"));
     }
 
+    [Fact]
+    public async Task OrphanMaintenanceRemovesOnlyStructuredOrphansAndRetainsAmbiguousLegacyKeys() {
+        var filePath = CreateTemporaryFilePath();
+        var protector = new TestCredentialProtector();
+        string workValue = protector.Protect("work-secret");
+        string knownLegacyValue = protector.Protect("known-legacy-secret");
+        string unresolvedLegacyValue = protector.Protect("unresolved-legacy-secret");
+        File.WriteAllText(filePath,
+            "{\"Version\":2,\"ProfileSecrets\":{" +
+            $"\"work\":{{\"password\":\"{workValue}\"}}," +
+            "\"retired\":{\"password\":\"not-valid-protected-data\"}}," +
+            "\"Secrets\":{" +
+            $"\"work::api::token\":\"{knownLegacyValue}\"," +
+            $"\"lost::api::token\":\"{unresolvedLegacyValue}\"}}}}");
+        var store = new FileMailSecretStore(filePath, protector);
+        var maintenance = (IMailProfileSecretMaintenanceStore)store;
+
+        MailProfileSecretMaintenanceResult inspection = await maintenance.InspectOrphanedSecretsAsync(
+            new[] { "work" });
+        MailProfileSecretMaintenanceResult cleanup = await maintenance.RemoveOrphanedSecretsAsync(
+            new[] { "work" });
+
+        Assert.True(inspection.Succeeded);
+        Assert.Equal(new[] { "retired" }, inspection.OrphanedProfileIds);
+        Assert.Equal(new[] { "lost::api::token" }, inspection.UnresolvedLegacyKeys);
+        Assert.Equal(new[] { "retired" }, cleanup.RemovedProfileIds);
+        Assert.Equal("work-secret", await store.GetSecretAsync("work", "password"));
+        Assert.Null(await store.GetSecretAsync("retired", "password"));
+        Assert.Equal("known-legacy-secret", await store.GetSecretAsync("work", "api::token"));
+        Assert.Equal("unresolved-legacy-secret", await store.GetSecretAsync("lost", "api::token"));
+    }
+
     private static string CreateTemporaryFilePath() {
         var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);

--- a/Sources/Mailozaurr.Tests/CliRunnerTests.FakeStoresRead.cs
+++ b/Sources/Mailozaurr.Tests/CliRunnerTests.FakeStoresRead.cs
@@ -8,7 +8,8 @@ namespace Mailozaurr.Tests;
 public sealed partial class CliRunnerTests {
     private static TestApplicationFixture CreateFixture() => new();
 
-    private sealed class InMemoryProfileStore : IMailProfileStore {
+    private sealed class InMemoryProfileStore : IMailProfileStore, IMailProfileMaintenanceCoordinator {
+        private readonly SemaphoreSlim _writerGate = new(1, 1);
         private readonly Dictionary<string, MailProfile> _profiles;
 
         public InMemoryProfileStore(IEnumerable<MailProfile> profiles) {
@@ -23,16 +24,37 @@ public sealed partial class CliRunnerTests {
             return Task.FromResult(profile);
         }
 
-        public Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default) =>
-            Task.FromResult(_profiles.Remove(profileId));
+        public async Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default) {
+            await _writerGate.WaitAsync(cancellationToken);
+            try {
+                return _profiles.Remove(profileId);
+            } finally {
+                _writerGate.Release();
+            }
+        }
 
-        public Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
-            _profiles[profile.Id] = profile;
-            return Task.CompletedTask;
+        public async Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+            await _writerGate.WaitAsync(cancellationToken);
+            try {
+                _profiles[profile.Id] = profile;
+            } finally {
+                _writerGate.Release();
+            }
+        }
+
+        public async Task<TResult> ExecuteWithStableProfileIdsAsync<TResult>(
+            Func<IReadOnlyCollection<string>, CancellationToken, Task<TResult>> operation,
+            CancellationToken cancellationToken = default) {
+            await _writerGate.WaitAsync(cancellationToken);
+            try {
+                return await operation(_profiles.Keys.ToArray(), cancellationToken);
+            } finally {
+                _writerGate.Release();
+            }
         }
     }
 
-    private sealed class InMemorySecretStore : IMailSecretStore {
+    private sealed class InMemorySecretStore : IMailSecretStore, IMailProfileSecretMaintenanceStore {
         private readonly Dictionary<string, Dictionary<string, string>> _secrets = new(StringComparer.OrdinalIgnoreCase);
 
         public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
@@ -58,6 +80,35 @@ public sealed partial class CliRunnerTests {
 
             profileSecrets[secretName] = secretValue;
             return Task.CompletedTask;
+        }
+
+        public Task<MailProfileSecretMaintenanceResult> InspectOrphanedSecretsAsync(
+            IReadOnlyCollection<string> knownProfileIds,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateMaintenanceResult(knownProfileIds, remove: false));
+
+        public Task<MailProfileSecretMaintenanceResult> RemoveOrphanedSecretsAsync(
+            IReadOnlyCollection<string> knownProfileIds,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateMaintenanceResult(knownProfileIds, remove: true));
+
+        private MailProfileSecretMaintenanceResult CreateMaintenanceResult(
+            IReadOnlyCollection<string> knownProfileIds,
+            bool remove) {
+            var knownProfiles = new HashSet<string>(knownProfileIds, StringComparer.OrdinalIgnoreCase);
+            string[] orphans = _secrets.Keys
+                .Where(profileId => !knownProfiles.Contains(profileId))
+                .OrderBy(profileId => profileId, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var result = new MailProfileSecretMaintenanceResult { Succeeded = true };
+            result.OrphanedProfileIds.AddRange(orphans);
+            if (remove) {
+                foreach (string orphan in orphans) {
+                    _secrets.Remove(orphan);
+                    result.RemovedProfileIds.Add(orphan);
+                }
+            }
+            return result;
         }
     }
 

--- a/Sources/Mailozaurr.Tests/CliRunnerTests.Profile.cs
+++ b/Sources/Mailozaurr.Tests/CliRunnerTests.Profile.cs
@@ -135,6 +135,32 @@ public sealed partial class CliRunnerTests {
     }
 
     [Fact]
+    public async Task ProfileOrphanSecretCommandsUseSharedMaintenanceService() {
+        using var inspectOutput = new StringWriter();
+        using var cleanupOutput = new StringWriter();
+        using var stderr = new StringWriter();
+        var fixture = CreateFixture();
+        await fixture.SecretStore.SetSecretAsync("retired", "password", "retired-secret");
+
+        int inspectExitCode = await CliRunner.RunAsync(
+            new[] { "profile", "inspect-orphan-secrets", "--json" },
+            inspectOutput,
+            stderr,
+            _ => fixture.CreateBuilder());
+        int cleanupExitCode = await CliRunner.RunAsync(
+            new[] { "profile", "cleanup-orphan-secrets", "--json" },
+            cleanupOutput,
+            stderr,
+            _ => fixture.CreateBuilder());
+
+        Assert.Equal(0, inspectExitCode);
+        Assert.Equal(0, cleanupExitCode);
+        Assert.Contains("\"retired\"", inspectOutput.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"RemovedProfileIds\"", cleanupOutput.ToString(), StringComparison.Ordinal);
+        Assert.Null(await fixture.SecretStore.GetSecretAsync("retired", "password"));
+    }
+
+    [Fact]
     public async Task ProfileGraphBootstrapSavesProfileAndSecretsThroughApplicationServices() {
         using var stdout = new StringWriter();
         using var stderr = new StringWriter();

--- a/Sources/Mailozaurr.Tests/MailMcpToolsMetadataTests.cs
+++ b/Sources/Mailozaurr.Tests/MailMcpToolsMetadataTests.cs
@@ -32,6 +32,19 @@ public sealed class MailMcpToolsMetadataTests {
     }
 
     [Fact]
+    public void OrphanSecretToolsDeclareAccurateMcpMetadata() {
+        var inspection = GetToolAttribute(nameof(MailMcpTools.mail_profile_secrets_orphaned_inspect));
+        var cleanup = GetToolAttribute(nameof(MailMcpTools.mail_profile_secrets_orphaned_cleanup));
+
+        Assert.True(inspection.ReadOnly);
+        Assert.False(inspection.Destructive);
+        Assert.True(inspection.Idempotent);
+        Assert.False(cleanup.ReadOnly);
+        Assert.True(cleanup.Destructive);
+        Assert.True(cleanup.Idempotent);
+    }
+
+    [Fact]
     public void McpToolsDoNotAcceptRawSecretValues() {
         var unsafeParameters = typeof(MailMcpTools)
             .GetMethods(BindingFlags.Instance | BindingFlags.Public)

--- a/Sources/Mailozaurr.Tests/MailMcpToolsTests.FakeStoresRead.cs
+++ b/Sources/Mailozaurr.Tests/MailMcpToolsTests.FakeStoresRead.cs
@@ -5,7 +5,8 @@ using Mailozaurr.Cli.Mcp;
 namespace Mailozaurr.Tests;
 
 public sealed partial class MailMcpToolsTests {
-    private sealed class InMemoryProfileStore : IMailProfileStore {
+    private sealed class InMemoryProfileStore : IMailProfileStore, IMailProfileMaintenanceCoordinator {
+        private readonly SemaphoreSlim _writerGate = new(1, 1);
         private readonly Dictionary<string, MailProfile> _profiles;
 
         public InMemoryProfileStore(IEnumerable<MailProfile> profiles) {
@@ -20,13 +21,34 @@ public sealed partial class MailMcpToolsTests {
             return Task.FromResult(profile == null ? null : CloneProfile(profile));
         }
 
-        public Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
-            _profiles[profile.Id] = CloneProfile(profile);
-            return Task.CompletedTask;
+        public async Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+            await _writerGate.WaitAsync(cancellationToken);
+            try {
+                _profiles[profile.Id] = CloneProfile(profile);
+            } finally {
+                _writerGate.Release();
+            }
         }
 
-        public Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default) =>
-            Task.FromResult(_profiles.Remove(profileId));
+        public async Task<bool> RemoveAsync(string profileId, CancellationToken cancellationToken = default) {
+            await _writerGate.WaitAsync(cancellationToken);
+            try {
+                return _profiles.Remove(profileId);
+            } finally {
+                _writerGate.Release();
+            }
+        }
+
+        public async Task<TResult> ExecuteWithStableProfileIdsAsync<TResult>(
+            Func<IReadOnlyCollection<string>, CancellationToken, Task<TResult>> operation,
+            CancellationToken cancellationToken = default) {
+            await _writerGate.WaitAsync(cancellationToken);
+            try {
+                return await operation(_profiles.Keys.ToArray(), cancellationToken);
+            } finally {
+                _writerGate.Release();
+            }
+        }
 
         private static MailProfile CloneProfile(MailProfile profile) => new() {
             Id = profile.Id,
@@ -43,7 +65,7 @@ public sealed partial class MailMcpToolsTests {
         };
     }
 
-    private sealed class InMemorySecretStore : IMailSecretStore {
+    private sealed class InMemorySecretStore : IMailSecretStore, IMailProfileSecretMaintenanceStore {
         private readonly Dictionary<string, string> _secrets = new(StringComparer.OrdinalIgnoreCase);
 
         public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
@@ -58,6 +80,44 @@ public sealed partial class MailMcpToolsTests {
 
         public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) =>
             Task.FromResult(_secrets.Remove(CreateKey(profileId, secretName)));
+
+        public Task<MailProfileSecretMaintenanceResult> InspectOrphanedSecretsAsync(
+            IReadOnlyCollection<string> knownProfileIds,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateMaintenanceResult(knownProfileIds, remove: false));
+
+        public Task<MailProfileSecretMaintenanceResult> RemoveOrphanedSecretsAsync(
+            IReadOnlyCollection<string> knownProfileIds,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateMaintenanceResult(knownProfileIds, remove: true));
+
+        private MailProfileSecretMaintenanceResult CreateMaintenanceResult(
+            IReadOnlyCollection<string> knownProfileIds,
+            bool remove) {
+            var knownProfiles = new HashSet<string>(knownProfileIds, StringComparer.OrdinalIgnoreCase);
+            string[] orphanKeys = _secrets.Keys
+                .Where(key => !knownProfiles.Contains(GetProfileId(key)))
+                .ToArray();
+            string[] orphanProfiles = orphanKeys
+                .Select(GetProfileId)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(profileId => profileId, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var result = new MailProfileSecretMaintenanceResult { Succeeded = true };
+            result.OrphanedProfileIds.AddRange(orphanProfiles);
+            if (remove) {
+                foreach (string key in orphanKeys) {
+                    _secrets.Remove(key);
+                }
+                result.RemovedProfileIds.AddRange(orphanProfiles);
+            }
+            return result;
+        }
+
+        private static string GetProfileId(string key) {
+            int separator = key.IndexOf("::", StringComparison.Ordinal);
+            return separator < 0 ? key : key.Substring(0, separator);
+        }
 
         private static string CreateKey(string profileId, string secretName) => $"{profileId}::{secretName}";
     }

--- a/Sources/Mailozaurr.Tests/MailMcpToolsTests.Profile.cs
+++ b/Sources/Mailozaurr.Tests/MailMcpToolsTests.Profile.cs
@@ -505,6 +505,21 @@ public sealed partial class MailMcpToolsTests {
     }
 
     [Fact]
+    public async Task MailProfileOrphanSecretToolsInspectAndCleanThroughTheSharedService() {
+        using var fixture = new TestFixture();
+        await fixture.SecretStore.SetSecretAsync("retired", "password", "retired-secret");
+
+        MailProfileSecretMaintenanceResult inspection =
+            await fixture.Tools.mail_profile_secrets_orphaned_inspect();
+        MailProfileSecretMaintenanceResult cleanup =
+            await fixture.Tools.mail_profile_secrets_orphaned_cleanup();
+
+        Assert.Equal(new[] { "retired" }, inspection.OrphanedProfileIds);
+        Assert.Equal(new[] { "retired" }, cleanup.RemovedProfileIds);
+        Assert.Null(await fixture.SecretStore.GetSecretAsync("retired", "password"));
+    }
+
+    [Fact]
     public async Task MailProfileDeleteRemovesProfile() {
         using var fixture = new TestFixture();
         await fixture.Tools.mail_profile_save(


### PR DESCRIPTION
## Summary

- share JSON writer coordination by canonical path and bound the total writer-lock wait to 15 seconds while keeping ordinary reads lock-artifact-free
- add real multi-process regression coverage so concurrent profile writers cannot silently overwrite one another
- add orphaned profile-secret inspection and cleanup in `Mailozaurr.Application`; cleanup never decrypts values, retains ambiguous legacy keys, and holds a stable profile inventory across the destructive operation
- expose the shared maintenance service through `MailApplication`, the CLI, and MCP with accurate read-only/destructive/idempotent metadata
- document the built-in coordination contract and the optional interfaces required by custom stores

## Compatibility and ownership

- keeps the existing `IMailProfileSecretService` contract unchanged
- keeps JSON as the lightweight configuration owner; no DbaClientX dependency is added
- leaves the separate JSONL pending-message queue untouched
- custom stores can implement `IMailProfileMaintenanceCoordinator` and `IMailProfileSecretMaintenanceStore`, or inject a complete `IMailProfileSecretMaintenanceService`

## Validation

- focused contracts: 40/40 on .NET 8 and 33/33 on .NET Framework 4.7.2
- full suites: 1,165 passed on .NET 8 and 976 passed on .NET Framework 4.7.2, with the one intentional PGP skip on each framework
- no-sign/no-publish PowerForge package build completed and verified all package payloads
- packaged PowerShell AssemblyLoadContext regression passed
- locally packed `Mailozaurr.Cli 2.0.0` installed from an isolated local-only feed and completed orphan inspection/cleanup without exposing the stored secret

No packages or modules were published.