### PR TITLE
Use stable versioned tags for coordinated releases

### DIFF
--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -39,6 +39,6 @@
   "GitHubGenerateReleaseNotes": true,
   "GitHubReleaseMode": "Single",
   "GitHubPrimaryProject": "Mailozaurr",
-  "GitHubTagTemplate": "{Repo}-v{UtcTimestamp}",
-  "GitHubReleaseName": "{Repo} {UtcDateTime}"
+  "GitHubTagTemplate": "{Repo}-v{PrimaryVersion}",
+  "GitHubReleaseName": "{Repo} {PrimaryVersion}"
 }


### PR DESCRIPTION
## Summary

- derive the coordinated GitHub tag from the primary package version instead of the current timestamp
- name the GitHub release from that same version
- make a failed or interrupted `3.0.0` release retry the same `Mailozaurr-v3.0.0` target

This configuration change is sufficient to unblock the current release with PSPublishModule 3.0.123.1. EvotecIT/PSPublishModule#792 separately improves PowerForge so this configuration error fails before package build and signing work begins.

## Validation

- `Build/project.build.json` passes the PowerForge project-build schema
- version `3.0.0` resolves to tag `Mailozaurr-v3.0.0` and release name `Mailozaurr 3.0.0`
- confirmed no Mailozaurr 3.0.0 package, PSGallery module, GitHub release, or tag was partially published by the failed attempt