### PR TITLE
Restore PowerShell 7 and SMTP relay compatibility

### DIFF
--- a/Docs/Send-EmailMessage.md
+++ b/Docs/Send-EmailMessage.md
@@ -123,13 +123,13 @@ Accept wildcard characters: False
 ```
 
 ### -AuthenticationMechanism
-Specifies the SASL mechanism for authentication. Defaults to Plain.
+Specifies the SASL mechanism for authentication. Defaults to Auto, which negotiates a mechanism advertised by the server.
 
 ```yaml
 Type: AuthenticationMechanism
 Parameter Sets: SecureString
 Aliases: None
-Possible values: Plain, Login, CramMd5
+Possible values: Plain, Login, CramMd5, Auto
 
 Required: False
 Position: named

--- a/Sources/Mailozaurr.Internet/Enums/AuthenticationMechanism.cs
+++ b/Sources/Mailozaurr.Internet/Enums/AuthenticationMechanism.cs
@@ -11,15 +11,20 @@ public enum AuthenticationMechanism {
     /// <summary>
     /// Plain text authentication mechanism.
     /// </summary>
-    Plain,
+    Plain = 0,
 
     /// <summary>
     /// LOGIN authentication mechanism.
     /// </summary>
-    Login,
+    Login = 1,
 
     /// <summary>
     /// Challenge-response authentication using CRAM-MD5.
     /// </summary>
-    CramMd5
+    CramMd5 = 2,
+
+    /// <summary>
+    /// Automatically selects a mechanism advertised by the SMTP server.
+    /// </summary>
+    Auto = 3
 }

--- a/Sources/Mailozaurr.Internet/Smtp/Smtp.cs
+++ b/Sources/Mailozaurr.Internet/Smtp/Smtp.cs
@@ -912,7 +912,7 @@ public partial class Smtp {
     /// previously protected.</param>
     /// <param name="mechanism">Authentication mechanism to use.</param>
     /// <returns>An <see cref="SmtpResult"/> representing the outcome.</returns>
-    public SmtpResult Authenticate(string username, string password, bool isSecureString, AuthenticationMechanism mechanism = AuthenticationMechanism.Plain) {
+    public SmtpResult Authenticate(string username, string password, bool isSecureString, AuthenticationMechanism mechanism = AuthenticationMechanism.Auto) {
         if (DryRun) {
             LogVerbose("Send-EmailMessage - DryRun enabled, skipping authentication.");
             return new SmtpResult(true, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, "Authentication skipped (WhatIf)");
@@ -935,9 +935,14 @@ public partial class Smtp {
                 case AuthenticationMechanism.Login:
                     Client.Authenticate(new SaslMechanismLogin(username, password));
                     break;
-                default:
+                case AuthenticationMechanism.Plain:
                     Client.Authenticate(new SaslMechanismPlain(username, password));
                     break;
+                case AuthenticationMechanism.Auto:
+                    Client.Authenticate(username, password);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mechanism), mechanism, "Unsupported SMTP authentication mechanism.");
             }
             LogVerbose($"Send-EmailMessage - Authenticated as {username}");
             return new SmtpResult(true, EmailAction.Authenticate, SentTo, SentFrom, Server, Port, Stopwatch.Elapsed, Logging);

--- a/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
+++ b/Sources/Mailozaurr.PowerShell/CmdletSendEmailMessage.Parameters.cs
@@ -171,10 +171,10 @@ public sealed partial class CmdletSendEmailMessage : PSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "SecureString")]
     public string? Password { get; set; }
     /// <summary>
-    /// <para>Specifies the SASL mechanism for authentication. Defaults to Plain.</para>
+    /// <para>Specifies the SASL mechanism for authentication. Defaults to Auto, which negotiates a mechanism advertised by the server.</para>
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "SecureString")]
-    public AuthenticationMechanism AuthenticationMechanism { get; set; } = AuthenticationMechanism.Plain;
+    public AuthenticationMechanism AuthenticationMechanism { get; set; } = AuthenticationMechanism.Auto;
     /// <summary>
     /// <para>Specifies the secure socket options for SMTP connection. Options: None, Auto, StartTls, StartTlsWhenAvailable, SslOnConnect. Default is Auto.</para>
     /// </summary>

--- a/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
+++ b/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
@@ -52,14 +52,12 @@
         <Delete Files="$(OutDir)System.Management.dll" />
     </Target>
 
-    <!-- Do not ship framework assemblies for PowerShell 7+ (net8.0) to avoid version conflicts with
-    the host -->
+    <!-- Remove PowerShell host assemblies and adjacent framework facades from the publish root.
+    Package-owned runtime and crypto dependencies stay in the isolated module payload so older hosts
+    do not have to satisfy newer assembly references. -->
     <Target Name="RemoveFilesAfterPublish" AfterTargets="Publish"
         Condition=" '$(TargetFramework)' == 'net8.0' ">
         <ItemGroup>
-            <FilesToDelete Include="$(PublishDir)System.Formats.Asn1.dll" />
-            <FilesToDelete Include="$(PublishDir)System.Security.Cryptography.Pkcs.dll" />
-            <FilesToDelete Include="$(PublishDir)System.Security.Cryptography.ProtectedData.dll" />
             <FilesToDelete Include="$(PublishDir)System.Management.Automation.dll" />
             <FilesToDelete Include="$(PublishDir)System.Management.dll" />
         </ItemGroup>

--- a/Sources/Mailozaurr.Tests/SmtpAuthenticationMechanismTests.cs
+++ b/Sources/Mailozaurr.Tests/SmtpAuthenticationMechanismTests.cs
@@ -7,9 +7,35 @@ namespace Mailozaurr.Tests;
 public class SmtpAuthenticationMechanismTests {
     private class FakeClient : ClientSmtp {
         public SaslMechanism? Mechanism;
+        public bool UsedAutomaticNegotiation;
+
         public override void Authenticate(SaslMechanism mechanism, System.Threading.CancellationToken cancellationToken = default) {
             Mechanism = mechanism;
         }
+
+        public override void Authenticate(System.Text.Encoding encoding, System.Net.ICredentials credentials, System.Threading.CancellationToken cancellationToken = default) {
+            UsedAutomaticNegotiation = true;
+        }
+    }
+
+    [Fact]
+    public void SendEmailMessage_DefaultsToAutomaticMechanismSelection() {
+        var cmdlet = new Mailozaurr.PowerShell.CmdletSendEmailMessage();
+
+        Assert.Equal(AuthenticationMechanism.Auto, cmdlet.AuthenticationMechanism);
+    }
+
+    [Fact]
+    public void Authenticate_DefaultsToAutomaticMechanismSelection() {
+        var smtp = new Smtp();
+        var fake = new FakeClient();
+        var field = typeof(Smtp).GetField("<Client>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(smtp, fake);
+
+        smtp.Authenticate("user", "pass", false);
+
+        Assert.True(fake.UsedAutomaticNegotiation);
+        Assert.Null(fake.Mechanism);
     }
 
     [Fact]
@@ -21,6 +47,7 @@ public class SmtpAuthenticationMechanismTests {
 
         smtp.Authenticate("user", "pass", false, AuthenticationMechanism.CramMd5);
 
+        Assert.False(fake.UsedAutomaticNegotiation);
         Assert.IsType<SaslMechanismCramMd5>(fake.Mechanism);
     }
 }

--- a/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Tests.ps1
@@ -1,5 +1,5 @@
 Describe 'Packaged AssemblyLoadContext isolation' {
-    It 'loads binary cmdlets and allowlisted public types from the module ALC' {
+    It 'loads binary cmdlets, package dependencies, and allowlisted public types from the module ALC' {
         if ($PSVersionTable.PSEdition -ne 'Core') {
             Set-ItResult -Skipped -Because 'module-scoped AssemblyLoadContext is PowerShell Core-only'
             return
@@ -11,6 +11,15 @@ Describe 'Packaged AssemblyLoadContext isolation' {
         $packagedModule = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $packagedLoader.FullName))
         $packagedModuleRoot = Split-Path -Parent $packagedModule
         $expectedCommandAssemblyPath = (Resolve-Path -LiteralPath (Join-Path $packagedModule 'Lib\Core\Mailozaurr.PowerShell.dll')).ProviderPath
+        $expectedIsolatedDependencyNames = @(
+            'System.Formats.Asn1'
+            'System.Security.Cryptography.Pkcs'
+            'System.Security.Cryptography.ProtectedData'
+        )
+        $expectedCorePath = (Resolve-Path -LiteralPath (Join-Path $packagedModule 'Lib\Core')).ProviderPath
+        foreach ($dependencyName in $expectedIsolatedDependencyNames) {
+            $null = Get-Item -LiteralPath (Join-Path $expectedCorePath "$dependencyName.dll") -ErrorAction Stop
+        }
 
         $moduleRootLiteral = $packagedModuleRoot.Replace("'", "''")
         $script = @"
@@ -32,6 +41,39 @@ Import-Module Mailozaurr -Force
 `$mimeAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$message.GetType().Assembly)
 `$mailKitAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$query.GetType().Assembly)
 `$smtp = [Mailozaurr.Smtp]::new()
+`$securePassword = ConvertTo-SecureString 'mailozaurr-regression' -AsPlainText -Force
+`$protectedPassword = ConvertFrom-SecureString `$securePassword
+`$plainPassword = `$smtp.ConvertSecureStringToPlainString(`$protectedPassword, `$true)
+`$isolatedDependencyNames = @(
+    'System.Formats.Asn1'
+    'System.Security.Cryptography.Pkcs'
+    'System.Security.Cryptography.ProtectedData'
+)
+foreach (`$dependencyName in `$isolatedDependencyNames) {
+    `$dependencyAssemblyName = [System.Reflection.AssemblyName]::new(`$dependencyName)
+    `$null = `$commandAlc.LoadFromAssemblyName(`$dependencyAssemblyName)
+}
+`$isolatedDependencies = [ordered] @{}
+foreach (`$dependencyName in `$isolatedDependencyNames) {
+    `$dependencyAssembly = @(
+        [AppDomain]::CurrentDomain.GetAssemblies() | Where-Object {
+            `$_.GetName().Name -eq `$dependencyName -and
+            [object]::ReferenceEquals(
+                [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$_),
+                `$commandAlc
+            )
+        }
+    ) | Select-Object -First 1
+    `$isolatedDependencies[`$dependencyName] = [pscustomobject] @{
+        Path = `$dependencyAssembly.Location
+        Version = `$dependencyAssembly.GetName().Version.ToString()
+        ALC = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$dependencyAssembly).Name
+        ALCIsDefault = [object]::ReferenceEquals(
+            [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$dependencyAssembly),
+            [System.Runtime.Loader.AssemblyLoadContext]::Default
+        )
+    }
+}
 `$expectedAllowedTypes = @(
     'Mailozaurr.Definitions.EmailMessageContent'
     'Mailozaurr.EmailEncryption'
@@ -135,6 +177,8 @@ try {
     SearchQueryALC = `$mailKitAlc.Name
     SearchQueryALCIsDefault = [object]::ReferenceEquals(`$mailKitAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
     SmtpCreated = `$null -ne `$smtp
+    SecurePasswordRoundTrip = `$plainPassword
+    IsolatedDependencies = `$isolatedDependencies
     AllowedTypeCount = `$expectedAllowedTypes.Count
     ActualAllowedTypeCount = `$actualAllowedTypes.Count
     MissingAllowedTypes = @(`$missingAllowedTypes)
@@ -175,6 +219,14 @@ try {
         $result.SearchQueryALC | Should -Be 'Mailozaurr'
         $result.SearchQueryALCIsDefault | Should -BeFalse
         $result.SmtpCreated | Should -BeTrue
+        $result.SecurePasswordRoundTrip | Should -Be 'mailozaurr-regression'
+        foreach ($dependencyName in $expectedIsolatedDependencyNames) {
+            $dependency = $result.IsolatedDependencies.$dependencyName
+            ($dependency.Path -replace '\\', '/') | Should -BeLike "$(($expectedCorePath -replace '\\', '/'))/*"
+            $dependency.Version | Should -Be '10.0.0.0'
+            $dependency.ALC | Should -Be 'Mailozaurr'
+            $dependency.ALCIsDefault | Should -BeFalse
+        }
         $result.AllowedTypeCount | Should -Be 41
         $result.ActualAllowedTypeCount | Should -Be 41
         @($result.MissingAllowedTypes).Count | Should -Be 0

--- a/en-US/Mailozaurr-help.xml
+++ b/en-US/Mailozaurr-help.xml
@@ -26554,13 +26554,14 @@ StartTls to be used automatically.</maml:para>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>AuthenticationMechanism</maml:name>
           <maml:description>
-            <maml:para>Specifies the SASL mechanism for authentication. Defaults to Plain.</maml:para>
+            <maml:para>Specifies the SASL mechanism for authentication. Defaults to Auto, which negotiates a mechanism advertised by the server.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">AuthenticationMechanism</command:parameterValue>
           <command:parameterValueGroup>
             <command:parameterValue required="false" variableLength="false">Plain</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Login</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">CramMd5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
           </command:parameterValueGroup>
           <dev:type>
             <maml:name>AuthenticationMechanism</maml:name>
@@ -29865,13 +29866,14 @@ type. Without this switch, only transient errors are retried.</maml:para>
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>AuthenticationMechanism</maml:name>
         <maml:description>
-          <maml:para>Specifies the SASL mechanism for authentication. Defaults to Plain.</maml:para>
+          <maml:para>Specifies the SASL mechanism for authentication. Defaults to Auto, which negotiates a mechanism advertised by the server.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">AuthenticationMechanism</command:parameterValue>
         <command:parameterValueGroup>
           <command:parameterValue required="false" variableLength="false">Plain</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">Login</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">CramMd5</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
         </command:parameterValueGroup>
         <dev:type>
           <maml:name>AuthenticationMechanism</maml:name>


### PR DESCRIPTION
## Summary

- Keep the package-owned `System.Formats.Asn1`, `System.Security.Cryptography.Pkcs`, and `System.Security.Cryptography.ProtectedData` assemblies in Mailozaurr's isolated module payload.
- Restore automatic SMTP authentication negotiation for username/password calls while retaining explicit `Plain`, `Login`, and `CramMd5` overrides.
- Preserve the existing authentication enum values and add `Auto` as the new default.
- Cover the packaged secure-password path and SMTP mechanism routing with regression tests, and refresh generated command help.

## Why

Mailozaurr 2.1.6 can fail before SMTP authentication on PowerShell 7.4 because its binaries reference the version 10 cryptography family while the module package removes those assemblies and the .NET 8 host only supplies version 8. The same release line also forces `AUTH PLAIN` for username/password calls, which breaks relays that accept a different advertised mechanism with `504 5.7.4 Unrecognized authentication type`.

These failures do not require a PasswordSolution configuration or password change. The module should own its newer cryptography dependencies inside its non-default load context and let MailKit negotiate the server-supported SMTP mechanism unless the caller explicitly selects one.

## Compatibility

The packaged module was exercised on PowerShell 7.4.6 and Windows PowerShell 5.1 with the secure-password round trip and the `Auto` cmdlet default. Focused SMTP tests pass on both `net8.0` and `net472`, and the repository-native coordinated module/package build completes successfully.

Existing explicit authentication mechanism selections remain supported. Compiled .NET callers that relied on the former optional argument value must rebuild to adopt the new default; the rebuilt PowerShell cmdlet uses `Auto` directly.