### PR TITLE
Align v2 product docs and accelerator contracts

### DIFF
--- a/Docs/Configuration-and-Usage.md
+++ b/Docs/Configuration-and-Usage.md
@@ -173,6 +173,7 @@ The CLI also supports per-run overrides:
 ## CLI usage overview
 
 The executable is built from [Mailozaurr.Cli](../Sources/Mailozaurr.Cli).
+The Application and CLI package definitions are release-ready but are not published yet. Until a public release exists, use project references for `Mailozaurr.Application` and run the CLI from this checkout or from a locally built PowerForge artifact.
 
 To inspect current commands:
 

--- a/Docs/Platform-Architecture.md
+++ b/Docs/Platform-Architecture.md
@@ -31,9 +31,10 @@ The preferred long-term structure is:
 - `Mailozaurr`
 - `Mailozaurr.Application`
 - `Mailozaurr.PowerShell`
-- `Mailozaurr.Cli`
-- `Mailozaurr.Mcp`
+- `Mailozaurr.Cli`, including the MCP host
 - Desktop/GUI app projects
+
+`Mailozaurr.Application` and `Mailozaurr.Cli` have package definitions and are built by the shared release pipeline, but they are not public packages yet. Until they are explicitly published, consume Application through a project reference and run the CLI from source or from a locally built PowerForge artifact. Public installation instructions should only be added after those artifacts exist on the public feed.
 
 ### Layer Responsibilities
 
@@ -71,9 +72,6 @@ The preferred long-term structure is:
 - Human-readable output
 - JSON output
 - Exit codes
-
-`Mailozaurr.Mcp`
-
 - MCP transport and tool registration
 - Tool schema definitions
 - Mapping tool calls to application services
@@ -119,7 +117,7 @@ Examples:
 
 - PowerShell parameter sets and pipeline binding belong in `Mailozaurr.PowerShell`
 - CLI help text and shell-friendly formatting belong in `Mailozaurr.Cli`
-- MCP tool schemas belong in `Mailozaurr.Mcp`
+- MCP tool schemas belong in `Mailozaurr.Cli/Mcp`
 - GUI dialogs, views, and local UX behavior belong in the GUI project
 
 ## Feature Placement Guide
@@ -156,9 +154,6 @@ Place it in `Mailozaurr.Cli` if it is:
 - argument parsing
 - console output formatting
 - shell completion and exit code concerns
-
-Place it in `Mailozaurr.Mcp` if it is:
-
 - MCP server bootstrapping
 - tool declaration and transport behavior
 - mapping between tool requests and application services
@@ -237,7 +232,8 @@ Safety behavior should be shared, not reimplemented separately in each surface.
 Preferred defaults:
 
 - drafts before send when practical
-- queue-first sending for automation and agents
+- immediate delivery for explicit send requests
+- queue-on-failure only when the caller asks for it, with queue processing kept as a separate workflow
 - explicit confirmation for destructive actions
 - provider-limit validation before send
 - dry-run support where possible
@@ -251,7 +247,7 @@ The recommended shape is:
 
 - CLI for human and automation use
 - MCP as a structured tool surface over the same workflows
-- one executable host eventually able to run both normal CLI commands and `mcp serve`
+- one executable host that runs both normal CLI commands and `mcp serve`
 
 This avoids duplicating logic and gives one headless contract for the ecosystem.
 
@@ -267,7 +263,7 @@ The preferred split is:
 Examples of skill responsibilities:
 
 - when to prefer drafts over immediate send
-- when to use queue-first sending
+- when to opt into queue-on-failure or process the persistent queue
 - how to summarize before delete/move
 - how to select compact versus rich read surfaces
 

--- a/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Tests.ps1
@@ -32,6 +32,59 @@ Import-Module Mailozaurr -Force
 `$mimeAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$message.GetType().Assembly)
 `$mailKitAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$query.GetType().Assembly)
 `$smtp = [Mailozaurr.Smtp]::new()
+`$expectedAllowedTypes = @(
+    'Mailozaurr.EmailEncryption'
+    'Mailozaurr.EmailMessage'
+    'Mailozaurr.EmailProvider'
+    'Mailozaurr.FileSentMessageRepository'
+    'Mailozaurr.GraphApiErrorParser'
+    'Mailozaurr.GraphAttachment'
+    'Mailozaurr.GraphContent'
+    'Mailozaurr.GraphHttpMethod'
+    'Mailozaurr.GraphMessage'
+    'Mailozaurr.GraphSendPolicy'
+    'Mailozaurr.HtmlUtils'
+    'Mailozaurr.MailozaurrOptions'
+    'Mailozaurr.MailFileAddress'
+    'Mailozaurr.MailFileAttachment'
+    'Mailozaurr.MailFileFormat'
+    'Mailozaurr.MailFileMessage'
+    'Mailozaurr.MailFileReader'
+    'Mailozaurr.MailFileReaderOptions'
+    'Mailozaurr.MailFileRecipient'
+    'Mailozaurr.MailFileRecipientType'
+    'Mailozaurr.SendLogResolver'
+    'Mailozaurr.Smtp'
+    'Mailozaurr.SmtpConnectionPool'
+)
+`$missingAllowedTypes = [Collections.Generic.List[string]]::new()
+`$wrongAllowedTypeContexts = [Collections.Generic.List[string]]::new()
+foreach (`$typeName in `$expectedAllowedTypes) {
+    try {
+        `$allowedType = [type] `$typeName
+        `$allowedTypeAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$allowedType.Assembly)
+        if (-not [object]::ReferenceEquals(`$allowedTypeAlc, `$commandAlc)) {
+            `$wrongAllowedTypeContexts.Add(`$typeName)
+        }
+    } catch {
+        `$missingAllowedTypes.Add(`$typeName)
+    }
+}
+`$typeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+`$getTypeAccelerators = `$typeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
+`$actualAllowedTypes = @(
+    foreach (`$entry in `$getTypeAccelerators.GetValue(`$null).GetEnumerator()) {
+        if (`$entry.Key -notlike 'Mailozaurr.*') {
+            continue
+        }
+
+        `$entryAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$entry.Value.Assembly)
+        if ([object]::ReferenceEquals(`$entryAlc, `$commandAlc)) {
+            `$entry.Key
+        }
+    }
+)
+`$unexpectedAllowedTypes = @(`$actualAllowedTypes | Where-Object { `$expectedAllowedTypes -notcontains `$_ })
 `$unlistedTypeVisibleByName = `$true
 try {
     `$null = [type]'Mailozaurr.MicrosoftGraphUtils'
@@ -64,6 +117,11 @@ try {
     SearchQueryALC = `$mailKitAlc.Name
     SearchQueryALCIsDefault = [object]::ReferenceEquals(`$mailKitAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
     SmtpCreated = `$null -ne `$smtp
+    AllowedTypeCount = `$expectedAllowedTypes.Count
+    ActualAllowedTypeCount = `$actualAllowedTypes.Count
+    MissingAllowedTypes = @(`$missingAllowedTypes)
+    UnexpectedAllowedTypes = @(`$unexpectedAllowedTypes)
+    WrongAllowedTypeContexts = @(`$wrongAllowedTypeContexts)
     UnlistedTypeVisibleByName = `$unlistedTypeVisibleByName
 } | ConvertTo-Json -Compress
 "@
@@ -99,6 +157,11 @@ try {
         $result.SearchQueryALC | Should -Be 'Mailozaurr'
         $result.SearchQueryALCIsDefault | Should -BeFalse
         $result.SmtpCreated | Should -BeTrue
+        $result.AllowedTypeCount | Should -Be 23
+        $result.ActualAllowedTypeCount | Should -Be 23
+        @($result.MissingAllowedTypes).Count | Should -Be 0
+        @($result.UnexpectedAllowedTypes).Count | Should -Be 0
+        @($result.WrongAllowedTypeContexts).Count | Should -Be 0
         $result.UnlistedTypeVisibleByName | Should -BeFalse
     }
 }


### PR DESCRIPTION
## Summary

- document the current combined CLI/MCP host instead of a separate future MCP project
- align safety guidance with the adopted immediate-send plus explicit queue-on-failure contract
- clearly mark `Mailozaurr.Application` and `Mailozaurr.Cli` as package-ready but unpublished, with source/local-artifact usage until a public release exists
- turn the PowerForge type-accelerator allowlist into an exact packaged contract: all 23 supported names must resolve from the module ALC, no extra Mailozaurr accelerators may appear there, and unlisted internal types remain hidden

## Validation

- no-publish PowerForge package/module build passed; all three package payloads matched fresh Release builds
- packaged PowerShell Core AssemblyLoadContext regression passed
- Windows PowerShell 5.1 imported the installed validation module and resolved all 23 supported type names

No packages or modules were published.