### PR TITLE
Configure grouped low-noise Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,28 @@
 version: 2
 updates:
-  - package-ecosystem: "nuget"
-    directory: "/Sources"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-      timezone: "Europe/Warsaw"
-    open-pull-requests-limit: 10
-    groups:
-      dotnet-platform:
-        patterns:
-          - "Microsoft.*"
-          - "System.*"
-      mail-stack:
-        patterns:
-          - "BouncyCastle.Cryptography"
-          - "MailKit"
-          - "MimeKit"
-      test-packages:
-        patterns:
-          - "coverlet.*"
-          - "Microsoft.NET.Test.Sdk"
-          - "Moq"
-          - "PowerShellStandard.Library"
-          - "xunit*"
+- package-ecosystem: nuget
+  directory: /Sources
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 7
+    include:
+    - '*'
+  open-pull-requests-limit: 1
+  groups:
+    all-dependencies:
+      patterns:
+      - '*'
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 7
+    include:
+    - '*'
+  open-pull-requests-limit: 1
+  groups:
+    all-dependencies:
+      patterns:
+      - '*'


### PR DESCRIPTION
Group ordinary dependency updates so the repository stays current without producing a PR storm.

This covers `nuget`, `github-actions`, checks daily, waits seven days before proposing ordinary releases, and keeps one grouped version-update PR open per ecosystem. Security updates remain immediate.