### PR TITLE
Add normalized multi-provider delivery handlers

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -93,7 +93,7 @@ Build-Module -ModuleName 'Mailozaurr' {
         SignModule                        = $SignModule
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
-        CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+        CertificateThumbprint             = '92E95FB58EFFA6A4A75E77A33CDD6BFE6DD30F1A'
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'Mailozaurr.PowerShell'
         NETProjectPath                    = 'Sources\Mailozaurr.PowerShell\Mailozaurr.PowerShell.csproj'

--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -21,7 +21,7 @@
   "PublishNuget": false,
   "PublishGitHub": false,
   "CreateReleaseZip": true,
-  "CertificateThumbprint": "483292C9E317AA13B07BB7A96AE9D1A5ED9E7703",
+  "CertificateThumbprint": "92E95FB58EFFA6A4A75E77A33CDD6BFE6DD30F1A",
   "CertificateStore": "CurrentUser",
   "TimeStampServer": "http://timestamp.digicert.com",
   "PublishSource": "https://api.nuget.org/v3/index.json",

--- a/Sources/Mailozaurr.Application/DraftMessage.cs
+++ b/Sources/Mailozaurr.Application/DraftMessage.cs
@@ -31,6 +31,9 @@ public sealed class DraftMessage {
     /// <summary>HTML body.</summary>
     public string? HtmlBody { get; set; }
 
+    /// <summary>Message priority shared by all delivery providers.</summary>
+    public MessagePriority Priority { get; set; } = MessagePriority.Normal;
+
     /// <summary>Attachments included with the draft.</summary>
     public List<DraftAttachment> Attachments { get; set; } = new();
 

--- a/Sources/Mailozaurr.Application/DraftMessageCloner.cs
+++ b/Sources/Mailozaurr.Application/DraftMessageCloner.cs
@@ -1,0 +1,50 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Creates detached copies of reusable draft messages.
+/// </summary>
+public static class DraftMessageCloner {
+    /// <summary>
+    /// Creates a deep copy of a draft and its mutable recipient, header, and
+    /// attachment collections.
+    /// </summary>
+    /// <param name="draft">Draft to copy.</param>
+    /// <returns>A detached draft copy.</returns>
+    public static DraftMessage Clone(DraftMessage draft) {
+        if (draft == null) {
+            throw new ArgumentNullException(nameof(draft));
+        }
+
+        return new DraftMessage {
+            ProfileId = draft.ProfileId,
+            From = draft.From == null ? null : CloneRecipient(draft.From),
+            To = draft.To.Select(CloneRecipient).ToList(),
+            Cc = draft.Cc.Select(CloneRecipient).ToList(),
+            Bcc = draft.Bcc.Select(CloneRecipient).ToList(),
+            ReplyTo = draft.ReplyTo.Select(CloneRecipient).ToList(),
+            Subject = draft.Subject,
+            TextBody = draft.TextBody,
+            HtmlBody = draft.HtmlBody,
+            Priority = draft.Priority,
+            Headers = new Dictionary<string, string>(
+                draft.Headers,
+                StringComparer.OrdinalIgnoreCase),
+            Attachments = draft.Attachments.Select(CloneAttachment).ToList()
+        };
+    }
+
+    private static MessageRecipient CloneRecipient(
+        MessageRecipient recipient) => new() {
+        Name = recipient.Name,
+        Address = recipient.Address
+    };
+
+    private static DraftAttachment CloneAttachment(
+        DraftAttachment attachment) => new() {
+        Path = attachment.Path,
+        FileName = attachment.FileName,
+        ContentType = attachment.ContentType,
+        IsInline = attachment.IsInline,
+        ContentId = attachment.ContentId
+    };
+}

--- a/Sources/Mailozaurr.Application/DraftMimeMessageFactory.cs
+++ b/Sources/Mailozaurr.Application/DraftMimeMessageFactory.cs
@@ -21,7 +21,12 @@ public sealed class DraftMimeMessageFactory : IDraftMimeMessageFactory {
         var message = new MimeMessage {
             Subject = draft.Subject ?? string.Empty,
             Date = DateTimeOffset.UtcNow,
-            MessageId = MimeUtils.GenerateMessageId()
+            MessageId = MimeUtils.GenerateMessageId(),
+            Priority = draft.Priority switch {
+                MessagePriority.High => MimeKit.MessagePriority.Urgent,
+                MessagePriority.Low => MimeKit.MessagePriority.NonUrgent,
+                _ => MimeKit.MessagePriority.Normal
+            }
         };
 
         AddSender(message, profile, draft);

--- a/Sources/Mailozaurr.Application/FileMailDraftStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailDraftStore.cs
@@ -100,34 +100,6 @@ public sealed class FileMailDraftStore : IMailDraftStore {
         Name = draft.Name,
         CreatedAt = draft.CreatedAt,
         UpdatedAt = draft.UpdatedAt,
-        Message = CloneMessage(draft.Message)
+        Message = DraftMessageCloner.Clone(draft.Message)
     };
-
-    private static DraftMessage CloneMessage(DraftMessage message) => new() {
-        ProfileId = message.ProfileId,
-        From = message.From == null ? null : CloneRecipient(message.From),
-        To = message.To.Select(CloneRecipient).ToList(),
-        Cc = message.Cc.Select(CloneRecipient).ToList(),
-        Bcc = message.Bcc.Select(CloneRecipient).ToList(),
-        ReplyTo = message.ReplyTo.Select(CloneRecipient).ToList(),
-        Subject = message.Subject,
-        TextBody = message.TextBody,
-        HtmlBody = message.HtmlBody,
-        Headers = new Dictionary<string, string>(message.Headers, StringComparer.OrdinalIgnoreCase),
-        Attachments = message.Attachments.Select(CloneAttachment).ToList()
-    };
-
-    private static MessageRecipient CloneRecipient(MessageRecipient recipient) => new() {
-        Name = recipient.Name,
-        Address = recipient.Address
-    };
-
-    private static DraftAttachment CloneAttachment(DraftAttachment attachment) => new() {
-        Path = attachment.Path,
-        FileName = attachment.FileName,
-        ContentType = attachment.ContentType,
-        IsInline = attachment.IsInline,
-        ContentId = attachment.ContentId
-    };
-
 }

--- a/Sources/Mailozaurr.Application/FileMailProfileStore.cs
+++ b/Sources/Mailozaurr.Application/FileMailProfileStore.cs
@@ -25,7 +25,7 @@ public sealed class FileMailProfileStore : IMailProfileStore, IMailProfileMainte
 
     /// <inheritdoc />
     public Task<IReadOnlyList<MailProfile>> GetAllAsync(CancellationToken cancellationToken = default) =>
-        _store.ReadAsync(document => CloneProfiles(document.Profiles), cancellationToken);
+        _store.ReadAsync(document => MailProfileCloner.CloneAll(document.Profiles), cancellationToken);
 
     /// <inheritdoc />
     public Task<MailProfile?> GetByIdAsync(string profileId, CancellationToken cancellationToken = default) {
@@ -36,17 +36,17 @@ public sealed class FileMailProfileStore : IMailProfileStore, IMailProfileMainte
         return _store.ReadAsync(document => {
             MailProfile? profile = document.Profiles.FirstOrDefault(p =>
                 string.Equals(p.Id, profileId, StringComparison.OrdinalIgnoreCase));
-            return profile == null ? null : CloneProfile(profile);
+            return profile == null ? null : MailProfileCloner.Clone(profile);
         }, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
-        ValidateProfile(profile);
+        MailProfileCloner.Validate(profile);
 
         await _store.UpdateAsync(document => {
             var existingIndex = document.Profiles.FindIndex(p => string.Equals(p.Id, profile.Id, StringComparison.OrdinalIgnoreCase));
-            var profileToStore = CloneProfile(profile);
+            var profileToStore = MailProfileCloner.Clone(profile);
 
             if (profileToStore.IsDefault) {
                 foreach (var existing in document.Profiles) {
@@ -86,36 +86,5 @@ public sealed class FileMailProfileStore : IMailProfileStore, IMailProfileMainte
             return operation(profileIds, cancellationToken);
         }, cancellationToken);
     }
-
-    private static void ValidateProfile(MailProfile? profile) {
-        if (profile == null) {
-            throw new ArgumentNullException(nameof(profile));
-        }
-
-        if (string.IsNullOrWhiteSpace(profile.Id)) {
-            throw new InvalidOperationException("Profile id is required.");
-        }
-
-        if (string.IsNullOrWhiteSpace(profile.DisplayName)) {
-            throw new InvalidOperationException("Profile display name is required.");
-        }
-    }
-
-    private static IReadOnlyList<MailProfile> CloneProfiles(IEnumerable<MailProfile> profiles) =>
-        profiles.Select(CloneProfile).ToArray();
-
-    private static MailProfile CloneProfile(MailProfile profile) => new() {
-        Id = profile.Id,
-        DisplayName = profile.DisplayName,
-        Description = profile.Description,
-        Kind = profile.Kind,
-        DefaultSender = profile.DefaultSender,
-        DefaultMailbox = profile.DefaultMailbox,
-        IsDefault = profile.IsDefault,
-        Settings = new Dictionary<string, string>(profile.Settings, StringComparer.OrdinalIgnoreCase),
-        Capabilities = profile.Capabilities == null
-            ? null
-            : new ProfileCapabilities(profile.Capabilities.Kind, profile.Capabilities.Capabilities)
-    };
 
 }

--- a/Sources/Mailozaurr.Application/InMemoryMailProfileStore.cs
+++ b/Sources/Mailozaurr.Application/InMemoryMailProfileStore.cs
@@ -1,0 +1,92 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Stores mail profiles in process memory for transient applications, tests, and one-shot delivery workflows.
+/// </summary>
+public sealed class InMemoryMailProfileStore : IMailProfileStore, IMailProfileMaintenanceCoordinator {
+    private readonly Dictionary<string, MailProfile> _profiles = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailProfile>> GetAllAsync(CancellationToken cancellationToken = default) {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            return MailProfileCloner.CloneAll(
+                _profiles.Values.OrderBy(static profile => profile.Id, StringComparer.OrdinalIgnoreCase));
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<MailProfile?> GetByIdAsync(
+        string profileId,
+        CancellationToken cancellationToken = default) {
+        ValidateProfileId(profileId);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            return _profiles.TryGetValue(profileId.Trim(), out MailProfile? profile)
+                ? MailProfileCloner.Clone(profile)
+                : null;
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+        MailProfileCloner.Validate(profile);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            MailProfile profileToStore = MailProfileCloner.Clone(profile);
+            profileToStore.Id = profileToStore.Id.Trim();
+            profileToStore.DisplayName = profileToStore.DisplayName.Trim();
+
+            if (profileToStore.IsDefault) {
+                foreach (MailProfile existing in _profiles.Values) {
+                    existing.IsDefault = false;
+                }
+            }
+
+            _profiles[profileToStore.Id] = profileToStore;
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveAsync(
+        string profileId,
+        CancellationToken cancellationToken = default) {
+        ValidateProfileId(profileId);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            return _profiles.Remove(profileId.Trim());
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<TResult> ExecuteWithStableProfileIdsAsync<TResult>(
+        Func<IReadOnlyCollection<string>, CancellationToken, Task<TResult>> operation,
+        CancellationToken cancellationToken = default) {
+        if (operation == null) throw new ArgumentNullException(nameof(operation));
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            string[] profileIds = _profiles.Keys
+                .OrderBy(static profileId => profileId, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            return await operation(profileIds, cancellationToken).ConfigureAwait(false);
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    private static void ValidateProfileId(string profileId) {
+        if (string.IsNullOrWhiteSpace(profileId)) {
+            throw new ArgumentException("Profile id is required.", nameof(profileId));
+        }
+    }
+}

--- a/Sources/Mailozaurr.Application/InMemoryMailSecretStore.cs
+++ b/Sources/Mailozaurr.Application/InMemoryMailSecretStore.cs
@@ -1,0 +1,110 @@
+namespace Mailozaurr.Application;
+
+/// <summary>
+/// Stores profile secrets in process memory for transient applications, tests, and one-shot delivery workflows.
+/// Values are not persisted or protected outside the current process.
+/// </summary>
+public sealed class InMemoryMailSecretStore : IMailSecretStore, IMailProfileSecretCleanup {
+    private readonly Dictionary<string, Dictionary<string, string>> _profileSecrets =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    /// <inheritdoc />
+    public async Task<string?> GetSecretAsync(
+        string profileId,
+        string secretName,
+        CancellationToken cancellationToken = default) {
+        ValidateKeyPart(profileId, nameof(profileId));
+        ValidateKeyPart(secretName, nameof(secretName));
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            return _profileSecrets.TryGetValue(profileId.Trim(), out Dictionary<string, string>? secrets) &&
+                   secrets.TryGetValue(secretName.Trim(), out string? value)
+                ? value
+                : null;
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SetSecretAsync(
+        string profileId,
+        string secretName,
+        string secretValue,
+        CancellationToken cancellationToken = default) {
+        ValidateKeyPart(profileId, nameof(profileId));
+        ValidateKeyPart(secretName, nameof(secretName));
+        if (secretValue == null) throw new ArgumentNullException(nameof(secretValue));
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            string normalizedProfileId = profileId.Trim();
+            if (!_profileSecrets.TryGetValue(normalizedProfileId, out Dictionary<string, string>? secrets)) {
+                secrets = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                _profileSecrets[normalizedProfileId] = secrets;
+            }
+            secrets[secretName.Trim()] = secretValue;
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveSecretAsync(
+        string profileId,
+        string secretName,
+        CancellationToken cancellationToken = default) {
+        ValidateKeyPart(profileId, nameof(profileId));
+        ValidateKeyPart(secretName, nameof(secretName));
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            string normalizedProfileId = profileId.Trim();
+            if (!_profileSecrets.TryGetValue(normalizedProfileId, out Dictionary<string, string>? secrets)) {
+                return false;
+            }
+
+            bool removed = secrets.Remove(secretName.Trim());
+            if (secrets.Count == 0) {
+                _profileSecrets.Remove(normalizedProfileId);
+            }
+            return removed;
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyDictionary<string, string>> GetProfileSecretsAsync(
+        string profileId,
+        CancellationToken cancellationToken = default) {
+        ValidateKeyPart(profileId, nameof(profileId));
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            return _profileSecrets.TryGetValue(profileId.Trim(), out Dictionary<string, string>? secrets)
+                ? new Dictionary<string, string>(secrets, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task RemoveProfileSecretsAsync(
+        string profileId,
+        CancellationToken cancellationToken = default) {
+        ValidateKeyPart(profileId, nameof(profileId));
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            _profileSecrets.Remove(profileId.Trim());
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    private static void ValidateKeyPart(string value, string parameterName) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            throw new ArgumentException("Value is required.", parameterName);
+        }
+    }
+}

--- a/Sources/Mailozaurr.Application/MailApplicationBuilder.cs
+++ b/Sources/Mailozaurr.Application/MailApplicationBuilder.cs
@@ -308,6 +308,15 @@ public sealed class MailApplicationBuilder {
         if (_options.EnableSmtpSendHandler && !sendHandlers.Any(handler => handler.Kind == MailProfileKind.Smtp)) {
             sendHandlers.Add(new SmtpMailSendHandler(smtpSessionFactory, draftMimeMessageFactory, pendingMessageRepository));
         }
+        if (_options.EnableSendGridSendHandler && !sendHandlers.Any(handler => handler.Kind == MailProfileKind.SendGrid)) {
+            sendHandlers.Add(new SendGridMailSendHandler(secretStore, pendingMessageRepository));
+        }
+        if (_options.EnableMailgunSendHandler && !sendHandlers.Any(handler => handler.Kind == MailProfileKind.Mailgun)) {
+            sendHandlers.Add(new MailgunMailSendHandler(secretStore, pendingMessageRepository));
+        }
+        if (_options.EnableSesSendHandler && !sendHandlers.Any(handler => handler.Kind == MailProfileKind.Ses)) {
+            sendHandlers.Add(new SesMailSendHandler(secretStore, pendingMessageRepository));
+        }
 
         var availableCapabilities = MailCapabilityCatalog.ForRegisteredHandlers(
             readHandlers,

--- a/Sources/Mailozaurr.Application/MailApplicationOptions.cs
+++ b/Sources/Mailozaurr.Application/MailApplicationOptions.cs
@@ -36,4 +36,13 @@ public sealed class MailApplicationOptions {
 
     /// <summary>Whether the built-in SMTP send handler should be registered.</summary>
     public bool EnableSmtpSendHandler { get; set; } = true;
+
+    /// <summary>Whether the built-in SendGrid send handler should be registered.</summary>
+    public bool EnableSendGridSendHandler { get; set; } = true;
+
+    /// <summary>Whether the built-in Mailgun send handler should be registered.</summary>
+    public bool EnableMailgunSendHandler { get; set; } = true;
+
+    /// <summary>Whether the built-in Amazon SES send handler should be registered.</summary>
+    public bool EnableSesSendHandler { get; set; } = true;
 }

--- a/Sources/Mailozaurr.Application/MailCapabilityCatalog.cs
+++ b/Sources/Mailozaurr.Application/MailCapabilityCatalog.cs
@@ -60,6 +60,9 @@ public static class MailCapabilityCatalog {
                 | MailCapability.DeleteMessages
                 | MailCapability.SendMessages,
             MailProfileKind.Smtp => MailCapability.SendMessages,
+            MailProfileKind.SendGrid => MailCapability.SendMessages,
+            MailProfileKind.Mailgun => MailCapability.SendMessages,
+            MailProfileKind.Ses => MailCapability.SendMessages,
             _ => MailCapability.None,
         };
 

--- a/Sources/Mailozaurr.Application/MailProfileBootstrapService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileBootstrapService.cs
@@ -9,7 +9,10 @@ public sealed class MailProfileBootstrapService : IMailProfileBootstrapService {
         MailSecretNames.ClientSecret,
         MailSecretNames.AccessToken,
         MailSecretNames.RefreshToken,
-        MailSecretNames.CertificatePassword
+        MailSecretNames.CertificatePassword,
+        MailSecretNames.ApiKey,
+        MailSecretNames.AccessKeyId,
+        MailSecretNames.SecretAccessKey
     };
     private readonly IMailProfileService _profiles;
     private readonly IMailProfileSecretService _profileSecrets;

--- a/Sources/Mailozaurr.Application/MailProfileCloner.cs
+++ b/Sources/Mailozaurr.Application/MailProfileCloner.cs
@@ -1,0 +1,34 @@
+namespace Mailozaurr.Application;
+
+internal static class MailProfileCloner {
+    public static IReadOnlyList<MailProfile> CloneAll(IEnumerable<MailProfile> profiles) =>
+        profiles.Select(Clone).ToArray();
+
+    public static MailProfile Clone(MailProfile profile) => new() {
+        Id = profile.Id,
+        DisplayName = profile.DisplayName,
+        Description = profile.Description,
+        Kind = profile.Kind,
+        DefaultSender = profile.DefaultSender,
+        DefaultMailbox = profile.DefaultMailbox,
+        IsDefault = profile.IsDefault,
+        Settings = new Dictionary<string, string>(profile.Settings, StringComparer.OrdinalIgnoreCase),
+        Capabilities = profile.Capabilities == null
+            ? null
+            : new ProfileCapabilities(profile.Capabilities.Kind, profile.Capabilities.Capabilities)
+    };
+
+    public static void Validate(MailProfile? profile) {
+        if (profile == null) {
+            throw new ArgumentNullException(nameof(profile));
+        }
+
+        if (string.IsNullOrWhiteSpace(profile.Id)) {
+            throw new InvalidOperationException("Profile id is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(profile.DisplayName)) {
+            throw new InvalidOperationException("Profile display name is required.");
+        }
+    }
+}

--- a/Sources/Mailozaurr.Application/MailProfileService.cs
+++ b/Sources/Mailozaurr.Application/MailProfileService.cs
@@ -9,7 +9,10 @@ public sealed class MailProfileService : IMailProfileService {
         MailSecretNames.ClientSecret,
         MailSecretNames.AccessToken,
         MailSecretNames.RefreshToken,
-        MailSecretNames.CertificatePassword
+        MailSecretNames.CertificatePassword,
+        MailSecretNames.ApiKey,
+        MailSecretNames.AccessKeyId,
+        MailSecretNames.SecretAccessKey
     };
     private readonly IMailProfileStore _profileStore;
     private readonly IMailSecretStore? _secretStore;
@@ -179,6 +182,19 @@ public sealed class MailProfileService : IMailProfileService {
                 var hasGmailClientId = HasSetting(profile, MailProfileSettingsKeys.ClientId);
                 if (!hasGmailAccessToken && (!hasGmailRefreshToken || !hasGmailClientId || !hasGmailClientSecret)) {
                     result.Errors.Add("Gmail profiles need an access token or a refresh token with a client id and client secret.");
+                }
+                break;
+            case MailProfileKind.SendGrid:
+            case MailProfileKind.Mailgun:
+                if (!await HasSecretAsync(profile.Id, MailSecretNames.ApiKey, cancellationToken).ConfigureAwait(false)) {
+                    result.Errors.Add($"{profile.Kind} profiles need an API key.");
+                }
+                break;
+            case MailProfileKind.Ses:
+                var hasSesAccessKeyId = await HasSecretAsync(profile.Id, MailSecretNames.AccessKeyId, cancellationToken).ConfigureAwait(false);
+                var hasSesSecretAccessKey = await HasSecretAsync(profile.Id, MailSecretNames.SecretAccessKey, cancellationToken).ConfigureAwait(false);
+                if (!hasSesAccessKeyId || !hasSesSecretAccessKey) {
+                    result.Errors.Add("SES profiles need an access key id and secret access key.");
                 }
                 break;
         }

--- a/Sources/Mailozaurr.Application/MailProfileSettingsKeys.cs
+++ b/Sources/Mailozaurr.Application/MailProfileSettingsKeys.cs
@@ -43,6 +43,9 @@ public static class MailProfileSettingsKeys {
     /// <summary>Authentication mode identifier.</summary>
     public const string AuthMode = "authMode";
 
+    /// <summary>Whether the transport should authenticate after connecting.</summary>
+    public const string AuthenticationEnabled = "authenticationEnabled";
+
     /// <summary>Secure socket options mode.</summary>
     public const string SecureSocketOptions = "secureSocketOptions";
 

--- a/Sources/Mailozaurr.Application/MailProfileSettingsKeys.cs
+++ b/Sources/Mailozaurr.Application/MailProfileSettingsKeys.cs
@@ -61,6 +61,21 @@ public static class MailProfileSettingsKeys {
     /// <summary>Retry backoff multiplier.</summary>
     public const string RetryDelayBackoff = "retryDelayBackoff";
 
+    /// <summary>Maximum retry delay in milliseconds.</summary>
+    public const string MaxDelayMilliseconds = "maxDelayMilliseconds";
+
+    /// <summary>Random retry jitter window in milliseconds.</summary>
+    public const string JitterMilliseconds = "jitterMilliseconds";
+
+    /// <summary>Whether non-transient failures should also be retried.</summary>
+    public const string RetryAlways = "retryAlways";
+
+    /// <summary>Provider sending domain, where the transport supports an explicit domain.</summary>
+    public const string Domain = "domain";
+
+    /// <summary>Cloud region used by a regional transport such as Amazon SES.</summary>
+    public const string Region = "region";
+
     /// <summary>Whether certificate revocation checks should be skipped.</summary>
     public const string SkipCertificateRevocation = "skipCertificateRevocation";
 

--- a/Sources/Mailozaurr.Application/MailProfileValidator.cs
+++ b/Sources/Mailozaurr.Application/MailProfileValidator.cs
@@ -94,4 +94,5 @@ public static class MailProfileValidator {
             result.Errors.Add($"Profile setting '{MailProfileSettingsKeys.Port}' must be a valid TCP port.");
         }
     }
+
 }

--- a/Sources/Mailozaurr.Application/MailSecretNames.cs
+++ b/Sources/Mailozaurr.Application/MailSecretNames.cs
@@ -18,4 +18,13 @@ public static class MailSecretNames {
 
     /// <summary>Certificate password when certificate auth is used.</summary>
     public const string CertificatePassword = "certificatePassword";
+
+    /// <summary>API key used by an HTTP delivery provider.</summary>
+    public const string ApiKey = "apiKey";
+
+    /// <summary>Amazon access key identifier.</summary>
+    public const string AccessKeyId = "accessKeyId";
+
+    /// <summary>Amazon secret access key.</summary>
+    public const string SecretAccessKey = "secretAccessKey";
 }

--- a/Sources/Mailozaurr.Application/MailgunMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/MailgunMailSendHandler.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using MimeKit;
+
+namespace Mailozaurr.Application;
+
+/// <summary>Normalized Mailgun delivery handler backed by Mailozaurr.</summary>
+public sealed class MailgunMailSendHandler : IMailSendHandler {
+    private readonly IMailSecretStore _secretStore;
+    private readonly IPendingMessageRepository? _pendingMessageRepository;
+    private readonly Func<MailgunClient, CancellationToken, Task<SmtpResult>> _sendAsync;
+
+    /// <summary>Creates a Mailgun delivery handler.</summary>
+    public MailgunMailSendHandler(
+        IMailSecretStore secretStore,
+        IPendingMessageRepository? pendingMessageRepository = null,
+        Func<MailgunClient, CancellationToken, Task<SmtpResult>>? sendAsync = null) {
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+        _pendingMessageRepository = pendingMessageRepository;
+        _sendAsync = sendAsync ?? DefaultSendAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Mailgun;
+
+    /// <inheritdoc />
+    public async Task<SendResult> SendAsync(MailProfile profile, SendMessageRequest request, CancellationToken cancellationToken = default) {
+        ProviderMailSendHandlerSupport.Validate(profile, request, Kind);
+        var apiKey = await ProviderMailSendHandlerSupport.RequireSecretAsync(
+            _secretStore, profile, MailSecretNames.ApiKey, cancellationToken).ConfigureAwait(false);
+
+        using var client = new MailgunClient {
+            Credentials = new NetworkCredential("api", apiKey),
+            Domain = ProviderMailSendHandlerSupport.GetSetting(profile, MailProfileSettingsKeys.Domain),
+            From = ProviderMailSendHandlerSupport.ToMailboxAddress(
+                ProviderMailSendHandlerSupport.ResolveSender(profile, request.Message)),
+            To = ProviderMailSendHandlerSupport.Recipients(request.Message.To),
+            Cc = ProviderMailSendHandlerSupport.Recipients(request.Message.Cc),
+            Bcc = ProviderMailSendHandlerSupport.Recipients(request.Message.Bcc),
+            ReplyTo = request.Message.ReplyTo.Count == 0
+                ? null
+                : ProviderMailSendHandlerSupport.ToMailboxAddress(request.Message.ReplyTo[0]),
+            Subject = request.Message.Subject,
+            Text = request.Message.TextBody ?? string.Empty,
+            Html = request.Message.HtmlBody ?? string.Empty,
+            Headers = request.Message.Headers,
+            Attachments = ProviderMailSendHandlerSupport.Attachments(request.Message).Where(attachment =>
+                !string.Equals(attachment.ContentDisposition?.Disposition, ContentDisposition.Inline, StringComparison.OrdinalIgnoreCase)).ToList(),
+            InlineAttachments = ProviderMailSendHandlerSupport.Attachments(request.Message).Where(attachment =>
+                string.Equals(attachment.ContentDisposition?.Disposition, ContentDisposition.Inline, StringComparison.OrdinalIgnoreCase)).ToList(),
+            PendingMessageRepository = request.QueueOnFailure ? _pendingMessageRepository : null
+        };
+        ProviderMailSendHandlerSupport.ApplyRetrySettings(profile, (count, delay, backoff, max, jitter, always) => {
+            client.RetryCount = count;
+            client.RetryDelayMilliseconds = delay;
+            client.RetryDelayBackoff = backoff;
+            client.MaxDelayMilliseconds = max;
+            client.JitterMilliseconds = jitter;
+            client.RetryAlways = always;
+        });
+
+        var result = await _sendAsync(client, cancellationToken).ConfigureAwait(false);
+        return await ProviderMailSendHandlerSupport.ToResultAsync(
+            profile,
+            result,
+            request.QueueOnFailure ? _pendingMessageRepository : null,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Task<SmtpResult> DefaultSendAsync(MailgunClient client, CancellationToken cancellationToken) =>
+        client.SendEmailAsync(cancellationToken);
+}

--- a/Sources/Mailozaurr.Application/MailgunMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/MailgunMailSendHandler.cs
@@ -27,6 +27,7 @@ public sealed class MailgunMailSendHandler : IMailSendHandler {
         ProviderMailSendHandlerSupport.Validate(profile, request, Kind);
         var apiKey = await ProviderMailSendHandlerSupport.RequireSecretAsync(
             _secretStore, profile, MailSecretNames.ApiKey, cancellationToken).ConfigureAwait(false);
+        var attachments = ProviderMailSendHandlerSupport.Attachments(request.Message);
 
         using var client = new MailgunClient {
             Credentials = new NetworkCredential("api", apiKey),
@@ -42,10 +43,11 @@ public sealed class MailgunMailSendHandler : IMailSendHandler {
             Subject = request.Message.Subject,
             Text = request.Message.TextBody ?? string.Empty,
             Html = request.Message.HtmlBody ?? string.Empty,
+            Priority = request.Message.Priority,
             Headers = request.Message.Headers,
-            Attachments = ProviderMailSendHandlerSupport.Attachments(request.Message).Where(attachment =>
+            Attachments = attachments.Where(attachment =>
                 !string.Equals(attachment.ContentDisposition?.Disposition, ContentDisposition.Inline, StringComparison.OrdinalIgnoreCase)).ToList(),
-            InlineAttachments = ProviderMailSendHandlerSupport.Attachments(request.Message).Where(attachment =>
+            InlineAttachments = attachments.Where(attachment =>
                 string.Equals(attachment.ContentDisposition?.Disposition, ContentDisposition.Inline, StringComparison.OrdinalIgnoreCase)).ToList(),
             PendingMessageRepository = request.QueueOnFailure ? _pendingMessageRepository : null
         };

--- a/Sources/Mailozaurr.Application/MailgunMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/MailgunMailSendHandler.cs
@@ -61,11 +61,7 @@ public sealed class MailgunMailSendHandler : IMailSendHandler {
         });
 
         var result = await _sendAsync(client, cancellationToken).ConfigureAwait(false);
-        return await ProviderMailSendHandlerSupport.ToResultAsync(
-            profile,
-            result,
-            request.QueueOnFailure ? _pendingMessageRepository : null,
-            cancellationToken).ConfigureAwait(false);
+        return ProviderMailSendHandlerSupport.ToResult(profile, result);
     }
 
     private static Task<SmtpResult> DefaultSendAsync(MailgunClient client, CancellationToken cancellationToken) =>

--- a/Sources/Mailozaurr.Application/MailgunMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/MailgunMailSendHandler.cs
@@ -36,9 +36,9 @@ public sealed class MailgunMailSendHandler : IMailSendHandler {
             To = ProviderMailSendHandlerSupport.Recipients(request.Message.To),
             Cc = ProviderMailSendHandlerSupport.Recipients(request.Message.Cc),
             Bcc = ProviderMailSendHandlerSupport.Recipients(request.Message.Bcc),
-            ReplyTo = request.Message.ReplyTo.Count == 0
-                ? null
-                : ProviderMailSendHandlerSupport.ToMailboxAddress(request.Message.ReplyTo[0]),
+            ReplyTo = ProviderMailSendHandlerSupport.ResolveReplyTo(request.Message) is { } replyTo
+                ? ProviderMailSendHandlerSupport.ToMailboxAddress(replyTo)
+                : null,
             Subject = request.Message.Subject,
             Text = request.Message.TextBody ?? string.Empty,
             Html = request.Message.HtmlBody ?? string.Empty,

--- a/Sources/Mailozaurr.Application/Mailozaurr.Application.csproj
+++ b/Sources/Mailozaurr.Application/Mailozaurr.Application.csproj
@@ -20,7 +20,7 @@
         <PackageProjectUrl>https://github.com/EvotecIT/Mailozaurr</PackageProjectUrl>
         <PackageReadmeFile>README.MD</PackageReadmeFile>
         <RepositoryUrl>https://github.com/EvotecIT/Mailozaurr</RepositoryUrl>
-        <PackageTags>Windows;MacOS;Linux;Mail;Email;Graph;Gmail;IMAP;SMTP</PackageTags>
+        <PackageTags>Windows;MacOS;Linux;Mail;Email;Graph;Gmail;IMAP;SMTP;SendGrid;Mailgun;AmazonSES</PackageTags>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
+++ b/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
@@ -73,13 +73,17 @@ internal static class ProviderMailSendHandlerSupport {
             .ToList();
 
     public static void ApplyRetrySettings(MailProfile profile, Action<int, int, double, int, int, bool> apply) {
-        apply(
-            GetInt(profile, MailProfileSettingsKeys.RetryCount) ?? 0,
-            GetInt(profile, MailProfileSettingsKeys.RetryDelayMilliseconds) ?? 0,
-            GetDouble(profile, MailProfileSettingsKeys.RetryDelayBackoff) ?? 1.0,
-            GetInt(profile, MailProfileSettingsKeys.MaxDelayMilliseconds) ?? 0,
-            GetInt(profile, MailProfileSettingsKeys.JitterMilliseconds) ?? 0,
-            GetBool(profile, MailProfileSettingsKeys.RetryAlways) ?? false);
+        var retryCount = RequireNonNegative(profile, MailProfileSettingsKeys.RetryCount, GetInt(profile, MailProfileSettingsKeys.RetryCount) ?? 0);
+        var retryDelay = RequireNonNegative(profile, MailProfileSettingsKeys.RetryDelayMilliseconds, GetInt(profile, MailProfileSettingsKeys.RetryDelayMilliseconds) ?? 0);
+        var backoff = GetDouble(profile, MailProfileSettingsKeys.RetryDelayBackoff) ?? 1.0;
+        if (double.IsNaN(backoff) || double.IsInfinity(backoff) || backoff < 1.0) {
+            throw new InvalidOperationException(
+                $"Profile '{profile.Id}' setting '{MailProfileSettingsKeys.RetryDelayBackoff}' must be a finite number greater than or equal to 1.");
+        }
+        var maxDelay = RequireNonNegative(profile, MailProfileSettingsKeys.MaxDelayMilliseconds, GetInt(profile, MailProfileSettingsKeys.MaxDelayMilliseconds) ?? 0);
+        var jitter = RequireNonNegative(profile, MailProfileSettingsKeys.JitterMilliseconds, GetInt(profile, MailProfileSettingsKeys.JitterMilliseconds) ?? 0);
+
+        apply(retryCount, retryDelay, backoff, maxDelay, jitter, GetBool(profile, MailProfileSettingsKeys.RetryAlways) ?? false);
     }
 
     public static string? GetSetting(MailProfile profile, string key) =>
@@ -116,7 +120,12 @@ internal static class ProviderMailSendHandlerSupport {
     }
 
     private static AttachmentDescriptor CreateAttachment(DraftAttachment attachment) {
-        var descriptor = new FileAttachmentDescriptor(attachment.Path) {
+        var fullPath = Path.GetFullPath(attachment.Path);
+        if (!File.Exists(fullPath)) {
+            throw new FileNotFoundException($"Attachment '{attachment.Path}' was not found.", fullPath);
+        }
+
+        var descriptor = new FileAttachmentDescriptor(fullPath) {
             ContentDisposition = new ContentDisposition(
                 attachment.IsInline ? ContentDisposition.Inline : ContentDisposition.Attachment)
         };
@@ -154,5 +163,12 @@ internal static class ProviderMailSendHandlerSupport {
         if (value == null) return null;
         if (bool.TryParse(value, out var parsed)) return parsed;
         throw new InvalidOperationException($"Profile '{profile.Id}' has invalid boolean setting '{key}'.");
+    }
+
+    private static int RequireNonNegative(MailProfile profile, string key, int value) {
+        if (value < 0) {
+            throw new InvalidOperationException($"Profile '{profile.Id}' setting '{key}' must not be negative.");
+        }
+        return value;
     }
 }

--- a/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
+++ b/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
@@ -94,19 +94,10 @@ internal static class ProviderMailSendHandlerSupport {
             ? value.Trim()
             : null;
 
-    public static async Task<SendResult> ToResultAsync(
-        MailProfile profile,
-        SmtpResult result,
-        IPendingMessageRepository? pendingMessageRepository,
-        CancellationToken cancellationToken) {
-        var queued = false;
-        if (!result.Status &&
-            pendingMessageRepository != null &&
-            !string.IsNullOrWhiteSpace(result.MessageId)) {
-            queued = await pendingMessageRepository
-                .GetByMessageIdAsync(result.MessageId!, cancellationToken)
-                .ConfigureAwait(false) != null;
-        }
+    public static SendResult ToResult(MailProfile profile, SmtpResult result) {
+        var queued = !result.Status &&
+                     result.Queued &&
+                     !string.IsNullOrWhiteSpace(result.MessageId);
         return new SendResult {
             Succeeded = result.Status || queued,
             ProfileId = profile.Id,

--- a/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
+++ b/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
@@ -36,10 +36,13 @@ internal static class ProviderMailSendHandlerSupport {
 
     public static MessageRecipient ResolveSender(MailProfile profile, DraftMessage message) {
         if (message.From is { } sender && HasAddress(sender)) return sender;
-        if (string.IsNullOrWhiteSpace(profile.DefaultSender)) {
+        var profileSender = !string.IsNullOrWhiteSpace(profile.DefaultSender)
+            ? profile.DefaultSender
+            : profile.DefaultMailbox;
+        if (string.IsNullOrWhiteSpace(profileSender)) {
             throw new InvalidOperationException($"Profile '{profile.Id}' requires a default sender or message sender.");
         }
-        var parsed = MailboxAddress.Parse(profile.DefaultSender!.Trim());
+        var parsed = MailboxAddress.Parse(profileSender!.Trim());
         return new MessageRecipient { Name = parsed.Name, Address = parsed.Address };
     }
 

--- a/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
+++ b/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
@@ -1,5 +1,6 @@
 using Mailozaurr.Definitions;
 using MimeKit;
+using MimeKit.Utils;
 using System.Globalization;
 
 namespace Mailozaurr.Application;
@@ -34,7 +35,7 @@ internal static class ProviderMailSendHandlerSupport {
     }
 
     public static MessageRecipient ResolveSender(MailProfile profile, DraftMessage message) {
-        if (message.From is { Address.Length: > 0 } sender) return sender;
+        if (message.From is { } sender && HasAddress(sender)) return sender;
         if (string.IsNullOrWhiteSpace(profile.DefaultSender)) {
             throw new InvalidOperationException($"Profile '{profile.Id}' requires a default sender or message sender.");
         }
@@ -121,7 +122,13 @@ internal static class ProviderMailSendHandlerSupport {
         };
         if (attachment.FileName is { } fileName && !string.IsNullOrWhiteSpace(fileName)) descriptor.FileName = fileName.Trim();
         if (attachment.ContentType is { } contentType && !string.IsNullOrWhiteSpace(contentType)) descriptor.ContentType = contentType.Trim();
-        if (attachment.ContentId is { } contentId && !string.IsNullOrWhiteSpace(contentId)) descriptor.ContentId = contentId.Trim();
+        if (attachment.ContentId is { } contentId && !string.IsNullOrWhiteSpace(contentId)) {
+            descriptor.ContentId = contentId.Trim();
+        } else if (attachment.IsInline) {
+            descriptor.ContentId = !string.IsNullOrWhiteSpace(descriptor.FileName)
+                ? descriptor.FileName
+                : MimeUtils.GenerateMessageId();
+        }
         return descriptor;
     }
 

--- a/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
+++ b/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
@@ -14,6 +14,11 @@ internal static class ProviderMailSendHandlerSupport {
         if (request.NotBefore.HasValue) {
             throw new NotSupportedException($"Scheduled {expectedKind} sends are not yet supported by the application send handler.");
         }
+        if (!request.Message.To.Any(HasAddress) &&
+            !request.Message.Cc.Any(HasAddress) &&
+            !request.Message.Bcc.Any(HasAddress)) {
+            throw new InvalidOperationException("At least one non-empty To, Cc, or Bcc recipient is required.");
+        }
     }
 
     public static async Task<string> RequireSecretAsync(
@@ -56,6 +61,9 @@ internal static class ProviderMailSendHandlerSupport {
         Name = string.IsNullOrWhiteSpace(recipient.Name) ? null : recipient.Name!.Trim(),
         Email = recipient.Address.Trim()
     };
+
+    public static MessageRecipient? ResolveReplyTo(DraftMessage message) =>
+        message.ReplyTo.FirstOrDefault(HasAddress);
 
     public static List<AttachmentDescriptor> Attachments(DraftMessage message) =>
         message.Attachments
@@ -108,14 +116,17 @@ internal static class ProviderMailSendHandlerSupport {
 
     private static AttachmentDescriptor CreateAttachment(DraftAttachment attachment) {
         var descriptor = new FileAttachmentDescriptor(attachment.Path) {
-            FileName = attachment.FileName,
-            ContentType = attachment.ContentType,
-            ContentId = attachment.ContentId,
             ContentDisposition = new ContentDisposition(
                 attachment.IsInline ? ContentDisposition.Inline : ContentDisposition.Attachment)
         };
+        if (attachment.FileName is { } fileName && !string.IsNullOrWhiteSpace(fileName)) descriptor.FileName = fileName.Trim();
+        if (attachment.ContentType is { } contentType && !string.IsNullOrWhiteSpace(contentType)) descriptor.ContentType = contentType.Trim();
+        if (attachment.ContentId is { } contentId && !string.IsNullOrWhiteSpace(contentId)) descriptor.ContentId = contentId.Trim();
         return descriptor;
     }
+
+    private static bool HasAddress(MessageRecipient recipient) =>
+        !string.IsNullOrWhiteSpace(recipient.Address);
 
     private static int? GetInt(MailProfile profile, string key) {
         var value = GetSetting(profile, key);

--- a/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
+++ b/Sources/Mailozaurr.Application/ProviderMailSendHandlerSupport.cs
@@ -1,0 +1,140 @@
+using Mailozaurr.Definitions;
+using MimeKit;
+using System.Globalization;
+
+namespace Mailozaurr.Application;
+
+internal static class ProviderMailSendHandlerSupport {
+    public static void Validate(MailProfile profile, SendMessageRequest request, MailProfileKind expectedKind) {
+        if (profile == null) throw new ArgumentNullException(nameof(profile));
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        if (profile.Kind != expectedKind) {
+            throw new InvalidOperationException($"Profile '{profile.Id}' is not a {expectedKind} profile.");
+        }
+        if (request.NotBefore.HasValue) {
+            throw new NotSupportedException($"Scheduled {expectedKind} sends are not yet supported by the application send handler.");
+        }
+    }
+
+    public static async Task<string> RequireSecretAsync(
+        IMailSecretStore secretStore,
+        MailProfile profile,
+        string secretName,
+        CancellationToken cancellationToken) {
+        var value = await secretStore.GetSecretAsync(profile.Id, secretName, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(value)) {
+            throw new InvalidOperationException($"Secret '{secretName}' is required for profile '{profile.Id}'.");
+        }
+        return value!.Trim();
+    }
+
+    public static MessageRecipient ResolveSender(MailProfile profile, DraftMessage message) {
+        if (message.From is { Address.Length: > 0 } sender) return sender;
+        if (string.IsNullOrWhiteSpace(profile.DefaultSender)) {
+            throw new InvalidOperationException($"Profile '{profile.Id}' requires a default sender or message sender.");
+        }
+        var parsed = MailboxAddress.Parse(profile.DefaultSender!.Trim());
+        return new MessageRecipient { Name = parsed.Name, Address = parsed.Address };
+    }
+
+    public static List<object> Recipients(IEnumerable<MessageRecipient> recipients) =>
+        recipients
+            .Where(recipient => !string.IsNullOrWhiteSpace(recipient.Address))
+            .Select(recipient => (object)ToMailboxAddress(recipient))
+            .ToList();
+
+    public static List<object> SendGridRecipients(IEnumerable<MessageRecipient> recipients) =>
+        recipients
+            .Where(recipient => !string.IsNullOrWhiteSpace(recipient.Address))
+            .Select(recipient => (object)ToSendGridAddress(recipient))
+            .ToList();
+
+    public static MailboxAddress ToMailboxAddress(MessageRecipient recipient) =>
+        new(recipient.Name ?? string.Empty, recipient.Address.Trim());
+
+    public static SendGridEmailAddress ToSendGridAddress(MessageRecipient recipient) => new() {
+        Name = string.IsNullOrWhiteSpace(recipient.Name) ? null : recipient.Name!.Trim(),
+        Email = recipient.Address.Trim()
+    };
+
+    public static List<AttachmentDescriptor> Attachments(DraftMessage message) =>
+        message.Attachments
+            .Where(attachment => !string.IsNullOrWhiteSpace(attachment.Path))
+            .Select(CreateAttachment)
+            .ToList();
+
+    public static void ApplyRetrySettings(MailProfile profile, Action<int, int, double, int, int, bool> apply) {
+        apply(
+            GetInt(profile, MailProfileSettingsKeys.RetryCount) ?? 0,
+            GetInt(profile, MailProfileSettingsKeys.RetryDelayMilliseconds) ?? 0,
+            GetDouble(profile, MailProfileSettingsKeys.RetryDelayBackoff) ?? 1.0,
+            GetInt(profile, MailProfileSettingsKeys.MaxDelayMilliseconds) ?? 0,
+            GetInt(profile, MailProfileSettingsKeys.JitterMilliseconds) ?? 0,
+            GetBool(profile, MailProfileSettingsKeys.RetryAlways) ?? false);
+    }
+
+    public static string? GetSetting(MailProfile profile, string key) =>
+        profile.Settings.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value.Trim()
+            : null;
+
+    public static async Task<SendResult> ToResultAsync(
+        MailProfile profile,
+        SmtpResult result,
+        IPendingMessageRepository? pendingMessageRepository,
+        CancellationToken cancellationToken) {
+        var queued = false;
+        if (!result.Status &&
+            pendingMessageRepository != null &&
+            !string.IsNullOrWhiteSpace(result.MessageId)) {
+            queued = await pendingMessageRepository
+                .GetByMessageIdAsync(result.MessageId!, cancellationToken)
+                .ConfigureAwait(false) != null;
+        }
+        return new SendResult {
+            Succeeded = result.Status || queued,
+            ProfileId = profile.Id,
+            ProfileKind = profile.Kind,
+            ProviderMessageId = result.Status ? result.MessageId : null,
+            Queued = queued,
+            QueueMessageId = queued ? result.MessageId : null,
+            Message = result.Status
+                ? "Message sent successfully."
+                : queued
+                    ? $"Message queued after send failure: {result.Error ?? result.Message ?? "Provider send failed."}"
+                    : result.Error ?? result.Message ?? "Provider send failed."
+        };
+    }
+
+    private static AttachmentDescriptor CreateAttachment(DraftAttachment attachment) {
+        var descriptor = new FileAttachmentDescriptor(attachment.Path) {
+            FileName = attachment.FileName,
+            ContentType = attachment.ContentType,
+            ContentId = attachment.ContentId,
+            ContentDisposition = new ContentDisposition(
+                attachment.IsInline ? ContentDisposition.Inline : ContentDisposition.Attachment)
+        };
+        return descriptor;
+    }
+
+    private static int? GetInt(MailProfile profile, string key) {
+        var value = GetSetting(profile, key);
+        if (value == null) return null;
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)) return parsed;
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid integer setting '{key}'.");
+    }
+
+    private static double? GetDouble(MailProfile profile, string key) {
+        var value = GetSetting(profile, key);
+        if (value == null) return null;
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)) return parsed;
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid numeric setting '{key}'.");
+    }
+
+    private static bool? GetBool(MailProfile profile, string key) {
+        var value = GetSetting(profile, key);
+        if (value == null) return null;
+        if (bool.TryParse(value, out var parsed)) return parsed;
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid boolean setting '{key}'.");
+    }
+}

--- a/Sources/Mailozaurr.Application/SendGridMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/SendGridMailSendHandler.cs
@@ -1,0 +1,67 @@
+using System.Net;
+
+namespace Mailozaurr.Application;
+
+/// <summary>Normalized SendGrid delivery handler backed by Mailozaurr.</summary>
+public sealed class SendGridMailSendHandler : IMailSendHandler {
+    private readonly IMailSecretStore _secretStore;
+    private readonly IPendingMessageRepository? _pendingMessageRepository;
+    private readonly Func<SendGridClient, CancellationToken, Task<SmtpResult>> _sendAsync;
+
+    /// <summary>Creates a SendGrid delivery handler.</summary>
+    public SendGridMailSendHandler(
+        IMailSecretStore secretStore,
+        IPendingMessageRepository? pendingMessageRepository = null,
+        Func<SendGridClient, CancellationToken, Task<SmtpResult>>? sendAsync = null) {
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+        _pendingMessageRepository = pendingMessageRepository;
+        _sendAsync = sendAsync ?? DefaultSendAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.SendGrid;
+
+    /// <inheritdoc />
+    public async Task<SendResult> SendAsync(MailProfile profile, SendMessageRequest request, CancellationToken cancellationToken = default) {
+        ProviderMailSendHandlerSupport.Validate(profile, request, Kind);
+        var apiKey = await ProviderMailSendHandlerSupport.RequireSecretAsync(
+            _secretStore, profile, MailSecretNames.ApiKey, cancellationToken).ConfigureAwait(false);
+
+        using var client = new SendGridClient {
+            Credentials = new NetworkCredential(string.Empty, apiKey),
+            From = ProviderMailSendHandlerSupport.ToSendGridAddress(
+                ProviderMailSendHandlerSupport.ResolveSender(profile, request.Message)),
+            To = ProviderMailSendHandlerSupport.SendGridRecipients(request.Message.To),
+            Cc = ProviderMailSendHandlerSupport.SendGridRecipients(request.Message.Cc),
+            Bcc = ProviderMailSendHandlerSupport.SendGridRecipients(request.Message.Bcc),
+            ReplyTo = request.Message.ReplyTo.Count == 0
+                ? null
+                : ProviderMailSendHandlerSupport.ToSendGridAddress(request.Message.ReplyTo[0]),
+            Subject = request.Message.Subject,
+            Text = request.Message.TextBody ?? string.Empty,
+            Html = request.Message.HtmlBody ?? string.Empty,
+            Headers = request.Message.Headers,
+            Attachments = ProviderMailSendHandlerSupport.Attachments(request.Message),
+            PendingMessageRepository = request.QueueOnFailure ? _pendingMessageRepository : null
+        };
+        ProviderMailSendHandlerSupport.ApplyRetrySettings(profile, (count, delay, backoff, max, jitter, always) => {
+            client.RetryCount = count;
+            client.RetryDelayMilliseconds = delay;
+            client.RetryDelayBackoff = backoff;
+            client.MaxDelayMilliseconds = max;
+            client.JitterMilliseconds = jitter;
+            client.RetryAlways = always;
+        });
+        client.CreateMessage();
+
+        var result = await _sendAsync(client, cancellationToken).ConfigureAwait(false);
+        return await ProviderMailSendHandlerSupport.ToResultAsync(
+            profile,
+            result,
+            request.QueueOnFailure ? _pendingMessageRepository : null,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Task<SmtpResult> DefaultSendAsync(SendGridClient client, CancellationToken cancellationToken) =>
+        client.SendEmailAsync(cancellationToken);
+}

--- a/Sources/Mailozaurr.Application/SendGridMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/SendGridMailSendHandler.cs
@@ -34,9 +34,9 @@ public sealed class SendGridMailSendHandler : IMailSendHandler {
             To = ProviderMailSendHandlerSupport.SendGridRecipients(request.Message.To),
             Cc = ProviderMailSendHandlerSupport.SendGridRecipients(request.Message.Cc),
             Bcc = ProviderMailSendHandlerSupport.SendGridRecipients(request.Message.Bcc),
-            ReplyTo = request.Message.ReplyTo.Count == 0
-                ? null
-                : ProviderMailSendHandlerSupport.ToSendGridAddress(request.Message.ReplyTo[0]),
+            ReplyTo = ProviderMailSendHandlerSupport.ResolveReplyTo(request.Message) is { } replyTo
+                ? ProviderMailSendHandlerSupport.ToSendGridAddress(replyTo)
+                : null,
             Subject = request.Message.Subject,
             Text = request.Message.TextBody ?? string.Empty,
             Html = request.Message.HtmlBody ?? string.Empty,

--- a/Sources/Mailozaurr.Application/SendGridMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/SendGridMailSendHandler.cs
@@ -40,6 +40,7 @@ public sealed class SendGridMailSendHandler : IMailSendHandler {
             Subject = request.Message.Subject,
             Text = request.Message.TextBody ?? string.Empty,
             Html = request.Message.HtmlBody ?? string.Empty,
+            Priority = request.Message.Priority,
             Headers = request.Message.Headers,
             Attachments = ProviderMailSendHandlerSupport.Attachments(request.Message),
             PendingMessageRepository = request.QueueOnFailure ? _pendingMessageRepository : null

--- a/Sources/Mailozaurr.Application/SendGridMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/SendGridMailSendHandler.cs
@@ -56,11 +56,7 @@ public sealed class SendGridMailSendHandler : IMailSendHandler {
         client.CreateMessage();
 
         var result = await _sendAsync(client, cancellationToken).ConfigureAwait(false);
-        return await ProviderMailSendHandlerSupport.ToResultAsync(
-            profile,
-            result,
-            request.QueueOnFailure ? _pendingMessageRepository : null,
-            cancellationToken).ConfigureAwait(false);
+        return ProviderMailSendHandlerSupport.ToResult(profile, result);
     }
 
     private static Task<SmtpResult> DefaultSendAsync(SendGridClient client, CancellationToken cancellationToken) =>

--- a/Sources/Mailozaurr.Application/SesMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/SesMailSendHandler.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using MimeKit;
+
+namespace Mailozaurr.Application;
+
+/// <summary>Normalized Amazon SES delivery handler backed by Mailozaurr.</summary>
+public sealed class SesMailSendHandler : IMailSendHandler {
+    private readonly IMailSecretStore _secretStore;
+    private readonly IPendingMessageRepository? _pendingMessageRepository;
+    private readonly Func<SesClient, CancellationToken, Task<SmtpResult>> _sendAsync;
+
+    /// <summary>Creates an Amazon SES delivery handler.</summary>
+    public SesMailSendHandler(
+        IMailSecretStore secretStore,
+        IPendingMessageRepository? pendingMessageRepository = null,
+        Func<SesClient, CancellationToken, Task<SmtpResult>>? sendAsync = null) {
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+        _pendingMessageRepository = pendingMessageRepository;
+        _sendAsync = sendAsync ?? DefaultSendAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Ses;
+
+    /// <inheritdoc />
+    public async Task<SendResult> SendAsync(MailProfile profile, SendMessageRequest request, CancellationToken cancellationToken = default) {
+        ProviderMailSendHandlerSupport.Validate(profile, request, Kind);
+        var accessKeyId = await ProviderMailSendHandlerSupport.RequireSecretAsync(
+            _secretStore, profile, MailSecretNames.AccessKeyId, cancellationToken).ConfigureAwait(false);
+        var secretAccessKey = await ProviderMailSendHandlerSupport.RequireSecretAsync(
+            _secretStore, profile, MailSecretNames.SecretAccessKey, cancellationToken).ConfigureAwait(false);
+
+        using var client = new SesClient {
+            Credentials = new NetworkCredential(accessKeyId, secretAccessKey),
+            Region = ProviderMailSendHandlerSupport.GetSetting(profile, MailProfileSettingsKeys.Region) ?? "us-east-1",
+            From = ProviderMailSendHandlerSupport.ToMailboxAddress(
+                ProviderMailSendHandlerSupport.ResolveSender(profile, request.Message)),
+            To = ProviderMailSendHandlerSupport.Recipients(request.Message.To),
+            Cc = ProviderMailSendHandlerSupport.Recipients(request.Message.Cc),
+            Bcc = ProviderMailSendHandlerSupport.Recipients(request.Message.Bcc),
+            ReplyTo = request.Message.ReplyTo.Count == 0
+                ? null
+                : ProviderMailSendHandlerSupport.ToMailboxAddress(request.Message.ReplyTo[0]),
+            Subject = request.Message.Subject,
+            Text = request.Message.TextBody ?? string.Empty,
+            Html = request.Message.HtmlBody ?? string.Empty,
+            Headers = request.Message.Headers,
+            Attachments = ProviderMailSendHandlerSupport.Attachments(request.Message).Where(attachment =>
+                !string.Equals(attachment.ContentDisposition?.Disposition, ContentDisposition.Inline, StringComparison.OrdinalIgnoreCase)).ToList(),
+            InlineAttachments = ProviderMailSendHandlerSupport.Attachments(request.Message).Where(attachment =>
+                string.Equals(attachment.ContentDisposition?.Disposition, ContentDisposition.Inline, StringComparison.OrdinalIgnoreCase)).ToList(),
+            PendingMessageRepository = request.QueueOnFailure ? _pendingMessageRepository : null
+        };
+        ProviderMailSendHandlerSupport.ApplyRetrySettings(profile, (count, delay, backoff, max, jitter, always) => {
+            client.RetryCount = count;
+            client.RetryDelayMilliseconds = delay;
+            client.RetryDelayBackoff = backoff;
+            client.MaxDelayMilliseconds = max;
+            client.JitterMilliseconds = jitter;
+            client.RetryAlways = always;
+        });
+
+        var result = await _sendAsync(client, cancellationToken).ConfigureAwait(false);
+        return await ProviderMailSendHandlerSupport.ToResultAsync(
+            profile,
+            result,
+            request.QueueOnFailure ? _pendingMessageRepository : null,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Task<SmtpResult> DefaultSendAsync(SesClient client, CancellationToken cancellationToken) =>
+        client.SendEmailAsync(cancellationToken);
+}

--- a/Sources/Mailozaurr.Application/SesMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/SesMailSendHandler.cs
@@ -29,6 +29,7 @@ public sealed class SesMailSendHandler : IMailSendHandler {
             _secretStore, profile, MailSecretNames.AccessKeyId, cancellationToken).ConfigureAwait(false);
         var secretAccessKey = await ProviderMailSendHandlerSupport.RequireSecretAsync(
             _secretStore, profile, MailSecretNames.SecretAccessKey, cancellationToken).ConfigureAwait(false);
+        var attachments = ProviderMailSendHandlerSupport.Attachments(request.Message);
 
         using var client = new SesClient {
             Credentials = new NetworkCredential(accessKeyId, secretAccessKey),
@@ -44,10 +45,11 @@ public sealed class SesMailSendHandler : IMailSendHandler {
             Subject = request.Message.Subject,
             Text = request.Message.TextBody ?? string.Empty,
             Html = request.Message.HtmlBody ?? string.Empty,
+            Priority = request.Message.Priority,
             Headers = request.Message.Headers,
-            Attachments = ProviderMailSendHandlerSupport.Attachments(request.Message).Where(attachment =>
+            Attachments = attachments.Where(attachment =>
                 !string.Equals(attachment.ContentDisposition?.Disposition, ContentDisposition.Inline, StringComparison.OrdinalIgnoreCase)).ToList(),
-            InlineAttachments = ProviderMailSendHandlerSupport.Attachments(request.Message).Where(attachment =>
+            InlineAttachments = attachments.Where(attachment =>
                 string.Equals(attachment.ContentDisposition?.Disposition, ContentDisposition.Inline, StringComparison.OrdinalIgnoreCase)).ToList(),
             PendingMessageRepository = request.QueueOnFailure ? _pendingMessageRepository : null
         };

--- a/Sources/Mailozaurr.Application/SesMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/SesMailSendHandler.cs
@@ -38,9 +38,9 @@ public sealed class SesMailSendHandler : IMailSendHandler {
             To = ProviderMailSendHandlerSupport.Recipients(request.Message.To),
             Cc = ProviderMailSendHandlerSupport.Recipients(request.Message.Cc),
             Bcc = ProviderMailSendHandlerSupport.Recipients(request.Message.Bcc),
-            ReplyTo = request.Message.ReplyTo.Count == 0
-                ? null
-                : ProviderMailSendHandlerSupport.ToMailboxAddress(request.Message.ReplyTo[0]),
+            ReplyTo = ProviderMailSendHandlerSupport.ResolveReplyTo(request.Message) is { } replyTo
+                ? ProviderMailSendHandlerSupport.ToMailboxAddress(replyTo)
+                : null,
             Subject = request.Message.Subject,
             Text = request.Message.TextBody ?? string.Empty,
             Html = request.Message.HtmlBody ?? string.Empty,

--- a/Sources/Mailozaurr.Application/SesMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/SesMailSendHandler.cs
@@ -63,11 +63,7 @@ public sealed class SesMailSendHandler : IMailSendHandler {
         });
 
         var result = await _sendAsync(client, cancellationToken).ConfigureAwait(false);
-        return await ProviderMailSendHandlerSupport.ToResultAsync(
-            profile,
-            result,
-            request.QueueOnFailure ? _pendingMessageRepository : null,
-            cancellationToken).ConfigureAwait(false);
+        return ProviderMailSendHandlerSupport.ToResult(profile, result);
     }
 
     private static Task<SmtpResult> DefaultSendAsync(SesClient client, CancellationToken cancellationToken) =>

--- a/Sources/Mailozaurr.Application/SmtpMailSendHandler.cs
+++ b/Sources/Mailozaurr.Application/SmtpMailSendHandler.cs
@@ -59,20 +59,17 @@ public sealed class SmtpMailSendHandler : IMailSendHandler {
                 };
             }
 
-            if (queueEnabled) {
+            if (providerResult.Queued) {
                 var queuedId = providerResult.MessageId ?? message.MessageId;
                 if (!string.IsNullOrWhiteSpace(queuedId)) {
-                    var queued = await _pendingMessageRepository!.GetByMessageIdAsync(queuedId!, cancellationToken).ConfigureAwait(false);
-                    if (queued != null) {
-                        return new SendResult {
-                            Succeeded = true,
-                            ProfileId = profile.Id,
-                            ProfileKind = profile.Kind,
-                            Queued = true,
-                            QueueMessageId = queued.MessageId,
-                            Message = $"Message queued after send failure: {providerResult.Error ?? providerResult.Message ?? "SMTP send failed."}"
-                        };
-                    }
+                    return new SendResult {
+                        Succeeded = true,
+                        ProfileId = profile.Id,
+                        ProfileKind = profile.Kind,
+                        Queued = true,
+                        QueueMessageId = queuedId,
+                        Message = $"Message queued after send failure: {providerResult.Error ?? providerResult.Message ?? "SMTP send failed."}"
+                    };
                 }
             }
 

--- a/Sources/Mailozaurr.Application/SmtpSessionFactory.cs
+++ b/Sources/Mailozaurr.Application/SmtpSessionFactory.cs
@@ -36,9 +36,12 @@ public sealed class SmtpSessionFactory : ISmtpSessionFactory {
     private async Task<SmtpSessionRequest> CreateRequestAsync(MailProfile profile, CancellationToken cancellationToken) {
         var server = RequireSetting(profile, MailProfileSettingsKeys.Server);
         var port = GetIntSetting(profile, MailProfileSettingsKeys.Port) ?? 587;
+        var authenticationEnabled = GetBoolSetting(profile, MailProfileSettingsKeys.AuthenticationEnabled) ?? true;
         var authMode = GetAuthMode(profile);
-        var userName = ResolveUserName(profile);
-        var secret = await ResolveSecretAsync(profile, authMode, cancellationToken).ConfigureAwait(false);
+        var userName = authenticationEnabled ? ResolveUserName(profile) : string.Empty;
+        var secret = authenticationEnabled
+            ? await ResolveSecretAsync(profile, authMode, cancellationToken).ConfigureAwait(false)
+            : string.Empty;
 
         return new SmtpSessionRequest {
             Server = server,
@@ -49,8 +52,11 @@ public sealed class SmtpSessionFactory : ISmtpSessionFactory {
             RetryCount = GetIntSetting(profile, MailProfileSettingsKeys.RetryCount) ?? 3,
             RetryDelayMilliseconds = GetIntSetting(profile, MailProfileSettingsKeys.RetryDelayMilliseconds) ?? 500,
             RetryDelayBackoff = GetDoubleSetting(profile, MailProfileSettingsKeys.RetryDelayBackoff) ?? 2.0,
+            MaxDelayMilliseconds = GetIntSetting(profile, MailProfileSettingsKeys.MaxDelayMilliseconds) ?? 10_000,
+            JitterMilliseconds = GetIntSetting(profile, MailProfileSettingsKeys.JitterMilliseconds) ?? 250,
             SkipCertificateValidation = GetBoolSetting(profile, MailProfileSettingsKeys.SkipCertificateValidation) ?? false,
             SkipCertificateRevocation = GetBoolSetting(profile, MailProfileSettingsKeys.SkipCertificateRevocation) ?? false,
+            Authenticate = authenticationEnabled,
             UserName = userName,
             Password = secret,
             AuthMode = authMode

--- a/Sources/Mailozaurr.Application/SmtpSessionFactory.cs
+++ b/Sources/Mailozaurr.Application/SmtpSessionFactory.cs
@@ -86,17 +86,21 @@ public sealed class SmtpSessionFactory : ISmtpSessionFactory {
         return secret!;
     }
 
-    private static async Task<Smtp> DefaultConnectAsync(SmtpSessionRequest request, CancellationToken cancellationToken) {
+    internal static async Task<Smtp> DefaultConnectAsync(SmtpSessionRequest request, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
         var smtp = new Smtp();
-        var result = await SmtpSessionService.ConnectAndAuthenticateAsync(smtp, request, cancellationToken).ConfigureAwait(false);
-        if (result.IsSuccess) {
-            return smtp;
-        }
+        try {
+            var result = await SmtpSessionService.ConnectAndAuthenticateAsync(smtp, request, cancellationToken).ConfigureAwait(false);
+            if (result.IsSuccess) {
+                return smtp;
+            }
 
-        SmtpSessionService.DisposeQuietly(smtp);
-        throw new InvalidOperationException($"SMTP connection/authentication failed ({result.ErrorCode}): {result.Error}");
+            throw new InvalidOperationException($"SMTP connection/authentication failed ({result.ErrorCode}): {result.Error}");
+        } catch {
+            SmtpSessionService.DisposeQuietly(smtp);
+            throw;
+        }
     }
 
     private static string ResolveUserName(MailProfile profile) {

--- a/Sources/Mailozaurr.Application/SmtpSessionFactory.cs
+++ b/Sources/Mailozaurr.Application/SmtpSessionFactory.cs
@@ -54,6 +54,7 @@ public sealed class SmtpSessionFactory : ISmtpSessionFactory {
             RetryDelayBackoff = GetDoubleSetting(profile, MailProfileSettingsKeys.RetryDelayBackoff) ?? 2.0,
             MaxDelayMilliseconds = GetIntSetting(profile, MailProfileSettingsKeys.MaxDelayMilliseconds) ?? 10_000,
             JitterMilliseconds = GetIntSetting(profile, MailProfileSettingsKeys.JitterMilliseconds) ?? 250,
+            RetryAlways = GetBoolSetting(profile, MailProfileSettingsKeys.RetryAlways) ?? false,
             SkipCertificateValidation = GetBoolSetting(profile, MailProfileSettingsKeys.SkipCertificateValidation) ?? false,
             SkipCertificateRevocation = GetBoolSetting(profile, MailProfileSettingsKeys.SkipCertificateRevocation) ?? false,
             Authenticate = authenticationEnabled,

--- a/Sources/Mailozaurr.Cli/CliRunner.Builders.cs
+++ b/Sources/Mailozaurr.Cli/CliRunner.Builders.cs
@@ -208,7 +208,7 @@ public static partial class CliRunner {
     private static SendMessageRequest CreateSendRequestFromDraft(DraftMessage draft, bool queueOnFailure) =>
         new() {
             ProfileId = draft.ProfileId,
-            Message = CloneDraftMessage(draft),
+            Message = DraftMessageCloner.Clone(draft),
             QueueOnFailure = queueOnFailure
         };
 
@@ -259,34 +259,6 @@ public static partial class CliRunner {
 
         return draft;
     }
-
-    private static DraftMessage CloneDraftMessage(DraftMessage draft) => new() {
-        ProfileId = draft.ProfileId,
-        From = draft.From == null ? null : new MessageRecipient {
-            Name = draft.From.Name,
-            Address = draft.From.Address
-        },
-        To = draft.To.Select(ToRecipientCopy).ToList(),
-        Cc = draft.Cc.Select(ToRecipientCopy).ToList(),
-        Bcc = draft.Bcc.Select(ToRecipientCopy).ToList(),
-        ReplyTo = draft.ReplyTo.Select(ToRecipientCopy).ToList(),
-        Subject = draft.Subject,
-        TextBody = draft.TextBody,
-        HtmlBody = draft.HtmlBody,
-        Headers = new Dictionary<string, string>(draft.Headers, StringComparer.OrdinalIgnoreCase),
-        Attachments = draft.Attachments.Select(attachment => new DraftAttachment {
-            Path = attachment.Path,
-            FileName = attachment.FileName,
-            ContentType = attachment.ContentType,
-            IsInline = attachment.IsInline,
-            ContentId = attachment.ContentId
-        }).ToList()
-    };
-
-    private static MessageRecipient ToRecipientCopy(MessageRecipient recipient) => new() {
-        Name = recipient.Name,
-        Address = recipient.Address
-    };
 
     private static async Task WriteItemAsync<T>(
         TextWriter output,

--- a/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.DraftsQueue.cs
+++ b/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.DraftsQueue.cs
@@ -114,7 +114,7 @@ public sealed partial class MailMcpTools {
         return await _application.Send.SendAsync(new SendMessageRequest {
             ProfileId = draft.Message.ProfileId,
             QueueOnFailure = queueOnFailure,
-            Message = CloneDraftMessage(draft.Message)
+            Message = DraftMessageCloner.Clone(draft.Message)
         }, cancellationToken).ConfigureAwait(false);
     }
 
@@ -198,29 +198,6 @@ public sealed partial class MailMcpTools {
         return draft;
     }
 
-    private static DraftMessage CloneDraftMessage(DraftMessage draft) => new() {
-        ProfileId = draft.ProfileId,
-        From = draft.From == null ? null : new MessageRecipient {
-            Name = draft.From.Name,
-            Address = draft.From.Address
-        },
-        To = draft.To.Select(ToRecipientCopy).ToList(),
-        Cc = draft.Cc.Select(ToRecipientCopy).ToList(),
-        Bcc = draft.Bcc.Select(ToRecipientCopy).ToList(),
-        ReplyTo = draft.ReplyTo.Select(ToRecipientCopy).ToList(),
-        Subject = draft.Subject,
-        TextBody = draft.TextBody,
-        HtmlBody = draft.HtmlBody,
-        Headers = new Dictionary<string, string>(draft.Headers, StringComparer.OrdinalIgnoreCase),
-        Attachments = draft.Attachments.Select(attachment => new DraftAttachment {
-            Path = attachment.Path,
-            FileName = attachment.FileName,
-            ContentType = attachment.ContentType,
-            IsInline = attachment.IsInline,
-            ContentId = attachment.ContentId
-        }).ToList()
-    };
-
     private static void AddRecipients(ICollection<MessageRecipient> destination, IEnumerable<string>? addresses) {
         if (addresses == null) {
             return;
@@ -232,11 +209,6 @@ public sealed partial class MailMcpTools {
             });
         }
     }
-
-    private static MessageRecipient ToRecipientCopy(MessageRecipient recipient) => new() {
-        Name = recipient.Name,
-        Address = recipient.Address
-    };
 
     private static MailMessageActionPlanBatchQuery? BuildBatchQuery(IReadOnlyList<string>? planNames, IReadOnlyList<string>? profileIds, IReadOnlyList<string>? actions, string? sortBy, bool descending) {
         var normalizedPlanNames = (planNames ?? Array.Empty<string>())

--- a/Sources/Mailozaurr.Tests/ApplicationBuilderTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationBuilderTests.cs
@@ -46,6 +46,9 @@ public sealed class ApplicationBuilderTests {
         Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Graph);
         Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Gmail);
         Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Smtp);
+        Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.SendGrid);
+        Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Mailgun);
+        Assert.Contains(app.SendHandlers, handler => handler.Kind == MailProfileKind.Ses);
     }
 
     [Fact]
@@ -57,6 +60,9 @@ public sealed class ApplicationBuilderTests {
             EnableGmailReadHandler = false,
             EnableGmailSendHandler = false,
             EnableSmtpSendHandler = false,
+            EnableSendGridSendHandler = false,
+            EnableMailgunSendHandler = false,
+            EnableSesSendHandler = false,
             ProfileStore = new MailProfileStoreOptions { DirectoryPath = CreateTemporaryDirectory() },
             SecretStore = new MailSecretStoreOptions { DirectoryPath = CreateTemporaryDirectory() }
         });
@@ -69,6 +75,9 @@ public sealed class ApplicationBuilderTests {
         Assert.DoesNotContain(app.SendHandlers, handler => handler.Kind == MailProfileKind.Graph);
         Assert.DoesNotContain(app.SendHandlers, handler => handler.Kind == MailProfileKind.Gmail);
         Assert.DoesNotContain(app.SendHandlers, handler => handler.Kind == MailProfileKind.Smtp);
+        Assert.DoesNotContain(app.SendHandlers, handler => handler.Kind == MailProfileKind.SendGrid);
+        Assert.DoesNotContain(app.SendHandlers, handler => handler.Kind == MailProfileKind.Mailgun);
+        Assert.DoesNotContain(app.SendHandlers, handler => handler.Kind == MailProfileKind.Ses);
     }
 
     [Fact]
@@ -80,6 +89,9 @@ public sealed class ApplicationBuilderTests {
             EnableGmailReadHandler = false,
             EnableGmailSendHandler = false,
             EnableSmtpSendHandler = false,
+            EnableSendGridSendHandler = false,
+            EnableMailgunSendHandler = false,
+            EnableSesSendHandler = false,
             ProfileStore = new MailProfileStoreOptions { DirectoryPath = CreateTemporaryDirectory() },
             SecretStore = new MailSecretStoreOptions { DirectoryPath = CreateTemporaryDirectory() }
         });
@@ -256,6 +268,9 @@ public sealed class ApplicationBuilderTests {
             EnableGmailReadHandler = false,
             EnableGmailSendHandler = false,
             EnableSmtpSendHandler = false,
+            EnableSendGridSendHandler = false,
+            EnableMailgunSendHandler = false,
+            EnableSesSendHandler = false,
             ProfileStore = new MailProfileStoreOptions { DirectoryPath = CreateTemporaryDirectory() },
             SecretStore = new MailSecretStoreOptions { DirectoryPath = CreateTemporaryDirectory() }
         });
@@ -275,6 +290,9 @@ public sealed class ApplicationBuilderTests {
             EnableGmailReadHandler = false,
             EnableGmailSendHandler = false,
             EnableSmtpSendHandler = false,
+            EnableSendGridSendHandler = false,
+            EnableMailgunSendHandler = false,
+            EnableSesSendHandler = false,
             ProfileStore = new MailProfileStoreOptions { DirectoryPath = CreateTemporaryDirectory() },
             SecretStore = new MailSecretStoreOptions { DirectoryPath = CreateTemporaryDirectory() }
         });
@@ -313,6 +331,9 @@ public sealed class ApplicationBuilderTests {
             EnableGmailReadHandler = false,
             EnableGmailSendHandler = false,
             EnableSmtpSendHandler = false,
+            EnableSendGridSendHandler = false,
+            EnableMailgunSendHandler = false,
+            EnableSesSendHandler = false,
             SecretStore = new MailSecretStoreOptions { DirectoryPath = Path.Combine(directory, "secrets") }
         }).UseProfileStore(store);
 

--- a/Sources/Mailozaurr.Tests/ApplicationCapabilitiesTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationCapabilitiesTests.cs
@@ -8,6 +8,9 @@ public sealed class ApplicationCapabilitiesTests {
     [InlineData(MailProfileKind.Graph, MailCapability.ListFolders | MailCapability.SendMessages | MailCapability.MarkMessages)]
     [InlineData(MailProfileKind.Gmail, MailCapability.SearchMessages | MailCapability.MarkMessages | MailCapability.MoveMessages | MailCapability.SendMessages)]
     [InlineData(MailProfileKind.Smtp, MailCapability.SendMessages)]
+    [InlineData(MailProfileKind.SendGrid, MailCapability.SendMessages)]
+    [InlineData(MailProfileKind.Mailgun, MailCapability.SendMessages)]
+    [InlineData(MailProfileKind.Ses, MailCapability.SendMessages)]
     public void CatalogExposesExpectedCapabilities(MailProfileKind kind, MailCapability required) {
         var capabilities = MailCapabilityCatalog.For(kind);
 
@@ -32,9 +35,6 @@ public sealed class ApplicationCapabilitiesTests {
 
     [Theory]
     [InlineData(MailProfileKind.Pop3)]
-    [InlineData(MailProfileKind.SendGrid)]
-    [InlineData(MailProfileKind.Mailgun)]
-    [InlineData(MailProfileKind.Ses)]
     public void CatalogDoesNotAdvertiseProvidersWithoutNormalizedHandlers(MailProfileKind kind) {
         Assert.Equal(MailCapability.None, MailCapabilityCatalog.For(kind).Capabilities);
     }
@@ -77,5 +77,20 @@ public sealed class ApplicationCapabilitiesTests {
         Assert.Equal("Queued", success.Message);
         Assert.False(failure.Succeeded);
         Assert.Equal("auth_failed", failure.Code);
+    }
+
+    [Theory]
+    [InlineData(MailProfileKind.SendGrid)]
+    [InlineData(MailProfileKind.Mailgun)]
+    [InlineData(MailProfileKind.Ses)]
+    public void ProviderProfileAllowsSenderToBeSuppliedPerMessage(MailProfileKind kind) {
+        var result = MailProfileValidator.Validate(new MailProfile {
+            Id = kind.ToString().ToLowerInvariant(),
+            DisplayName = kind.ToString(),
+            Kind = kind
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Contains(result.Warnings, warning => warning.Contains("DefaultSender", StringComparison.Ordinal));
     }
 }

--- a/Sources/Mailozaurr.Tests/ApplicationDraftStoreTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationDraftStoreTests.cs
@@ -13,6 +13,7 @@ public sealed class ApplicationDraftStoreTests {
                 ProfileId = "work-gmail",
                 Subject = "Report",
                 TextBody = "Hello",
+                Priority = MessagePriority.High,
                 To = {
                     new MessageRecipient { Address = "alice@example.com" }
                 }
@@ -26,6 +27,7 @@ public sealed class ApplicationDraftStoreTests {
         Assert.Equal("Quarterly report", saved!.Name);
         Assert.Equal("work-gmail", saved.Message.ProfileId);
         Assert.Equal("alice@example.com", saved.Message.To[0].Address);
+        Assert.Equal(MessagePriority.High, saved.Message.Priority);
         Assert.NotEqual(default, saved.CreatedAt);
         Assert.NotEqual(default, saved.UpdatedAt);
     }

--- a/Sources/Mailozaurr.Tests/ApplicationInMemoryStoreTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationInMemoryStoreTests.cs
@@ -1,0 +1,78 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationInMemoryStoreTests {
+    [Fact]
+    public async Task ProfileStoreClonesValuesAndKeepsSingleDefault() {
+        var store = new InMemoryMailProfileStore();
+        var first = new MailProfile {
+            Id = "first",
+            DisplayName = "First",
+            IsDefault = true,
+            Settings = new Dictionary<string, string> {
+                ["mode"] = "one"
+            }
+        };
+        await store.SaveAsync(first);
+
+        first.DisplayName = "Changed outside store";
+        first.Settings["mode"] = "changed";
+        await store.SaveAsync(new MailProfile {
+            Id = "second",
+            DisplayName = "Second",
+            IsDefault = true
+        });
+
+        MailProfile storedFirst = Assert.IsType<MailProfile>(await store.GetByIdAsync("FIRST"));
+        MailProfile storedSecond = Assert.IsType<MailProfile>(await store.GetByIdAsync("second"));
+        Assert.Equal("First", storedFirst.DisplayName);
+        Assert.Equal("one", storedFirst.Settings["mode"]);
+        Assert.False(storedFirst.IsDefault);
+        Assert.True(storedSecond.IsDefault);
+
+        storedFirst.Settings["mode"] = "mutated";
+        Assert.Equal("one", (await store.GetByIdAsync("first"))!.Settings["mode"]);
+    }
+
+    [Fact]
+    public async Task ProfileStoreStableInventoryBlocksConcurrentMutation() {
+        var store = new InMemoryMailProfileStore();
+        await store.SaveAsync(new MailProfile { Id = "first", DisplayName = "First" });
+        var entered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<string[]> inventory = store.ExecuteWithStableProfileIdsAsync(async (ids, cancellationToken) => {
+            entered.SetResult(true);
+            cancellationToken.ThrowIfCancellationRequested();
+            await release.Task;
+            return ids.ToArray();
+        });
+        await entered.Task;
+
+        Task save = store.SaveAsync(new MailProfile { Id = "second", DisplayName = "Second" });
+        Assert.False(save.IsCompleted);
+
+        release.SetResult(true);
+        Assert.Equal(new[] { "first" }, await inventory);
+        await save;
+        Assert.NotNull(await store.GetByIdAsync("second"));
+    }
+
+    [Fact]
+    public async Task SecretStoreKeepsProfilesIsolatedAndSupportsCleanup() {
+        var store = new InMemoryMailSecretStore();
+        await store.SetSecretAsync("first", MailSecretNames.ClientSecret, "secret-one");
+        await store.SetSecretAsync("second", MailSecretNames.ClientSecret, "secret-two");
+
+        Assert.Equal("secret-one", await store.GetSecretAsync("FIRST", MailSecretNames.ClientSecret));
+        Assert.Equal("secret-two", await store.GetSecretAsync("second", MailSecretNames.ClientSecret));
+
+        IReadOnlyDictionary<string, string> snapshot = await store.GetProfileSecretsAsync("first");
+        Assert.Equal("secret-one", snapshot[MailSecretNames.ClientSecret]);
+
+        await store.RemoveProfileSecretsAsync("first");
+        Assert.Null(await store.GetSecretAsync("first", MailSecretNames.ClientSecret));
+        Assert.Equal("secret-two", await store.GetSecretAsync("second", MailSecretNames.ClientSecret));
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationProfileBootstrapServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileBootstrapServiceTests.cs
@@ -264,6 +264,36 @@ public sealed class ApplicationProfileBootstrapServiceTests {
         Assert.Contains(result.Errors, error => error.IndexOf("Gmail profiles need an access token", StringComparison.Ordinal) >= 0);
     }
 
+    [Theory]
+    [InlineData(MailProfileKind.SendGrid, MailSecretNames.ApiKey, null)]
+    [InlineData(MailProfileKind.Mailgun, MailSecretNames.ApiKey, null)]
+    [InlineData(MailProfileKind.Ses, MailSecretNames.AccessKeyId, MailSecretNames.SecretAccessKey)]
+    public async Task DiagnoseAsyncVerifiesProviderCredentials(
+        MailProfileKind kind,
+        string firstSecret,
+        string? secondSecret) {
+        var profileId = kind.ToString().ToLowerInvariant();
+        var profileStore = new InMemoryProfileStore();
+        var secretStore = new InMemorySecretStore();
+        await profileStore.SaveAsync(new MailProfile {
+            Id = profileId,
+            DisplayName = kind.ToString(),
+            Kind = kind
+        });
+        var service = new MailProfileService(profileStore, secretStore);
+
+        var missing = await service.DiagnoseAsync(profileId);
+        await secretStore.SetSecretAsync(profileId, firstSecret, "first");
+        if (secondSecret != null) {
+            await secretStore.SetSecretAsync(profileId, secondSecret, "second");
+        }
+        var ready = await service.DiagnoseAsync(profileId);
+
+        Assert.False(missing.Succeeded);
+        Assert.Equal("profile_not_ready", missing.Code);
+        Assert.True(ready.Succeeded);
+    }
+
     private sealed class InMemoryProfileStore : IMailProfileStore {
         private readonly Dictionary<string, MailProfile> _profiles = new(StringComparer.OrdinalIgnoreCase);
 

--- a/Sources/Mailozaurr.Tests/ApplicationProfileServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileServiceTests.cs
@@ -147,6 +147,27 @@ public sealed class ApplicationProfileServiceTests {
         Assert.NotNull(await service.GetProfileAsync("team"));
     }
 
+    [Theory]
+    [InlineData(MailSecretNames.ApiKey)]
+    [InlineData(MailSecretNames.AccessKeyId)]
+    [InlineData(MailSecretNames.SecretAccessKey)]
+    public async Task DeleteAsyncRemovesProviderSecretsFromBasicStores(string secretName) {
+        var profileStore = new FileMailProfileStore(CreateTemporaryFilePath("profiles.json"));
+        var secretStore = new BasicSecretStore();
+        var service = new MailProfileService(profileStore, secretStore);
+        await service.SaveAsync(new MailProfile {
+            Id = "provider",
+            DisplayName = "Provider",
+            Kind = MailProfileKind.SendGrid
+        });
+        await secretStore.SetSecretAsync("provider", secretName, "secret");
+
+        var result = await service.DeleteAsync("provider");
+
+        Assert.True(result.Succeeded);
+        Assert.Null(await secretStore.GetSecretAsync("provider", secretName));
+    }
+
     private static string CreateTemporaryFilePath(string fileName) {
         var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
@@ -202,5 +223,22 @@ public sealed class ApplicationProfileServiceTests {
 
         public Task RemoveProfileSecretsAsync(string profileId, CancellationToken cancellationToken = default) =>
             Task.FromException(new IOException("Simulated secret cleanup failure."));
+    }
+
+    private sealed class BasicSecretStore : IMailSecretStore {
+        private readonly Dictionary<string, string> _secrets = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            _secrets.TryGetValue($"{profileId}::{secretName}", out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+            _secrets[$"{profileId}::{secretName}"] = secretValue;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_secrets.Remove($"{profileId}::{secretName}"));
     }
 }

--- a/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
@@ -183,6 +183,36 @@ public sealed class ApplicationProviderMailSendHandlerTests {
         await handler.SendAsync(CreateProfile("ses", MailProfileKind.Ses), request);
     }
 
+    [Fact]
+    public async Task ProviderHandlerFallsBackToProfileSenderWhenDraftSenderIsWhitespace() {
+        var secrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
+        var request = CreateRequest("sendgrid");
+        request.Message.From = new MessageRecipient { Address = "  " };
+        var handler = new SendGridMailSendHandler(secrets, sendAsync: (client, cancellationToken) => {
+            var sender = Assert.IsType<SendGridEmailAddress>(client.From);
+            Assert.Equal("sender@example.com", sender.Email);
+            return Task.FromResult(Succeeded("sendgrid-message"));
+        });
+
+        await handler.SendAsync(CreateProfile("sendgrid", MailProfileKind.SendGrid), request);
+    }
+
+    [Fact]
+    public async Task ProviderInlineAttachmentGetsAUsableContentIdWhenNoOverrideIsProvided() {
+        var secrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
+        var request = CreateRequest("sendgrid");
+        request.Message.Attachments[0].IsInline = true;
+        request.Message.Attachments[0].ContentId = null;
+        var handler = new SendGridMailSendHandler(secrets, sendAsync: (client, cancellationToken) => {
+            var attachment = Assert.Single(client.Attachments!);
+            Assert.Equal("renamed-report.pdf", attachment.ContentId);
+            Assert.Equal(ContentDisposition.Inline, attachment.ContentDisposition?.Disposition);
+            return Task.FromResult(Succeeded("sendgrid-message"));
+        });
+
+        await handler.SendAsync(CreateProfile("sendgrid", MailProfileKind.SendGrid), request);
+    }
+
     private static MailProfile CreateProfile(string id, MailProfileKind kind) => new() {
         Id = id,
         DisplayName = id,

--- a/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
@@ -6,7 +6,9 @@ using System.Runtime.CompilerServices;
 
 namespace Mailozaurr.Tests;
 
-public sealed class ApplicationProviderMailSendHandlerTests {
+public sealed class ApplicationProviderMailSendHandlerTests : IDisposable {
+    private readonly List<string> _temporaryFiles = new();
+
     [Fact]
     public async Task SendGridHandlerMapsProfileMessageAndSecret() {
         var secrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
@@ -20,6 +22,7 @@ public sealed class ApplicationProviderMailSendHandlerTests {
             Assert.Equal("Alice", recipient.Name);
             Assert.Equal("alice@example.com", recipient.Email);
             Assert.Equal("Provider test", client.Subject);
+            Assert.Equal(MessagePriority.High, client.Priority);
             Assert.Equal(2, client.RetryCount);
             AssertAttachmentMetadata(Assert.Single(client.Attachments!));
             return Task.FromResult(Succeeded("sendgrid-message"));
@@ -43,6 +46,7 @@ public sealed class ApplicationProviderMailSendHandlerTests {
             var recipient = Assert.IsType<MailboxAddress>(Assert.Single(client.To));
             Assert.Equal("Alice", recipient.Name);
             Assert.Equal("alice@example.com", recipient.Address);
+            Assert.Equal(MessagePriority.High, client.Priority);
             AssertAttachmentMetadata(Assert.Single(client.Attachments!));
             return Task.FromResult(Succeeded("mailgun-message"));
         });
@@ -68,6 +72,7 @@ public sealed class ApplicationProviderMailSendHandlerTests {
             var recipient = Assert.IsType<MailboxAddress>(Assert.Single(client.To));
             Assert.Equal("Alice", recipient.Name);
             Assert.Equal("alice@example.com", recipient.Address);
+            Assert.Equal(MessagePriority.High, client.Priority);
             AssertAttachmentMetadata(Assert.Single(client.Attachments!));
             return Task.FromResult(Succeeded("ses-message"));
         });
@@ -128,6 +133,24 @@ public sealed class ApplicationProviderMailSendHandlerTests {
             handler.SendAsync(CreateProfile("sendgrid", MailProfileKind.SendGrid), request));
 
         Assert.Contains("recipient", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ProviderHandlerRejectsAMissingAttachmentBeforeDispatch() {
+        var secrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
+        var request = CreateRequest("sendgrid");
+        File.Delete(request.Message.Attachments[0].Path);
+        var dispatched = false;
+        var handler = new SendGridMailSendHandler(secrets, sendAsync: (client, cancellationToken) => {
+            dispatched = true;
+            return Task.FromResult(Succeeded("sendgrid-message"));
+        });
+
+        var exception = await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            handler.SendAsync(CreateProfile("sendgrid", MailProfileKind.SendGrid), request));
+
+        Assert.False(dispatched);
+        Assert.Equal(Path.GetFullPath(request.Message.Attachments[0].Path), exception.FileName);
     }
 
     [Fact]
@@ -223,27 +246,32 @@ public sealed class ApplicationProviderMailSendHandlerTests {
         }
     };
 
-    private static SendMessageRequest CreateRequest(string profileId) => new() {
-        ProfileId = profileId,
-        Message = new DraftMessage {
+    private SendMessageRequest CreateRequest(string profileId) {
+        var path = Path.GetTempFileName();
+        _temporaryFiles.Add(path);
+        return new SendMessageRequest {
             ProfileId = profileId,
-            Subject = "Provider test",
-            TextBody = "Hello",
-            To = {
-                new MessageRecipient { Name = "Alice", Address = "alice@example.com" }
-            },
-            Attachments = {
-                new DraftAttachment {
-                    Path = Path.Combine(Path.GetTempPath(), "mailozaurr-provider-test.bin"),
-                    FileName = "renamed-report.pdf",
-                    ContentType = "application/pdf",
-                    ContentId = "report-content"
+            Message = new DraftMessage {
+                ProfileId = profileId,
+                Subject = "Provider test",
+                TextBody = "Hello",
+                Priority = MessagePriority.High,
+                To = {
+                    new MessageRecipient { Name = "Alice", Address = "alice@example.com" }
+                },
+                Attachments = {
+                    new DraftAttachment {
+                        Path = path,
+                        FileName = "renamed-report.pdf",
+                        ContentType = "application/pdf",
+                        ContentId = "report-content"
+                    }
                 }
             }
-        }
-    };
+        };
+    }
 
-    private static SendMessageRequest CreateRequestWithReplyTo(string profileId) {
+    private SendMessageRequest CreateRequestWithReplyTo(string profileId) {
         var request = CreateRequest(profileId);
         request.Message.ReplyTo.Add(new MessageRecipient { Address = "  " });
         request.Message.ReplyTo.Add(new MessageRecipient { Name = "Reply", Address = "reply@example.com" });
@@ -261,6 +289,15 @@ public sealed class ApplicationProviderMailSendHandlerTests {
         new(true, EmailAction.Send, "alice@example.com", "sender@example.com", "provider", 0, TimeSpan.Zero) {
             MessageId = messageId
         };
+
+    public void Dispose() {
+        foreach (var path in _temporaryFiles) {
+            try {
+                File.Delete(path);
+            } catch (IOException) {
+            }
+        }
+    }
 
     private sealed class FakeSecretStore : IMailSecretStore {
         private readonly Dictionary<string, string> _secrets;

--- a/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
@@ -84,12 +84,13 @@ public sealed class ApplicationProviderMailSendHandlerTests : IDisposable {
     }
 
     [Fact]
-    public async Task ProviderHandlerReportsAQueuedFailure() {
+    public async Task ProviderHandlerPreservesConfirmedQueueAfterRecordIsConsumed() {
         var secrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
-        var pending = new FakePendingMessageRepository(new PendingMessageRecord { MessageId = "queued-message" });
+        var pending = new FakePendingMessageRepository();
         var handler = new SendGridMailSendHandler(secrets, pending, sendAsync: (client, cancellationToken) =>
             Task.FromResult(new SmtpResult(false, EmailAction.Send, "alice@example.com", "sender@example.com", "SendGridApi", 0, TimeSpan.Zero, error: "temporary failure") {
-                MessageId = "queued-message"
+                MessageId = "queued-message",
+                Queued = true
             }));
 
         var request = CreateRequest("sendgrid");
@@ -107,7 +108,8 @@ public sealed class ApplicationProviderMailSendHandlerTests : IDisposable {
         var pending = new FakePendingMessageRepository();
         var handler = new SendGridMailSendHandler(secrets, pending, sendAsync: (client, cancellationToken) =>
             Task.FromResult(new SmtpResult(false, EmailAction.Send, "alice@example.com", "sender@example.com", "SendGridApi", 0, TimeSpan.Zero, error: "temporary failure") {
-                MessageId = "not-persisted"
+                MessageId = "not-persisted",
+                Queued = false
             }));
 
         var request = CreateRequest("sendgrid");

--- a/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
@@ -1,0 +1,221 @@
+using Mailozaurr.Application;
+using Mailozaurr.Definitions;
+using MimeKit;
+using System.Net;
+using System.Runtime.CompilerServices;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationProviderMailSendHandlerTests {
+    [Fact]
+    public async Task SendGridHandlerMapsProfileMessageAndSecret() {
+        var secrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
+        var handler = new SendGridMailSendHandler(secrets, sendAsync: (client, cancellationToken) => {
+            var credential = Assert.IsType<NetworkCredential>(client.Credentials);
+            Assert.Equal("sg-secret", credential.Password);
+            var sender = Assert.IsType<SendGridEmailAddress>(client.From);
+            Assert.Equal("Sender", sender.Name);
+            Assert.Equal("sender@example.com", sender.Email);
+            var recipient = Assert.IsType<SendGridEmailAddress>(Assert.Single(client.To!));
+            Assert.Equal("Alice", recipient.Name);
+            Assert.Equal("alice@example.com", recipient.Email);
+            Assert.Equal("Provider test", client.Subject);
+            Assert.Equal(2, client.RetryCount);
+            AssertAttachmentMetadata(Assert.Single(client.Attachments!));
+            return Task.FromResult(Succeeded("sendgrid-message"));
+        });
+
+        var result = await handler.SendAsync(CreateProfile("sendgrid", MailProfileKind.SendGrid), CreateRequest("sendgrid"));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("sendgrid-message", result.ProviderMessageId);
+    }
+
+    [Fact]
+    public async Task MailgunHandlerMapsDomainAndApiKey() {
+        var secrets = new FakeSecretStore(("mailgun", MailSecretNames.ApiKey, "mg-secret"));
+        var profile = CreateProfile("mailgun", MailProfileKind.Mailgun);
+        profile.Settings[MailProfileSettingsKeys.Domain] = "mg.example.com";
+        var handler = new MailgunMailSendHandler(secrets, sendAsync: (client, cancellationToken) => {
+            var credential = Assert.IsType<NetworkCredential>(client.Credentials);
+            Assert.Equal("mg-secret", credential.Password);
+            Assert.Equal("mg.example.com", client.Domain);
+            var recipient = Assert.IsType<MailboxAddress>(Assert.Single(client.To));
+            Assert.Equal("Alice", recipient.Name);
+            Assert.Equal("alice@example.com", recipient.Address);
+            AssertAttachmentMetadata(Assert.Single(client.Attachments!));
+            return Task.FromResult(Succeeded("mailgun-message"));
+        });
+
+        var result = await handler.SendAsync(profile, CreateRequest("mailgun"));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("mailgun-message", result.ProviderMessageId);
+    }
+
+    [Fact]
+    public async Task SesHandlerMapsRegionAndCredentialPair() {
+        var secrets = new FakeSecretStore(
+            ("ses", MailSecretNames.AccessKeyId, "access-key"),
+            ("ses", MailSecretNames.SecretAccessKey, "secret-key"));
+        var profile = CreateProfile("ses", MailProfileKind.Ses);
+        profile.Settings[MailProfileSettingsKeys.Region] = "eu-central-1";
+        var handler = new SesMailSendHandler(secrets, sendAsync: (client, cancellationToken) => {
+            var credential = Assert.IsType<NetworkCredential>(client.Credentials);
+            Assert.Equal("access-key", credential.UserName);
+            Assert.Equal("secret-key", credential.Password);
+            Assert.Equal("eu-central-1", client.Region);
+            var recipient = Assert.IsType<MailboxAddress>(Assert.Single(client.To));
+            Assert.Equal("Alice", recipient.Name);
+            Assert.Equal("alice@example.com", recipient.Address);
+            AssertAttachmentMetadata(Assert.Single(client.Attachments!));
+            return Task.FromResult(Succeeded("ses-message"));
+        });
+
+        var result = await handler.SendAsync(profile, CreateRequest("ses"));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("ses-message", result.ProviderMessageId);
+    }
+
+    [Fact]
+    public async Task ProviderHandlerReportsAQueuedFailure() {
+        var secrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
+        var pending = new FakePendingMessageRepository(new PendingMessageRecord { MessageId = "queued-message" });
+        var handler = new SendGridMailSendHandler(secrets, pending, sendAsync: (client, cancellationToken) =>
+            Task.FromResult(new SmtpResult(false, EmailAction.Send, "alice@example.com", "sender@example.com", "SendGridApi", 0, TimeSpan.Zero, error: "temporary failure") {
+                MessageId = "queued-message"
+            }));
+
+        var request = CreateRequest("sendgrid");
+        request.QueueOnFailure = true;
+        var result = await handler.SendAsync(CreateProfile("sendgrid", MailProfileKind.SendGrid), request);
+
+        Assert.True(result.Succeeded);
+        Assert.True(result.Queued);
+        Assert.Equal("queued-message", result.QueueMessageId);
+    }
+
+    [Fact]
+    public async Task ProviderHandlerDoesNotClaimQueueSuccessWithoutPersistedRecord() {
+        var secrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
+        var pending = new FakePendingMessageRepository();
+        var handler = new SendGridMailSendHandler(secrets, pending, sendAsync: (client, cancellationToken) =>
+            Task.FromResult(new SmtpResult(false, EmailAction.Send, "alice@example.com", "sender@example.com", "SendGridApi", 0, TimeSpan.Zero, error: "temporary failure") {
+                MessageId = "not-persisted"
+            }));
+
+        var request = CreateRequest("sendgrid");
+        request.QueueOnFailure = true;
+        var result = await handler.SendAsync(CreateProfile("sendgrid", MailProfileKind.SendGrid), request);
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.Queued);
+        Assert.Null(result.QueueMessageId);
+    }
+
+    private static MailProfile CreateProfile(string id, MailProfileKind kind) => new() {
+        Id = id,
+        DisplayName = id,
+        Kind = kind,
+        DefaultSender = "Sender <sender@example.com>",
+        Settings = new Dictionary<string, string> {
+            [MailProfileSettingsKeys.RetryCount] = "2"
+        }
+    };
+
+    private static SendMessageRequest CreateRequest(string profileId) => new() {
+        ProfileId = profileId,
+        Message = new DraftMessage {
+            ProfileId = profileId,
+            Subject = "Provider test",
+            TextBody = "Hello",
+            To = {
+                new MessageRecipient { Name = "Alice", Address = "alice@example.com" }
+            },
+            Attachments = {
+                new DraftAttachment {
+                    Path = Path.Combine(Path.GetTempPath(), "mailozaurr-provider-test.bin"),
+                    FileName = "renamed-report.pdf",
+                    ContentType = "application/pdf",
+                    ContentId = "report-content"
+                }
+            }
+        }
+    };
+
+    private static void AssertAttachmentMetadata(AttachmentDescriptor attachment) {
+        Assert.Equal("renamed-report.pdf", attachment.FileName);
+        Assert.Equal("application/pdf", attachment.ContentType);
+        Assert.Equal("report-content", attachment.ContentId);
+        Assert.Equal(ContentDisposition.Attachment, attachment.ContentDisposition?.Disposition);
+    }
+
+    private static SmtpResult Succeeded(string messageId) =>
+        new(true, EmailAction.Send, "alice@example.com", "sender@example.com", "provider", 0, TimeSpan.Zero) {
+            MessageId = messageId
+        };
+
+    private sealed class FakeSecretStore : IMailSecretStore {
+        private readonly Dictionary<string, string> _secrets;
+
+        public FakeSecretStore(params (string ProfileId, string Name, string Value)[] secrets) {
+            _secrets = secrets.ToDictionary(
+                secret => $"{secret.ProfileId}:{secret.Name}",
+                secret => secret.Value,
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        public Task<string?> GetSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) {
+            _secrets.TryGetValue($"{profileId}:{secretName}", out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task SetSecretAsync(string profileId, string secretName, string secretValue, CancellationToken cancellationToken = default) {
+            _secrets[$"{profileId}:{secretName}"] = secretValue;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> RemoveSecretAsync(string profileId, string secretName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_secrets.Remove($"{profileId}:{secretName}"));
+    }
+
+    private sealed class FakePendingMessageRepository : IPendingMessageRepository {
+        private readonly Dictionary<string, PendingMessageRecord> _records;
+
+        public FakePendingMessageRepository(params PendingMessageRecord[] records) {
+            _records = records.ToDictionary(record => record.MessageId, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public Task SaveAsync(PendingMessageRecord record, CancellationToken cancellationToken = default) {
+            _records[record.MessageId] = record;
+            return Task.CompletedTask;
+        }
+
+        public Task<PendingMessageRecord?> TryAcquireLeaseAsync(
+            string messageId,
+            DateTimeOffset dueBeforeOrAt,
+            DateTimeOffset leaseUntil,
+            CancellationToken cancellationToken = default) =>
+            GetByMessageIdAsync(messageId, cancellationToken);
+
+        public Task<PendingMessageRecord?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken = default) {
+            _records.TryGetValue(messageId, out var record);
+            return Task.FromResult<PendingMessageRecord?>(record);
+        }
+
+        public async IAsyncEnumerable<PendingMessageRecord> GetAllAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            foreach (var record in _records.Values) {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return record;
+                await Task.Yield();
+            }
+        }
+
+        public Task RemoveAsync(string messageId, CancellationToken cancellationToken = default) {
+            _records.Remove(messageId);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
@@ -114,6 +114,75 @@ public sealed class ApplicationProviderMailSendHandlerTests {
         Assert.Null(result.QueueMessageId);
     }
 
+    [Fact]
+    public async Task ProviderHandlerRejectsMessagesWithoutAUsableRecipient() {
+        var secrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
+        var handler = new SendGridMailSendHandler(secrets, sendAsync: (client, cancellationToken) =>
+            throw new InvalidOperationException("Provider dispatch must not be reached."));
+        var request = CreateRequest("sendgrid");
+        request.Message.To.Clear();
+        request.Message.Cc.Add(new MessageRecipient { Address = "  " });
+        request.Message.Bcc.Add(new MessageRecipient { Address = string.Empty });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            handler.SendAsync(CreateProfile("sendgrid", MailProfileKind.SendGrid), request));
+
+        Assert.Contains("recipient", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ProviderHandlersUseTheFirstNonBlankReplyToAddress() {
+        var sendGridSecrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
+        var sendGrid = new SendGridMailSendHandler(sendGridSecrets, sendAsync: (client, cancellationToken) => {
+            var replyTo = Assert.IsType<SendGridEmailAddress>(client.ReplyTo);
+            Assert.Equal("reply@example.com", replyTo.Email);
+            return Task.FromResult(Succeeded("sendgrid-message"));
+        });
+        await sendGrid.SendAsync(
+            CreateProfile("sendgrid", MailProfileKind.SendGrid),
+            CreateRequestWithReplyTo("sendgrid"));
+
+        var mailgunSecrets = new FakeSecretStore(("mailgun", MailSecretNames.ApiKey, "mg-secret"));
+        var mailgun = new MailgunMailSendHandler(mailgunSecrets, sendAsync: (client, cancellationToken) => {
+            var replyTo = Assert.IsType<MailboxAddress>(client.ReplyTo);
+            Assert.Equal("reply@example.com", replyTo.Address);
+            return Task.FromResult(Succeeded("mailgun-message"));
+        });
+        await mailgun.SendAsync(
+            CreateProfile("mailgun", MailProfileKind.Mailgun),
+            CreateRequestWithReplyTo("mailgun"));
+
+        var sesSecrets = new FakeSecretStore(
+            ("ses", MailSecretNames.AccessKeyId, "access-key"),
+            ("ses", MailSecretNames.SecretAccessKey, "secret-key"));
+        var ses = new SesMailSendHandler(sesSecrets, sendAsync: (client, cancellationToken) => {
+            var replyTo = Assert.IsType<MailboxAddress>(client.ReplyTo);
+            Assert.Equal("reply@example.com", replyTo.Address);
+            return Task.FromResult(Succeeded("ses-message"));
+        });
+        await ses.SendAsync(
+            CreateProfile("ses", MailProfileKind.Ses),
+            CreateRequestWithReplyTo("ses"));
+    }
+
+    [Fact]
+    public async Task ProviderAttachmentKeepsThePathDerivedFileNameWhenNoOverrideIsProvided() {
+        var secrets = new FakeSecretStore(
+            ("ses", MailSecretNames.AccessKeyId, "access-key"),
+            ("ses", MailSecretNames.SecretAccessKey, "secret-key"));
+        var request = CreateRequest("ses");
+        request.Message.Attachments[0].FileName = null;
+        request.Message.Attachments[0].ContentType = null;
+        var expectedFileName = Path.GetFileName(request.Message.Attachments[0].Path);
+        var handler = new SesMailSendHandler(secrets, sendAsync: (client, cancellationToken) => {
+            var attachment = Assert.IsType<FileAttachmentDescriptor>(Assert.Single(client.Attachments!));
+            Assert.Equal(expectedFileName, attachment.FileName);
+            return Task.FromResult(Succeeded("ses-message"));
+        });
+
+        await handler.SendAsync(CreateProfile("ses", MailProfileKind.Ses), request);
+    }
+
     private static MailProfile CreateProfile(string id, MailProfileKind kind) => new() {
         Id = id,
         DisplayName = id,
@@ -143,6 +212,13 @@ public sealed class ApplicationProviderMailSendHandlerTests {
             }
         }
     };
+
+    private static SendMessageRequest CreateRequestWithReplyTo(string profileId) {
+        var request = CreateRequest(profileId);
+        request.Message.ReplyTo.Add(new MessageRecipient { Address = "  " });
+        request.Message.ReplyTo.Add(new MessageRecipient { Name = "Reply", Address = "reply@example.com" });
+        return request;
+    }
 
     private static void AssertAttachmentMetadata(AttachmentDescriptor attachment) {
         Assert.Equal("renamed-report.pdf", attachment.FileName);

--- a/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProviderMailSendHandlerTests.cs
@@ -221,6 +221,24 @@ public sealed class ApplicationProviderMailSendHandlerTests : IDisposable {
     }
 
     [Fact]
+    public async Task ProviderHandlerFallsBackToDefaultMailboxWhenDefaultSenderIsMissing() {
+        var secrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
+        var request = CreateRequest("sendgrid");
+        request.Message.From = null;
+        var profile = CreateProfile("sendgrid", MailProfileKind.SendGrid);
+        profile.DefaultSender = null;
+        profile.DefaultMailbox = "Mailbox Sender <mailbox@example.com>";
+        var handler = new SendGridMailSendHandler(secrets, sendAsync: (client, cancellationToken) => {
+            var sender = Assert.IsType<SendGridEmailAddress>(client.From);
+            Assert.Equal("Mailbox Sender", sender.Name);
+            Assert.Equal("mailbox@example.com", sender.Email);
+            return Task.FromResult(Succeeded("sendgrid-message"));
+        });
+
+        await handler.SendAsync(profile, request);
+    }
+
+    [Fact]
     public async Task ProviderInlineAttachmentGetsAUsableContentIdWhenNoOverrideIsProvided() {
         var secrets = new FakeSecretStore(("sendgrid", MailSecretNames.ApiKey, "sg-secret"));
         var request = CreateRequest("sendgrid");

--- a/Sources/Mailozaurr.Tests/ApplicationSmtpMailSendHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationSmtpMailSendHandlerTests.cs
@@ -46,7 +46,7 @@ public sealed class ApplicationSmtpMailSendHandlerTests {
     }
 
     [Fact]
-    public async Task HandlerReturnsQueuedResultWhenRepositoryCapturesFailedSend() {
+    public async Task HandlerPreservesConfirmedQueueAfterRecordIsConsumed() {
         var repository = new FilePendingMessageRepository(new PendingMessageRepositoryOptions {
             DirectoryPath = CreateTemporaryDirectory()
         });
@@ -62,9 +62,11 @@ public sealed class ApplicationSmtpMailSendHandlerTests {
                     Provider = EmailProvider.None,
                     MimeMessage = Convert.ToBase64String(Array.Empty<byte>())
                 }, cancellationToken).ConfigureAwait(false);
+                await repository.RemoveAsync(message.MessageId ?? "queued-1", cancellationToken).ConfigureAwait(false);
 
                 return new SmtpResult(false, EmailAction.Send, "alice@example.com", "sender@example.com", "smtp.example.com", 587, TimeSpan.Zero, error: "temporary smtp failure") {
-                    MessageId = message.MessageId ?? "queued-1"
+                    MessageId = message.MessageId ?? "queued-1",
+                    Queued = true
                 };
             });
 

--- a/Sources/Mailozaurr.Tests/ApplicationSmtpSessionFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationSmtpSessionFactoryTests.cs
@@ -27,7 +27,8 @@ public sealed class ApplicationSmtpSessionFactoryTests {
                 [MailProfileSettingsKeys.SecureSocketOptions] = SecureSocketOptions.StartTls.ToString(),
                 [MailProfileSettingsKeys.UseSsl] = "true",
                 [MailProfileSettingsKeys.MaxDelayMilliseconds] = "9000",
-                [MailProfileSettingsKeys.JitterMilliseconds] = "175"
+                [MailProfileSettingsKeys.JitterMilliseconds] = "175",
+                [MailProfileSettingsKeys.RetryAlways] = "true"
             }
         });
 
@@ -38,6 +39,7 @@ public sealed class ApplicationSmtpSessionFactoryTests {
         Assert.True(captured.UseSsl);
         Assert.Equal(9000, captured.MaxDelayMilliseconds);
         Assert.Equal(175, captured.JitterMilliseconds);
+        Assert.True(captured.RetryAlways);
         Assert.Equal("sender@example.com", captured.UserName);
         Assert.Equal("super-secret", captured.Password);
         Assert.Equal(ProtocolAuthMode.Basic, captured.AuthMode);

--- a/Sources/Mailozaurr.Tests/ApplicationSmtpSessionFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationSmtpSessionFactoryTests.cs
@@ -25,7 +25,9 @@ public sealed class ApplicationSmtpSessionFactoryTests {
                 [MailProfileSettingsKeys.Server] = "smtp.example.com",
                 [MailProfileSettingsKeys.Port] = "1587",
                 [MailProfileSettingsKeys.SecureSocketOptions] = SecureSocketOptions.StartTls.ToString(),
-                [MailProfileSettingsKeys.UseSsl] = "true"
+                [MailProfileSettingsKeys.UseSsl] = "true",
+                [MailProfileSettingsKeys.MaxDelayMilliseconds] = "9000",
+                [MailProfileSettingsKeys.JitterMilliseconds] = "175"
             }
         });
 
@@ -34,6 +36,8 @@ public sealed class ApplicationSmtpSessionFactoryTests {
         Assert.Equal(1587, captured.Port);
         Assert.Equal(SecureSocketOptions.StartTls, captured.SecureSocketOptions);
         Assert.True(captured.UseSsl);
+        Assert.Equal(9000, captured.MaxDelayMilliseconds);
+        Assert.Equal(175, captured.JitterMilliseconds);
         Assert.Equal("sender@example.com", captured.UserName);
         Assert.Equal("super-secret", captured.Password);
         Assert.Equal(ProtocolAuthMode.Basic, captured.AuthMode);
@@ -65,6 +69,31 @@ public sealed class ApplicationSmtpSessionFactoryTests {
         Assert.Equal(ProtocolAuthMode.OAuth2, captured!.AuthMode);
         Assert.Equal("oauth-token", captured.Password);
         Assert.Equal("user@gmail.com", captured.UserName);
+    }
+
+    [Fact]
+    public async Task FactorySupportsAnonymousSmtpWithoutCredentials() {
+        SmtpSessionRequest? captured = null;
+        var factory = new SmtpSessionFactory(null, (request, _) => {
+            captured = request;
+            return Task.FromResult(new Smtp());
+        });
+
+        await factory.ConnectAsync(new MailProfile {
+            Id = "anonymous-relay",
+            DisplayName = "Anonymous relay",
+            Kind = MailProfileKind.Smtp,
+            DefaultSender = "sender@example.com",
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Server] = "relay.example.com",
+                [MailProfileSettingsKeys.AuthenticationEnabled] = "false"
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.False(captured!.Authenticate);
+        Assert.Equal(string.Empty, captured.UserName);
+        Assert.Equal(string.Empty, captured.Password);
     }
 
     private sealed class InMemorySecretStore : IMailSecretStore {

--- a/Sources/Mailozaurr.Tests/ApplicationSmtpSessionFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationSmtpSessionFactoryTests.cs
@@ -98,6 +98,48 @@ public sealed class ApplicationSmtpSessionFactoryTests {
         Assert.Equal(string.Empty, captured.Password);
     }
 
+    [Fact]
+    public async Task DefaultConnectAsync_CancellationAfterConnect_DisposesOwnedSession() {
+        var previousFactory = Smtp.ClientFactory;
+        var trackingClient = new TrackingClientSmtp();
+        Smtp.ClientFactory = _ => trackingClient;
+        try {
+            using var cancellationSource = new CancellationTokenSource();
+            var request = new SmtpSessionRequest {
+                Server = "smtp.example.com",
+                Authenticate = false,
+                ConnectWithCancellationAsync = (_, _) => {
+                    cancellationSource.Cancel();
+                    return Task.FromResult(new SmtpResult(
+                        true,
+                        default,
+                        string.Empty,
+                        string.Empty,
+                        "smtp.example.com",
+                        587,
+                        TimeSpan.Zero));
+                }
+            };
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => SmtpSessionFactory.DefaultConnectAsync(request, cancellationSource.Token));
+
+            Assert.True(trackingClient.IsDisposed);
+        } finally {
+            Smtp.ClientFactory = previousFactory;
+            trackingClient.Dispose();
+        }
+    }
+
+    private sealed class TrackingClientSmtp : ClientSmtp {
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing) {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
     private sealed class InMemorySecretStore : IMailSecretStore {
         private readonly Dictionary<string, string> _values = new(StringComparer.OrdinalIgnoreCase);
 

--- a/Sources/Mailozaurr.Tests/DraftMessageClonerTests.cs
+++ b/Sources/Mailozaurr.Tests/DraftMessageClonerTests.cs
@@ -1,0 +1,38 @@
+using Mailozaurr.Application;
+
+namespace Mailozaurr.Tests;
+
+public sealed class DraftMessageClonerTests {
+    [Fact]
+    public void Clone_PreservesPriorityAndDetachesMutableValues() {
+        var source = new DraftMessage {
+            ProfileId = "profile",
+            Priority = MessagePriority.High,
+            To = {
+                new MessageRecipient {
+                    Name = "Recipient",
+                    Address = "recipient@example.com"
+                }
+            },
+            Headers = {
+                ["X-Test"] = "value"
+            },
+            Attachments = {
+                new DraftAttachment {
+                    Path = "report.pdf",
+                    FileName = "renamed.pdf"
+                }
+            }
+        };
+
+        DraftMessage clone = DraftMessageCloner.Clone(source);
+        clone.To[0].Address = "changed@example.com";
+        clone.Headers["X-Test"] = "changed";
+        clone.Attachments[0].FileName = "changed.pdf";
+
+        Assert.Equal(MessagePriority.High, clone.Priority);
+        Assert.Equal("recipient@example.com", source.To[0].Address);
+        Assert.Equal("value", source.Headers["X-Test"]);
+        Assert.Equal("renamed.pdf", source.Attachments[0].FileName);
+    }
+}

--- a/Sources/Mailozaurr.Tests/DraftMimeMessageFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/DraftMimeMessageFactoryTests.cs
@@ -20,6 +20,7 @@ public sealed class DraftMimeMessageFactoryTests {
                 Subject = "Hello",
                 TextBody = "plain text",
                 HtmlBody = "<b>html</b>",
+                Priority = MessagePriority.High,
                 To = {
                     new MessageRecipient { Name = "Alice", Address = "alice@example.com" }
                 },
@@ -42,6 +43,7 @@ public sealed class DraftMimeMessageFactoryTests {
         Assert.Equal("Hello", message.Subject);
         Assert.Equal("plain text", message.TextBody);
         Assert.Equal("<b>html</b>", message.HtmlBody);
+        Assert.Equal(MimeKit.MessagePriority.Urgent, message.Priority);
         Assert.Equal("value", message.Headers["X-Test"]);
         Assert.Single(message.Attachments);
     }

--- a/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphBatchAndRetryTests.cs
@@ -11,6 +11,34 @@ namespace Mailozaurr.Tests;
 
 [Collection("GraphCollection")]
 public class GraphBatchAndRetryTests {
+    [Fact]
+    public void BuildGraphTokenCacheKey_DoesNotExposeSecretAndSeparatesCredentials() {
+        var first = new GraphCredential {
+            ClientId = "client",
+            DirectoryId = "tenant",
+            ClientSecret = "first-super-secret"
+        };
+        var second = new GraphCredential {
+            ClientId = "client",
+            DirectoryId = "tenant",
+            ClientSecret = "second-super-secret"
+        };
+
+        string firstKey = MicrosoftGraphUtils.BuildGraphTokenCacheKey(
+            first,
+            first.DirectoryId,
+            "https://graph.microsoft.com");
+        string secondKey = MicrosoftGraphUtils.BuildGraphTokenCacheKey(
+            second,
+            second.DirectoryId,
+            "https://graph.microsoft.com");
+
+        Assert.StartsWith("v2:", firstKey, StringComparison.Ordinal);
+        Assert.DoesNotContain(first.ClientSecret, firstKey, StringComparison.Ordinal);
+        Assert.DoesNotContain(first.ClientId, firstKey, StringComparison.Ordinal);
+        Assert.NotEqual(firstKey, secondKey);
+    }
+
     private class BatchHandler : HttpMessageHandler {
         public HttpRequestMessage? BatchRequest;
         public string? BatchPayload;
@@ -295,7 +323,10 @@ public class GraphBatchAndRetryTests {
 
             Assert.Equal("Bearer token", token);
             Assert.Equal(1, handler.CallCount);
-            var key = "id|tenant||secret|https://graph.microsoft.com";
+            var key = MicrosoftGraphUtils.BuildGraphTokenCacheKey(
+                credential,
+                "tenant",
+                "https://graph.microsoft.com");
             Assert.True(cache.TryGetValue(key, out var authorization));
             Assert.InRange(authorization.ExpiresOn, before.AddSeconds(1100), DateTimeOffset.UtcNow.AddSeconds(1300));
         } finally {

--- a/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/GraphCreateMessageTests.cs
@@ -65,6 +65,21 @@ public class GraphCreateMessageTests {
     }
 
     [Fact]
+    public void GraphMimePreparation_MapsMimePriorityToImportance() {
+        var message = new MimeMessage {
+            Subject = "priority",
+            Body = new TextPart("plain") { Text = "body" },
+            Priority = MimeKit.MessagePriority.Urgent
+        };
+        message.From.Add(MailboxAddress.Parse("from@example.com"));
+        message.To.Add(MailboxAddress.Parse("to@example.com"));
+
+        var graphMessage = GraphMimePreparation.ConvertToGraphMessage(message);
+
+        Assert.Equal("high", graphMessage.Importance);
+    }
+
+    [Fact]
     public void CreateMessage_WithoutExplicitContentType_DefaultsToHtml() {
         using var graph = new Graph {
             From = "from@example.com",

--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -1,4 +1,5 @@
 using Mailozaurr;
+using MimeKit;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,6 +19,21 @@ public class HelpersTests {
     public void GetEmailAddress_ReturnsInputString_WhenStringProvided() {
         var result = Mailozaurr.Helpers.GetEmailAddress("test@example.com");
         Assert.Equal("test@example.com", result);
+    }
+
+    [Fact]
+    public void GetEmailAddress_ReturnsAddressFromNamedMailbox() {
+        var result = Mailozaurr.Helpers.GetEmailAddress(new MailboxAddress("Sender", "sender@example.com"));
+
+        Assert.Equal("sender@example.com", result);
+    }
+
+    [Fact]
+    public void GetEmailAndName_ReturnsStructuredMailboxValues() {
+        var result = Mailozaurr.Helpers.GetEmailAndName(new MailboxAddress("Sender", "sender@example.com"));
+
+        Assert.Equal("sender@example.com", result.Email);
+        Assert.Equal("Sender", result.Name);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/HelpersTests.cs
+++ b/Sources/Mailozaurr.Tests/HelpersTests.cs
@@ -16,6 +16,11 @@ namespace Mailozaurr.Tests;
 /// </summary>
 public class HelpersTests {
     [Fact]
+    public void IsTransient_DoesNotTreatCallerCancellationAsRetryable() {
+        Assert.False(Helpers.IsTransient(new TaskCanceledException("caller canceled")));
+    }
+
+    [Fact]
     public void GetEmailAddress_ReturnsInputString_WhenStringProvided() {
         var result = Mailozaurr.Helpers.GetEmailAddress("test@example.com");
         Assert.Equal("test@example.com", result);

--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -243,6 +243,22 @@ public class MailgunClientTests {
     }
 
     [Fact]
+    public async Task CreateContentAsync_SkipsMissingStructuredFileAttachment() {
+        string missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        using var client = new MailgunClient {
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            Attachments = new List<AttachmentDescriptor> { new FileAttachmentDescriptor(missing) }
+        };
+
+        MethodInfo? method = typeof(MailgunClient).GetMethod("CreateContentAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+        var task = (Task<MultipartFormDataContent>)method!.Invoke(client, new object[] { default(CancellationToken) })!;
+        using var content = await task;
+
+        Assert.DoesNotContain(content, part => part.Headers.ContentDisposition?.Name?.Trim('"') == "attachment");
+    }
+
+    [Fact]
     public async Task SendEmailAsync_InvalidCredentials_ThrowsInvalidOperationException() {
         using var client = new MailgunClient {
             From = "sender@example.com",

--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Mailozaurr.Definitions;
 
 namespace Mailozaurr.Tests;
 
@@ -77,6 +78,18 @@ public class MailgunClientTests {
         var ex = Assert.Throws<TargetInvocationException>(() => prop!.GetValue(client));
         Assert.IsType<ArgumentException>(ex.InnerException);
         Assert.Contains("invalid", ex.InnerException!.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmailDomain_UsesStructuredNamedSenderAddress() {
+        using var client = new MailgunClient {
+            From = new MimeKit.MailboxAddress("Sender", "sender@example.com")
+        };
+        PropertyInfo? prop = typeof(MailgunClient).GetProperty("EmailDomain", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        var domain = Assert.IsType<string>(prop!.GetValue(client));
+
+        Assert.Equal("example.com", domain);
     }
 
     [Fact]
@@ -197,6 +210,35 @@ public class MailgunClientTests {
         } finally {
             File.Delete(attachment);
             File.Delete(inline);
+        }
+    }
+
+    [Fact]
+    public async Task CreateContentAsync_PreservesStructuredAttachmentMetadata() {
+        var file = Path.GetTempFileName();
+        try {
+            using var client = new MailgunClient {
+                From = "sender@example.com",
+                To = new List<object> { "to@example.com" },
+                Attachments = new List<AttachmentDescriptor> {
+                    new FileAttachmentDescriptor(file) {
+                        FileName = "report.pdf",
+                        ContentType = "application/pdf",
+                        ContentId = "report-content"
+                    }
+                }
+            };
+
+            MethodInfo? method = typeof(MailgunClient).GetMethod("CreateContentAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            var task = (Task<MultipartFormDataContent>)method!.Invoke(client, new object[] { default(CancellationToken) })!;
+            using var content = await task;
+            var attachment = content.Single(part => part.Headers.ContentDisposition?.Name?.Trim('"') == "attachment");
+
+            Assert.Equal("report.pdf", attachment.Headers.ContentDisposition?.FileName?.Trim('"'));
+            Assert.Equal("application/pdf", attachment.Headers.ContentType?.MediaType);
+            Assert.Contains("report-content", attachment.Headers.GetValues("Content-ID"));
+        } finally {
+            File.Delete(file);
         }
     }
 

--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -194,6 +194,32 @@ public class MailgunClientTests {
     }
 
     [Fact]
+    public async Task CreateContentAsync_DuplicatePathsAcrossLegacyAndStructuredCollections_SkipsDuplicates() {
+        var legacyFile = Path.GetTempFileName();
+        var structuredFile = Path.GetTempFileName();
+        try {
+            using var client = new MailgunClient {
+                From = "sender@example.com",
+                To = new List<object> { "to@example.com" },
+                Attachment = new[] { legacyFile },
+                Attachments = new List<AttachmentDescriptor> {
+                    new FileAttachmentDescriptor(Path.GetFullPath(legacyFile)),
+                    new FileAttachmentDescriptor(structuredFile),
+                    new FileAttachmentDescriptor(Path.GetFullPath(structuredFile))
+                }
+            };
+            MethodInfo? method = typeof(MailgunClient).GetMethod("CreateContentAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            var task = (Task<MultipartFormDataContent>)method!.Invoke(client, new object[] { default(CancellationToken) })!;
+            using var content = await task;
+            var parts = content.Count(c => c.Headers.ContentDisposition?.Name?.Trim('"') == "attachment");
+            Assert.Equal(2, parts);
+        } finally {
+            File.Delete(legacyFile);
+            File.Delete(structuredFile);
+        }
+    }
+
+    [Fact]
     public async Task CreateContentAsync_UsesStreamContentForFiles() {
         var attachment = Path.GetTempFileName();
         var inline = Path.GetTempFileName();

--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -266,6 +266,28 @@ public class MailgunClientTests {
     }
 
     [Fact]
+    public async Task CreateContentAsync_InfersStructuredAttachmentContentTypeFromFileName() {
+        using var client = new MailgunClient {
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            Attachments = new List<AttachmentDescriptor> {
+                new ByteArrayAttachmentDescriptor(new byte[] { 1, 2, 3 }, "report.pdf")
+            }
+        };
+        MethodInfo? method = typeof(MailgunClient).GetMethod(
+            "CreateContentAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        using var content = await (Task<MultipartFormDataContent>)method!.Invoke(
+            client,
+            new object[] { CancellationToken.None })!;
+        var attachment = Assert.Single(content, item =>
+            item.Headers.ContentDisposition?.Name?.Trim('"') == "attachment");
+
+        Assert.Equal("application/pdf", attachment.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
     public async Task CreateContentAsync_RejectsMissingStructuredFileAttachment() {
         string missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
         using var client = new MailgunClient {

--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -301,6 +301,21 @@ public class MailgunClientTests {
     }
 
     [Fact]
+    public async Task SendEmailAsync_ReturnsNativeMessageId() {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent(
+                    "{\"id\":\"<mailgun-123@example.com>\",\"message\":\"Queued\"}")
+            });
+        using var client = CreateClient(handler);
+
+        var result = await client.SendEmailAsync();
+
+        Assert.True(result.Status);
+        Assert.Equal("<mailgun-123@example.com>", result.MessageId);
+    }
+
+    [Fact]
     public async Task SendEmailAsync_DisposesResponse_OnFailure() {
         var handler = new TrackingHandler(HttpStatusCode.BadRequest, "bad");
         using var client = CreateClient(handler);

--- a/Sources/Mailozaurr.Tests/MailgunClientTests.cs
+++ b/Sources/Mailozaurr.Tests/MailgunClientTests.cs
@@ -21,6 +21,7 @@ public class MailgunClientTests {
         private readonly HttpStatusCode _statusCode;
         private readonly string _content;
         public bool ResponseDisposed { get; private set; }
+        public int Calls { get; private set; }
 
         public TrackingHandler(HttpStatusCode statusCode, string content = "") {
             _statusCode = statusCode;
@@ -28,6 +29,7 @@ public class MailgunClientTests {
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Calls++;
             var response = new HttpResponseMessage(_statusCode) {
                 Content = new TrackingContent(_content, () => ResponseDisposed = true)
             };
@@ -61,6 +63,9 @@ public class MailgunClientTests {
     }
 
     private sealed class DerivedMailgunClient : MailgunClient {
+        public DerivedMailgunClient(HttpMessageHandler handler) : base(handler) {
+        }
+
         public bool Disposed { get; private set; }
 
         protected override void Dispose(bool disposing) {
@@ -106,6 +111,24 @@ public class MailgunClientTests {
         string body = await content.ReadAsStringAsync();
         Assert.Contains("h:X-Test", body, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("123", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CreateContentAsync_WithHighPriority_IncludesPriorityHeaders() {
+        using var client = new MailgunClient {
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            Priority = MessagePriority.High
+        };
+        MethodInfo? method = typeof(MailgunClient).GetMethod("CreateContentAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        var task = (Task<MultipartFormDataContent>)method!.Invoke(client, new object[] { default(CancellationToken) })!;
+        using var content = await task;
+        string body = await content.ReadAsStringAsync();
+
+        Assert.Contains("h:X-Priority", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("h:Importance", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("high", body, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -243,7 +266,7 @@ public class MailgunClientTests {
     }
 
     [Fact]
-    public async Task CreateContentAsync_SkipsMissingStructuredFileAttachment() {
+    public async Task CreateContentAsync_RejectsMissingStructuredFileAttachment() {
         string missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
         using var client = new MailgunClient {
             From = "sender@example.com",
@@ -252,10 +275,9 @@ public class MailgunClientTests {
         };
 
         MethodInfo? method = typeof(MailgunClient).GetMethod("CreateContentAsync", BindingFlags.NonPublic | BindingFlags.Instance);
-        var task = (Task<MultipartFormDataContent>)method!.Invoke(client, new object[] { default(CancellationToken) })!;
-        using var content = await task;
-
-        Assert.DoesNotContain(content, part => part.Headers.ContentDisposition?.Name?.Trim('"') == "attachment");
+        var exception = Assert.Throws<TargetInvocationException>(() =>
+            method!.Invoke(client, new object[] { default(CancellationToken) }));
+        Assert.IsType<FileNotFoundException>(exception.InnerException);
     }
 
     [Fact]
@@ -288,16 +310,50 @@ public class MailgunClientTests {
     }
 
     [Fact]
+    public async Task SendEmailAsync_PermanentFailureDoesNotRetry() {
+        var handler = new TrackingHandler(HttpStatusCode.BadRequest, "invalid request");
+        using var client = CreateClient(handler);
+        client.RetryCount = 3;
+
+        var result = await client.SendEmailAsync();
+
+        Assert.False(result.Status);
+        Assert.Equal(1, handler.Calls);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_StreamAttachmentCanBeReadAcrossRetries() {
+        var contentBytes = System.Text.Encoding.UTF8.GetBytes("repeatable-content");
+        var source = new NonSeekableReadStream(contentBytes);
+        var handler = new SequencedHandler(
+            HttpStatusCode.InternalServerError,
+            HttpStatusCode.OK);
+        using var client = new MailgunClient(handler) {
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            Credentials = new NetworkCredential(string.Empty, "key"),
+            RetryCount = 1,
+            Attachments = new List<AttachmentDescriptor> {
+                new StreamAttachmentDescriptor(source, "report.bin", leaveStreamOpen: false)
+            }
+        };
+
+        var result = await client.SendEmailAsync();
+
+        Assert.True(result.Status);
+        Assert.Equal(2, handler.RequestBodies.Count);
+        Assert.All(handler.RequestBodies, body => Assert.Contains("repeatable-content", body, StringComparison.Ordinal));
+        Assert.False(source.CanRead);
+    }
+
+    [Fact]
     public void Dispose_DerivedType_DisposesHttpClient() {
         var handler = new DisposingHandler();
-        var httpClient = new HttpClient(handler);
-        var client = new DerivedMailgunClient {
+        var client = new DerivedMailgunClient(handler) {
             From = "sender@example.com",
             To = new List<object> { "to@example.com" },
             Credentials = new NetworkCredential(string.Empty, "key")
         };
-        var field = typeof(MailgunClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance);
-        field!.SetValue(client, httpClient);
 
         client.Dispose();
 
@@ -319,14 +375,58 @@ public class MailgunClientTests {
     }
 
     private static MailgunClient CreateClient(HttpMessageHandler handler) {
-        var httpClient = new HttpClient(handler);
-        var client = new MailgunClient {
+        return new MailgunClient(handler) {
             From = "sender@example.com",
             To = new List<object> { "to@example.com" },
             Credentials = new NetworkCredential(string.Empty, "key")
         };
-        var field = typeof(MailgunClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance);
-        field!.SetValue(client, httpClient);
-        return client;
+    }
+
+    private sealed class SequencedHandler : HttpMessageHandler {
+        private readonly Queue<HttpStatusCode> _statuses;
+
+        public SequencedHandler(params HttpStatusCode[] statuses) {
+            _statuses = new Queue<HttpStatusCode>(statuses);
+        }
+
+        public List<string> RequestBodies { get; } = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) {
+            RequestBodies.Add(await request.Content!.ReadAsStringAsync());
+            return new HttpResponseMessage(_statuses.Dequeue()) {
+                Content = new StringContent("response")
+            };
+        }
+    }
+
+    private sealed class NonSeekableReadStream : Stream {
+        private readonly MemoryStream _inner;
+
+        public NonSeekableReadStream(byte[] bytes) {
+            _inner = new MemoryStream(bytes, writable: false);
+        }
+
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+        public override void Flush() => _inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing) {
+            if (disposing) {
+                _inner.Dispose();
+            }
+            base.Dispose(disposing);
+        }
     }
 }

--- a/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsPagingTests.cs
+++ b/Sources/Mailozaurr.Tests/MicrosoftGraphUtilsPagingTests.cs
@@ -34,7 +34,10 @@ public class MicrosoftGraphUtilsPagingTests {
         var tokenCacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var tokenCache = (ConcurrentDictionary<string, GraphAuthorization>)tokenCacheField.GetValue(null)!;
         var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
-        var key = "id|tenant||secret|https://graph.microsoft.com";
+        var key = MicrosoftGraphUtils.BuildGraphTokenCacheKey(
+            cred,
+            "tenant",
+            "https://graph.microsoft.com");
         tokenCache[key] = new GraphAuthorization { AccessToken = "token", TokenType = "Bearer", ExpiresOn = DateTimeOffset.UtcNow.AddHours(1) };
         try {
             var messages = await MicrosoftGraphUtils.GetMailMessagesAsync(cred, "u", limit: 3);
@@ -62,7 +65,10 @@ public class MicrosoftGraphUtilsPagingTests {
         var tokenCacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var tokenCache = (ConcurrentDictionary<string, GraphAuthorization>)tokenCacheField.GetValue(null)!;
         var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
-        var key = "id|tenant||secret|https://graph.microsoft.com";
+        var key = MicrosoftGraphUtils.BuildGraphTokenCacheKey(
+            cred,
+            "tenant",
+            "https://graph.microsoft.com");
         tokenCache[key] = new GraphAuthorization { AccessToken = "token", TokenType = "Bearer", ExpiresOn = DateTimeOffset.UtcNow.AddHours(1) };
         using var cts = new CancellationTokenSource();
         try {
@@ -96,7 +102,10 @@ public class MicrosoftGraphUtilsPagingTests {
         var tokenCacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var tokenCache = (ConcurrentDictionary<string, GraphAuthorization>)tokenCacheField.GetValue(null)!;
         var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
-        var key = "id|tenant||secret|https://graph.microsoft.com";
+        var key = MicrosoftGraphUtils.BuildGraphTokenCacheKey(
+            cred,
+            "tenant",
+            "https://graph.microsoft.com");
         tokenCache[key] = new GraphAuthorization { AccessToken = "token", TokenType = "Bearer", ExpiresOn = DateTimeOffset.UtcNow.AddHours(1) };
         try {
             var attachments = await MicrosoftGraphUtils.GetMailMessageAttachmentsAsync(cred, "u", "m");
@@ -129,7 +138,10 @@ public class MicrosoftGraphUtilsPagingTests {
         var tokenCacheField = typeof(MicrosoftGraphUtils).GetField("TokenCache", BindingFlags.NonPublic | BindingFlags.Static)!;
         var tokenCache = (ConcurrentDictionary<string, GraphAuthorization>)tokenCacheField.GetValue(null)!;
         var cred = new GraphCredential { ClientId = "id", DirectoryId = "tenant", ClientSecret = "secret" };
-        var key = "id|tenant||secret|https://graph.microsoft.com";
+        var key = MicrosoftGraphUtils.BuildGraphTokenCacheKey(
+            cred,
+            "tenant",
+            "https://graph.microsoft.com");
         tokenCache[key] = new GraphAuthorization { AccessToken = "token", TokenType = "Bearer", ExpiresOn = DateTimeOffset.UtcNow.AddHours(1) };
         try {
             var folders = await MicrosoftGraphUtils.GetMailFoldersAsync(cred, "u");

--- a/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
@@ -234,4 +234,25 @@ public sealed class OAuthTokenCacheProtectionTests {
         Assert.NotNull(await OAuthTokenCache.GetAsync("external:entry"));
     }
 
+    [Fact]
+    public async Task SetAsync_PersistentlyHeldCacheLock_ThrowsIOException() {
+        var lockPath = OAuthCacheTestHelper.GetOAuthCacheFilePath() + ".lock";
+        var directory = Path.GetDirectoryName(lockPath);
+        if (!string.IsNullOrWhiteSpace(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var lockStream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+        using var cancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await Assert.ThrowsAsync<IOException>(() => OAuthTokenCache.SetAsync(
+            "locked:entry",
+            new OAuthCredential {
+                UserName = "locked@example.com",
+                AccessToken = "locked-token",
+                ExpiresOn = DateTimeOffset.UtcNow.AddMinutes(30)
+            },
+            cancellationSource.Token));
+    }
+
 }

--- a/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
+++ b/Sources/Mailozaurr.Tests/OAuthTokenCacheProtectionTests.cs
@@ -14,6 +14,25 @@ public sealed class OAuthTokenCacheProtectionTests {
     }
 
     [Fact]
+    public async Task LoadCacheAsync_RemovesLegacyGraphKeysThatContainClientSecrets() {
+        const string secret = "legacy-client-secret";
+        string legacyKey = $"graph:client|tenant||{secret}|https://graph.microsoft.com";
+        await OAuthTokenCache.SetAsync(legacyKey, new OAuthCredential {
+            UserName = "client",
+            AccessToken = "token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+        });
+
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+
+        OAuthCredential? loaded = await OAuthTokenCache.GetAsync(legacyKey);
+        string cacheText = OAuthCacheTestHelper.ReadOAuthCacheFileText();
+
+        Assert.Null(loaded);
+        Assert.DoesNotContain(secret, cacheText, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task SetAsync_WritesProtectedSecretsToDisk() {
         var cacheKey = "oauth:protected@example.com";
         var credential = new OAuthCredential {
@@ -175,6 +194,44 @@ public sealed class OAuthTokenCacheProtectionTests {
         } finally {
             lockStream.Dispose();
         }
+    }
+
+    [Fact]
+    public async Task SetAsync_ReloadsAndMergesEntriesWrittenByAnotherProcess() {
+        await OAuthTokenCache.SetAsync("local:first", new OAuthCredential {
+            UserName = "first@example.com",
+            AccessToken = "first-token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddMinutes(30)
+        });
+
+        var path = OAuthCacheTestHelper.GetOAuthCacheFilePath();
+        var json = OAuthCacheTestHelper.ReadOAuthCacheFileText();
+        var entries = JsonSerializer.Deserialize(
+            json,
+            MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry)!;
+        entries["external:entry"] = OAuthCredentialCacheEntry.FromCredential(
+            new OAuthCredential {
+                UserName = "external@example.com",
+                AccessToken = "external-token",
+                ExpiresOn = DateTimeOffset.UtcNow.AddMinutes(30)
+            },
+            CredentialProtection.Default);
+        File.WriteAllText(
+            path,
+            JsonSerializer.Serialize(
+                entries,
+                MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry));
+
+        await OAuthTokenCache.SetAsync("local:second", new OAuthCredential {
+            UserName = "second@example.com",
+            AccessToken = "second-token",
+            ExpiresOn = DateTimeOffset.UtcNow.AddMinutes(30)
+        });
+
+        OAuthCacheTestHelper.ResetOAuthTokenCache();
+        Assert.NotNull(await OAuthTokenCache.GetAsync("local:first"));
+        Assert.NotNull(await OAuthTokenCache.GetAsync("local:second"));
+        Assert.NotNull(await OAuthTokenCache.GetAsync("external:entry"));
     }
 
 }

--- a/Sources/Mailozaurr.Tests/RetryDelayCalculatorTests.cs
+++ b/Sources/Mailozaurr.Tests/RetryDelayCalculatorTests.cs
@@ -1,0 +1,42 @@
+namespace Mailozaurr.Tests;
+
+public sealed class RetryDelayCalculatorTests {
+    [Fact]
+    public void Calculate_BaseDelayAtCapWithJitter_ReturnsCap() {
+        var delay = RetryDelayCalculator.Calculate(
+            baseDelayMilliseconds: 1000,
+            backoff: 2.0,
+            attempt: 10,
+            maxDelayMilliseconds: 1000,
+            jitterMilliseconds: 60_000);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(1000), delay);
+    }
+
+    [Fact]
+    public void SmtpCalculateRetryDelay_BaseDelayAtCapWithJitter_ReturnsCap() {
+        var smtp = new Smtp {
+            RetryDelayMilliseconds = 1000,
+            RetryDelayBackoff = 2.0,
+            MaxDelayMilliseconds = 1000,
+            JitterMilliseconds = 60_000
+        };
+
+        var delay = smtp.CalculateRetryDelay(10);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(1000), delay);
+    }
+
+    [Fact]
+    public void GraphCalculateDelay_BaseDelayAtCapWithJitter_ReturnsCap() {
+        var policy = new GraphSendPolicy {
+            BaseDelayMs = 1000,
+            MaxDelayMs = 1000,
+            JitterMs = 60_000
+        };
+
+        var delay = GraphRetryHelper.CalculateDelay(policy, 10);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(1000), delay);
+    }
+}

--- a/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SendGridCreateMessageTests.cs
@@ -58,6 +58,25 @@ public class SendGridCreateMessageTests {
     }
 
     [Fact]
+    public void CreateMessage_WithHighPriority_IncludesProviderPriorityHeaders() {
+        using var client = new SendGridClient {
+            From = "from@example.com",
+            To = new List<object> { "to@example.com" },
+            Subject = "subject",
+            Text = "text",
+            Credentials = new NetworkCredential("apikey", "test"),
+            Priority = MessagePriority.High
+        };
+
+        client.CreateMessage();
+
+        PropertyInfo? prop = typeof(SendGridClient).GetProperty("MessageJson", BindingFlags.NonPublic | BindingFlags.Instance);
+        var json = Assert.IsType<string>(prop?.GetValue(client));
+        Assert.Contains("\"X-Priority\":\"1\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"Importance\":\"high\"", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CreateMessage_DuplicateAttachments_IncludedOnce() {
         var tmp = Path.GetTempFileName();
         File.WriteAllText(tmp, "data");

--- a/Sources/Mailozaurr.Tests/SendGridSendEmailAsyncTests.cs
+++ b/Sources/Mailozaurr.Tests/SendGridSendEmailAsyncTests.cs
@@ -40,6 +40,30 @@ public sealed class SendGridSendEmailAsyncTests {
         Assert.Single(handler.Requests);
     }
 
+    [Fact]
+    public async Task SendEmailAsync_ReturnsNativeMessageId() {
+        var response = new HttpResponseMessage(HttpStatusCode.Accepted);
+        response.Headers.Add("X-Message-Id", "sendgrid-123");
+        var handler = new RecordingHandler(response);
+        using var client = CreateClient(handler);
+
+        var result = await client.SendEmailAsync();
+
+        Assert.True(result.Status);
+        Assert.Equal("sendgrid-123", result.MessageId);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_SharedRequestDeadlineCancelsStalledRequest() {
+        using var client = CreateClient(new BlockingHandler());
+        client.RequestTimeout = TimeSpan.FromMilliseconds(50);
+
+        var result = await client.SendEmailAsync();
+
+        Assert.False(result.Status);
+        Assert.True(client.Stopwatch.Elapsed < TimeSpan.FromSeconds(5));
+    }
+
     private static SendGridClient CreateClient(HttpMessageHandler handler) {
         var client = new SendGridClient(handler) {
             From = "sender@example.com",
@@ -50,5 +74,17 @@ public sealed class SendGridSendEmailAsyncTests {
         };
         client.CreateMessage();
         return client;
+    }
+
+    private sealed class BlockingHandler : HttpMessageHandler {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) {
+
+            await Task.Delay(
+                Timeout.InfiniteTimeSpan,
+                cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.Accepted);
+        }
     }
 }

--- a/Sources/Mailozaurr.Tests/SendGridSendEmailAsyncTests.cs
+++ b/Sources/Mailozaurr.Tests/SendGridSendEmailAsyncTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Net.Http;
+using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class SendGridSendEmailAsyncTests {
+    [Fact]
+    public async Task SendEmailAsync_PermanentFailureDoesNotRetry() {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.BadRequest) {
+                Content = new StringContent("invalid")
+            });
+        using var client = CreateClient(handler);
+        client.RetryCount = 3;
+
+        var result = await client.SendEmailAsync();
+
+        Assert.False(result.Status);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_ErrorActionStopThrowsProviderFailure() {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.Forbidden) {
+                Content = new StringContent("forbidden")
+            });
+        using var client = CreateClient(handler);
+        client.RetryCount = 3;
+        client.ErrorAction = ActionPreference.Stop;
+
+        var exception = await Record.ExceptionAsync(() => client.SendEmailAsync());
+
+        var httpException = Assert.IsAssignableFrom<HttpRequestException>(exception);
+        Assert.Contains("Forbidden", httpException.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(handler.Requests);
+    }
+
+    private static SendGridClient CreateClient(HttpMessageHandler handler) {
+        var client = new SendGridClient(handler) {
+            From = "sender@example.com",
+            To = new List<object> { "recipient@example.com" },
+            Credentials = new NetworkCredential(string.Empty, "api-key"),
+            Subject = "subject",
+            Text = "body"
+        };
+        client.CreateMessage();
+        return client;
+    }
+}

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -537,6 +537,31 @@ public sealed class ProviderPendingMessageTests {
     }
 
     [Fact]
+    public async Task SesClient_HttpTimeoutQueuesPendingMessage() {
+        var repository = new InMemoryPendingMessageRepository();
+        using var client = new SesClient {
+            PendingMessageRepository = repository,
+            Credentials = new NetworkCredential("AKIA123", "secret-key"),
+            Region = "us-east-1",
+            From = "sender@example.com",
+            To = new List<object> { "recipient@example.com" },
+            Subject = "ses-timeout",
+            Text = "body"
+        };
+        var timeoutHandler = new TestHandler((_, _) =>
+            Task.FromException<HttpResponseMessage>(new TaskCanceledException("HTTP request timeout")));
+        var httpClientField = typeof(SesClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        httpClientField.SetValue(client, new HttpClient(timeoutHandler));
+
+        var result = await client.SendEmailAsync(CancellationToken.None);
+
+        Assert.False(result.Status);
+        Assert.NotNull(repository.LastSaved);
+        Assert.Equal(repository.LastSaved!.MessageId, result.MessageId);
+        Assert.Equal(EmailProvider.SES, repository.LastSaved.Provider);
+    }
+
+    [Fact]
     public async Task SesClient_CancellationDuringPendingSave_PropagatesCancellation() {
         var repository = new CancellationOnSavePendingMessageRepository();
         using var client = new SesClient {

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -156,6 +156,7 @@ public sealed class ProviderPendingMessageTests {
         Assert.NotNull(record);
         Assert.Equal(EmailProvider.SendGrid, record.Provider);
         Assert.False(string.IsNullOrWhiteSpace(record.MessageId));
+        Assert.Equal(record.MessageId, result.MessageId);
         Assert.True(record.ProviderData.TryGetValue(SendGridPendingMessageSender.MessageJsonKey, out var json));
         Assert.False(string.IsNullOrWhiteSpace(json));
         Assert.True(record.ProviderData.TryGetValue(SendGridPendingMessageSender.ApiKeyProtectedKey, out var apiKeyProtected));
@@ -259,6 +260,7 @@ public sealed class ProviderPendingMessageTests {
         var record = repository.LastSaved;
         Assert.NotNull(record);
         Assert.Equal(EmailProvider.Mailgun, record.Provider);
+        Assert.Equal(record.MessageId, result.MessageId);
         Assert.Equal("example.com", record.ProviderData[MailgunPendingMessageSender.DomainKey]);
         Assert.True(record.ProviderData.TryGetValue(MailgunPendingMessageSender.ApiKeyProtectedKey, out var mailgunProtected));
         Assert.False(string.IsNullOrWhiteSpace(mailgunProtected));
@@ -507,6 +509,7 @@ public sealed class ProviderPendingMessageTests {
         var record = repository.LastSaved;
         Assert.NotNull(record);
         Assert.Equal(EmailProvider.SES, record.Provider);
+        Assert.Equal(record.MessageId, result.MessageId);
         Assert.True(record.ProviderData.TryGetValue(SesPendingMessageSender.AccessKeyIdProtectedKey, out var sesAccessProtected));
         Assert.True(record.ProviderData.TryGetValue(SesPendingMessageSender.SecretAccessKeyProtectedKey, out var sesSecretProtected));
         Assert.Equal("AKIA123", CredentialProtection.UnprotectWithFallback(sesAccessProtected));

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -292,6 +292,8 @@ public sealed class ProviderPendingMessageTests {
         var repository = new InMemoryPendingMessageRepository();
         using var client = new MailgunClient {
             PendingMessageRepository = repository,
+            RetryCount = 1,
+            RetryDelayMilliseconds = 0,
             Credentials = new NetworkCredential("user", "mailgun-api-key"),
             From = "sender@example.com",
             To = new List<object> { "recipient@example.com" },
@@ -306,6 +308,7 @@ public sealed class ProviderPendingMessageTests {
         var result = await client.SendEmailAsync(CancellationToken.None);
 
         Assert.False(result.Status);
+        Assert.Equal(2, timeoutHandler.CallCount);
         Assert.NotNull(repository.LastSaved);
         Assert.Equal(repository.LastSaved!.MessageId, result.MessageId);
         Assert.Equal(EmailProvider.Mailgun, repository.LastSaved.Provider);
@@ -565,6 +568,8 @@ public sealed class ProviderPendingMessageTests {
         var repository = new InMemoryPendingMessageRepository();
         using var client = new SesClient {
             PendingMessageRepository = repository,
+            RetryCount = 1,
+            RetryDelayMilliseconds = 0,
             Credentials = new NetworkCredential("AKIA123", "secret-key"),
             Region = "us-east-1",
             From = "sender@example.com",
@@ -580,6 +585,7 @@ public sealed class ProviderPendingMessageTests {
         var result = await client.SendEmailAsync(CancellationToken.None);
 
         Assert.False(result.Status);
+        Assert.Equal(2, timeoutHandler.CallCount);
         Assert.NotNull(repository.LastSaved);
         Assert.Equal(repository.LastSaved!.MessageId, result.MessageId);
         Assert.Equal(EmailProvider.SES, repository.LastSaved.Provider);

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -151,6 +151,7 @@ public sealed class ProviderPendingMessageTests {
 
         var result = await client.SendEmailAsync(CancellationToken.None);
         Assert.False(result.Status);
+        Assert.True(result.Queued);
 
         var record = repository.LastSaved;
         Assert.NotNull(record);
@@ -257,6 +258,7 @@ public sealed class ProviderPendingMessageTests {
 
         var result = await client.SendEmailAsync(CancellationToken.None);
         Assert.False(result.Status);
+        Assert.True(result.Queued);
 
         var record = repository.LastSaved;
         Assert.NotNull(record);
@@ -534,6 +536,7 @@ public sealed class ProviderPendingMessageTests {
 
         var result = await client.SendEmailAsync(CancellationToken.None);
         Assert.False(result.Status);
+        Assert.True(result.Queued);
 
         var record = repository.LastSaved;
         Assert.NotNull(record);

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -245,7 +245,8 @@ public sealed class ProviderPendingMessageTests {
             From = "sender@example.com",
             To = new List<object> { "recipient@example.com" },
             Subject = "mailgun",
-            Text = "body"
+            Text = "body",
+            Priority = MessagePriority.High
         };
 
         var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest) {
@@ -268,6 +269,7 @@ public sealed class ProviderPendingMessageTests {
         Assert.DoesNotContain(MailgunPendingMessageSender.ApiKeyBase64Key, record.ProviderData.Keys);
         var mime = await MimeMessage.LoadAsync(new MemoryStream(Convert.FromBase64String(record.MimeMessage)));
         Assert.Equal("mailgun", mime.Subject);
+        Assert.Equal(MimeKit.MessagePriority.Urgent, mime.Priority);
 
         var successHandler = new TestHandler((request, _) => {
             Assert.Equal(HttpMethod.Post, request.Method);

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -143,7 +143,7 @@ public sealed class ProviderPendingMessageTests {
         var repository = new InMemoryPendingMessageRepository();
         client.PendingMessageRepository = repository;
 
-        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError) {
+        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest) {
             Content = new StringContent("failure", Encoding.UTF8, "text/plain")
         }));
         var httpClientField = typeof(SendGridClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
@@ -248,7 +248,7 @@ public sealed class ProviderPendingMessageTests {
             Text = "body"
         };
 
-        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway) {
+        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest) {
             Content = new StringContent("error", Encoding.UTF8, "text/plain")
         }));
         var httpClientField = typeof(MailgunClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
@@ -524,7 +524,7 @@ public sealed class ProviderPendingMessageTests {
             Text = "body"
         };
 
-        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) {
+        var failureHandler = new TestHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest) {
             Content = new StringContent("failure", Encoding.UTF8, "text/plain")
         }));
         var httpClientField = typeof(SesClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -1,4 +1,5 @@
 using MimeKit;
+using Mailozaurr.Definitions;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -289,6 +290,56 @@ public sealed class ProviderPendingMessageTests {
 
         Assert.Equal(1, successHandler.CallCount);
         Assert.Null(await repository.GetByMessageIdAsync(record!.MessageId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task MailgunClient_QueuesEachFileBackedAttachmentOnceAcrossAllInputs() {
+        var file = Path.GetTempFileName();
+        try {
+            var repository = new InMemoryPendingMessageRepository();
+            using var client = new MailgunClient {
+                PendingMessageRepository = repository,
+                Credentials = new NetworkCredential("user", "mailgun-api-key"),
+                From = "sender@example.com",
+                To = new List<object> { "recipient@example.com" },
+                Subject = "mailgun-attachment-dedup",
+                Text = "body",
+                Attachment = new[] { file },
+                InlineAttachment = new[] { file },
+                Attachments = new List<AttachmentDescriptor> {
+                    new FileAttachmentDescriptor(file)
+                },
+                InlineAttachments = new List<AttachmentDescriptor> {
+                    new FileAttachmentDescriptor(file)
+                }
+            };
+            var failureHandler = new TestHandler((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest) {
+                    Content = new StringContent("error", Encoding.UTF8, "text/plain")
+                }));
+            var httpClientField = typeof(MailgunClient).GetField(
+                "_client",
+                BindingFlags.NonPublic | BindingFlags.Instance)!;
+            httpClientField.SetValue(client, new HttpClient(failureHandler));
+
+            var result = await client.SendEmailAsync(CancellationToken.None);
+
+            Assert.False(result.Status);
+            Assert.True(result.Queued);
+            var record = Assert.IsType<PendingMessageRecord>(repository.LastSaved);
+            var mime = await MimeMessage.LoadAsync(
+                new MemoryStream(Convert.FromBase64String(record.MimeMessage)));
+            var matchingParts = mime.BodyParts
+                .OfType<MimePart>()
+                .Where(part => string.Equals(
+                    part.FileName,
+                    Path.GetFileName(file),
+                    StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            Assert.Single(matchingParts);
+        } finally {
+            File.Delete(file);
+        }
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/ProviderPendingMessageTests.cs
@@ -288,6 +288,30 @@ public sealed class ProviderPendingMessageTests {
     }
 
     [Fact]
+    public async Task MailgunClient_HttpTimeoutQueuesPendingMessage() {
+        var repository = new InMemoryPendingMessageRepository();
+        using var client = new MailgunClient {
+            PendingMessageRepository = repository,
+            Credentials = new NetworkCredential("user", "mailgun-api-key"),
+            From = "sender@example.com",
+            To = new List<object> { "recipient@example.com" },
+            Subject = "mailgun-timeout",
+            Text = "body"
+        };
+        var timeoutHandler = new TestHandler((_, _) =>
+            Task.FromException<HttpResponseMessage>(new TaskCanceledException("HTTP request timeout")));
+        var httpClientField = typeof(MailgunClient).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        httpClientField.SetValue(client, new HttpClient(timeoutHandler));
+
+        var result = await client.SendEmailAsync(CancellationToken.None);
+
+        Assert.False(result.Status);
+        Assert.NotNull(repository.LastSaved);
+        Assert.Equal(repository.LastSaved!.MessageId, result.MessageId);
+        Assert.Equal(EmailProvider.Mailgun, repository.LastSaved.Provider);
+    }
+
+    [Fact]
     public async Task MailgunClient_CancellationDuringPendingSave_PropagatesCancellation() {
         var repository = new CancellationOnSavePendingMessageRepository();
         using var client = new MailgunClient {

--- a/Sources/Mailozaurr.Tests/SentMessages/SesPendingMessageSenderTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/SesPendingMessageSenderTests.cs
@@ -1,7 +1,5 @@
-using MimeKit;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 
 namespace Mailozaurr.Tests.SentMessages;
 
@@ -21,8 +19,10 @@ public sealed class SesPendingMessageSenderTests {
     public async Task SendAsync_ComputesAwsSignature() {
         string? actualAuth = null;
         string? actualDate = null;
+        string? actualBody = null;
+        string? actualContentType = null;
         Uri? requestUri = null;
-        var handler = new TestHandler((request, _) => {
+        var handler = new TestHandler(async (request, _) => {
             requestUri = request.RequestUri;
             actualAuth = request.Headers.TryGetValues("Authorization", out var authValues)
                 ? authValues.Single()
@@ -30,25 +30,18 @@ public sealed class SesPendingMessageSenderTests {
             actualDate = request.Headers.TryGetValues("x-amz-date", out var dateValues)
                 ? dateValues.Single()
                 : null;
-            var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            actualBody = await request.Content!.ReadAsStringAsync();
+            actualContentType = request.Content.Headers.ContentType?.ToString();
+            return new HttpResponseMessage(HttpStatusCode.OK) {
                 Content = new StringContent("<SendRawEmailResponse/>")
             };
-            return Task.FromResult(response);
         });
         using var httpClient = new HttpClient(handler);
         var fixedTime = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc);
         var sender = new SesPendingMessageSender(httpClient, () => fixedTime);
 
-        var message = new MimeMessage();
-        message.From.Add(MailboxAddress.Parse("sender@example.com"));
-        message.To.Add(MailboxAddress.Parse("recipient@example.com"));
-        message.Subject = "queued";
-        message.Body = new TextPart("plain") { Text = "body" };
-        using var ms = new MemoryStream();
-        await message.WriteToAsync(ms);
-
         var record = new PendingMessageRecord {
-            MimeMessage = Convert.ToBase64String(ms.ToArray())
+            MimeMessage = "AQID"
         };
         const string accessKey = "AKIDEXAMPLE";
         const string secretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
@@ -58,21 +51,16 @@ public sealed class SesPendingMessageSenderTests {
 
         await sender.SendAsync(record, CancellationToken.None);
 
-        using var expected = CreateExpectedRequest(accessKey, secretKey, "us-east-1", record.MimeMessage, fixedTime);
-        var expectedAuth = expected.Headers.GetValues("Authorization").Single();
-        Assert.Equal(expectedAuth, actualAuth);
-        var expectedDate = expected.Headers.GetValues("x-amz-date").Single();
-        Assert.Equal(expectedDate, actualDate);
+        Assert.Equal(
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20240102/us-east-1/ses/aws4_request, " +
+            "SignedHeaders=content-type;host;x-amz-date, " +
+            "Signature=9fb67414a234bd795c0599f48c535c5d21ab8873229b1d1052dd716297a385d0",
+            actualAuth);
+        Assert.Equal("20240102T030405Z", actualDate);
         Assert.Equal(new Uri("https://email.us-east-1.amazonaws.com/"), requestUri);
-    }
-
-    private static HttpRequestMessage CreateExpectedRequest(string accessKey, string secretKey, string region, string base64Mime, DateTime now) {
-        var type = typeof(SesPendingMessageSender);
-        var buildBody = type.GetMethod("BuildRequestBody", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
-        var body = (string)buildBody.Invoke(null, new object[] { base64Mime })!;
-        var createRequest = type.GetMethod("CreateRequest", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
-        var request = (HttpRequestMessage)createRequest.Invoke(null, new object[] { accessKey, secretKey, region, body, now })!;
-        request.Content = new StringContent(body, Encoding.UTF8, "application/x-www-form-urlencoded");
-        return request;
+        Assert.Equal(
+            "Action=SendRawEmail&RawMessage.Data=AQID&Version=2010-12-01",
+            actualBody);
+        Assert.Equal("application/x-www-form-urlencoded", actualContentType);
     }
 }

--- a/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageEncryptionTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageEncryptionTests.cs
@@ -49,6 +49,7 @@ public sealed class SmtpPendingMessageEncryptionTests {
 
             var result = await smtp.SendAsync(CancellationToken.None);
             Assert.False(result.Status);
+            Assert.True(result.Queued);
 
             var record = Assert.Single(repository.Records);
             Assert.Equal("queued-user", record.UserName);

--- a/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageProcessorIntegrationTests.cs
+++ b/Sources/Mailozaurr.Tests/SentMessages/SmtpPendingMessageProcessorIntegrationTests.cs
@@ -40,6 +40,7 @@ public sealed class SmtpPendingMessageProcessorIntegrationTests {
 
             var sendResult = await smtp.SendAsync(CancellationToken.None);
             Assert.False(sendResult.Status);
+            Assert.True(sendResult.Queued);
 
             var record = Assert.Single(repository.Records);
             Assert.Equal("smtp.integration.test", record.Server);

--- a/Sources/Mailozaurr.Tests/SesClientSendEmailAsyncTests.cs
+++ b/Sources/Mailozaurr.Tests/SesClientSendEmailAsyncTests.cs
@@ -73,6 +73,7 @@ public class SesClientSendEmailAsyncTests {
         string auth = request.Headers.GetValues("Authorization").Single();
         string body = await request.Content!.ReadAsStringAsync();
         string expected = ExpectedAuthorization("AKID", "SECRET", "us-east-1", amzDate, body);
+        Assert.Equal("application/x-www-form-urlencoded", request.Content.Headers.ContentType?.ToString());
         Assert.Equal(expected, auth);
     }
 

--- a/Sources/Mailozaurr.Tests/SesClientSendEmailAsyncTests.cs
+++ b/Sources/Mailozaurr.Tests/SesClientSendEmailAsyncTests.cs
@@ -101,6 +101,19 @@ public class SesClientSendEmailAsyncTests {
     }
 
     [Fact]
+    public async Task SendEmailAsync_PermanentFailureDoesNotRetry() {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent("invalid") });
+        using var client = CreateClient(handler);
+        client.RetryCount = 3;
+
+        var result = await client.SendEmailAsync();
+
+        Assert.False(result.Status);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
     public async Task SendEmailAsync_PostsWebhook_OnSuccess() {
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
         using var client = CreateClient(handler);

--- a/Sources/Mailozaurr.Tests/SesClientSendEmailAsyncTests.cs
+++ b/Sources/Mailozaurr.Tests/SesClientSendEmailAsyncTests.cs
@@ -57,13 +57,17 @@ public class SesClientSendEmailAsyncTests {
 
     [Fact]
     public async Task SendEmailAsync_ComputesSignature() {
-        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StringContent(
+                "<SendRawEmailResponse><SendRawEmailResult><MessageId>ses-123</MessageId></SendRawEmailResult></SendRawEmailResponse>")
+        });
         using var client = CreateClient(handler);
         client.WebhookUrl = null;
 
         var result = await client.SendEmailAsync();
 
         Assert.True(result.Status);
+        Assert.Equal("ses-123", result.MessageId);
         var request = Assert.Single(handler.Requests);
         string amzDate = request.Headers.GetValues("x-amz-date").Single();
         string auth = request.Headers.GetValues("Authorization").Single();
@@ -136,5 +140,16 @@ public class SesClientSendEmailAsyncTests {
 
         Assert.Equal(2, handler.Requests.Count);
         Assert.Contains(handler.Requests, r => r.RequestUri!.ToString() == "http://localhost/");
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_AfterDispose_ThrowsObjectDisposedException() {
+        var client = CreateClient(new RecordingHandler());
+        client.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => client.SendEmailAsync());
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => client.SendTemplatedEmailAsync());
     }
 }

--- a/Sources/Mailozaurr.Tests/SesClientTests.cs
+++ b/Sources/Mailozaurr.Tests/SesClientTests.cs
@@ -37,6 +37,21 @@ public class SesClientTests {
     }
 
     [Fact]
+    public void BuildMessage_WithHighPriority_SetsMimePriority() {
+        using var client = new SesClient {
+            From = "sender@example.com",
+            To = new List<object> { "to@example.com" },
+            Subject = "subject",
+            Priority = MessagePriority.High
+        };
+        MethodInfo? method = typeof(SesClient).GetMethod("BuildMessage", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        var message = Assert.IsType<MimeMessage>(method!.Invoke(client, null));
+
+        Assert.Equal(MimeKit.MessagePriority.Urgent, message.Priority);
+    }
+
+    [Fact]
     public void BuildMessage_PreservesStructuredAttachmentMetadata() {
         var file = Path.GetTempFileName();
         try {

--- a/Sources/Mailozaurr.Tests/SesClientTests.cs
+++ b/Sources/Mailozaurr.Tests/SesClientTests.cs
@@ -1,4 +1,5 @@
 using MimeKit;
+using Mailozaurr.Definitions;
 using System.Collections.Generic;
 using System.Reflection;
 using Xunit;
@@ -33,5 +34,34 @@ public class SesClientTests {
         var message = method!.Invoke(client, null) as MimeMessage;
         Assert.NotNull(message);
         Assert.Equal("123", message!.Headers["X-Test"]);
+    }
+
+    [Fact]
+    public void BuildMessage_PreservesStructuredAttachmentMetadata() {
+        var file = Path.GetTempFileName();
+        try {
+            using var client = new SesClient {
+                From = "sender@example.com",
+                To = new List<object> { "to@example.com" },
+                Subject = "subject",
+                Attachments = new List<AttachmentDescriptor> {
+                    new FileAttachmentDescriptor(file) {
+                        FileName = "report.pdf",
+                        ContentType = "application/pdf",
+                        ContentId = "report-content"
+                    }
+                }
+            };
+            MethodInfo? method = typeof(SesClient).GetMethod("BuildMessage", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var message = Assert.IsType<MimeMessage>(method!.Invoke(client, null));
+            var attachment = Assert.IsType<MimePart>(Assert.Single(message.Attachments));
+
+            Assert.Equal("report.pdf", attachment.FileName);
+            Assert.Equal("application/pdf", attachment.ContentType.MimeType);
+            Assert.Equal("report-content", attachment.ContentId);
+        } finally {
+            File.Delete(file);
+        }
     }
 }

--- a/Sources/Mailozaurr.Tests/SmtpAttachmentTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAttachmentTests.cs
@@ -9,7 +9,7 @@ namespace Mailozaurr.Tests;
 
 public class SmtpAttachmentTests {
     [Fact]
-    public void CreateMessage_MissingAttachment_SkipsAttachment() {
+    public void CreateMessage_MissingAttachment_Throws() {
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         if (File.Exists(path)) File.Delete(path);
         var smtp = new Smtp {
@@ -20,9 +20,8 @@ public class SmtpAttachmentTests {
             Attachments = new List<AttachmentDescriptor> { new FileAttachmentDescriptor(path) }
         };
 
-        smtp.CreateMessage();
-
-        Assert.IsNotType<Multipart>(smtp.Message.Body);
+        var exception = Assert.Throws<FileNotFoundException>(() => smtp.CreateMessage());
+        Assert.Equal(path, exception.FileName);
     }
 
     [Fact]
@@ -57,6 +56,20 @@ public class SmtpAttachmentTests {
         Assert.Equal(data, extracted.ToArray());
 
         Assert.True(source.CanRead);
+    }
+
+    [Fact]
+    public void StreamAttachmentDescriptor_ClosedSourceRemainsReusable() {
+        var bytes = Encoding.UTF8.GetBytes("repeatable");
+        var source = new MemoryStream(bytes);
+        var descriptor = new StreamAttachmentDescriptor(source, "repeatable.txt", leaveStreamOpen: false);
+
+        var first = descriptor.GetContentBytes();
+        var second = descriptor.GetContentBytes();
+
+        Assert.Equal(bytes, first);
+        Assert.Equal(bytes, second);
+        Assert.False(source.CanRead);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/SmtpInlineAttachmentTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpInlineAttachmentTests.cs
@@ -44,7 +44,7 @@ public class SmtpInlineAttachmentTests {
     }
 
     [Fact]
-    public void CreateMessage_MissingInlineAttachment_SkipsResource() {
+    public void CreateMessage_MissingInlineAttachment_Throws() {
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         if (File.Exists(path)) File.Delete(path);
         var smtp = new Smtp {
@@ -55,8 +55,7 @@ public class SmtpInlineAttachmentTests {
             InlineAttachments = new List<AttachmentDescriptor> { new FileAttachmentDescriptor(path) }
         };
 
-        smtp.CreateMessage();
-
-        Assert.IsType<TextPart>(smtp.Message.Body);
+        var exception = Assert.Throws<FileNotFoundException>(() => smtp.CreateMessage());
+        Assert.Equal(path, exception.FileName);
     }
 }

--- a/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpPendingMessageTests.cs
@@ -133,6 +133,7 @@ public sealed class SmtpPendingMessageTests {
         var result = await smtp.SendAsync();
 
         Assert.False(result.Status);
+        Assert.True(result.Queued);
         Assert.NotNull(result.MessageId);
         Assert.Single(repo.Saved);
         Assert.Equal(result.MessageId, repo.Saved[0].MessageId);
@@ -178,6 +179,7 @@ public sealed class SmtpPendingMessageTests {
         var result = await smtp.SendAsync();
 
         Assert.True(result.Status);
+        Assert.False(result.Queued);
         Assert.Single(repo.Removed);
         Assert.Equal("msg-1", repo.Removed[0]);
     }

--- a/Sources/Mailozaurr.Tests/SmtpSessionServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSessionServiceTests.cs
@@ -8,6 +8,16 @@ namespace Mailozaurr.Tests;
 
 public class SmtpSessionServiceTests {
     [Fact]
+    public void SmtpSessionRequest_PreservesLegacyDelegatePropertyTypes() {
+        Assert.Equal(
+            typeof(Func<Smtp, Task<SmtpResult>>),
+            typeof(SmtpSessionRequest).GetProperty(nameof(SmtpSessionRequest.ConnectAsync))!.PropertyType);
+        Assert.Equal(
+            typeof(Func<Smtp, Task<SmtpResult>>),
+            typeof(SmtpSessionRequest).GetProperty(nameof(SmtpSessionRequest.AuthenticateAsync))!.PropertyType);
+    }
+
+    [Fact]
     public async Task ConnectAndAuthenticateAsync_ReturnsSuccess() {
         var request = new SmtpSessionRequest {
             Server = "smtp.test",
@@ -16,8 +26,8 @@ public class SmtpSessionServiceTests {
             UserName = "user",
             Password = "pass",
             RetryAlways = true,
-            ConnectAsync = (_, _) => Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero)),
-            AuthenticateAsync = (_, _) => Task.FromResult(new SmtpResult(true, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero))
+            ConnectAsync = _ => Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero)),
+            AuthenticateAsync = _ => Task.FromResult(new SmtpResult(true, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero))
         };
 
         var smtp = new Smtp();
@@ -35,7 +45,7 @@ public class SmtpSessionServiceTests {
         var request = new SmtpSessionRequest {
             Server = "relay.example.com",
             Authenticate = false,
-            ConnectAsync = (_, _) => Task.FromResult(new SmtpResult(
+            ConnectAsync = _ => Task.FromResult(new SmtpResult(
                 true,
                 EmailAction.Connect,
                 string.Empty,
@@ -43,7 +53,7 @@ public class SmtpSessionServiceTests {
                 "relay.example.com",
                 25,
                 TimeSpan.Zero)),
-            AuthenticateAsync = (_, _) => {
+            AuthenticateAsync = _ => {
                 authenticateCalled = true;
                 return Task.FromResult(new SmtpResult(
                     true,
@@ -70,7 +80,7 @@ public class SmtpSessionServiceTests {
             SecureSocketOptions = SecureSocketOptions.Auto,
             UserName = "user",
             Password = "pass",
-            ConnectAsync = (_, _) => Task.FromResult(new SmtpResult(false, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero, error: "nope"))
+            ConnectAsync = _ => Task.FromResult(new SmtpResult(false, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero, error: "nope"))
         };
 
         var smtp = new Smtp();
@@ -90,8 +100,8 @@ public class SmtpSessionServiceTests {
             SecureSocketOptions = SecureSocketOptions.Auto,
             UserName = "user",
             Password = "pass",
-            ConnectAsync = (_, _) => Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero)),
-            AuthenticateAsync = (_, _) => Task.FromResult(new SmtpResult(false, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero, error: "bad auth"))
+            ConnectAsync = _ => Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero)),
+            AuthenticateAsync = _ => Task.FromResult(new SmtpResult(false, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero, error: "bad auth"))
         };
 
         var smtp = new Smtp();
@@ -108,11 +118,11 @@ public class SmtpSessionServiceTests {
         using var cancellation = new CancellationTokenSource();
         var request = new SmtpSessionRequest {
             Server = "smtp.test",
-            ConnectAsync = (_, token) => {
+            ConnectWithCancellationAsync = (_, token) => {
                 Assert.Equal(cancellation.Token, token);
                 return Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero));
             },
-            AuthenticateAsync = (_, token) => {
+            AuthenticateWithCancellationAsync = (_, token) => {
                 Assert.Equal(cancellation.Token, token);
                 return Task.FromResult(new SmtpResult(true, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero));
             }

--- a/Sources/Mailozaurr.Tests/SmtpSessionServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSessionServiceTests.cs
@@ -1,5 +1,6 @@
 using MailKit.Security;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -14,8 +15,8 @@ public class SmtpSessionServiceTests {
             SecureSocketOptions = SecureSocketOptions.Auto,
             UserName = "user",
             Password = "pass",
-            ConnectAsync = _ => Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero)),
-            AuthenticateAsync = _ => Task.FromResult(new SmtpResult(true, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero))
+            ConnectAsync = (_, _) => Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero)),
+            AuthenticateAsync = (_, _) => Task.FromResult(new SmtpResult(true, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero))
         };
 
         var smtp = new Smtp();
@@ -27,6 +28,39 @@ public class SmtpSessionServiceTests {
     }
 
     [Fact]
+    public async Task ConnectAndAuthenticateAsync_AnonymousRelaySkipsAuthentication() {
+        bool authenticateCalled = false;
+        var request = new SmtpSessionRequest {
+            Server = "relay.example.com",
+            Authenticate = false,
+            ConnectAsync = (_, _) => Task.FromResult(new SmtpResult(
+                true,
+                EmailAction.Connect,
+                string.Empty,
+                string.Empty,
+                "relay.example.com",
+                25,
+                TimeSpan.Zero)),
+            AuthenticateAsync = (_, _) => {
+                authenticateCalled = true;
+                return Task.FromResult(new SmtpResult(
+                    true,
+                    EmailAction.Authenticate,
+                    string.Empty,
+                    string.Empty,
+                    "relay.example.com",
+                    25,
+                    TimeSpan.Zero));
+            }
+        };
+
+        var result = await SmtpSessionService.ConnectAndAuthenticateAsync(new Smtp(), request);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(authenticateCalled);
+    }
+
+    [Fact]
     public async Task ConnectAndAuthenticateAsync_FlagsConnectFailures() {
         var request = new SmtpSessionRequest {
             Server = "smtp.test",
@@ -34,7 +68,7 @@ public class SmtpSessionServiceTests {
             SecureSocketOptions = SecureSocketOptions.Auto,
             UserName = "user",
             Password = "pass",
-            ConnectAsync = _ => Task.FromResult(new SmtpResult(false, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero, error: "nope"))
+            ConnectAsync = (_, _) => Task.FromResult(new SmtpResult(false, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero, error: "nope"))
         };
 
         var smtp = new Smtp();
@@ -54,8 +88,8 @@ public class SmtpSessionServiceTests {
             SecureSocketOptions = SecureSocketOptions.Auto,
             UserName = "user",
             Password = "pass",
-            ConnectAsync = _ => Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero)),
-            AuthenticateAsync = _ => Task.FromResult(new SmtpResult(false, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero, error: "bad auth"))
+            ConnectAsync = (_, _) => Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero)),
+            AuthenticateAsync = (_, _) => Task.FromResult(new SmtpResult(false, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero, error: "bad auth"))
         };
 
         var smtp = new Smtp();
@@ -65,5 +99,28 @@ public class SmtpSessionServiceTests {
         Assert.Equal("auth_failed", result.ErrorCode);
         Assert.Equal("bad auth", result.Error);
         Assert.False(result.IsTransient);
+    }
+
+    [Fact]
+    public async Task ConnectAndAuthenticateAsync_PropagatesCancellationTokenToBothDelegates() {
+        using var cancellation = new CancellationTokenSource();
+        var request = new SmtpSessionRequest {
+            Server = "smtp.test",
+            ConnectAsync = (_, token) => {
+                Assert.Equal(cancellation.Token, token);
+                return Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero));
+            },
+            AuthenticateAsync = (_, token) => {
+                Assert.Equal(cancellation.Token, token);
+                return Task.FromResult(new SmtpResult(true, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero));
+            }
+        };
+
+        var result = await SmtpSessionService.ConnectAndAuthenticateAsync(
+            new Smtp(),
+            request,
+            cancellation.Token);
+
+        Assert.True(result.IsSuccess);
     }
 }

--- a/Sources/Mailozaurr.Tests/SmtpSessionServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpSessionServiceTests.cs
@@ -15,6 +15,7 @@ public class SmtpSessionServiceTests {
             SecureSocketOptions = SecureSocketOptions.Auto,
             UserName = "user",
             Password = "pass",
+            RetryAlways = true,
             ConnectAsync = (_, _) => Task.FromResult(new SmtpResult(true, EmailAction.Connect, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero)),
             AuthenticateAsync = (_, _) => Task.FromResult(new SmtpResult(true, EmailAction.Authenticate, string.Empty, string.Empty, "smtp.test", 587, TimeSpan.Zero))
         };
@@ -25,6 +26,7 @@ public class SmtpSessionServiceTests {
         Assert.True(result.IsSuccess);
         Assert.Equal(SecureSocketOptions.Auto, result.SecureSocketOptions);
         Assert.Null(result.ErrorCode);
+        Assert.True(smtp.RetryAlways);
     }
 
     [Fact]

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -282,6 +282,11 @@ public class SesClient : IDisposable {
             } catch (HttpRequestException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SES: {ex.Message}");
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                throw;
+            } catch (TaskCanceledException ex) {
+                lastException = ex;
+                LogCollector.LogWarning($"Send-EmailMessage - SES request timed out: {ex.Message}");
             }
 
             if ((!Helpers.IsTransient(lastException) && !RetryAlways) || attempts >= RetryCount) {

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -311,7 +311,8 @@ public class SesClient : IDisposable {
                     throw lastException;
                 }
                 SmtpResult fail = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message) {
-                    MessageId = queuedMessageId
+                    MessageId = queuedMessageId,
+                    Queued = queuedMessageId != null
                 };
                 await Helpers.PostWebhookAsync(WebhookUrl, fail, cancellationToken, _client);
                 return fail;

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -296,7 +296,12 @@ public class SesClient : IDisposable {
                 LogCollector.LogWarning($"Send-EmailMessage - SES request timed out: {ex.Message}");
             }
 
-            if (!HttpRetryPolicy.ShouldRetry(lastException, attempts, RetryCount, RetryAlways)) {
+            if (!HttpRetryPolicy.ShouldRetry(
+                    lastException,
+                    attempts,
+                    RetryCount,
+                    RetryAlways,
+                    isKnownTransient: lastException is TaskCanceledException)) {
                 var queuedMessageId =
                     await QueuePendingMessageAsync(
                         message,

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 
 namespace Mailozaurr;
 
@@ -16,6 +17,7 @@ namespace Mailozaurr;
 public class SesClient : IDisposable {
     private readonly HttpClient _client;
     private readonly bool _ownsClient;
+    private int _disposed;
 
     /// <summary>Measures send latency.</summary>
     public readonly Stopwatch Stopwatch;
@@ -271,13 +273,14 @@ public class SesClient : IDisposable {
             try {
                 using HttpRequestMessage request = CreateRequest(body, DateTime.UtcNow);
                 using HttpResponseMessage response = await _client.SendAsync(request, cancellationToken);
-#if NET5_0_OR_GREATER
-                string respContent = await response.Content.ReadAsStringAsync(cancellationToken);
-#else
-                string respContent = await response.Content.ReadAsStringAsync();
-#endif
+                string respContent = await ProviderResponseParser
+                    .ReadContentAsync(response, cancellationToken)
+                    .ConfigureAwait(false);
                 if (response.IsSuccessStatusCode) {
-                    SmtpResult ok = new(true, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString());
+                    SmtpResult ok = new(true, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString()) {
+                        MessageId = ProviderResponseParser
+                            .GetSesMessageId(respContent)
+                    };
                     await Helpers.PostWebhookAsync(WebhookUrl, ok, cancellationToken, _client);
                     return ok;
                 }
@@ -294,9 +297,11 @@ public class SesClient : IDisposable {
             }
 
             if (!HttpRetryPolicy.ShouldRetry(lastException, attempts, RetryCount, RetryAlways)) {
-                var queuedMessageId = HttpRetryPolicy.ShouldQueue(lastException, RetryAlways)
-                    ? await QueuePendingMessageAsync(message, mimeMessageBase64, cancellationToken).ConfigureAwait(false)
-                    : null;
+                var queuedMessageId =
+                    await QueuePendingMessageAsync(
+                        message,
+                        mimeMessageBase64,
+                        cancellationToken).ConfigureAwait(false);
                 if (ErrorAction == ActionPreference.Stop && lastException != null) {
                     throw lastException;
                 }
@@ -327,6 +332,7 @@ public class SesClient : IDisposable {
     /// Sends the email using Amazon SES.
     /// </summary>
     public async Task<SmtpResult> SendEmailAsync(CancellationToken cancellationToken) {
+        ThrowIfDisposed();
         MimeMessage message = BuildMessage();
         using MemoryStream stream = new();
         await message.WriteToAsync(stream, cancellationToken);
@@ -344,6 +350,7 @@ public class SesClient : IDisposable {
     /// Sends a templated email using Amazon SES.
     /// </summary>
     public async Task<SmtpResult> SendTemplatedEmailAsync(CancellationToken cancellationToken) {
+        ThrowIfDisposed();
         StringBuilder sb = new("Action=SendTemplatedEmail&Version=2010-12-01");
         if (!string.IsNullOrEmpty(TemplateName)) sb.Append("&Template=").Append(Uri.EscapeDataString(TemplateName));
         sb.Append("&Source=").Append(Uri.EscapeDataString(SentFrom));
@@ -372,8 +379,17 @@ public class SesClient : IDisposable {
     /// Releases resources used by the <see cref="SesClient"/> instance.
     /// </summary>
     public void Dispose() {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) {
+            return;
+        }
         if (_ownsClient) {
             _client.Dispose();
+        }
+    }
+
+    private void ThrowIfDisposed() {
+        if (Volatile.Read(ref _disposed) != 0) {
+            throw new ObjectDisposedException(nameof(SesClient));
         }
     }
 }

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -44,6 +44,10 @@ public class SesClient : IDisposable {
     public string[]? Attachment { get; set; }
     /// <summary>Paths to inline attachments to include.</summary>
     public string[]? InlineAttachment { get; set; }
+    /// <summary>Structured attachments to include.</summary>
+    public List<AttachmentDescriptor>? Attachments { get; set; }
+    /// <summary>Structured inline attachments to include.</summary>
+    public List<AttachmentDescriptor>? InlineAttachments { get; set; }
 
     /// <summary>Name of the SES template to use.</summary>
     public string? TemplateName { get; set; }
@@ -130,6 +134,14 @@ public class SesClient : IDisposable {
         smtp.HtmlBody = Html;
         if (Attachment != null) smtp.Attachments = Attachment.Select(path => (AttachmentDescriptor)new FileAttachmentDescriptor(path)).ToList();
         if (InlineAttachment != null) smtp.InlineAttachments = InlineAttachment.Select(path => (AttachmentDescriptor)new FileAttachmentDescriptor(path)).ToList();
+        if (Attachments != null) {
+            smtp.Attachments ??= new List<AttachmentDescriptor>();
+            smtp.Attachments.AddRange(Attachments);
+        }
+        if (InlineAttachments != null) {
+            smtp.InlineAttachments ??= new List<AttachmentDescriptor>();
+            smtp.InlineAttachments.AddRange(InlineAttachments);
+        }
         if (Headers != null) smtp.Headers = Headers;
         smtp.CreateMessage();
         return smtp.Message;
@@ -175,18 +187,18 @@ public class SesClient : IDisposable {
         return request;
     }
 
-    private async Task QueuePendingMessageAsync(MimeMessage? message, string? mimeMessageBase64, CancellationToken cancellationToken) {
+    private async Task<string?> QueuePendingMessageAsync(MimeMessage? message, string? mimeMessageBase64, CancellationToken cancellationToken) {
         if (PendingMessageRepository == null) {
-            return;
+            return null;
         }
 
         if (Credentials is not NetworkCredential net) {
             LogCollector.LogWarning("Send-EmailMessage - Unable to queue SES message because credentials are not network credentials.");
-            return;
+            return null;
         }
 
         if (string.IsNullOrEmpty(net.UserName) || string.IsNullOrEmpty(net.Password)) {
-            return;
+            return null;
         }
 
         var base64 = mimeMessageBase64;
@@ -205,14 +217,14 @@ public class SesClient : IDisposable {
             messageId = message.MessageId!;
         } else {
             if (string.IsNullOrEmpty(base64)) {
-                return;
+                return null;
             }
 
             messageId = Guid.NewGuid().ToString("N");
         }
 
         if (string.IsNullOrEmpty(base64)) {
-            return;
+            return null;
         }
 
         var now = DateTimeOffset.UtcNow;
@@ -234,10 +246,12 @@ public class SesClient : IDisposable {
 
         try {
             await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+            return record.MessageId;
         } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
             throw;
         } catch (Exception ex) {
             LogCollector.LogWarning($"Send-EmailMessage - Failed to persist SES pending message: {ex.Message}");
+            return null;
         }
     }
 
@@ -271,11 +285,13 @@ public class SesClient : IDisposable {
             }
 
             if ((!Helpers.IsTransient(lastException) && !RetryAlways) || attempts >= RetryCount) {
-                await QueuePendingMessageAsync(message, mimeMessageBase64, cancellationToken).ConfigureAwait(false);
+                var queuedMessageId = await QueuePendingMessageAsync(message, mimeMessageBase64, cancellationToken).ConfigureAwait(false);
                 if (ErrorAction == ActionPreference.Stop && lastException != null) {
                     throw lastException;
                 }
-                SmtpResult fail = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message);
+                SmtpResult fail = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message) {
+                    MessageId = queuedMessageId
+                };
                 await Helpers.PostWebhookAsync(WebhookUrl, fail, cancellationToken, _client);
                 return fail;
             }
@@ -294,8 +310,10 @@ public class SesClient : IDisposable {
         }
         while (attempts <= RetryCount);
 
-        await QueuePendingMessageAsync(message, mimeMessageBase64, cancellationToken).ConfigureAwait(false);
-        SmtpResult final = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message);
+        var finalQueuedMessageId = await QueuePendingMessageAsync(message, mimeMessageBase64, cancellationToken).ConfigureAwait(false);
+        SmtpResult final = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message) {
+            MessageId = finalQueuedMessageId
+        };
         await Helpers.PostWebhookAsync(WebhookUrl, final, cancellationToken, _client);
         return final;
     }

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -1,7 +1,5 @@
 using Mailozaurr.Definitions;
 using System.Net.Http;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using System.Threading;
 
@@ -154,44 +152,14 @@ public class SesClient : IDisposable {
         return smtp.Message;
     }
 
-    private static byte[] HmacSha256(byte[] key, string data) {
-        using HMACSHA256 hmac = new(key);
-        return hmac.ComputeHash(Encoding.UTF8.GetBytes(data));
-    }
-
-    private static string Sha256Hex(string data) {
-        using SHA256 sha = SHA256.Create();
-        byte[] hash = sha.ComputeHash(Encoding.UTF8.GetBytes(data));
-        return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
-    }
-
     private HttpRequestMessage CreateRequest(string content, DateTime utcNow) {
         NetworkCredential net = Credentials as NetworkCredential ?? throw new InvalidCastException("Credentials must be NetworkCredential");
-        string accessKey = net.UserName;
-        string secretKey = net.Password;
-        string service = "ses";
-        string region = Region;
-        string amzDate = utcNow.ToString("yyyyMMdd'T'HHmmss'Z'");
-        string dateStamp = utcNow.ToString("yyyyMMdd");
-        string canonicalHeaders = $"content-type:application/x-www-form-urlencoded\nhost:email.{region}.amazonaws.com\nx-amz-date:{amzDate}\n";
-        string signedHeaders = "content-type;host;x-amz-date";
-        string payloadHash = Sha256Hex(content);
-        string canonicalRequest = $"POST\n/\n\n{canonicalHeaders}\n{signedHeaders}\n{payloadHash}";
-        string credentialScope = $"{dateStamp}/{region}/{service}/aws4_request";
-        string stringToSign = $"AWS4-HMAC-SHA256\n{amzDate}\n{credentialScope}\n{Sha256Hex(canonicalRequest)}";
-        byte[] kDate = HmacSha256(Encoding.UTF8.GetBytes("AWS4" + secretKey), dateStamp);
-        byte[] kRegion = HmacSha256(kDate, region);
-        byte[] kService = HmacSha256(kRegion, service);
-        byte[] kSigning = HmacSha256(kService, "aws4_request");
-        byte[] sigBytes = HmacSha256(kSigning, stringToSign);
-        string signature = BitConverter.ToString(sigBytes).Replace("-", string.Empty).ToLowerInvariant();
-        string authorization = $"AWS4-HMAC-SHA256 Credential={accessKey}/{credentialScope}, SignedHeaders={signedHeaders}, Signature={signature}";
-
-        HttpRequestMessage request = new(HttpMethod.Post, $"https://email.{region}.amazonaws.com/");
-        request.Content = new StringContent(content, Encoding.UTF8, "application/x-www-form-urlencoded");
-        request.Headers.TryAddWithoutValidation("x-amz-date", amzDate);
-        request.Headers.TryAddWithoutValidation("Authorization", authorization);
-        return request;
+        return SesRequestFactory.Create(
+            net.UserName,
+            net.Password,
+            Region,
+            content,
+            utcNow);
     }
 
     private async Task<string?> QueuePendingMessageAsync(MimeMessage? message, string? mimeMessageBase64, CancellationToken cancellationToken) {

--- a/Sources/Mailozaurr/AmazonSES/SesClient.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesClient.cs
@@ -15,6 +15,7 @@ namespace Mailozaurr;
 /// </remarks>
 public class SesClient : IDisposable {
     private readonly HttpClient _client;
+    private readonly bool _ownsClient;
 
     /// <summary>Measures send latency.</summary>
     public readonly Stopwatch Stopwatch;
@@ -56,6 +57,8 @@ public class SesClient : IDisposable {
 
     /// <summary>Custom headers to include with the message.</summary>
     public Dictionary<string, string>? Headers { get; set; }
+    /// <summary>Message priority written into the MIME payload.</summary>
+    public MessagePriority Priority { get; set; } = MessagePriority.Normal;
 
     /// <summary>Number of retry attempts on failure.</summary>
     public int RetryCount { get; set; } = 0;
@@ -110,7 +113,7 @@ public class SesClient : IDisposable {
     /// </summary>
     public SesClient() {
         Stopwatch = Stopwatch.StartNew();
-        _client = new HttpClient();
+        _client = Helpers.SharedHttpClient;
     }
 
     /// <summary>
@@ -120,6 +123,7 @@ public class SesClient : IDisposable {
     public SesClient(HttpMessageHandler handler) {
         Stopwatch = Stopwatch.StartNew();
         _client = new HttpClient(handler);
+        _ownsClient = true;
     }
 
     private MimeMessage BuildMessage() {
@@ -132,6 +136,7 @@ public class SesClient : IDisposable {
         smtp.Subject = Subject ?? string.Empty;
         smtp.TextBody = Text;
         smtp.HtmlBody = Html;
+        smtp.Priority = Priority;
         if (Attachment != null) smtp.Attachments = Attachment.Select(path => (AttachmentDescriptor)new FileAttachmentDescriptor(path)).ToList();
         if (InlineAttachment != null) smtp.InlineAttachments = InlineAttachment.Select(path => (AttachmentDescriptor)new FileAttachmentDescriptor(path)).ToList();
         if (Attachments != null) {
@@ -262,10 +267,10 @@ public class SesClient : IDisposable {
         }
         int attempts = 0;
         Exception? lastException = null;
-        do {
+        while (true) {
             try {
                 using HttpRequestMessage request = CreateRequest(body, DateTime.UtcNow);
-                HttpResponseMessage response = await _client.SendAsync(request, cancellationToken);
+                using HttpResponseMessage response = await _client.SendAsync(request, cancellationToken);
 #if NET5_0_OR_GREATER
                 string respContent = await response.Content.ReadAsStringAsync(cancellationToken);
 #else
@@ -277,8 +282,7 @@ public class SesClient : IDisposable {
                     return ok;
                 }
 
-                lastException = new HttpRequestException(respContent);
-                LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SES: {respContent}");
+                throw HttpRetryPolicy.CreateFailure(response.StatusCode, respContent);
             } catch (HttpRequestException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SES: {ex.Message}");
@@ -289,8 +293,10 @@ public class SesClient : IDisposable {
                 LogCollector.LogWarning($"Send-EmailMessage - SES request timed out: {ex.Message}");
             }
 
-            if ((!Helpers.IsTransient(lastException) && !RetryAlways) || attempts >= RetryCount) {
-                var queuedMessageId = await QueuePendingMessageAsync(message, mimeMessageBase64, cancellationToken).ConfigureAwait(false);
+            if (!HttpRetryPolicy.ShouldRetry(lastException, attempts, RetryCount, RetryAlways)) {
+                var queuedMessageId = HttpRetryPolicy.ShouldQueue(lastException, RetryAlways)
+                    ? await QueuePendingMessageAsync(message, mimeMessageBase64, cancellationToken).ConfigureAwait(false)
+                    : null;
                 if (ErrorAction == ActionPreference.Stop && lastException != null) {
                     throw lastException;
                 }
@@ -301,26 +307,15 @@ public class SesClient : IDisposable {
                 return fail;
             }
 
-            int delay = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-            if (MaxDelayMilliseconds > 0 && delay > MaxDelayMilliseconds) {
-                delay = MaxDelayMilliseconds;
-            }
-            if (JitterMilliseconds > 0 && delay > 0) {
-                delay += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
-            }
-            if (delay > 0) {
-                await Task.Delay(TimeSpan.FromMilliseconds(delay), cancellationToken);
-            }
+            await HttpRetryPolicy.DelayAsync(
+                RetryDelayMilliseconds,
+                RetryDelayBackoff,
+                attempts,
+                MaxDelayMilliseconds,
+                JitterMilliseconds,
+                cancellationToken).ConfigureAwait(false);
             attempts++;
         }
-        while (attempts <= RetryCount);
-
-        var finalQueuedMessageId = await QueuePendingMessageAsync(message, mimeMessageBase64, cancellationToken).ConfigureAwait(false);
-        SmtpResult final = new(false, EmailAction.Send, SentTo, SentFrom, "SESApi", 0, Stopwatch.Elapsed, string.Empty, lastException?.Message) {
-            MessageId = finalQueuedMessageId
-        };
-        await Helpers.PostWebhookAsync(WebhookUrl, final, cancellationToken, _client);
-        return final;
     }
 
     /// <summary>
@@ -377,6 +372,8 @@ public class SesClient : IDisposable {
     /// Releases resources used by the <see cref="SesClient"/> instance.
     /// </summary>
     public void Dispose() {
-        _client.Dispose();
+        if (_ownsClient) {
+            _client.Dispose();
+        }
     }
 }

--- a/Sources/Mailozaurr/AmazonSES/SesRequestFactory.cs
+++ b/Sources/Mailozaurr/AmazonSES/SesRequestFactory.cs
@@ -1,0 +1,77 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Creates Amazon SES requests whose signed headers exactly match the transmitted request.
+/// </summary>
+internal static class SesRequestFactory {
+    internal const string FormContentType = "application/x-www-form-urlencoded";
+
+    internal static HttpRequestMessage Create(
+        string accessKey,
+        string secretKey,
+        string region,
+        string content,
+        DateTime utcNow) {
+        var amzDate = utcNow.ToString("yyyyMMdd'T'HHmmss'Z'", CultureInfo.InvariantCulture);
+        var dateStamp = utcNow.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+        var canonicalHeaders =
+            $"content-type:{FormContentType}\n" +
+            $"host:email.{region}.amazonaws.com\n" +
+            $"x-amz-date:{amzDate}\n";
+        const string signedHeaders = "content-type;host;x-amz-date";
+        var payloadHash = Sha256Hex(content);
+        var canonicalRequest = $"POST\n/\n\n{canonicalHeaders}\n{signedHeaders}\n{payloadHash}";
+        var credentialScope = $"{dateStamp}/{region}/ses/aws4_request";
+        var stringToSign =
+            $"AWS4-HMAC-SHA256\n{amzDate}\n{credentialScope}\n{Sha256Hex(canonicalRequest)}";
+        var signingKey = GetSignatureKey(secretKey, dateStamp, region, "ses");
+        var signature = ToHex(HmacSha256(signingKey, stringToSign));
+        var authorization =
+            $"AWS4-HMAC-SHA256 Credential={accessKey}/{credentialScope}, " +
+            $"SignedHeaders={signedHeaders}, Signature={signature}";
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            new Uri($"https://email.{region}.amazonaws.com/"));
+        var requestContent = new StringContent(content, Encoding.UTF8);
+        requestContent.Headers.ContentType = new MediaTypeHeaderValue(FormContentType);
+        request.Content = requestContent;
+        request.Headers.TryAddWithoutValidation("x-amz-date", amzDate);
+        request.Headers.TryAddWithoutValidation("Authorization", authorization);
+        return request;
+    }
+
+    private static byte[] GetSignatureKey(
+        string key,
+        string dateStamp,
+        string regionName,
+        string serviceName) {
+        var kDate = HmacSha256(Encoding.UTF8.GetBytes("AWS4" + key), dateStamp);
+        var kRegion = HmacSha256(kDate, regionName);
+        var kService = HmacSha256(kRegion, serviceName);
+        return HmacSha256(kService, "aws4_request");
+    }
+
+    private static byte[] HmacSha256(byte[] key, string data) {
+        using var hmac = new HMACSHA256(key);
+        return hmac.ComputeHash(Encoding.UTF8.GetBytes(data));
+    }
+
+    private static string Sha256Hex(string data) {
+        using var sha = SHA256.Create();
+        return ToHex(sha.ComputeHash(Encoding.UTF8.GetBytes(data)));
+    }
+
+    private static string ToHex(byte[] bytes) {
+        var builder = new StringBuilder(bytes.Length * 2);
+        for (var index = 0; index < bytes.Length; index++) {
+            builder.Append(bytes[index].ToString("x2", CultureInfo.InvariantCulture));
+        }
+        return builder.ToString();
+    }
+}

--- a/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
@@ -188,7 +188,7 @@ internal static class OAuthTokenCache {
         }
         Directory.CreateDirectory(directory);
 
-        while (true) {
+        for (var attempt = 0; ; attempt++) {
             cancellationToken.ThrowIfCancellationRequested();
             try {
                 return new FileStream(
@@ -198,7 +198,7 @@ internal static class OAuthTokenCache {
                     FileShare.None,
                     1,
                     FileOptions.None);
-            } catch (IOException) {
+            } catch (IOException) when (attempt < IoRetryCount - 1) {
                 await Task.Delay(FileLockRetryDelay, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
+++ b/Sources/Mailozaurr/Authentication/OAuthTokenCache.cs
@@ -12,7 +12,9 @@ namespace Mailozaurr;
 /// </summary>
 internal static class OAuthTokenCache {
     private static readonly object LockObj = new();
+    private static readonly SemaphoreSlim WriteGate = new(1, 1);
     private const int IoRetryCount = 5;
+    private static readonly TimeSpan FileLockRetryDelay = TimeSpan.FromMilliseconds(25);
     private const string CachePathEnvironmentVariable = "MAILOZAURR_OAUTH_CACHE_PATH";
     private static string CacheFilePath => ResolveCacheFilePath();
 
@@ -20,13 +22,19 @@ internal static class OAuthTokenCache {
 
     private static Dictionary<string, OAuthCredential> ConvertCacheEntries(
         Dictionary<string, OAuthCredentialCacheEntry>? cacheEntries,
-        ICredentialProtector protector) {
+        ICredentialProtector protector,
+        out bool removedUnsafeKeys) {
         var cache = new Dictionary<string, OAuthCredential>(StringComparer.Ordinal);
+        removedUnsafeKeys = false;
         if (cacheEntries == null) {
             return cache;
         }
 
         foreach (var pair in cacheEntries) {
+            if (IsUnsafeLegacyGraphCacheKey(pair.Key)) {
+                removedUnsafeKeys = true;
+                continue;
+            }
             if (pair.Value == null) {
                 continue;
             }
@@ -36,6 +44,11 @@ internal static class OAuthTokenCache {
 
         return cache;
     }
+
+    private static bool IsUnsafeLegacyGraphCacheKey(string key) =>
+        key.StartsWith("graph:", StringComparison.Ordinal) &&
+        !key.StartsWith("graph:v2:", StringComparison.Ordinal) &&
+        key.IndexOf('|') >= 0;
 
     private static Dictionary<string, OAuthCredentialCacheEntry> CreateCacheEntries(
         Dictionary<string, OAuthCredential> cache,
@@ -60,12 +73,13 @@ internal static class OAuthTokenCache {
         }
 
         Dictionary<string, OAuthCredential> cache;
+        bool rewriteSanitizedCache = false;
         if (File.Exists(CacheFilePath)) {
             try {
                 var json = await ReadCacheFileAsync(cancellationToken).ConfigureAwait(false);
                 var protector = CredentialProtection.Default;
                 var cacheEntries = JsonSerializer.Deserialize(json, MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry);
-                cache = ConvertCacheEntries(cacheEntries, protector);
+                cache = ConvertCacheEntries(cacheEntries, protector, out rewriteSanitizedCache);
             } catch (FileNotFoundException) {
                 cache = new Dictionary<string, OAuthCredential>();
             } catch (DirectoryNotFoundException) {
@@ -79,10 +93,18 @@ internal static class OAuthTokenCache {
             cache = new Dictionary<string, OAuthCredential>();
         }
 
+        bool shouldRewrite;
         lock (LockObj) {
+            shouldRewrite = _cache == null && rewriteSanitizedCache;
             _cache ??= cache;
-            return _cache;
+            cache = _cache;
         }
+
+        if (shouldRewrite) {
+            await MutateAndPersistCacheAsync(static _ => { }, cancellationToken).ConfigureAwait(false);
+        }
+
+        return cache;
     }
 
     /// <summary>
@@ -107,21 +129,79 @@ internal static class OAuthTokenCache {
     /// <param name="credential">Credential to cache.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public static async Task SetAsync(string key, OAuthCredential credential, CancellationToken cancellationToken = default) {
-        var cache = await LoadCacheAsync(cancellationToken).ConfigureAwait(false);
-        string? dir;
-        string json;
-        lock (LockObj) {
+        await LoadCacheAsync(cancellationToken).ConfigureAwait(false);
+        await MutateAndPersistCacheAsync(
+            cache => cache[key] = credential,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task MutateAndPersistCacheAsync(
+        Action<Dictionary<string, OAuthCredential>> mutation,
+        CancellationToken cancellationToken) {
+        await WriteGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            using var fileLock = await AcquireFileLockAsync(cancellationToken).ConfigureAwait(false);
+            var cache = await ReadLatestCacheAsync(cancellationToken).ConfigureAwait(false);
+            mutation(cache);
             cancellationToken.ThrowIfCancellationRequested();
-            cache[key] = credential;
-            dir = Path.GetDirectoryName(CacheFilePath);
-            if (!Directory.Exists(dir)) {
-                Directory.CreateDirectory(dir!);
-            }
+
             var cacheEntries = CreateCacheEntries(cache, CredentialProtection.Default);
-            json = JsonSerializer.Serialize(cacheEntries, MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry);
+            var json = JsonSerializer.Serialize(
+                cacheEntries,
+                MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry);
+            await WriteCacheFileAsync(json, cancellationToken).ConfigureAwait(false);
+
+            lock (LockObj) {
+                _cache = cache;
+            }
+        } finally {
+            WriteGate.Release();
         }
-        cancellationToken.ThrowIfCancellationRequested();
-        await WriteCacheFileAsync(json, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<Dictionary<string, OAuthCredential>> ReadLatestCacheAsync(
+        CancellationToken cancellationToken) {
+        if (!File.Exists(CacheFilePath)) {
+            return new Dictionary<string, OAuthCredential>(StringComparer.Ordinal);
+        }
+
+        try {
+            var json = await ReadCacheFileAsync(cancellationToken).ConfigureAwait(false);
+            var entries = JsonSerializer.Deserialize(
+                json,
+                MailozaurrJsonContext.Default.DictionaryStringOAuthCredentialCacheEntry);
+            return ConvertCacheEntries(entries, CredentialProtection.Default, out _);
+        } catch (FileNotFoundException) {
+            return new Dictionary<string, OAuthCredential>(StringComparer.Ordinal);
+        } catch (DirectoryNotFoundException) {
+            return new Dictionary<string, OAuthCredential>(StringComparer.Ordinal);
+        } catch (JsonException) {
+            return new Dictionary<string, OAuthCredential>(StringComparer.Ordinal);
+        }
+    }
+
+    private static async Task<FileStream> AcquireFileLockAsync(CancellationToken cancellationToken) {
+        var lockPath = CacheFilePath + ".lock";
+        var directory = Path.GetDirectoryName(lockPath);
+        if (string.IsNullOrWhiteSpace(directory)) {
+            throw new InvalidOperationException("OAuth cache path is invalid.");
+        }
+        Directory.CreateDirectory(directory);
+
+        while (true) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                return new FileStream(
+                    lockPath,
+                    FileMode.OpenOrCreate,
+                    FileAccess.ReadWrite,
+                    FileShare.None,
+                    1,
+                    FileOptions.None);
+            } catch (IOException) {
+                await Task.Delay(FileLockRetryDelay, cancellationToken).ConfigureAwait(false);
+            }
+        }
     }
 
     private static async Task<string> ReadCacheFileAsync(CancellationToken cancellationToken) {

--- a/Sources/Mailozaurr/Connections/ConnectionRetrier.cs
+++ b/Sources/Mailozaurr/Connections/ConnectionRetrier.cs
@@ -82,10 +82,15 @@ internal static class ConnectionRetrier {
                 if ((!Helpers.IsTransient(ex)) || attempts >= retryCount) {
                     throw;
                 }
-                var delay = (int)Math.Round(retryDelayMilliseconds * Math.Pow(retryDelayBackoff, attempts));
-                if (delay > 0) {
+                var delay = RetryDelayCalculator.Calculate(
+                    retryDelayMilliseconds,
+                    retryDelayBackoff,
+                    attempts,
+                    0,
+                    0);
+                if (delay > TimeSpan.Zero) {
                     if (delayAsync != null) {
-                        await delayAsync(delay, cancellationToken).ConfigureAwait(false);
+                        await delayAsync((int)delay.TotalMilliseconds, cancellationToken).ConfigureAwait(false);
                     } else {
                         await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                     }

--- a/Sources/Mailozaurr/Connections/SmtpSessionService.cs
+++ b/Sources/Mailozaurr/Connections/SmtpSessionService.cs
@@ -67,12 +67,18 @@ public sealed class SmtpSessionRequest {
     public int RetryDelayMilliseconds { get; init; }
     /// <summary>Backoff multiplier.</summary>
     public double RetryDelayBackoff { get; init; } = 1.0;
+    /// <summary>Maximum delay between retries in milliseconds.</summary>
+    public int MaxDelayMilliseconds { get; init; }
+    /// <summary>Maximum random jitter added to retry delays in milliseconds.</summary>
+    public int JitterMilliseconds { get; init; }
     /// <summary>Skip certificate validation.</summary>
     public bool SkipCertificateValidation { get; init; }
     /// <summary>Skip certificate revocation checks.</summary>
     public bool SkipCertificateRevocation { get; init; }
     /// <summary>Implements DryRun (no network).</summary>
     public bool DryRun { get; init; }
+    /// <summary>Whether the connected session should authenticate.</summary>
+    public bool Authenticate { get; init; } = true;
     /// <summary>Auth username.</summary>
     public string UserName { get; init; } = string.Empty;
     /// <summary>Auth password.</summary>
@@ -80,9 +86,9 @@ public sealed class SmtpSessionRequest {
     /// <summary>Protocol auth mode.</summary>
     public ProtocolAuthMode AuthMode { get; init; } = ProtocolAuthMode.Basic;
     /// <summary>Optional connect delegate used for testing.</summary>
-    public Func<Smtp, Task<SmtpResult>>? ConnectAsync { get; init; }
+    public Func<Smtp, CancellationToken, Task<SmtpResult>>? ConnectAsync { get; init; }
     /// <summary>Optional authenticate delegate used for testing.</summary>
-    public Func<Smtp, Task<SmtpResult>>? AuthenticateAsync { get; init; }
+    public Func<Smtp, CancellationToken, Task<SmtpResult>>? AuthenticateAsync { get; init; }
 }
 
 /// <summary>
@@ -104,22 +110,30 @@ public static class SmtpSessionService {
         smtp.RetryCount = request.RetryCount;
         smtp.RetryDelayMilliseconds = request.RetryDelayMilliseconds;
         smtp.RetryDelayBackoff = request.RetryDelayBackoff;
+        smtp.MaxDelayMilliseconds = request.MaxDelayMilliseconds;
+        smtp.JitterMilliseconds = request.JitterMilliseconds;
         smtp.SkipCertificateValidation = request.SkipCertificateValidation;
         smtp.CheckCertificateRevocation = !request.SkipCertificateRevocation;
         smtp.DryRun = request.DryRun;
 
         var secureOptions = request.SecureSocketOptions;
-        var connectFunc = request.ConnectAsync ?? (_ => smtp.ConnectAsync(request.Server, request.Port, secureOptions, request.UseSsl));
-        var connectResult = await connectFunc(smtp).ConfigureAwait(false);
+        var connectFunc = request.ConnectAsync ?? ((_, token) =>
+            smtp.ConnectAsync(request.Server, request.Port, secureOptions, request.UseSsl, token));
+        var connectResult = await connectFunc(smtp, cancellationToken).ConfigureAwait(false);
         if (!connectResult.Status) {
             return new SmtpConnectResult(false, secureOptions, "connect_failed", connectResult.Error ?? "Connect failed.", true);
         }
 
-        var authenticateFunc = request.AuthenticateAsync ?? (_ => smtp.AuthenticateAsync(
-            new NetworkCredential(request.UserName, request.Password),
-            request.AuthMode == ProtocolAuthMode.OAuth2));
+        if (!request.Authenticate) {
+            return new SmtpConnectResult(true, secureOptions, null, null, false);
+        }
 
-        var authResult = await authenticateFunc(smtp).ConfigureAwait(false);
+        var authenticateFunc = request.AuthenticateAsync ?? ((_, token) => smtp.AuthenticateAsync(
+            new NetworkCredential(request.UserName, request.Password),
+            request.AuthMode == ProtocolAuthMode.OAuth2,
+            token));
+
+        var authResult = await authenticateFunc(smtp, cancellationToken).ConfigureAwait(false);
         if (!authResult.Status) {
             return new SmtpConnectResult(false, secureOptions, "auth_failed", authResult.Error ?? "Authentication failed.", false);
         }

--- a/Sources/Mailozaurr/Connections/SmtpSessionService.cs
+++ b/Sources/Mailozaurr/Connections/SmtpSessionService.cs
@@ -71,6 +71,8 @@ public sealed class SmtpSessionRequest {
     public int MaxDelayMilliseconds { get; init; }
     /// <summary>Maximum random jitter added to retry delays in milliseconds.</summary>
     public int JitterMilliseconds { get; init; }
+    /// <summary>Retry non-transient SMTP failures.</summary>
+    public bool RetryAlways { get; init; }
     /// <summary>Skip certificate validation.</summary>
     public bool SkipCertificateValidation { get; init; }
     /// <summary>Skip certificate revocation checks.</summary>
@@ -112,6 +114,7 @@ public static class SmtpSessionService {
         smtp.RetryDelayBackoff = request.RetryDelayBackoff;
         smtp.MaxDelayMilliseconds = request.MaxDelayMilliseconds;
         smtp.JitterMilliseconds = request.JitterMilliseconds;
+        smtp.RetryAlways = request.RetryAlways;
         smtp.SkipCertificateValidation = request.SkipCertificateValidation;
         smtp.CheckCertificateRevocation = !request.SkipCertificateRevocation;
         smtp.DryRun = request.DryRun;

--- a/Sources/Mailozaurr/Connections/SmtpSessionService.cs
+++ b/Sources/Mailozaurr/Connections/SmtpSessionService.cs
@@ -87,10 +87,14 @@ public sealed class SmtpSessionRequest {
     public string Password { get; init; } = string.Empty;
     /// <summary>Protocol auth mode.</summary>
     public ProtocolAuthMode AuthMode { get; init; } = ProtocolAuthMode.Basic;
-    /// <summary>Optional connect delegate used for testing.</summary>
-    public Func<Smtp, CancellationToken, Task<SmtpResult>>? ConnectAsync { get; init; }
-    /// <summary>Optional authenticate delegate used for testing.</summary>
-    public Func<Smtp, CancellationToken, Task<SmtpResult>>? AuthenticateAsync { get; init; }
+    /// <summary>Optional connect delegate retained for source and binary compatibility.</summary>
+    public Func<Smtp, Task<SmtpResult>>? ConnectAsync { get; init; }
+    /// <summary>Optional authenticate delegate retained for source and binary compatibility.</summary>
+    public Func<Smtp, Task<SmtpResult>>? AuthenticateAsync { get; init; }
+    /// <summary>Optional cancellation-aware connect delegate used in preference to <see cref="ConnectAsync"/>.</summary>
+    public Func<Smtp, CancellationToken, Task<SmtpResult>>? ConnectWithCancellationAsync { get; init; }
+    /// <summary>Optional cancellation-aware authenticate delegate used in preference to <see cref="AuthenticateAsync"/>.</summary>
+    public Func<Smtp, CancellationToken, Task<SmtpResult>>? AuthenticateWithCancellationAsync { get; init; }
 }
 
 /// <summary>
@@ -120,9 +124,13 @@ public static class SmtpSessionService {
         smtp.DryRun = request.DryRun;
 
         var secureOptions = request.SecureSocketOptions;
-        var connectFunc = request.ConnectAsync ?? ((_, token) =>
-            smtp.ConnectAsync(request.Server, request.Port, secureOptions, request.UseSsl, token));
+        var connectFunc = request.ConnectWithCancellationAsync ??
+            (request.ConnectAsync is { } legacyConnect
+                ? new Func<Smtp, CancellationToken, Task<SmtpResult>>((client, _) => legacyConnect(client))
+                : (_, token) => smtp.ConnectAsync(request.Server, request.Port, secureOptions, request.UseSsl, token));
+        cancellationToken.ThrowIfCancellationRequested();
         var connectResult = await connectFunc(smtp, cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
         if (!connectResult.Status) {
             return new SmtpConnectResult(false, secureOptions, "connect_failed", connectResult.Error ?? "Connect failed.", true);
         }
@@ -131,12 +139,17 @@ public static class SmtpSessionService {
             return new SmtpConnectResult(true, secureOptions, null, null, false);
         }
 
-        var authenticateFunc = request.AuthenticateAsync ?? ((_, token) => smtp.AuthenticateAsync(
-            new NetworkCredential(request.UserName, request.Password),
-            request.AuthMode == ProtocolAuthMode.OAuth2,
-            token));
+        var authenticateFunc = request.AuthenticateWithCancellationAsync ??
+            (request.AuthenticateAsync is { } legacyAuthenticate
+                ? new Func<Smtp, CancellationToken, Task<SmtpResult>>((client, _) => legacyAuthenticate(client))
+                : (_, token) => smtp.AuthenticateAsync(
+                    new NetworkCredential(request.UserName, request.Password),
+                    request.AuthMode == ProtocolAuthMode.OAuth2,
+                    token));
 
+        cancellationToken.ThrowIfCancellationRequested();
         var authResult = await authenticateFunc(smtp, cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
         if (!authResult.Status) {
             return new SmtpConnectResult(false, secureOptions, "auth_failed", authResult.Error ?? "Authentication failed.", false);
         }

--- a/Sources/Mailozaurr/Definitions/AttachmentDescriptor.cs
+++ b/Sources/Mailozaurr/Definitions/AttachmentDescriptor.cs
@@ -153,6 +153,8 @@ public sealed class FileAttachmentDescriptor : AttachmentDescriptor {
 public sealed class StreamAttachmentDescriptor : AttachmentDescriptor {
     private readonly Stream _stream;
     private readonly bool _leaveStreamOpen;
+    private readonly object _materializationLock = new();
+    private byte[]? _buffer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StreamAttachmentDescriptor"/> class.
@@ -176,27 +178,31 @@ public sealed class StreamAttachmentDescriptor : AttachmentDescriptor {
 
     /// <inheritdoc />
     protected override Stream CreateContentStream() {
-        if (_stream.CanSeek) {
-            _stream.Position = 0;
-        }
+        lock (_materializationLock) {
+            if (_buffer == null) {
+                if (_stream.CanSeek) {
+                    _stream.Position = 0;
+                }
 
-        var memory = new MemoryStream();
-        _stream.CopyTo(memory);
-        memory.Position = 0;
+                using var memory = new MemoryStream();
+                _stream.CopyTo(memory);
+                _buffer = memory.ToArray();
 
-        if (_stream.CanSeek) {
-            try {
-                _stream.Position = 0;
-            } catch (ObjectDisposedException) {
-                // Ignore - stream may have been disposed externally.
+                if (_stream.CanSeek) {
+                    try {
+                        _stream.Position = 0;
+                    } catch (ObjectDisposedException) {
+                        // The immutable copy remains usable when the source was disposed externally.
+                    }
+                }
+
+                if (!_leaveStreamOpen) {
+                    _stream.Dispose();
+                }
             }
-        }
 
-        if (!_leaveStreamOpen) {
-            _stream.Dispose();
+            return new MemoryStream(_buffer, writable: false);
         }
-
-        return memory;
     }
 }
 

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -175,6 +175,11 @@ public static class Helpers {
     /// <returns><c>true</c> if the error is transient; otherwise <c>false</c>.</returns>
     public static bool IsTransient(Exception ex) {
         switch (ex) {
+#if !NET5_0_OR_GREATER
+            case HttpRetryPolicy.ProviderHttpRequestException providerEx:
+                var providerCode = (int)providerEx.StatusCode;
+                return providerCode >= 500 || providerCode == 408 || providerCode == 429;
+#endif
             case HttpRequestException httpEx:
                 // HttpRequestException.StatusCode was introduced in .NET 5.0
 #if NET5_0_OR_GREATER

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -6,6 +6,7 @@ using System.Security;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
+using MimeKit;
 
 namespace Mailozaurr;
 
@@ -93,6 +94,12 @@ public static class Helpers {
         if (from is string s) {
             return s;
         }
+        if (from is MailboxAddress mailboxAddress) {
+            return mailboxAddress.Address;
+        }
+        if (from is SendGridEmailAddress sendGridAddress) {
+            return sendGridAddress.Email;
+        }
         if (from is IDictionary<string, object> dict) {
             if (dict.TryGetValue("Email", out var emailObj)) {
                 return emailObj?.ToString() ?? string.Empty;
@@ -119,6 +126,12 @@ public static class Helpers {
     public static (string? Email, string? Name) GetEmailAndName(object? from) {
         if (from is string s) {
             return (s, null);
+        }
+        if (from is MailboxAddress mailboxAddress) {
+            return (mailboxAddress.Address, mailboxAddress.Name);
+        }
+        if (from is SendGridEmailAddress sendGridAddress) {
+            return (sendGridAddress.Email, sendGridAddress.Name);
         }
         if (from is IDictionary dict) {
             var email = dict.Contains("Email") ? dict["Email"]?.ToString() : null;

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -194,8 +194,6 @@ public static class Helpers {
                 return smtpCode >= 400 && smtpCode < 500;
             case SmtpProtocolException:
                 return true;
-            case TaskCanceledException:
-                return true;
             default:
                 return false;
         }

--- a/Sources/Mailozaurr/Helpers/Helpers.cs
+++ b/Sources/Mailozaurr/Helpers/Helpers.cs
@@ -189,6 +189,8 @@ public static class Helpers {
                 return smtpCode >= 400 && smtpCode < 500;
             case SmtpProtocolException:
                 return true;
+            case TaskCanceledException:
+                return true;
             default:
                 return false;
         }

--- a/Sources/Mailozaurr/Helpers/HttpRetryPolicy.cs
+++ b/Sources/Mailozaurr/Helpers/HttpRetryPolicy.cs
@@ -20,9 +20,14 @@ internal static class HttpRetryPolicy {
     /// <summary>
     /// Determines whether another attempt is allowed.
     /// </summary>
-    internal static bool ShouldRetry(Exception exception, int attempt, int retryCount, bool retryAlways) =>
+    internal static bool ShouldRetry(
+        Exception exception,
+        int attempt,
+        int retryCount,
+        bool retryAlways,
+        bool isKnownTransient = false) =>
         attempt < Math.Max(0, retryCount) &&
-        (retryAlways || Helpers.IsTransient(exception));
+        (retryAlways || isKnownTransient || Helpers.IsTransient(exception));
 
     /// <summary>
     /// Delays before the next attempt using bounded exponential backoff and jitter.

--- a/Sources/Mailozaurr/Helpers/HttpRetryPolicy.cs
+++ b/Sources/Mailozaurr/Helpers/HttpRetryPolicy.cs
@@ -1,0 +1,75 @@
+using System.Net;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Owns HTTP failure classification and retry timing for provider transports.
+/// </summary>
+internal static class HttpRetryPolicy {
+    /// <summary>
+    /// Creates an HTTP exception that preserves the provider response status.
+    /// </summary>
+    internal static HttpRequestException CreateFailure(HttpStatusCode statusCode, string message) {
+#if NET5_0_OR_GREATER
+        return new HttpRequestException(message, null, statusCode);
+#else
+        return new ProviderHttpRequestException(message, statusCode);
+#endif
+    }
+
+    /// <summary>
+    /// Determines whether another attempt is allowed.
+    /// </summary>
+    internal static bool ShouldRetry(Exception exception, int attempt, int retryCount, bool retryAlways) =>
+        attempt < Math.Max(0, retryCount) &&
+        (retryAlways || Helpers.IsTransient(exception));
+
+    /// <summary>
+    /// Determines whether a terminal failure is eligible for deferred retry.
+    /// </summary>
+    internal static bool ShouldQueue(Exception exception, bool retryAlways) =>
+        retryAlways || Helpers.IsTransient(exception);
+
+    /// <summary>
+    /// Delays before the next attempt using bounded exponential backoff and jitter.
+    /// </summary>
+    internal static Task DelayAsync(
+        int baseDelayMilliseconds,
+        double backoff,
+        int attempt,
+        int maxDelayMilliseconds,
+        int jitterMilliseconds,
+        CancellationToken cancellationToken) {
+        if (baseDelayMilliseconds <= 0) {
+            return Task.CompletedTask;
+        }
+
+        var safeBackoff = double.IsNaN(backoff) || backoff < 0 ? 0 : backoff;
+        var computed = baseDelayMilliseconds * Math.Pow(safeBackoff, Math.Max(0, attempt));
+        var cap = maxDelayMilliseconds > 0 ? maxDelayMilliseconds : int.MaxValue - 1;
+        var bounded = double.IsInfinity(computed) || computed > cap
+            ? cap
+            : Math.Max(0, computed);
+        var delay = (long)Math.Round(bounded);
+
+        if (jitterMilliseconds > 0 && delay > 0) {
+            var jitterBound = Math.Min(jitterMilliseconds, int.MaxValue - 1);
+            delay = Math.Min(cap, delay + GraphRetryHelperRandom.NextInt(jitterBound + 1));
+        }
+
+        return delay > 0
+            ? Task.Delay(TimeSpan.FromMilliseconds(delay), cancellationToken)
+            : Task.CompletedTask;
+    }
+
+#if !NET5_0_OR_GREATER
+    internal sealed class ProviderHttpRequestException : HttpRequestException {
+        internal ProviderHttpRequestException(string message, HttpStatusCode statusCode)
+            : base(message) {
+            StatusCode = statusCode;
+        }
+
+        internal HttpStatusCode StatusCode { get; }
+    }
+#endif
+}

--- a/Sources/Mailozaurr/Helpers/HttpRetryPolicy.cs
+++ b/Sources/Mailozaurr/Helpers/HttpRetryPolicy.cs
@@ -39,25 +39,14 @@ internal static class HttpRetryPolicy {
         int maxDelayMilliseconds,
         int jitterMilliseconds,
         CancellationToken cancellationToken) {
-        if (baseDelayMilliseconds <= 0) {
-            return Task.CompletedTask;
-        }
-
-        var safeBackoff = double.IsNaN(backoff) || backoff < 0 ? 0 : backoff;
-        var computed = baseDelayMilliseconds * Math.Pow(safeBackoff, Math.Max(0, attempt));
-        var cap = maxDelayMilliseconds > 0 ? maxDelayMilliseconds : int.MaxValue - 1;
-        var bounded = double.IsInfinity(computed) || computed > cap
-            ? cap
-            : Math.Max(0, computed);
-        var delay = (long)Math.Round(bounded);
-
-        if (jitterMilliseconds > 0 && delay > 0) {
-            var jitterBound = Math.Min(jitterMilliseconds, int.MaxValue - 1);
-            delay = Math.Min(cap, delay + GraphRetryHelperRandom.NextInt(jitterBound + 1));
-        }
-
-        return delay > 0
-            ? Task.Delay(TimeSpan.FromMilliseconds(delay), cancellationToken)
+        var delay = RetryDelayCalculator.Calculate(
+            baseDelayMilliseconds,
+            backoff,
+            attempt,
+            maxDelayMilliseconds,
+            jitterMilliseconds);
+        return delay > TimeSpan.Zero
+            ? Task.Delay(delay, cancellationToken)
             : Task.CompletedTask;
     }
 

--- a/Sources/Mailozaurr/Helpers/HttpRetryPolicy.cs
+++ b/Sources/Mailozaurr/Helpers/HttpRetryPolicy.cs
@@ -25,12 +25,6 @@ internal static class HttpRetryPolicy {
         (retryAlways || Helpers.IsTransient(exception));
 
     /// <summary>
-    /// Determines whether a terminal failure is eligible for deferred retry.
-    /// </summary>
-    internal static bool ShouldQueue(Exception exception, bool retryAlways) =>
-        retryAlways || Helpers.IsTransient(exception);
-
-    /// <summary>
     /// Delays before the next attempt using bounded exponential backoff and jitter.
     /// </summary>
     internal static Task DelayAsync(

--- a/Sources/Mailozaurr/Helpers/ProviderResponseParser.cs
+++ b/Sources/Mailozaurr/Helpers/ProviderResponseParser.cs
@@ -1,0 +1,98 @@
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Extracts native message identifiers from successful provider responses.
+/// </summary>
+internal static class ProviderResponseParser {
+    internal static async Task<string> ReadContentAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken) {
+
+        if (response.Content == null) {
+            return string.Empty;
+        }
+
+#if NET5_0_OR_GREATER
+        return await response.Content
+            .ReadAsStringAsync(cancellationToken)
+            .ConfigureAwait(false);
+#else
+        return await response.Content
+            .ReadAsStringAsync()
+            .ConfigureAwait(false);
+#endif
+    }
+
+    internal static string? GetSendGridMessageId(
+        HttpResponseMessage response) {
+
+        return response.Headers.TryGetValues(
+            "X-Message-Id",
+            out IEnumerable<string>? values)
+            ? Normalize(values.FirstOrDefault())
+            : null;
+    }
+
+    internal static string? GetJsonMessageId(string? content) {
+        if (content == null || content.Trim().Length == 0) {
+            return null;
+        }
+
+        try {
+            using JsonDocument document = JsonDocument.Parse(content);
+            if (!document.RootElement.TryGetProperty(
+                "id",
+                out JsonElement id)) {
+                return null;
+            }
+
+            return Normalize(
+                id.ValueKind == JsonValueKind.String
+                    ? id.GetString()
+                    : id.ToString());
+        } catch (JsonException) {
+            return null;
+        }
+    }
+
+    internal static string? GetSesMessageId(string? content) {
+        if (content == null || content.Trim().Length == 0) {
+            return null;
+        }
+
+        try {
+            using var textReader = new StringReader(content);
+            using XmlReader xmlReader = XmlReader.Create(
+                textReader,
+                new XmlReaderSettings {
+                    DtdProcessing = DtdProcessing.Prohibit,
+                    XmlResolver = null
+                });
+            XDocument document = XDocument.Load(
+                xmlReader,
+                LoadOptions.None);
+            return Normalize(document
+                .Descendants()
+                .FirstOrDefault(element =>
+                    string.Equals(
+                        element.Name.LocalName,
+                        "MessageId",
+                        StringComparison.Ordinal))
+                ?.Value);
+        } catch (System.Xml.XmlException) {
+            return null;
+        }
+    }
+
+    private static string? Normalize(string? value) {
+        if (value == null) {
+            return null;
+        }
+
+        string normalized = value.Trim();
+        return normalized.Length == 0 ? null : normalized;
+    }
+}

--- a/Sources/Mailozaurr/Helpers/RetryDelayCalculator.cs
+++ b/Sources/Mailozaurr/Helpers/RetryDelayCalculator.cs
@@ -1,0 +1,58 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Calculates bounded exponential retry delays consistently across transports.
+/// </summary>
+internal static class RetryDelayCalculator {
+#if !NET5_0_OR_GREATER
+    [ThreadStatic]
+    private static Random? s_random;
+#endif
+
+    internal static TimeSpan Calculate(
+        int baseDelayMilliseconds,
+        double backoff,
+        int attempt,
+        int maxDelayMilliseconds,
+        int jitterMilliseconds) {
+        if (baseDelayMilliseconds <= 0) {
+            return TimeSpan.Zero;
+        }
+
+        var safeBackoff = double.IsNaN(backoff) || backoff < 0
+            ? 0
+            : backoff;
+        var cap = maxDelayMilliseconds > 0
+            ? maxDelayMilliseconds
+            : int.MaxValue - 1;
+        var computed = baseDelayMilliseconds * Math.Pow(safeBackoff, Math.Max(0, attempt));
+        var bounded = double.IsInfinity(computed) || computed > cap
+            ? cap
+            : Math.Max(0, computed);
+        var delay = (long)Math.Round(bounded);
+
+        if (jitterMilliseconds > 0 && delay > 0) {
+            var jitterBound = Math.Min(jitterMilliseconds, int.MaxValue - 1);
+            delay = Math.Min(
+                cap,
+                delay + NextInt(jitterBound + 1));
+        }
+
+        return delay > 0
+            ? TimeSpan.FromMilliseconds(delay)
+            : TimeSpan.Zero;
+    }
+
+    private static int NextInt(int maxExclusive) {
+        if (maxExclusive <= 1) {
+            return 0;
+        }
+#if NET5_0_OR_GREATER
+        return System.Security.Cryptography.RandomNumberGenerator.GetInt32(0, maxExclusive);
+#else
+        var random = s_random ??= new Random(
+            unchecked(Environment.TickCount * 31 + Thread.CurrentThread.ManagedThreadId));
+        return random.Next(0, maxExclusive);
+#endif
+    }
+}

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -207,63 +207,21 @@ public class MailgunClient : IDisposable {
             content.Add(new StringContent(Priority == MessagePriority.High ? "1" : "5"), "h:X-Priority");
             content.Add(new StringContent(Priority == MessagePriority.High ? "high" : "low"), "h:Importance");
         }
-        var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (Attachment != null) {
-            foreach (var path in Attachment) {
-                var fullPath = Path.GetFullPath(path);
-                if (!files.Add(fullPath)) continue;
-                if (!File.Exists(fullPath)) {
-                    throw new FileNotFoundException($"Attachment '{path}' was not found.", fullPath);
-                }
-
-                var fileContent = CreateStreamContent(fullPath);
-                content.Add(fileContent, "attachment", Path.GetFileName(fullPath));
-            }
-        }
-        if (InlineAttachment != null) {
-            foreach (var path in InlineAttachment) {
-                var fullPath = Path.GetFullPath(path);
-                if (!files.Add(fullPath)) continue;
-                if (!File.Exists(fullPath)) {
-                    throw new FileNotFoundException($"Inline attachment '{path}' was not found.", fullPath);
-                }
-
-                var fileContent = CreateStreamContent(fullPath);
-                content.Add(fileContent, "inline", Path.GetFileName(fullPath));
-            }
-        }
-        AddStructuredAttachments(content, Attachments, "attachment", files);
-        AddStructuredAttachments(content, InlineAttachments, "inline", files);
+        ForEachUniqueAttachment((descriptor, isInline) => {
+            var fileName = string.IsNullOrWhiteSpace(descriptor.FileName)
+                ? Path.GetFileName(descriptor.SourcePath) ?? "attachment"
+                : descriptor.FileName!;
+            content.Add(
+                CreateStreamContent(descriptor),
+                isInline ? "inline" : "attachment",
+                fileName);
+        });
         if (Headers != null) {
             foreach (var kvp in Headers) {
                 content.Add(new StringContent(kvp.Value), $"h:{kvp.Key}");
             }
         }
         return Task.FromResult(content);
-    }
-
-    private void AddStructuredAttachments(
-        MultipartFormDataContent content,
-        IEnumerable<AttachmentDescriptor>? attachments,
-        string fieldName,
-        HashSet<string> files) {
-        if (attachments == null) return;
-        foreach (var descriptor in attachments) {
-            if (descriptor.SourcePath is { Length: > 0 } sourcePath) {
-                var fullPath = Path.GetFullPath(sourcePath);
-                if (!files.Add(fullPath)) continue;
-                if (descriptor is FileAttachmentDescriptor && !File.Exists(fullPath)) {
-                    throw new FileNotFoundException(
-                        $"Attachment '{sourcePath}' was not found.",
-                        fullPath);
-                }
-            }
-
-            var fileName = string.IsNullOrWhiteSpace(descriptor.FileName)
-                ? Path.GetFileName(descriptor.SourcePath) ?? "attachment"
-                : descriptor.FileName!;
-            content.Add(CreateStreamContent(descriptor), fieldName, fileName);
-        }
     }
 
     private MimeMessage BuildMimeMessage() {
@@ -279,22 +237,70 @@ public class MailgunClient : IDisposable {
             Headers = Headers,
             Priority = Priority
         };
-        if (Attachment != null) {
-            smtp.Attachments = Attachment.Select(path => new FileAttachmentDescriptor(path)).Cast<AttachmentDescriptor>().ToList();
-        }
-        if (InlineAttachment != null) {
-            smtp.InlineAttachments = InlineAttachment.Select(path => new FileAttachmentDescriptor(path)).Cast<AttachmentDescriptor>().ToList();
-        }
-        if (Attachments != null) {
-            smtp.Attachments ??= new List<AttachmentDescriptor>();
-            smtp.Attachments.AddRange(Attachments);
-        }
-        if (InlineAttachments != null) {
-            smtp.InlineAttachments ??= new List<AttachmentDescriptor>();
-            smtp.InlineAttachments.AddRange(InlineAttachments);
-        }
+        ForEachUniqueAttachment((descriptor, isInline) => {
+            var target = isInline
+                ? smtp.InlineAttachments ??= new List<AttachmentDescriptor>()
+                : smtp.Attachments ??= new List<AttachmentDescriptor>();
+            target.Add(descriptor);
+        });
         smtp.CreateMessage();
         return smtp.Message;
+    }
+
+    private void ForEachUniqueAttachment(Action<AttachmentDescriptor, bool> add) {
+        var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        AddFileAttachments(Attachment, isInline: false, files, add);
+        AddFileAttachments(InlineAttachment, isInline: true, files, add);
+        AddStructuredAttachments(Attachments, isInline: false, files, add);
+        AddStructuredAttachments(InlineAttachments, isInline: true, files, add);
+    }
+
+    private static void AddFileAttachments(
+        IEnumerable<string>? paths,
+        bool isInline,
+        HashSet<string> files,
+        Action<AttachmentDescriptor, bool> add) {
+        if (paths == null) {
+            return;
+        }
+
+        foreach (var path in paths) {
+            AddUniqueAttachment(new FileAttachmentDescriptor(path), isInline, files, add);
+        }
+    }
+
+    private static void AddStructuredAttachments(
+        IEnumerable<AttachmentDescriptor>? attachments,
+        bool isInline,
+        HashSet<string> files,
+        Action<AttachmentDescriptor, bool> add) {
+        if (attachments == null) {
+            return;
+        }
+
+        foreach (var descriptor in attachments) {
+            AddUniqueAttachment(descriptor, isInline, files, add);
+        }
+    }
+
+    private static void AddUniqueAttachment(
+        AttachmentDescriptor descriptor,
+        bool isInline,
+        HashSet<string> files,
+        Action<AttachmentDescriptor, bool> add) {
+        if (descriptor.SourcePath is { Length: > 0 } sourcePath) {
+            var fullPath = Path.GetFullPath(sourcePath);
+            if (!files.Add(fullPath)) {
+                return;
+            }
+            if (descriptor is FileAttachmentDescriptor && !File.Exists(fullPath)) {
+                throw new FileNotFoundException(
+                    $"Attachment '{sourcePath}' was not found.",
+                    fullPath);
+            }
+        }
+
+        add(descriptor, isInline);
     }
 
     private async Task<string?> QueuePendingMessageAsync(CancellationToken cancellationToken) {

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -13,6 +13,7 @@ namespace Mailozaurr;
 /// </summary>
 public class MailgunClient : IDisposable {
     private readonly HttpClient _client;
+    private readonly bool _ownsClient;
     private int _disposed;
     /// <summary>Measures total time spent sending.</summary>
     public readonly Stopwatch Stopwatch;
@@ -74,6 +75,8 @@ public class MailgunClient : IDisposable {
 
     /// <summary>Custom headers to include with the message.</summary>
     public Dictionary<string, string>? Headers { get; set; }
+    /// <summary>Message priority propagated as Mailgun message headers.</summary>
+    public MessagePriority Priority { get; set; } = MessagePriority.Normal;
 
     /// <summary>Collector used to store log entries.</summary>
     public LogCollector LogCollector { get; set; } = new();
@@ -124,7 +127,15 @@ public class MailgunClient : IDisposable {
     /// </summary>
     public MailgunClient() {
         Stopwatch = Stopwatch.StartNew();
-        _client = new HttpClient();
+        _client = Helpers.SharedHttpClient;
+    }
+
+    /// <summary>Initializes a client with an isolated HTTP handler.</summary>
+    /// <param name="handler">HTTP handler used for provider requests.</param>
+    public MailgunClient(HttpMessageHandler handler) {
+        Stopwatch = Stopwatch.StartNew();
+        _client = new HttpClient(handler ?? throw new ArgumentNullException(nameof(handler)));
+        _ownsClient = true;
     }
 
     /// <summary>
@@ -189,14 +200,16 @@ public class MailgunClient : IDisposable {
         if (!string.IsNullOrWhiteSpace(Subject)) content.Add(new StringContent(Subject), "subject");
         if (!string.IsNullOrWhiteSpace(Text)) content.Add(new StringContent(Text), "text");
         if (!string.IsNullOrWhiteSpace(Html)) content.Add(new StringContent(Html), "html");
+        if (Priority != MessagePriority.Normal) {
+            content.Add(new StringContent(Priority == MessagePriority.High ? "1" : "5"), "h:X-Priority");
+            content.Add(new StringContent(Priority == MessagePriority.High ? "high" : "low"), "h:Importance");
+        }
         var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (Attachment != null) {
             foreach (var path in Attachment) {
                 if (!files.Add(path)) continue;
                 if (!File.Exists(path)) {
-                    LogCollector.LogWarning($"Send-EmailMessage - Attachment file not found: {path}");
-                    LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{path}' is invalid. Verify the file exists and the path is correct.");
-                    continue;
+                    throw new FileNotFoundException($"Attachment '{path}' was not found.", path);
                 }
 
                 var fileContent = CreateStreamContent(path);
@@ -207,9 +220,7 @@ public class MailgunClient : IDisposable {
             foreach (var path in InlineAttachment) {
                 if (!files.Add(path)) continue;
                 if (!File.Exists(path)) {
-                    LogCollector.LogWarning($"Send-EmailMessage - Inline attachment file not found: {path}");
-                    LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{path}' is invalid. Verify the file exists and the path is correct.");
-                    continue;
+                    throw new FileNotFoundException($"Inline attachment '{path}' was not found.", path);
                 }
 
                 var fileContent = CreateStreamContent(path);
@@ -233,9 +244,9 @@ public class MailgunClient : IDisposable {
         if (attachments == null) return;
         foreach (var descriptor in attachments) {
             if (descriptor is FileAttachmentDescriptor fileDescriptor && !File.Exists(fileDescriptor.FilePath)) {
-                LogCollector.LogWarning($"Send-EmailMessage - Attachment file not found: {fileDescriptor.FilePath}");
-                LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{fileDescriptor.FilePath}' is invalid. Verify the file exists and the path is correct.");
-                continue;
+                throw new FileNotFoundException(
+                    $"Attachment '{fileDescriptor.FilePath}' was not found.",
+                    fileDescriptor.FilePath);
             }
 
             var fileName = string.IsNullOrWhiteSpace(descriptor.FileName)
@@ -357,8 +368,7 @@ public class MailgunClient : IDisposable {
         var auth = Convert.ToBase64String(Encoding.ASCII.GetBytes($"api:{ApiKey}"));
 
         int attempts = 0;
-        Exception? lastException = null;
-        do {
+        while (true) {
             try {
                 using var content = await CreateContentAsync(cancellationToken).ConfigureAwait(false);
                 using var request = new HttpRequestMessage(HttpMethod.Post, url) {
@@ -377,14 +387,15 @@ public class MailgunClient : IDisposable {
 #else
                 var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
-                throw new HttpRequestException(error);
+                throw HttpRetryPolicy.CreateFailure(response.StatusCode, error);
             } catch (Exception ex) when (
                 ex is HttpRequestException ||
                 ex is TaskCanceledException && !cancellationToken.IsCancellationRequested) {
-                lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Mailgun: {ex.Message}");
-                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
-                    var queuedMessageId = await QueuePendingMessageAsync(cancellationToken).ConfigureAwait(false);
+                if (!HttpRetryPolicy.ShouldRetry(ex, attempts, RetryCount, RetryAlways)) {
+                    var queuedMessageId = HttpRetryPolicy.ShouldQueue(ex, RetryAlways)
+                        ? await QueuePendingMessageAsync(cancellationToken).ConfigureAwait(false)
+                        : null;
                     if (ErrorAction == ActionPreference.Stop) throw;
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", ex.Message) {
                         MessageId = queuedMessageId
@@ -392,23 +403,16 @@ public class MailgunClient : IDisposable {
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;
                 }
-                var delay = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-                if (MaxDelayMilliseconds > 0 && delay > MaxDelayMilliseconds) {
-                    delay = MaxDelayMilliseconds;
-                }
-                if (JitterMilliseconds > 0 && delay > 0) {
-                    delay += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
-                }
-                if (delay > 0) await Task.Delay(TimeSpan.FromMilliseconds(delay), cancellationToken).ConfigureAwait(false);
+                await HttpRetryPolicy.DelayAsync(
+                    RetryDelayMilliseconds,
+                    RetryDelayBackoff,
+                    attempts,
+                    MaxDelayMilliseconds,
+                    JitterMilliseconds,
+                    cancellationToken).ConfigureAwait(false);
             }
             attempts++;
-        } while (attempts <= RetryCount);
-        var finalQueuedMessageId = await QueuePendingMessageAsync(cancellationToken).ConfigureAwait(false);
-        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", lastException?.Message) {
-            MessageId = finalQueuedMessageId
-        };
-        await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken).ConfigureAwait(false);
-        return finalResult;
+        }
     }
 
     /// <summary>
@@ -424,7 +428,7 @@ public class MailgunClient : IDisposable {
     /// <param name="disposing">When true, disposes managed resources as well.</param>
     protected virtual void Dispose(bool disposing) {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
-        if (disposing) {
+        if (disposing && _ownsClient) {
             _client.Dispose();
         }
     }

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -226,12 +226,18 @@ public class MailgunClient : IDisposable {
         return Task.FromResult(content);
     }
 
-    private static void AddStructuredAttachments(
+    private void AddStructuredAttachments(
         MultipartFormDataContent content,
         IEnumerable<AttachmentDescriptor>? attachments,
         string fieldName) {
         if (attachments == null) return;
         foreach (var descriptor in attachments) {
+            if (descriptor is FileAttachmentDescriptor fileDescriptor && !File.Exists(fileDescriptor.FilePath)) {
+                LogCollector.LogWarning($"Send-EmailMessage - Attachment file not found: {fileDescriptor.FilePath}");
+                LogCollector.LogWarning($"Send-EmailMessage - Possible issue: Path '{fileDescriptor.FilePath}' is invalid. Verify the file exists and the path is correct.");
+                continue;
+            }
+
             var fileName = string.IsNullOrWhiteSpace(descriptor.FileName)
                 ? Path.GetFileName(descriptor.SourcePath) ?? "attachment"
                 : descriptor.FileName!;

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -28,6 +28,9 @@ public class MailgunClient : IDisposable {
     }
     private string EmailDomain {
         get {
+            if (!string.IsNullOrWhiteSpace(Domain)) {
+                return Domain!.Trim();
+            }
             var address = Helpers.GetEmailAddress(From);
             if (!address.Contains('@')) {
                 throw new ArgumentException($"Invalid email address: {address}", nameof(From));
@@ -39,6 +42,8 @@ public class MailgunClient : IDisposable {
     /// <summary>Credentials used to authenticate to the API.</summary>
     /// <remarks>Must be <see cref="NetworkCredential"/>.</remarks>
     public ICredentials Credentials { get; set; } = null!;
+    /// <summary>Optional explicit Mailgun sending domain. Defaults to the sender address domain.</summary>
+    public string? Domain { get; set; }
     /// <summary>Determines how errors are handled.</summary>
     public ActionPreference? ErrorAction { get; set; }
 
@@ -62,6 +67,10 @@ public class MailgunClient : IDisposable {
     public string[]? Attachment { get; set; }
     /// <summary>File paths to include as inline attachments.</summary>
     public string[]? InlineAttachment { get; set; }
+    /// <summary>Structured attachments to include.</summary>
+    public List<AttachmentDescriptor>? Attachments { get; set; }
+    /// <summary>Structured inline attachments to include.</summary>
+    public List<AttachmentDescriptor>? InlineAttachments { get; set; }
 
     /// <summary>Custom headers to include with the message.</summary>
     public Dictionary<string, string>? Headers { get; set; }
@@ -143,6 +152,27 @@ public class MailgunClient : IDisposable {
         return streamContent;
     }
 
+    private static StreamContent CreateStreamContent(AttachmentDescriptor descriptor) {
+        Stream stream = descriptor.SourcePath is { Length: > 0 } sourcePath
+            ? new FileStream(
+                sourcePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                bufferSize: 8192,
+                options: FileOptions.Asynchronous | FileOptions.SequentialScan)
+            : new MemoryStream(descriptor.GetContentBytes(), writable: false);
+        var streamContent = new StreamContent(stream);
+        streamContent.Headers.ContentType = new MediaTypeHeaderValue(
+            string.IsNullOrWhiteSpace(descriptor.ContentType)
+                ? "application/octet-stream"
+                : descriptor.ContentType);
+        if (!string.IsNullOrWhiteSpace(descriptor.ContentId)) {
+            streamContent.Headers.TryAddWithoutValidation("Content-ID", descriptor.ContentId);
+        }
+        return streamContent;
+    }
+
     /// <summary>
     /// Builds the multipart HTTP content used for the Mailgun API request.
     /// </summary>
@@ -186,12 +216,27 @@ public class MailgunClient : IDisposable {
                 content.Add(fileContent, "inline", Path.GetFileName(path));
             }
         }
+        AddStructuredAttachments(content, Attachments, "attachment");
+        AddStructuredAttachments(content, InlineAttachments, "inline");
         if (Headers != null) {
             foreach (var kvp in Headers) {
                 content.Add(new StringContent(kvp.Value), $"h:{kvp.Key}");
             }
         }
         return Task.FromResult(content);
+    }
+
+    private static void AddStructuredAttachments(
+        MultipartFormDataContent content,
+        IEnumerable<AttachmentDescriptor>? attachments,
+        string fieldName) {
+        if (attachments == null) return;
+        foreach (var descriptor in attachments) {
+            var fileName = string.IsNullOrWhiteSpace(descriptor.FileName)
+                ? Path.GetFileName(descriptor.SourcePath) ?? "attachment"
+                : descriptor.FileName!;
+            content.Add(CreateStreamContent(descriptor), fieldName, fileName);
+        }
     }
 
     private MimeMessage BuildMimeMessage() {
@@ -212,13 +257,21 @@ public class MailgunClient : IDisposable {
         if (InlineAttachment != null) {
             smtp.InlineAttachments = InlineAttachment.Select(path => new FileAttachmentDescriptor(path)).Cast<AttachmentDescriptor>().ToList();
         }
+        if (Attachments != null) {
+            smtp.Attachments ??= new List<AttachmentDescriptor>();
+            smtp.Attachments.AddRange(Attachments);
+        }
+        if (InlineAttachments != null) {
+            smtp.InlineAttachments ??= new List<AttachmentDescriptor>();
+            smtp.InlineAttachments.AddRange(InlineAttachments);
+        }
         smtp.CreateMessage();
         return smtp.Message;
     }
 
-    private async Task QueuePendingMessageAsync(CancellationToken cancellationToken) {
+    private async Task<string?> QueuePendingMessageAsync(CancellationToken cancellationToken) {
         if (PendingMessageRepository == null) {
-            return;
+            return null;
         }
 
         string apiKey;
@@ -228,11 +281,11 @@ public class MailgunClient : IDisposable {
             domain = EmailDomain;
         } catch (Exception ex) {
             LogCollector.LogWarning($"Send-EmailMessage - Failed to capture Mailgun credentials for retry: {ex.Message}");
-            return;
+            return null;
         }
 
         if (string.IsNullOrEmpty(apiKey)) {
-            return;
+            return null;
         }
 
         MimeMessage message;
@@ -240,7 +293,7 @@ public class MailgunClient : IDisposable {
             message = BuildMimeMessage();
         } catch (Exception ex) {
             LogCollector.LogWarning($"Send-EmailMessage - Failed to serialize Mailgun message for retry: {ex.Message}");
-            return;
+            return null;
         }
 
         var messageId = string.IsNullOrEmpty(message.MessageId)
@@ -266,10 +319,12 @@ public class MailgunClient : IDisposable {
 
         try {
             await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+            return record.MessageId;
         } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
             throw;
         } catch (Exception ex) {
             LogCollector.LogWarning($"Send-EmailMessage - Failed to persist Mailgun pending message: {ex.Message}");
+            return null;
         }
     }
 
@@ -321,9 +376,11 @@ public class MailgunClient : IDisposable {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Mailgun: {ex.Message}");
                 if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
-                    await QueuePendingMessageAsync(cancellationToken).ConfigureAwait(false);
+                    var queuedMessageId = await QueuePendingMessageAsync(cancellationToken).ConfigureAwait(false);
                     if (ErrorAction == ActionPreference.Stop) throw;
-                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", ex.Message);
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", ex.Message) {
+                        MessageId = queuedMessageId
+                    };
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;
                 }
@@ -338,8 +395,10 @@ public class MailgunClient : IDisposable {
             }
             attempts++;
         } while (attempts <= RetryCount);
-        await QueuePendingMessageAsync(cancellationToken).ConfigureAwait(false);
-        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", lastException?.Message);
+        var finalQueuedMessageId = await QueuePendingMessageAsync(cancellationToken).ConfigureAwait(false);
+        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", lastException?.Message) {
+            MessageId = finalQueuedMessageId
+        };
         await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken).ConfigureAwait(false);
         return finalResult;
     }

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -376,26 +376,29 @@ public class MailgunClient : IDisposable {
                 };
                 request.Headers.Authorization = new AuthenticationHeaderValue("Basic", auth);
                 using var response = await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                var responseContent = await ProviderResponseParser
+                    .ReadContentAsync(response, cancellationToken)
+                    .ConfigureAwait(false);
                 if (response.IsSuccessStatusCode) {
                     var statusCode = response.StatusCode.ToString();
-                    var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, statusCode, "");
+                    var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, statusCode, "") {
+                        MessageId = ProviderResponseParser
+                            .GetJsonMessageId(responseContent)
+                    };
                     await Helpers.PostWebhookAsync(WebhookUrl, okResult, cancellationToken).ConfigureAwait(false);
                     return okResult;
                 }
-#if NET5_0_OR_GREATER
-                var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-#else
-                var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-#endif
-                throw HttpRetryPolicy.CreateFailure(response.StatusCode, error);
+                throw HttpRetryPolicy.CreateFailure(
+                    response.StatusCode,
+                    responseContent);
             } catch (Exception ex) when (
                 ex is HttpRequestException ||
                 ex is TaskCanceledException && !cancellationToken.IsCancellationRequested) {
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Mailgun: {ex.Message}");
                 if (!HttpRetryPolicy.ShouldRetry(ex, attempts, RetryCount, RetryAlways)) {
-                    var queuedMessageId = HttpRetryPolicy.ShouldQueue(ex, RetryAlways)
-                        ? await QueuePendingMessageAsync(cancellationToken).ConfigureAwait(false)
-                        : null;
+                    var queuedMessageId =
+                        await QueuePendingMessageAsync(
+                            cancellationToken).ConfigureAwait(false);
                     if (ErrorAction == ActionPreference.Stop) throw;
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", ex.Message) {
                         MessageId = queuedMessageId

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -378,7 +378,9 @@ public class MailgunClient : IDisposable {
                 var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
                 throw new HttpRequestException(error);
-            } catch (HttpRequestException ex) {
+            } catch (Exception ex) when (
+                ex is HttpRequestException ||
+                ex is TaskCanceledException && !cancellationToken.IsCancellationRequested) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Mailgun: {ex.Message}");
                 if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -210,28 +210,30 @@ public class MailgunClient : IDisposable {
         var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (Attachment != null) {
             foreach (var path in Attachment) {
-                if (!files.Add(path)) continue;
-                if (!File.Exists(path)) {
-                    throw new FileNotFoundException($"Attachment '{path}' was not found.", path);
+                var fullPath = Path.GetFullPath(path);
+                if (!files.Add(fullPath)) continue;
+                if (!File.Exists(fullPath)) {
+                    throw new FileNotFoundException($"Attachment '{path}' was not found.", fullPath);
                 }
 
-                var fileContent = CreateStreamContent(path);
-                content.Add(fileContent, "attachment", Path.GetFileName(path));
+                var fileContent = CreateStreamContent(fullPath);
+                content.Add(fileContent, "attachment", Path.GetFileName(fullPath));
             }
         }
         if (InlineAttachment != null) {
             foreach (var path in InlineAttachment) {
-                if (!files.Add(path)) continue;
-                if (!File.Exists(path)) {
-                    throw new FileNotFoundException($"Inline attachment '{path}' was not found.", path);
+                var fullPath = Path.GetFullPath(path);
+                if (!files.Add(fullPath)) continue;
+                if (!File.Exists(fullPath)) {
+                    throw new FileNotFoundException($"Inline attachment '{path}' was not found.", fullPath);
                 }
 
-                var fileContent = CreateStreamContent(path);
-                content.Add(fileContent, "inline", Path.GetFileName(path));
+                var fileContent = CreateStreamContent(fullPath);
+                content.Add(fileContent, "inline", Path.GetFileName(fullPath));
             }
         }
-        AddStructuredAttachments(content, Attachments, "attachment");
-        AddStructuredAttachments(content, InlineAttachments, "inline");
+        AddStructuredAttachments(content, Attachments, "attachment", files);
+        AddStructuredAttachments(content, InlineAttachments, "inline", files);
         if (Headers != null) {
             foreach (var kvp in Headers) {
                 content.Add(new StringContent(kvp.Value), $"h:{kvp.Key}");
@@ -243,13 +245,18 @@ public class MailgunClient : IDisposable {
     private void AddStructuredAttachments(
         MultipartFormDataContent content,
         IEnumerable<AttachmentDescriptor>? attachments,
-        string fieldName) {
+        string fieldName,
+        HashSet<string> files) {
         if (attachments == null) return;
         foreach (var descriptor in attachments) {
-            if (descriptor is FileAttachmentDescriptor fileDescriptor && !File.Exists(fileDescriptor.FilePath)) {
-                throw new FileNotFoundException(
-                    $"Attachment '{fileDescriptor.FilePath}' was not found.",
-                    fileDescriptor.FilePath);
+            if (descriptor.SourcePath is { Length: > 0 } sourcePath) {
+                var fullPath = Path.GetFullPath(sourcePath);
+                if (!files.Add(fullPath)) continue;
+                if (descriptor is FileAttachmentDescriptor && !File.Exists(fullPath)) {
+                    throw new FileNotFoundException(
+                        $"Attachment '{sourcePath}' was not found.",
+                        fullPath);
+                }
             }
 
             var fileName = string.IsNullOrWhiteSpace(descriptor.FileName)
@@ -410,7 +417,8 @@ public class MailgunClient : IDisposable {
                             cancellationToken).ConfigureAwait(false);
                     if (ErrorAction == ActionPreference.Stop) throw;
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "MailgunApi", 0, Stopwatch.Elapsed, "", ex.Message) {
-                        MessageId = queuedMessageId
+                        MessageId = queuedMessageId,
+                        Queued = queuedMessageId != null
                     };
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;

--- a/Sources/Mailozaurr/Mailgun/Mailgun.cs
+++ b/Sources/Mailozaurr/Mailgun/Mailgun.cs
@@ -174,9 +174,12 @@ public class MailgunClient : IDisposable {
                 options: FileOptions.Asynchronous | FileOptions.SequentialScan)
             : new MemoryStream(descriptor.GetContentBytes(), writable: false);
         var streamContent = new StreamContent(stream);
+        var contentTypeSource = string.IsNullOrWhiteSpace(descriptor.FileName)
+            ? descriptor.SourcePath
+            : descriptor.FileName;
         streamContent.Headers.ContentType = new MediaTypeHeaderValue(
             string.IsNullOrWhiteSpace(descriptor.ContentType)
-                ? "application/octet-stream"
+                ? MimeTypes.GetMimeType(contentTypeSource ?? string.Empty)
                 : descriptor.ContentType);
         if (!string.IsNullOrWhiteSpace(descriptor.ContentId)) {
             streamContent.Headers.TryAddWithoutValidation("Content-ID", descriptor.ContentId);
@@ -266,7 +269,8 @@ public class MailgunClient : IDisposable {
             Subject = Subject ?? string.Empty,
             TextBody = Text,
             HtmlBody = Html,
-            Headers = Headers
+            Headers = Headers,
+            Priority = Priority
         };
         if (Attachment != null) {
             smtp.Attachments = Attachment.Select(path => new FileAttachmentDescriptor(path)).Cast<AttachmentDescriptor>().ToList();
@@ -395,7 +399,12 @@ public class MailgunClient : IDisposable {
                 ex is HttpRequestException ||
                 ex is TaskCanceledException && !cancellationToken.IsCancellationRequested) {
                 LogCollector.LogWarning($"Send-EmailMessage - Error during sending using Mailgun: {ex.Message}");
-                if (!HttpRetryPolicy.ShouldRetry(ex, attempts, RetryCount, RetryAlways)) {
+                if (!HttpRetryPolicy.ShouldRetry(
+                        ex,
+                        attempts,
+                        RetryCount,
+                        RetryAlways,
+                        isKnownTransient: ex is TaskCanceledException)) {
                     var queuedMessageId =
                         await QueuePendingMessageAsync(
                             cancellationToken).ConfigureAwait(false);

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.AttachmentUpload.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.AttachmentUpload.cs
@@ -330,8 +330,12 @@ public partial class Graph {
                 delay = TimeSpan.FromMilliseconds(policy.MaxDelayMs);
             }
         } else {
-            var delayMs = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-            if (delayMs > 0) delay = TimeSpan.FromMilliseconds(delayMs);
+            delay = RetryDelayCalculator.Calculate(
+                RetryDelayMilliseconds,
+                RetryDelayBackoff,
+                attempts,
+                0,
+                0);
         }
 
         if (delay > TimeSpan.Zero) {

--- a/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/Graph.cs
@@ -385,7 +385,8 @@ public partial class Graph : IDisposable {
                 : $"{current.Error} | SMTP fallback error: {fallbackError}";
             return new SmtpResult(current.Status, current.EmailAction, current.SentTo, current.SentFrom, current.Server, current.Port, current.TimeToExecute, current.Message, mergedError) {
                 GraphError = current.GraphError,
-                MessageId = current.MessageId
+                MessageId = current.MessageId,
+                Queued = current.Queued
             };
         }
     }

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphMimePreparation.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphMimePreparation.cs
@@ -111,6 +111,11 @@ public static class GraphMimePreparation {
             Cc = ConvertRecipients(message.Cc),
             Bcc = ConvertRecipients(message.Bcc),
             ReplyTo = ConvertRecipients(message.ReplyTo),
+            Importance = message.Priority switch {
+                MimeKit.MessagePriority.Urgent => "high",
+                MimeKit.MessagePriority.NonUrgent => "low",
+                _ => "normal"
+            },
             InternetMessageHeaders = headers.Count == 0 ? null : headers,
             Attachments = attachments
         };

--- a/Sources/Mailozaurr/MicrosoftGraph/GraphRetryHelper.cs
+++ b/Sources/Mailozaurr/MicrosoftGraph/GraphRetryHelper.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Threading;
 
 namespace Mailozaurr;
 
@@ -75,38 +74,11 @@ internal static class GraphRetryHelper {
     /// <summary>
     /// Calculate exponential backoff delay with optional jitter and cap.
     /// </summary>
-    internal static TimeSpan CalculateDelay(GraphSendPolicy policy, int attempt) {
-        if (attempt < 0) attempt = 0;
-        var baseDelay = (double)Math.Max(0, policy.BaseDelayMs);
-        var delay = baseDelay * Math.Pow(2, attempt);
-        var max = Math.Max(0, policy.MaxDelayMs);
-        if (max > 0) {
-            delay = Math.Min(delay, max);
-        }
-
-        var jitterWindow = Math.Max(0, policy.JitterMs);
-        if (jitterWindow > 0) {
-            var jitter = GraphRetryHelperRandom.NextInt(jitterWindow + 1);
-            delay += jitter;
-        }
-
-        return TimeSpan.FromMilliseconds(Math.Max(0, (int)Math.Round(delay)));
-    }
-}
-
-internal static class GraphRetryHelperRandom {
-#if !NET5_0_OR_GREATER
-    [ThreadStatic]
-    private static Random? s_random;
-#endif
-
-    internal static int NextInt(int maxExclusive) {
-        if (maxExclusive <= 1) return 0;
-#if NET5_0_OR_GREATER
-        return System.Security.Cryptography.RandomNumberGenerator.GetInt32(0, maxExclusive);
-#else
-        var rnd = s_random ??= new Random(unchecked(Environment.TickCount * 31 + Thread.CurrentThread.ManagedThreadId));
-        return rnd.Next(0, maxExclusive);
-#endif
-    }
+    internal static TimeSpan CalculateDelay(GraphSendPolicy policy, int attempt) =>
+        RetryDelayCalculator.Calculate(
+            policy.BaseDelayMs,
+            2.0,
+            attempt,
+            policy.MaxDelayMs,
+            policy.JitterMs);
 }

--- a/Sources/Mailozaurr/MicrosoftGraphUtils.cs
+++ b/Sources/Mailozaurr/MicrosoftGraphUtils.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -108,6 +109,40 @@ namespace Mailozaurr {
                 ExpiresOn = authorization.ExpiresOn
             }).ConfigureAwait(false);
         }
+
+        internal static string BuildGraphTokenCacheKey(
+            GraphCredential credential,
+            string tenantDomain,
+            string resource) {
+            if (credential == null) {
+                throw new ArgumentNullException(nameof(credential));
+            }
+
+            string certificateBytesHash = credential.CertificateBytes == null
+                ? string.Empty
+                : ComputeSha256Hex(credential.CertificateBytes);
+            string identity = string.Join(
+                "\n",
+                credential.ClientId ?? string.Empty,
+                tenantDomain ?? string.Empty,
+                resource ?? string.Empty,
+                credential.CertificatePath ?? string.Empty,
+                credential.CertificatePemPath ?? string.Empty,
+                certificateBytesHash,
+                credential.ClientSecret ?? string.Empty);
+
+            return $"v2:{ComputeSha256Hex(Encoding.UTF8.GetBytes(identity))}";
+        }
+
+        private static string ComputeSha256Hex(byte[] value) {
+            using var sha256 = SHA256.Create();
+            byte[] hash = sha256.ComputeHash(value);
+            var builder = new StringBuilder(hash.Length * 2);
+            foreach (byte item in hash) {
+                builder.Append(item.ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
+            }
+            return builder.ToString();
+        }
         /// <summary>
         /// Converts a credential string (username@directory) and secret to a GraphCredential object.
         /// </summary>
@@ -153,7 +188,7 @@ namespace Mailozaurr {
                     : $"Bearer {accessToken}";
             }
 
-            var key = $"{credential.ClientId}|{tenantDomain}|{credential.CertificatePath}|{credential.ClientSecret}|{resource}";
+            string key = BuildGraphTokenCacheKey(credential, tenantDomain, resource);
             if (TokenCache.TryGetValue(key, out var cached) && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(5)) {
                 return $"{cached.TokenType} {cached.AccessToken}";
             }

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -392,11 +392,13 @@ public sealed class SendGridClient : IDisposable {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - HTTP error during sending using SendGrid: {ex.Message}");
                 if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
-                    await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
+                    var queuedMessageId = await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
                     if (ErrorAction == ActionPreference.Stop && lastException != null) {
                         throw lastException;
                     }
-                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message) {
+                        MessageId = queuedMessageId
+                    };
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;
                 }
@@ -417,11 +419,13 @@ public sealed class SendGridClient : IDisposable {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Request canceled: {ex.Message}");
                 if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
-                    await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
+                    var queuedMessageId = await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
                     if (ErrorAction == ActionPreference.Stop && lastException != null) {
                         throw lastException;
                     }
-                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message) {
+                        MessageId = queuedMessageId
+                    };
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;
                 }
@@ -439,23 +443,25 @@ public sealed class SendGridClient : IDisposable {
             attempts++;
         } while (attempts <= RetryCount);
 
-        await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
-        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message);
+        var finalQueuedMessageId = await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
+        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message) {
+            MessageId = finalQueuedMessageId
+        };
         await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken).ConfigureAwait(false);
         return finalResult;
     }
 
-    private async Task QueuePendingMessageAsync(string apiKey, CancellationToken cancellationToken) {
+    private async Task<string?> QueuePendingMessageAsync(string apiKey, CancellationToken cancellationToken) {
         if (PendingMessageRepository == null) {
-            return;
+            return null;
         }
 
         if (string.IsNullOrWhiteSpace(MessageJson)) {
-            return;
+            return null;
         }
 
         if (string.IsNullOrEmpty(apiKey)) {
-            return;
+            return null;
         }
 
         var now = DateTimeOffset.UtcNow;
@@ -473,10 +479,12 @@ public sealed class SendGridClient : IDisposable {
 
         try {
             await PendingMessageRepository.SaveAsync(record, cancellationToken).ConfigureAwait(false);
+            return record.MessageId;
         } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
             throw;
         } catch (Exception ex) {
             LogCollector.LogWarning($"Send-EmailMessage - Failed to persist SendGrid pending message: {ex.Message}");
+            return null;
         }
     }
 

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -22,6 +22,8 @@ public sealed class SendGridClient : IDisposable {
     private readonly HttpClient _client;
     private readonly bool _ownsClient;
     private bool _disposed;
+    internal TimeSpan RequestTimeout { get; set; } =
+        TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Stopwatch to measure the time taken to send an email.
@@ -391,16 +393,23 @@ public sealed class SendGridClient : IDisposable {
                 };
                 request.Headers.Add("Authorization", $"Bearer {apiKey}");
 
-                using var response = await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
-#if NET5_0_OR_GREATER
-                lastContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-#else
-                lastContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-#endif
+                using var requestTimeout =
+                    CancellationTokenSource.CreateLinkedTokenSource(
+                        cancellationToken);
+                requestTimeout.CancelAfter(RequestTimeout);
+                using var response = await _client.SendAsync(
+                    request,
+                    requestTimeout.Token).ConfigureAwait(false);
+                lastContent = await ProviderResponseParser
+                    .ReadContentAsync(response, cancellationToken)
+                    .ConfigureAwait(false);
                 LogCollector.LogVerbose($"Send-EmailMessage - Sent email to {SentTo} using SendGrid");
 
                 if (response.IsSuccessStatusCode) {
-                    var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString());
+                    var okResult = new SmtpResult(true, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, response.StatusCode.ToString()) {
+                        MessageId = ProviderResponseParser
+                            .GetSendGridMessageId(response)
+                    };
                     await Helpers.PostWebhookAsync(WebhookUrl, okResult, cancellationToken).ConfigureAwait(false);
                     return okResult;
                 }
@@ -411,9 +420,10 @@ public sealed class SendGridClient : IDisposable {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - HTTP error during sending using SendGrid: {ex.Message}");
                 if (!HttpRetryPolicy.ShouldRetry(ex, attempts, RetryCount, RetryAlways)) {
-                    var queuedMessageId = HttpRetryPolicy.ShouldQueue(ex, RetryAlways)
-                        ? await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false)
-                        : null;
+                    var queuedMessageId =
+                        await QueuePendingMessageAsync(
+                            apiKey,
+                            cancellationToken).ConfigureAwait(false);
                     if (ErrorAction == ActionPreference.Stop) {
                         throw;
                     }
@@ -437,9 +447,10 @@ public sealed class SendGridClient : IDisposable {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Request canceled: {ex.Message}");
                 if (!HttpRetryPolicy.ShouldRetry(ex, attempts, RetryCount, RetryAlways)) {
-                    var queuedMessageId = HttpRetryPolicy.ShouldQueue(ex, RetryAlways)
-                        ? await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false)
-                        : null;
+                    var queuedMessageId =
+                        await QueuePendingMessageAsync(
+                            apiKey,
+                            cancellationToken).ConfigureAwait(false);
                     if (ErrorAction == ActionPreference.Stop && lastException != null) {
                         throw lastException;
                     }

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -20,6 +20,7 @@ public sealed class SendGridClient : IDisposable {
     /// The HttpClient used to send HTTP requests.
     /// </summary>
     private readonly HttpClient _client;
+    private readonly bool _ownsClient;
     private bool _disposed;
 
     /// <summary>
@@ -169,9 +170,19 @@ public sealed class SendGridClient : IDisposable {
     /// </summary>
     public SendGridClient() {
         Stopwatch = Stopwatch.StartNew();
-        _client = new HttpClient {
+        _client = Helpers.SharedHttpClient;
+    }
+
+    /// <summary>
+    /// Initializes a client with an isolated HTTP handler.
+    /// </summary>
+    /// <param name="handler">HTTP handler used for provider requests.</param>
+    public SendGridClient(HttpMessageHandler handler) {
+        Stopwatch = Stopwatch.StartNew();
+        _client = new HttpClient(handler ?? throw new ArgumentNullException(nameof(handler))) {
             Timeout = TimeSpan.FromSeconds(30)
         };
+        _ownsClient = true;
     }
 
     /// <summary>
@@ -242,8 +253,9 @@ public sealed class SendGridClient : IDisposable {
                 }
 
                 if (descriptor is FileAttachmentDescriptor fileDescriptor && !File.Exists(fileDescriptor.FilePath)) {
-                    logger.LogWarning($"Send-EmailMessage - File not found: {fileDescriptor.FilePath}. Skipping attachment.");
-                    continue;
+                    throw new FileNotFoundException(
+                        $"Attachment '{fileDescriptor.FilePath}' was not found.",
+                        fileDescriptor.FilePath);
                 }
             }
 
@@ -317,6 +329,14 @@ public sealed class SendGridClient : IDisposable {
 
         var fromAddress = ConvertToEmailObject(From) ?? throw new InvalidOperationException("From address is required.");
 
+        var headers = Headers == null
+            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(Headers, StringComparer.OrdinalIgnoreCase);
+        if (Priority != MessagePriority.Normal) {
+            headers["X-Priority"] = Priority == MessagePriority.High ? "1" : "5";
+            headers["Importance"] = Priority == MessagePriority.High ? "high" : "low";
+        }
+
         var message = new SendGridMessage {
             Personalizations = personalizations,
             From = fromAddress,
@@ -324,7 +344,7 @@ public sealed class SendGridClient : IDisposable {
             Content = content,
             ReplyTo = ConvertToEmailObject(ReplyTo),
             Attachments = attachments,
-            Headers = Headers
+            Headers = headers.Count == 0 ? null : headers
         };
 
         MessageJson = JsonSerializer.Serialize(message, MailozaurrJsonContext.Default.SendGridMessage);
@@ -364,7 +384,7 @@ public sealed class SendGridClient : IDisposable {
         int attempts = 0;
         Exception? lastException = null;
         string? lastContent = null;
-        do {
+        while (true) {
             try {
                 using var request = new HttpRequestMessage(HttpMethod.Post, "https://api.sendgrid.com/v3/mail/send") {
                     Content = new StringContent(MessageJson, Encoding.UTF8, "application/json")
@@ -386,40 +406,40 @@ public sealed class SendGridClient : IDisposable {
                 }
 
                 var message = $"Status code {response.StatusCode}: {lastContent}";
-                lastException = new HttpRequestException(message);
-                LogCollector.LogWarning($"Send-EmailMessage - Error during sending using SendGrid: {message}");
+                throw HttpRetryPolicy.CreateFailure(response.StatusCode, message);
             } catch (HttpRequestException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - HTTP error during sending using SendGrid: {ex.Message}");
-                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
-                    var queuedMessageId = await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
-                    if (ErrorAction == ActionPreference.Stop && lastException != null) {
-                        throw lastException;
+                if (!HttpRetryPolicy.ShouldRetry(ex, attempts, RetryCount, RetryAlways)) {
+                    var queuedMessageId = HttpRetryPolicy.ShouldQueue(ex, RetryAlways)
+                        ? await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false)
+                        : null;
+                    if (ErrorAction == ActionPreference.Stop) {
+                        throw;
                     }
-                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message) {
+                    var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, ex.Message) {
                         MessageId = queuedMessageId
                     };
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;
                 }
 
-                var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-                if (MaxDelayMilliseconds > 0 && delayMilliseconds > MaxDelayMilliseconds) {
-                    delayMilliseconds = MaxDelayMilliseconds;
-                }
-                if (JitterMilliseconds > 0 && delayMilliseconds > 0) {
-                    delayMilliseconds += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
-                }
-                if (delayMilliseconds > 0) {
-                    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), cancellationToken).ConfigureAwait(false);
-                }
+                await HttpRetryPolicy.DelayAsync(
+                    RetryDelayMilliseconds,
+                    RetryDelayBackoff,
+                    attempts,
+                    MaxDelayMilliseconds,
+                    JitterMilliseconds,
+                    cancellationToken).ConfigureAwait(false);
             } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
                 throw;
             } catch (TaskCanceledException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Request canceled: {ex.Message}");
-                if ((!Helpers.IsTransient(ex) && !RetryAlways) || attempts >= RetryCount) {
-                    var queuedMessageId = await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
+                if (!HttpRetryPolicy.ShouldRetry(ex, attempts, RetryCount, RetryAlways)) {
+                    var queuedMessageId = HttpRetryPolicy.ShouldQueue(ex, RetryAlways)
+                        ? await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false)
+                        : null;
                     if (ErrorAction == ActionPreference.Stop && lastException != null) {
                         throw lastException;
                     }
@@ -429,26 +449,16 @@ public sealed class SendGridClient : IDisposable {
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;
                 }
-                var delayMs = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempts));
-                if (MaxDelayMilliseconds > 0 && delayMs > MaxDelayMilliseconds) {
-                    delayMs = MaxDelayMilliseconds;
-                }
-                if (JitterMilliseconds > 0 && delayMs > 0) {
-                    delayMs += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
-                }
-                if (delayMs > 0) {
-                    await Task.Delay(TimeSpan.FromMilliseconds(delayMs), cancellationToken).ConfigureAwait(false);
-                }
+                await HttpRetryPolicy.DelayAsync(
+                    RetryDelayMilliseconds,
+                    RetryDelayBackoff,
+                    attempts,
+                    MaxDelayMilliseconds,
+                    JitterMilliseconds,
+                    cancellationToken).ConfigureAwait(false);
             }
             attempts++;
-        } while (attempts <= RetryCount);
-
-        var finalQueuedMessageId = await QueuePendingMessageAsync(apiKey, cancellationToken).ConfigureAwait(false);
-        var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message) {
-            MessageId = finalQueuedMessageId
-        };
-        await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken).ConfigureAwait(false);
-        return finalResult;
+        }
     }
 
     private async Task<string?> QueuePendingMessageAsync(string apiKey, CancellationToken cancellationToken) {
@@ -507,7 +517,7 @@ public sealed class SendGridClient : IDisposable {
             return;
         }
 
-        if (disposing) {
+        if (disposing && _ownsClient) {
             _client.Dispose();
         }
 

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -428,7 +428,8 @@ public sealed class SendGridClient : IDisposable {
                         throw;
                     }
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, ex.Message) {
-                        MessageId = queuedMessageId
+                        MessageId = queuedMessageId,
+                        Queued = queuedMessageId != null
                     };
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;
@@ -460,7 +461,8 @@ public sealed class SendGridClient : IDisposable {
                         throw lastException;
                     }
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, "SendGridApi", 0, Stopwatch.Elapsed, lastContent, lastException?.Message) {
-                        MessageId = queuedMessageId
+                        MessageId = queuedMessageId,
+                        Queued = queuedMessageId != null
                     };
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken).ConfigureAwait(false);
                     return failResult;

--- a/Sources/Mailozaurr/SendGrid/SendGridClient.cs
+++ b/Sources/Mailozaurr/SendGrid/SendGridClient.cs
@@ -446,7 +446,12 @@ public sealed class SendGridClient : IDisposable {
             } catch (TaskCanceledException ex) {
                 lastException = ex;
                 LogCollector.LogWarning($"Send-EmailMessage - Request canceled: {ex.Message}");
-                if (!HttpRetryPolicy.ShouldRetry(ex, attempts, RetryCount, RetryAlways)) {
+                if (!HttpRetryPolicy.ShouldRetry(
+                        ex,
+                        attempts,
+                        RetryCount,
+                        RetryAlways,
+                        isKnownTransient: true)) {
                     var queuedMessageId =
                         await QueuePendingMessageAsync(
                             apiKey,

--- a/Sources/Mailozaurr/SentMessages/Senders/MailgunPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/MailgunPendingMessageSender.cs
@@ -57,7 +57,9 @@ public sealed class MailgunPendingMessageSender : IPendingMessageSender {
 #else
             var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
-            throw new HttpRequestException($"Mailgun returned {(int)response.StatusCode} ({response.StatusCode}): {error}");
+            throw HttpRetryPolicy.CreateFailure(
+                response.StatusCode,
+                $"Mailgun returned {(int)response.StatusCode} ({response.StatusCode}): {error}");
         }
     }
 

--- a/Sources/Mailozaurr/SentMessages/Senders/SendGridPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/SendGridPendingMessageSender.cs
@@ -47,7 +47,9 @@ public sealed class SendGridPendingMessageSender : IPendingMessageSender {
 #else
             var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
-            throw new HttpRequestException($"SendGrid returned {(int)response.StatusCode} ({response.StatusCode}): {error}");
+            throw HttpRetryPolicy.CreateFailure(
+                response.StatusCode,
+                $"SendGrid returned {(int)response.StatusCode} ({response.StatusCode}): {error}");
         }
     }
 

--- a/Sources/Mailozaurr/SentMessages/Senders/SesPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/SesPendingMessageSender.cs
@@ -1,5 +1,3 @@
-using System.Globalization;
-using System.Security.Cryptography;
 using System.Text;
 
 namespace Mailozaurr;
@@ -44,8 +42,7 @@ public sealed class SesPendingMessageSender : IPendingMessageSender {
             : "us-east-1";
 
         var body = BuildRequestBody(record.MimeMessage);
-        var request = CreateRequest(accessKey, secretKey, region, body, utcNow());
-        request.Content = new StringContent(body, Encoding.UTF8, "application/x-www-form-urlencoded");
+        var request = SesRequestFactory.Create(accessKey, secretKey, region, body, utcNow());
 
         using (request)
         using (var response = await httpClient.SendAsync(request, ct).ConfigureAwait(false)) {
@@ -106,48 +103,4 @@ public sealed class SesPendingMessageSender : IPendingMessageSender {
         throw new InvalidOperationException("Pending SES message is missing the AWS secret access key.");
     }
 
-    private static HttpRequestMessage CreateRequest(string accessKey, string secretKey, string region, string content, DateTime nowUtc) {
-        var request = new HttpRequestMessage(HttpMethod.Post, new Uri($"https://email.{region}.amazonaws.com/"));
-        var amzDate = nowUtc.ToString("yyyyMMdd'T'HHmmss'Z'", CultureInfo.InvariantCulture);
-        var dateStamp = nowUtc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
-        var canonicalHeaders = $"content-type:application/x-www-form-urlencoded\nhost:email.{region}.amazonaws.com\nx-amz-date:{amzDate}\n";
-        const string signedHeaders = "content-type;host;x-amz-date";
-        var payloadHash = Sha256Hex(content);
-        var canonicalRequest = $"POST\n/\n\n{canonicalHeaders}\n{signedHeaders}\n{payloadHash}";
-        var credentialScope = $"{dateStamp}/{region}/ses/aws4_request";
-        var stringToSign = $"AWS4-HMAC-SHA256\n{amzDate}\n{credentialScope}\n{Sha256Hex(canonicalRequest)}";
-        var signingKey = GetSignatureKey(secretKey, dateStamp, region, "ses");
-        var signature = ToHex(HmacSha256(signingKey, stringToSign));
-        var authorization = $"AWS4-HMAC-SHA256 Credential={accessKey}/{credentialScope}, SignedHeaders={signedHeaders}, Signature={signature}";
-
-        request.Headers.TryAddWithoutValidation("x-amz-date", amzDate);
-        request.Headers.TryAddWithoutValidation("Authorization", authorization);
-        return request;
-    }
-
-    private static byte[] GetSignatureKey(string key, string dateStamp, string regionName, string serviceName) {
-        var kDate = HmacSha256(Encoding.UTF8.GetBytes("AWS4" + key), dateStamp);
-        var kRegion = HmacSha256(kDate, regionName);
-        var kService = HmacSha256(kRegion, serviceName);
-        return HmacSha256(kService, "aws4_request");
-    }
-
-    private static byte[] HmacSha256(byte[] key, string data) {
-        using var hmac = new HMACSHA256(key);
-        return hmac.ComputeHash(Encoding.UTF8.GetBytes(data));
-    }
-
-    private static string Sha256Hex(string data) {
-        using var sha = SHA256.Create();
-        var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(data));
-        return ToHex(hash);
-    }
-
-    private static string ToHex(byte[] bytes) {
-        var builder = new StringBuilder(bytes.Length * 2);
-        for (var i = 0; i < bytes.Length; i++) {
-            builder.Append(bytes[i].ToString("x2", CultureInfo.InvariantCulture));
-        }
-        return builder.ToString();
-    }
 }

--- a/Sources/Mailozaurr/SentMessages/Senders/SesPendingMessageSender.cs
+++ b/Sources/Mailozaurr/SentMessages/Senders/SesPendingMessageSender.cs
@@ -55,7 +55,9 @@ public sealed class SesPendingMessageSender : IPendingMessageSender {
 #else
                 var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
-                throw new HttpRequestException($"SES returned {(int)response.StatusCode} ({response.StatusCode}): {error}");
+                throw HttpRetryPolicy.CreateFailure(
+                    response.StatusCode,
+                    $"SES returned {(int)response.StatusCode} ({response.StatusCode}): {error}");
             }
         }
     }

--- a/Sources/Mailozaurr/Smtp/ClientSmtp.cs
+++ b/Sources/Mailozaurr/Smtp/ClientSmtp.cs
@@ -184,9 +184,9 @@ public partial class ClientSmtp : SmtpClient {
                 }
 
                 if (descriptor is FileAttachmentDescriptor fileDescriptor && !File.Exists(fileDescriptor.FilePath)) {
-                    LoggingMessages.Logger.WriteWarning(
-                        $"Send-EmailMessage - File not found: {fileDescriptor.FilePath}. Skipping attachment.");
-                    continue;
+                    throw new FileNotFoundException(
+                        $"Attachment '{fileDescriptor.FilePath}' was not found.",
+                        fileDescriptor.FilePath);
                 }
 
                 bodyBuilder.Attachments.Add(descriptor.CreateMimeEntity(inline: false));
@@ -205,9 +205,9 @@ public partial class ClientSmtp : SmtpClient {
                 }
 
                 if (descriptor is FileAttachmentDescriptor fileDescriptor && !File.Exists(fileDescriptor.FilePath)) {
-                    LoggingMessages.Logger.WriteWarning(
-                        $"Send-EmailMessage - File not found: {fileDescriptor.FilePath}. Skipping inline attachment.");
-                    continue;
+                    throw new FileNotFoundException(
+                        $"Inline attachment '{fileDescriptor.FilePath}' was not found.",
+                        fileDescriptor.FilePath);
                 }
 
                 var entity = descriptor.CreateMimeEntity(inline: true);

--- a/Sources/Mailozaurr/Smtp/Smtp.Send.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.Send.cs
@@ -207,19 +207,13 @@ public partial class Smtp {
         return $"{userName}|{_activeSecureSocketOptions}|{_activeUseSsl}";
     }
 
-    private TimeSpan CalculateRetryDelay(int attempt) {
-        if (attempt < 0) attempt = 0;
-        var delayMilliseconds = (int)Math.Round(RetryDelayMilliseconds * Math.Pow(RetryDelayBackoff, attempt));
-        if (MaxDelayMilliseconds > 0 && delayMilliseconds > MaxDelayMilliseconds) {
-            delayMilliseconds = MaxDelayMilliseconds;
-        }
-        if (JitterMilliseconds > 0 && delayMilliseconds > 0) {
-            delayMilliseconds += GraphRetryHelperRandom.NextInt(JitterMilliseconds + 1);
-        }
-        return delayMilliseconds > 0
-            ? TimeSpan.FromMilliseconds(delayMilliseconds)
-            : TimeSpan.Zero;
-    }
+    internal TimeSpan CalculateRetryDelay(int attempt) =>
+        RetryDelayCalculator.Calculate(
+            RetryDelayMilliseconds,
+            RetryDelayBackoff,
+            attempt,
+            MaxDelayMilliseconds,
+            JitterMilliseconds);
 
     private string EnsureMessageId() {
         var id = Message.MessageId;

--- a/Sources/Mailozaurr/Smtp/Smtp.Send.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.Send.cs
@@ -252,9 +252,9 @@ public partial class Smtp {
         await PendingMessageRepository.RemoveAsync(safeMessageId, cancellationToken);
     }
 
-    private async Task EnqueuePendingMessageAsync(string messageId, ICredentialProtector credentialProtector, CancellationToken cancellationToken) {
+    private async Task<bool> EnqueuePendingMessageAsync(string messageId, ICredentialProtector credentialProtector, CancellationToken cancellationToken) {
         if (PendingMessageRepository == null) {
-            return;
+            return false;
         }
 
         using var ms = new MemoryStream();
@@ -274,6 +274,7 @@ public partial class Smtp {
             ProviderData = CreateProviderDataSnapshot()
         };
         await PendingMessageRepository.SaveAsync(record, cancellationToken);
+        return true;
     }
 
     private async Task<SmtpResult?> EnsureMessageReadyAsync(CancellationToken cancellationToken) {
@@ -471,9 +472,10 @@ public partial class Smtp {
                         throw;
                     }
                     var id = EnsureMessageId();
-                    await EnqueuePendingMessageAsync(id, credentialProtector, cancellationToken);
+                    var queued = await EnqueuePendingMessageAsync(id, credentialProtector, cancellationToken);
                     var failResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", ex.Message) {
-                        MessageId = id
+                        MessageId = id,
+                        Queued = queued
                     };
                     await Helpers.PostWebhookAsync(WebhookUrl, failResult, cancellationToken);
                     return failResult;
@@ -488,9 +490,10 @@ public partial class Smtp {
         } while (attempts <= RetryCount);
 
         var finalId = EnsureMessageId();
-        await EnqueuePendingMessageAsync(finalId, credentialProtector, cancellationToken);
+        var finalQueued = await EnqueuePendingMessageAsync(finalId, credentialProtector, cancellationToken);
         var finalResult = new SmtpResult(false, EmailAction.Send, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "", lastException?.Message) {
-            MessageId = finalId
+            MessageId = finalId,
+            Queued = finalQueued
         };
         await Helpers.PostWebhookAsync(WebhookUrl, finalResult, cancellationToken);
         return finalResult;

--- a/Sources/Mailozaurr/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr/Smtp/Smtp.cs
@@ -805,7 +805,21 @@ public partial class Smtp {
     /// <param name="Credentials"></param>
     /// <param name="isOAuth"></param>
     /// <returns></returns>
-    public async Task<SmtpResult> AuthenticateAsync(ICredentials Credentials, bool isOAuth = false) {
+    public Task<SmtpResult> AuthenticateAsync(ICredentials Credentials, bool isOAuth = false) =>
+        AuthenticateAsync(Credentials, isOAuth, CancellationToken.None);
+
+    /// <summary>
+    /// Asynchronously authenticates using the provided credentials.
+    /// </summary>
+    /// <param name="Credentials">Credentials used for authentication.</param>
+    /// <param name="isOAuth">Whether the credentials contain an OAuth token.</param>
+    /// <param name="cancellationToken">Token used to cancel authentication.</param>
+    /// <returns>The authentication result.</returns>
+    public async Task<SmtpResult> AuthenticateAsync(
+        ICredentials Credentials,
+        bool isOAuth,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
         if (DryRun) {
             LogVerbose("Send-EmailMessage - DryRun enabled, skipping authentication.");
             return new SmtpResult(true, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "Authentication skipped (WhatIf)");
@@ -817,14 +831,16 @@ public partial class Smtp {
                     Credential = networkCredential;
                     var (userName, token) = Helpers.ConvertFromOAuth2Credential(networkCredential);
                     var oauth2 = new SaslMechanismOAuth2(userName, token);
-                    await Client.AuthenticateAsync(oauth2);
+                    await Client.AuthenticateAsync(oauth2, cancellationToken);
                 }
                 LogVerbose($"Send-EmailMessage - Authenticated using oAuth");
             } else {
                 Credential = Credentials as NetworkCredential;
-                await Client.AuthenticateAsync(Credentials);
+                await Client.AuthenticateAsync(Credentials, cancellationToken);
             }
             return new SmtpResult(true, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            throw;
         } catch (Exception ex) {
             LogWarning($"Send-EmailMessage - Error during authentication (oAuth): {ex.Message}");
             LogWarning($"Send-EmailMessage - Possible issue: OAuth? ({isOAuth} was used), ICredentials? ({Credentials}, was used).");

--- a/Sources/Mailozaurr/Smtp/SmtpResult.cs
+++ b/Sources/Mailozaurr/Smtp/SmtpResult.cs
@@ -18,6 +18,8 @@ public class SmtpResult {
     public string SentFrom { get; set; }
     /// <summary>Identifier of the message associated with the result.</summary>
     public string? MessageId { get; set; }
+    /// <summary>Whether the failed send was successfully persisted for later delivery.</summary>
+    public bool Queued { get; set; }
     /// <summary>Optional message returned by the operation.</summary>
     public string? Message { get; set; }
     /// <summary>Time taken to perform the action.</summary>


### PR DESCRIPTION
## What changed

- adds normalized `IMailSendService` handlers for SendGrid, Mailgun, and Amazon SES
- keeps SMTP, Graph, Gmail, REST, and the new providers behind the same draft, profile, secret, retry, cancellation, and durable-queue contracts
- preserves recipients, attachments, inline content, priority, and provider-native message IDs across normalized delivery paths
- makes confirmed queue persistence part of the shared `SmtpResult` contract, so fast workers cannot turn a successfully queued send into a false failure
- adds defensive in-memory profile and secret stores for embedded consumers

## Correctness and security

- missing attachments fail before dispatch instead of producing successful incomplete mail
- Mailgun selects file-backed attachments once across legacy, structured, regular, and inline inputs for both immediate multipart requests and queued MIME artifacts
- retries remain transient-aware; `RetryAlways` is honored by every provider, while explicit `QueueOnFailure` persists any terminal provider failure
- one bounded retry-delay calculator now serves SMTP, Graph, HTTP providers, connection retries, and Graph attachment uploads; jitter cannot exceed the configured maximum
- queue success is reported only after persistence completes and does not depend on a racy post-save lookup
- SendGrid retains its 30-second request deadline without mutating the shared HTTP client
- stream attachments remain reusable across retries and queue persistence
- OAuth cache keys no longer expose Graph client secrets; cache writes use cross-process reload-and-merge locking with bounded acquisition retries
- immediate and queued SES delivery share one SigV4 request factory, and the signed `Content-Type` exactly matches the transmitted header
- SMTP connect and authentication honor caller cancellation, including injected delegates, and owned sessions are disposed on every exceptional exit
- shared HTTP clients retain connection pooling while owned handlers, responses, and provider clients have deterministic disposal behavior

## Compatibility

Existing direct provider clients remain supported. `SmtpResult.Queued` is an additive result field and is true only when the failed message was actually persisted. The normalized draft uses the existing `Mailozaurr.MessagePriority` enum rather than introducing a second application-only enum. SMTP profiles can explicitly opt into anonymous relay; authentication remains enabled by default.

## Validation

- full Release test-project build: no warnings or errors
- .NET 8: 1,247 passed, one intentional PGP skip
- .NET Framework 4.7.2: 1,043 passed, one intentional PGP skip
- NuGet vulnerability audit: no vulnerable direct or transitive packages
- all actionable delivery and security review findings addressed, replied to, and resolved