### PR TITLE
Add POP3 application workflows and profile diagnostics

### DIFF
--- a/Docs/Configuration-and-Usage.md
+++ b/Docs/Configuration-and-Usage.md
@@ -55,7 +55,7 @@ In practice:
 | Kind | Read/Search | Folders | Move/Mark/Delete | Send | Notes |
 |---|---|---|---|---|---|
 | `imap` | Yes | Yes | Yes | No | strong mailbox model |
-| `pop3` | Yes | No real folder model | Delete only style workflows | No | limited mailbox model |
+| `pop3` | Yes | Virtual `INBOX` only | No normalized actions | No | UIDL-backed ids with content-hash fallback |
 | `graph` | Yes | Yes | Yes | Yes | also supports rules/events/permissions |
 | `gmail` | Yes | Yes | Yes | Yes | Gmail-specific threads/labels |
 | `smtp` | No | No | No | Yes | send only |
@@ -227,6 +227,28 @@ Remove-Item Env:MAILOZAURR_IMAP_PASSWORD
 mailozaurr profile test --profile work-imap --scope mailbox --json
 ```
 
+### Generic POP3 profile
+
+```powershell
+mailozaurr profile create --profile archive-pop3 --kind pop3 --name "Archive POP3" `
+  --default-mailbox user@example.com `
+  --setting server=pop.example.com `
+  --setting port=995 `
+  --setting userName=user@example.com `
+  --json
+
+$env:MAILOZAURR_POP3_PASSWORD = '<password>'
+mailozaurr profile set-secret --profile archive-pop3 --name password `
+  --value-env MAILOZAURR_POP3_PASSWORD --json
+Remove-Item Env:MAILOZAURR_POP3_PASSWORD
+
+mailozaurr profile test --profile archive-pop3 --scope mailbox --json
+mailozaurr mail folders --profile archive-pop3 --json
+mailozaurr mail search --profile archive-pop3 --query Invoice --json
+```
+
+Normalized POP3 operations expose one virtual `INBOX`. Message ids prefer the server UIDL as `uid:<value>` and fall back to a content-verified `hash:<value>` when UIDL is unavailable. The hash path safely re-identifies the message across sessions instead of reusing a session-local POP3 index. Use the returned id unchanged with `mail get` and attachment commands.
+
 ### Generic SMTP profile
 
 ```powershell
@@ -245,6 +267,8 @@ Remove-Item Env:MAILOZAURR_SMTP_PASSWORD
 
 mailozaurr profile test --profile alerts-smtp --scope send --json
 ```
+
+`profile test --json` keeps the existing summary fields and also returns ordered `Stages`. Each stage identifies the observable profile, session, mailbox, provider-probe, or send-preflight phase, its duration, target, and failure code. Mailozaurr reports the combined session operation exposed by each provider factory; it does not invent separate DNS, TCP, TLS, or authentication timings when those boundaries are not observable.
 
 ### Microsoft Graph profile
 

--- a/Docs/Configuration-and-Usage.md
+++ b/Docs/Configuration-and-Usage.md
@@ -311,7 +311,10 @@ mailozaurr mail folders --profile work-imap --compact --json
 mailozaurr mail search --profile work-imap --folder Inbox --query Invoice --compact --json
 mailozaurr mail get --profile work-imap --folder Inbox --message-id 123 --compact --json
 mailozaurr mail attachments --profile work-imap --folder Inbox --message-id 123 --json
+mailozaurr mail save-attachments --profile work-imap --folder Inbox --message-id 123 --path C:\Temp\Attachments --json
 ```
+
+When `--path` names a directory, saved files keep a readable prefix and add a deterministic SHA-256 identity suffix from the exact provider filename. This prevents distinct remote names from overwriting one another after path removal, character replacement, or case folding. An explicit file path is used unchanged.
 
 ### Save drafts and queue sends
 

--- a/Docs/Configuration-and-Usage.md
+++ b/Docs/Configuration-and-Usage.md
@@ -247,7 +247,7 @@ mailozaurr mail folders --profile archive-pop3 --json
 mailozaurr mail search --profile archive-pop3 --query Invoice --json
 ```
 
-Normalized POP3 operations expose one virtual `INBOX`. Message ids prefer the server UIDL as `uid:<value>` and fall back to a content-verified `hash:<value>` when UIDL is unavailable. The hash path safely re-identifies the message across sessions instead of reusing a session-local POP3 index. Use the returned id unchanged with `mail get` and attachment commands.
+Normalized POP3 operations expose one virtual `INBOX`. Message ids prefer the server UIDL as `uid:<value>` and fall back to `hash:<sha256>:<occurrence>` when UIDL is unavailable. The fallback verifies message content and disambiguates byte-identical entries by their oldest-first occurrence while those entries coexist; only UIDL provides a server-owned persistent identity across mailbox mutations. Use the returned id unchanged with `mail get` and attachment commands.
 
 ### Generic SMTP profile
 
@@ -314,7 +314,7 @@ mailozaurr mail attachments --profile work-imap --folder Inbox --message-id 123 
 mailozaurr mail save-attachments --profile work-imap --folder Inbox --message-id 123 --path C:\Temp\Attachments --json
 ```
 
-When `--path` names a directory, saved files keep a readable prefix and add a deterministic SHA-256 identity suffix from the exact provider filename. This prevents distinct remote names from overwriting one another after path removal, character replacement, or case folding. An explicit file path is used unchanged.
+When `--path` names a directory, saved files keep a readable prefix and add a deterministic SHA-256 identity suffix from the exact provider filename plus the profile, mailbox, folder, message, and provider/per-part identity. This prevents distinct remote names, repeated same-name parts, and cross-message batch saves from overwriting one another after path removal, character replacement, or case folding. An explicit file path is used unchanged.
 
 ### Save drafts and queue sends
 

--- a/Docs/Configuration-and-Usage.md
+++ b/Docs/Configuration-and-Usage.md
@@ -247,7 +247,7 @@ mailozaurr mail folders --profile archive-pop3 --json
 mailozaurr mail search --profile archive-pop3 --query Invoice --json
 ```
 
-Normalized POP3 operations expose one virtual `INBOX`. Message ids prefer the server UIDL as `uid:<value>` and fall back to `hash:<sha256>:<occurrence>` when UIDL is unavailable. The fallback verifies message content and disambiguates byte-identical entries by their oldest-first occurrence while those entries coexist; only UIDL provides a server-owned persistent identity across mailbox mutations. Use the returned id unchanged with `mail get` and attachment commands.
+Normalized POP3 operations expose one virtual `INBOX`. Message ids prefer the server UIDL as `uid:<value>` and fall back to `hash:<sha256>:<occurrence>` when UIDL is unavailable. The fallback verifies message content and disambiguates byte-identical entries by their newest-first occurrence while those entries coexist; only UIDL provides a server-owned persistent identity across mailbox mutations. Use the returned id unchanged with `mail get` and attachment commands.
 
 ### Generic SMTP profile
 

--- a/README.MD
+++ b/README.MD
@@ -245,6 +245,8 @@ mailozaurr profile summary --profile work-imap --json
 mailozaurr profile test --profile work-imap --scope mailbox --json
 ```
 
+Connection-test JSON includes ordered, timed stages for profile resolution, session acquisition, and the requested provider probe. POP3 profiles participate in the same application surface with a virtual `INBOX` and normalized `uid:` message identifiers (falling back to a content-verified `hash:` identity when UIDL is unavailable).
+
 Search and inspect mail:
 
 ```powershell

--- a/README.MD
+++ b/README.MD
@@ -257,6 +257,8 @@ mailozaurr mail attachments --profile work-imap --folder Inbox --message-id 123 
 mailozaurr mail save-attachments --profile work-imap --folder Inbox --message-id 123 --path C:\Temp\Attachments --json
 ```
 
+When `--path` names a directory, saved files keep a readable prefix and add a deterministic SHA-256 identity suffix from the exact provider filename. This prevents distinct remote names from overwriting one another after path removal, character replacement, or case folding. An explicit file path is used unchanged.
+
 Draft, send, and queue mail:
 
 ```powershell

--- a/README.MD
+++ b/README.MD
@@ -245,7 +245,7 @@ mailozaurr profile summary --profile work-imap --json
 mailozaurr profile test --profile work-imap --scope mailbox --json
 ```
 
-Connection-test JSON includes ordered, timed stages for profile resolution, session acquisition, and the requested provider probe. POP3 profiles participate in the same application surface with a virtual `INBOX` and normalized `uid:` message identifiers (falling back to a content-verified `hash:` identity when UIDL is unavailable).
+Connection-test JSON includes ordered, timed stages for profile resolution, session acquisition, and the requested provider probe. POP3 profiles participate in the same application surface with a virtual `INBOX` and normalized `uid:` message identifiers (falling back to a content-verified `hash:<sha256>:<occurrence>` identity when UIDL is unavailable).
 
 Search and inspect mail:
 
@@ -257,7 +257,7 @@ mailozaurr mail attachments --profile work-imap --folder Inbox --message-id 123 
 mailozaurr mail save-attachments --profile work-imap --folder Inbox --message-id 123 --path C:\Temp\Attachments --json
 ```
 
-When `--path` names a directory, saved files keep a readable prefix and add a deterministic SHA-256 identity suffix from the exact provider filename. This prevents distinct remote names from overwriting one another after path removal, character replacement, or case folding. An explicit file path is used unchanged.
+When `--path` names a directory, saved files keep a readable prefix and add a deterministic SHA-256 identity suffix from the exact provider filename plus the profile, mailbox, folder, message, and provider/per-part identity. This prevents distinct remote names, repeated same-name parts, and cross-message batch saves from overwriting one another after path removal, character replacement, or case folding. An explicit file path is used unchanged.
 
 Draft, send, and queue mail:
 

--- a/Sources/Mailozaurr.Cli/CliCommandModel.Profile.cs
+++ b/Sources/Mailozaurr.Cli/CliCommandModel.Profile.cs
@@ -39,7 +39,7 @@ internal static partial class CliCommandModel {
             ]),
         Leaf("refresh-auth", "Refresh saved authentication for a profile.", required: ["profile"]),
         Leaf("auth-status", "Show persisted authentication status.", required: ["profile"]),
-        Leaf("test", "Test profile authentication, mailbox, or send readiness.",
+        Leaf("test", "Test profile authentication, mailbox, or send readiness with timed phase evidence.",
             required: ["profile"], optional: ["scope"]),
         Leaf("summary", "Show the normalized profile summary.",
             required: ["profile"], optional: ["compact"]),

--- a/Sources/Mailozaurr.Cli/CliJsonContext.cs
+++ b/Sources/Mailozaurr.Cli/CliJsonContext.cs
@@ -10,6 +10,8 @@ namespace Mailozaurr.Cli;
 [JsonSerializable(typeof(MailProfileAuthenticationResult))]
 [JsonSerializable(typeof(MailProfileAuthStatus))]
 [JsonSerializable(typeof(MailProfileConnectionTestResult))]
+[JsonSerializable(typeof(MailProfileConnectionTestStage))]
+[JsonSerializable(typeof(IReadOnlyList<MailProfileConnectionTestStage>), TypeInfoPropertyName = "MailProfileConnectionTestStageList")]
 [JsonSerializable(typeof(MailProfileOverviewCompact))]
 [JsonSerializable(typeof(MailProfileOverview))]
 [JsonSerializable(typeof(MailProfile))]

--- a/Sources/Mailozaurr.Cli/Mailozaurr.Cli.csproj
+++ b/Sources/Mailozaurr.Cli/Mailozaurr.Cli.csproj
@@ -24,7 +24,7 @@
         <PackageProjectUrl>https://github.com/EvotecIT/Mailozaurr</PackageProjectUrl>
         <PackageReadmeFile>README.MD</PackageReadmeFile>
         <RepositoryUrl>https://github.com/EvotecIT/Mailozaurr</RepositoryUrl>
-        <PackageTags>Windows;MacOS;Linux;Mail;Email;Graph;Gmail;IMAP;SMTP;CLI;MCP</PackageTags>
+        <PackageTags>Windows;MacOS;Linux;Mail;Email;Graph;Gmail;IMAP;POP3;SMTP;CLI;MCP</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.Profiles.cs
+++ b/Sources/Mailozaurr.Cli/Mcp/MailMcpTools.Profiles.cs
@@ -270,7 +270,7 @@ public sealed partial class MailMcpTools {
     }
 
     [McpServerTool(ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = true)]
-    [Description("Runs a live provider connection test for a saved Mailozaurr profile.")]
+    [Description("Runs a provider connection test for a saved Mailozaurr profile and returns timed phase evidence.")]
     public Task<MailProfileConnectionTestResult> mail_profile_test(
         [Description("The saved profile identifier to test.")] string profileId,
         [Description("Optional test scope: auto, auth, mailbox, or send.")] string? scope = null,

--- a/Sources/Mailozaurr.Internet/Connections/ImapConnectionRequest.cs
+++ b/Sources/Mailozaurr.Internet/Connections/ImapConnectionRequest.cs
@@ -46,8 +46,8 @@ public sealed class ImapConnectionRequest {
         if (retryDelayMilliseconds < 0) {
             throw new ArgumentOutOfRangeException(nameof(retryDelayMilliseconds), "Retry delay must be >= 0.");
         }
-        if (retryDelayBackoff <= 0) {
-            throw new ArgumentOutOfRangeException(nameof(retryDelayBackoff), "Retry backoff must be > 0.");
+        if (retryDelayBackoff <= 0 || double.IsNaN(retryDelayBackoff) || double.IsInfinity(retryDelayBackoff)) {
+            throw new ArgumentOutOfRangeException(nameof(retryDelayBackoff), "Retry backoff must be a finite value > 0.");
         }
 
         Server = server;

--- a/Sources/Mailozaurr.Internet/Connections/Pop3ConnectionRequest.cs
+++ b/Sources/Mailozaurr.Internet/Connections/Pop3ConnectionRequest.cs
@@ -1,0 +1,57 @@
+using MailKit.Security;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Describes the transport settings used to establish a POP3 connection.
+/// </summary>
+public sealed class Pop3ConnectionRequest {
+    /// <summary>Creates a POP3 connection request.</summary>
+    public Pop3ConnectionRequest(
+        string server,
+        int port = 995,
+        SecureSocketOptions options = SecureSocketOptions.Auto,
+        int timeout = 30000,
+        bool skipCertificateRevocation = false,
+        bool skipCertificateValidation = false,
+        int retryCount = 3,
+        int retryDelayMilliseconds = 500,
+        double retryDelayBackoff = 2.0) {
+        Server = server;
+        Port = port;
+        Options = options;
+        Timeout = timeout;
+        SkipCertificateRevocation = skipCertificateRevocation;
+        SkipCertificateValidation = skipCertificateValidation;
+        RetryCount = retryCount;
+        RetryDelayMilliseconds = retryDelayMilliseconds;
+        RetryDelayBackoff = retryDelayBackoff;
+    }
+
+    /// <summary>POP3 server hostname.</summary>
+    public string Server { get; }
+
+    /// <summary>POP3 server port.</summary>
+    public int Port { get; }
+
+    /// <summary>TLS mode used for the connection.</summary>
+    public SecureSocketOptions Options { get; }
+
+    /// <summary>Connection timeout in milliseconds.</summary>
+    public int Timeout { get; }
+
+    /// <summary>Whether certificate revocation checks are skipped.</summary>
+    public bool SkipCertificateRevocation { get; }
+
+    /// <summary>Whether certificate validation is skipped.</summary>
+    public bool SkipCertificateValidation { get; }
+
+    /// <summary>Number of connection attempts.</summary>
+    public int RetryCount { get; }
+
+    /// <summary>Initial retry delay in milliseconds.</summary>
+    public int RetryDelayMilliseconds { get; }
+
+    /// <summary>Retry-delay backoff multiplier.</summary>
+    public double RetryDelayBackoff { get; }
+}

--- a/Sources/Mailozaurr.Internet/Connections/Pop3ConnectionRequest.cs
+++ b/Sources/Mailozaurr.Internet/Connections/Pop3ConnectionRequest.cs
@@ -17,6 +17,24 @@ public sealed class Pop3ConnectionRequest {
         int retryCount = 3,
         int retryDelayMilliseconds = 500,
         double retryDelayBackoff = 2.0) {
+        if (string.IsNullOrWhiteSpace(server)) {
+            throw new ArgumentException("Server cannot be null or whitespace.", nameof(server));
+        }
+        if (port <= 0 || port > 65535) {
+            throw new ArgumentOutOfRangeException(nameof(port), "Port must be between 1 and 65535.");
+        }
+        if (timeout < 0) {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be >= 0.");
+        }
+        if (retryCount < 0) {
+            throw new ArgumentOutOfRangeException(nameof(retryCount), "Retry count must be >= 0.");
+        }
+        if (retryDelayMilliseconds < 0) {
+            throw new ArgumentOutOfRangeException(nameof(retryDelayMilliseconds), "Retry delay must be >= 0.");
+        }
+        if (retryDelayBackoff <= 0 || double.IsNaN(retryDelayBackoff) || double.IsInfinity(retryDelayBackoff)) {
+            throw new ArgumentOutOfRangeException(nameof(retryDelayBackoff), "Retry backoff must be a finite value > 0.");
+        }
         Server = server;
         Port = port;
         Options = options;

--- a/Sources/Mailozaurr.Internet/Connections/Pop3Connector.cs
+++ b/Sources/Mailozaurr.Internet/Connections/Pop3Connector.cs
@@ -26,6 +26,34 @@ public static class Pop3Connector {
     /// Delegate used to delay between connection retries.
     /// </summary>
     public static Func<int, CancellationToken, Task>? DelayAsync { get; set; }
+
+    /// <summary>
+    /// Connects and authenticates to a POP3 server using a reusable connection request.
+    /// </summary>
+    public static Task<Pop3Client> ConnectAsync(
+        Pop3ConnectionRequest request,
+        Func<Pop3Client, CancellationToken, Task> authenticateAsync,
+        CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+        if (authenticateAsync == null) {
+            throw new ArgumentNullException(nameof(authenticateAsync));
+        }
+
+        return ConnectAsync(
+            request.Server,
+            request.Port,
+            request.Options,
+            request.Timeout,
+            request.SkipCertificateRevocation,
+            request.SkipCertificateValidation,
+            authenticateAsync,
+            request.RetryCount,
+            request.RetryDelayMilliseconds,
+            request.RetryDelayBackoff,
+            cancellationToken);
+    }
     /// <summary>
     /// Connects and authenticates to a POP3 server with retry support.
     /// </summary>

--- a/Sources/Mailozaurr.Internet/Connections/Pop3SessionService.cs
+++ b/Sources/Mailozaurr.Internet/Connections/Pop3SessionService.cs
@@ -1,0 +1,47 @@
+using MailKit.Net.Pop3;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Describes the parameters required for an authenticated POP3 session.
+/// </summary>
+public sealed class Pop3SessionRequest {
+    /// <summary>Underlying POP3 transport request.</summary>
+    public Pop3ConnectionRequest Connection { get; init; } = new("localhost");
+
+    /// <summary>Authentication username.</summary>
+    public string UserName { get; init; } = string.Empty;
+
+    /// <summary>Authentication secret or token.</summary>
+    public string Secret { get; init; } = string.Empty;
+
+    /// <summary>Protocol authentication mode.</summary>
+    public ProtocolAuthMode AuthMode { get; init; } = ProtocolAuthMode.Basic;
+
+    /// <summary>Optional authentication override used by custom flows and tests.</summary>
+    public Func<Pop3Client, CancellationToken, Task>? AuthenticateAsync { get; init; }
+}
+
+/// <summary>
+/// Establishes authenticated POP3 sessions from reusable requests.
+/// </summary>
+public static class Pop3SessionService {
+    /// <summary>Connects and authenticates a POP3 client.</summary>
+    public static Task<Pop3Client> ConnectAsync(
+        Pop3SessionRequest request,
+        CancellationToken cancellationToken = default) {
+        if (request == null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        return Pop3Connector.ConnectAsync(
+            request.Connection,
+            request.AuthenticateAsync ?? ((client, token) => ProtocolAuth.AuthenticatePop3Async(
+                client,
+                request.UserName,
+                request.Secret,
+                request.AuthMode,
+                token)),
+            cancellationToken);
+    }
+}

--- a/Sources/Mailozaurr.Internet/Receive/ImapMessageReader.cs
+++ b/Sources/Mailozaurr.Internet/Receive/ImapMessageReader.cs
@@ -63,13 +63,15 @@ public static class ImapMessageReader {
         var mailFolder = client.GetCachedFolder(request.Folder, FolderAccess.ReadOnly);
         var message = await mailFolder.GetMessageAsync(request.Uid, cancellationToken).ConfigureAwait(false);
 
-        var attachments = message.Attachments.Select(static attachment => attachment is MimePart part
-            ? new ImapMessageAttachmentInfo(
-                FileName: part.FileName ?? string.Empty,
-                ContentType: part.ContentType?.MimeType ?? string.Empty)
-            : new ImapMessageAttachmentInfo(
-                FileName: string.Empty,
-                ContentType: attachment.ContentType?.MimeType ?? string.Empty)).ToArray();
+        var attachments = message.Attachments.Select(static attachment => new ImapMessageAttachmentInfo(
+            FileName: attachment switch {
+                MimePart part => part.FileName ?? string.Empty,
+                MessagePart messagePart => messagePart.ContentDisposition?.FileName
+                    ?? messagePart.ContentType?.Name
+                    ?? string.Empty,
+                _ => string.Empty
+            },
+            ContentType: attachment.ContentType?.MimeType ?? string.Empty)).ToArray();
 
         var text = TruncateUtf8(message.TextBody, request.MaxBodyBytes, out var textTruncated);
         var html = TruncateUtf8(message.HtmlBody, request.MaxBodyBytes, out var htmlTruncated);

--- a/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.QueryParsing.cs
+++ b/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.QueryParsing.cs
@@ -120,6 +120,7 @@ public static partial class MailboxSearcher {
         public DateTime? Before { get; set; }
         public bool HasAttachment { get; set; }
         public List<SearchQuery> AdditionalQueries { get; } = new();
+        public List<string> MessageContainsTerms { get; } = new();
     }
 
     internal static ParsedQuery ParseQuery(string? query) {
@@ -147,14 +148,19 @@ public static partial class MailboxSearcher {
                 } else if (string.Equals(key, "body", StringComparison.OrdinalIgnoreCase)) {
                     result.BodyContains = value;
                 } else {
-                    result.AdditionalQueries.Add(SearchQuery.MessageContains(token));
+                    AddMessageContains(result, token);
                 }
             } else {
                 var text = Unquote(token);
-                result.AdditionalQueries.Add(SearchQuery.MessageContains(text));
+                AddMessageContains(result, text);
             }
         }
         return result;
+    }
+
+    private static void AddMessageContains(ParsedQuery result, string text) {
+        result.AdditionalQueries.Add(SearchQuery.MessageContains(text));
+        result.MessageContainsTerms.Add(text);
     }
 
     private static DateTime? NormalizeToUtc(DateTime? value) {

--- a/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.cs
@@ -146,20 +146,48 @@ public static partial class MailboxSearcher {
         var results = new List<Pop3EmailMessage>();
         var sinceUtc = NormalizeToUtc(since);
         var beforeUtc = NormalizeToUtc(before);
+        var requiresFullMessageForFiltering =
+            !string.IsNullOrWhiteSpace(bodyContains) ||
+            priority.HasValue ||
+            hasAttachment ||
+            messageContainsTerms.Count > 0;
+        var useHeaderPrefilter = !requiresFullMessageForFiltering &&
+            (!string.IsNullOrWhiteSpace(subject) ||
+             !string.IsNullOrWhiteSpace(fromContains) ||
+             !string.IsNullOrWhiteSpace(toContains) ||
+             sinceUtc.HasValue ||
+             beforeUtc.HasValue);
         for (int i = 0; i < client.Count; i++) {
+            if (useHeaderPrefilter) {
+                var headers = await client.GetMessageHeadersAsync(i, cancellationToken).ConfigureAwait(false);
+                if (!Pop3HeadersMatch(
+                    headers,
+                    subject,
+                    fromContains,
+                    toContains,
+                    sinceUtc,
+                    beforeUtc)) {
+                    continue;
+                }
+            }
+
             var message = await client.GetMessageAsync(i, cancellationToken).ConfigureAwait(false);
-            if (!string.IsNullOrWhiteSpace(subject) && (message.Subject == null || message.Subject.IndexOf(subject, StringComparison.OrdinalIgnoreCase) < 0)) continue;
-            if (!string.IsNullOrWhiteSpace(fromContains) && !AddressMatches(message.From, fromContains!)) continue;
-            if (!string.IsNullOrWhiteSpace(toContains) && !AddressMatches(message.To, toContains!)) continue;
+            if (requiresFullMessageForFiltering) {
+                if (!string.IsNullOrWhiteSpace(subject) && (message.Subject == null || message.Subject.IndexOf(subject, StringComparison.OrdinalIgnoreCase) < 0)) continue;
+                if (!string.IsNullOrWhiteSpace(fromContains) && !AddressMatches(message.From, fromContains!)) continue;
+                if (!string.IsNullOrWhiteSpace(toContains) && !AddressMatches(message.To, toContains!)) continue;
+            }
             if (!string.IsNullOrWhiteSpace(bodyContains)) {
                 var textBody = message.TextBody ?? string.Empty;
                 var htmlBody = message.HtmlBody ?? string.Empty;
                 if (textBody.IndexOf(bodyContains, StringComparison.OrdinalIgnoreCase) < 0 &&
                     htmlBody.IndexOf(bodyContains, StringComparison.OrdinalIgnoreCase) < 0) continue;
             }
-            var msgDate = message.Date.UtcDateTime;
-            if (sinceUtc.HasValue && msgDate < sinceUtc.Value) continue;
-            if (beforeUtc.HasValue && msgDate > beforeUtc.Value) continue;
+            if (requiresFullMessageForFiltering) {
+                var msgDate = message.Date.UtcDateTime;
+                if (sinceUtc.HasValue && msgDate < sinceUtc.Value) continue;
+                if (beforeUtc.HasValue && msgDate > beforeUtc.Value) continue;
+            }
             if (priority.HasValue && message.Priority != ConvertPriority(priority.Value)) continue;
             if (hasAttachment && !message.Attachments.Any()) continue;
             if (messageContainsTerms.Any(term => !MessageContains(message, term))) continue;
@@ -167,6 +195,31 @@ public static partial class MailboxSearcher {
             if (maxResults > 0 && results.Count >= maxResults) break;
         }
         return results;
+    }
+
+    private static bool Pop3HeadersMatch(
+        HeaderList headers,
+        string? subject,
+        string? fromContains,
+        string? toContains,
+        DateTime? sinceUtc,
+        DateTime? beforeUtc) {
+        var message = new MimeMessage(headers);
+        if ((!string.IsNullOrWhiteSpace(subject) &&
+             (message.Subject == null || message.Subject.IndexOf(subject, StringComparison.OrdinalIgnoreCase) < 0)) ||
+            (!string.IsNullOrWhiteSpace(fromContains) && !AddressMatches(message.From, fromContains!)) ||
+            (!string.IsNullOrWhiteSpace(toContains) && !AddressMatches(message.To, toContains!))) {
+            return false;
+        }
+
+        var messageDate = message.Date.UtcDateTime;
+        if (sinceUtc.HasValue && messageDate < sinceUtc.Value) {
+            return false;
+        }
+        if (beforeUtc.HasValue && messageDate > beforeUtc.Value) {
+            return false;
+        }
+        return true;
     }
 
     private static bool MessageContains(MimeMessage message, string text) {

--- a/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.cs
@@ -174,8 +174,15 @@ public static partial class MailboxSearcher {
              querySinceUtc.HasValue ||
              queryBeforeUtc.HasValue);
         for (int i = client.Count - 1; i >= 0; i--) {
+            MimeMessage? message = null;
             if (useHeaderPrefilter) {
-                var headers = await client.GetMessageHeadersAsync(i, cancellationToken).ConfigureAwait(false);
+                HeaderList headers;
+                try {
+                    headers = await client.GetMessageHeadersAsync(i, cancellationToken).ConfigureAwait(false);
+                } catch (NotSupportedException) {
+                    message = await client.GetMessageAsync(i, cancellationToken).ConfigureAwait(false);
+                    headers = message.Headers;
+                }
                 if (!Pop3HeadersMatch(
                     headers,
                     subject,
@@ -192,7 +199,7 @@ public static partial class MailboxSearcher {
                 }
             }
 
-            var message = await client.GetMessageAsync(i, cancellationToken).ConfigureAwait(false);
+            message ??= await client.GetMessageAsync(i, cancellationToken).ConfigureAwait(false);
             if (requiresFullMessageForFiltering) {
                 if (!string.IsNullOrWhiteSpace(subject) && (message.Subject == null || message.Subject.IndexOf(subject, StringComparison.OrdinalIgnoreCase) < 0)) continue;
                 if (!string.IsNullOrWhiteSpace(querySubject) && (message.Subject == null || message.Subject.IndexOf(querySubject, StringComparison.OrdinalIgnoreCase) < 0)) continue;

--- a/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.cs
@@ -126,6 +126,7 @@ public static partial class MailboxSearcher {
         int maxResults = 0,
         CancellationToken cancellationToken = default,
         string? queryString = null) {
+        IReadOnlyList<string> messageContainsTerms = Array.Empty<string>();
         if (!string.IsNullOrWhiteSpace(queryString)) {
             try {
                 var parsed = ParseQuery(queryString);
@@ -137,6 +138,7 @@ public static partial class MailboxSearcher {
                 if (!before.HasValue) before = parsed.Before;
                 if (!priority.HasValue) priority = parsed.Priority;
                 hasAttachment |= parsed.HasAttachment;
+                messageContainsTerms = parsed.MessageContainsTerms;
             } catch (Exception ex) {
                 LoggingMessages.Logger.WriteWarning("Failed to parse POP3 query string: {0}", ex.Message);
             }
@@ -160,10 +162,31 @@ public static partial class MailboxSearcher {
             if (beforeUtc.HasValue && msgDate > beforeUtc.Value) continue;
             if (priority.HasValue && message.Priority != ConvertPriority(priority.Value)) continue;
             if (hasAttachment && !message.Attachments.Any()) continue;
+            if (messageContainsTerms.Any(term => !MessageContains(message, term))) continue;
             results.Add(new Pop3EmailMessage(i, message));
             if (maxResults > 0 && results.Count >= maxResults) break;
         }
         return results;
+    }
+
+    private static bool MessageContains(MimeMessage message, string text) {
+        if (message.Headers.Any(header =>
+                header.Value?.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0)) {
+            return true;
+        }
+
+        foreach (var part in message.BodyParts) {
+            if (part.Headers.Any(header =>
+                    header.Value?.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0)) {
+                return true;
+            }
+            if (part is TextPart textPart &&
+                textPart.Text?.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 

--- a/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.cs
@@ -127,16 +127,23 @@ public static partial class MailboxSearcher {
         CancellationToken cancellationToken = default,
         string? queryString = null) {
         IReadOnlyList<string> messageContainsTerms = Array.Empty<string>();
+        string? querySubject = null;
+        string? queryFromContains = null;
+        string? queryToContains = null;
+        string? queryBodyContains = null;
+        MessagePriority? queryPriority = null;
+        DateTime? querySince = null;
+        DateTime? queryBefore = null;
         if (!string.IsNullOrWhiteSpace(queryString)) {
             try {
                 var parsed = ParseQuery(queryString);
-                if (string.IsNullOrWhiteSpace(subject)) subject = parsed.Subject;
-                if (string.IsNullOrWhiteSpace(fromContains)) fromContains = parsed.FromContains;
-                if (string.IsNullOrWhiteSpace(toContains)) toContains = parsed.ToContains;
-                if (string.IsNullOrWhiteSpace(bodyContains)) bodyContains = parsed.BodyContains;
-                if (!since.HasValue) since = parsed.Since;
-                if (!before.HasValue) before = parsed.Before;
-                if (!priority.HasValue) priority = parsed.Priority;
+                querySubject = parsed.Subject;
+                queryFromContains = parsed.FromContains;
+                queryToContains = parsed.ToContains;
+                queryBodyContains = parsed.BodyContains;
+                querySince = parsed.Since;
+                queryBefore = parsed.Before;
+                queryPriority = parsed.Priority;
                 hasAttachment |= parsed.HasAttachment;
                 messageContainsTerms = parsed.MessageContainsTerms;
             } catch (Exception ex) {
@@ -146,27 +153,41 @@ public static partial class MailboxSearcher {
         var results = new List<Pop3EmailMessage>();
         var sinceUtc = NormalizeToUtc(since);
         var beforeUtc = NormalizeToUtc(before);
+        var querySinceUtc = NormalizeToUtc(querySince);
+        var queryBeforeUtc = NormalizeToUtc(queryBefore);
         var requiresFullMessageForFiltering =
             !string.IsNullOrWhiteSpace(bodyContains) ||
+            !string.IsNullOrWhiteSpace(queryBodyContains) ||
             priority.HasValue ||
+            queryPriority.HasValue ||
             hasAttachment ||
             messageContainsTerms.Count > 0;
         var useHeaderPrefilter = !requiresFullMessageForFiltering &&
             (!string.IsNullOrWhiteSpace(subject) ||
+             !string.IsNullOrWhiteSpace(querySubject) ||
              !string.IsNullOrWhiteSpace(fromContains) ||
+             !string.IsNullOrWhiteSpace(queryFromContains) ||
              !string.IsNullOrWhiteSpace(toContains) ||
+             !string.IsNullOrWhiteSpace(queryToContains) ||
              sinceUtc.HasValue ||
-             beforeUtc.HasValue);
+             beforeUtc.HasValue ||
+             querySinceUtc.HasValue ||
+             queryBeforeUtc.HasValue);
         for (int i = 0; i < client.Count; i++) {
             if (useHeaderPrefilter) {
                 var headers = await client.GetMessageHeadersAsync(i, cancellationToken).ConfigureAwait(false);
                 if (!Pop3HeadersMatch(
                     headers,
                     subject,
+                    querySubject,
                     fromContains,
+                    queryFromContains,
                     toContains,
+                    queryToContains,
                     sinceUtc,
-                    beforeUtc)) {
+                    querySinceUtc,
+                    beforeUtc,
+                    queryBeforeUtc)) {
                     continue;
                 }
             }
@@ -174,8 +195,11 @@ public static partial class MailboxSearcher {
             var message = await client.GetMessageAsync(i, cancellationToken).ConfigureAwait(false);
             if (requiresFullMessageForFiltering) {
                 if (!string.IsNullOrWhiteSpace(subject) && (message.Subject == null || message.Subject.IndexOf(subject, StringComparison.OrdinalIgnoreCase) < 0)) continue;
+                if (!string.IsNullOrWhiteSpace(querySubject) && (message.Subject == null || message.Subject.IndexOf(querySubject, StringComparison.OrdinalIgnoreCase) < 0)) continue;
                 if (!string.IsNullOrWhiteSpace(fromContains) && !AddressMatches(message.From, fromContains!)) continue;
+                if (!string.IsNullOrWhiteSpace(queryFromContains) && !AddressMatches(message.From, queryFromContains!)) continue;
                 if (!string.IsNullOrWhiteSpace(toContains) && !AddressMatches(message.To, toContains!)) continue;
+                if (!string.IsNullOrWhiteSpace(queryToContains) && !AddressMatches(message.To, queryToContains!)) continue;
             }
             if (!string.IsNullOrWhiteSpace(bodyContains)) {
                 var textBody = message.TextBody ?? string.Empty;
@@ -183,12 +207,21 @@ public static partial class MailboxSearcher {
                 if (textBody.IndexOf(bodyContains, StringComparison.OrdinalIgnoreCase) < 0 &&
                     htmlBody.IndexOf(bodyContains, StringComparison.OrdinalIgnoreCase) < 0) continue;
             }
+            if (!string.IsNullOrWhiteSpace(queryBodyContains)) {
+                var textBody = message.TextBody ?? string.Empty;
+                var htmlBody = message.HtmlBody ?? string.Empty;
+                if (textBody.IndexOf(queryBodyContains, StringComparison.OrdinalIgnoreCase) < 0 &&
+                    htmlBody.IndexOf(queryBodyContains, StringComparison.OrdinalIgnoreCase) < 0) continue;
+            }
             if (requiresFullMessageForFiltering) {
                 var msgDate = message.Date.UtcDateTime;
                 if (sinceUtc.HasValue && msgDate < sinceUtc.Value) continue;
+                if (querySinceUtc.HasValue && msgDate < querySinceUtc.Value) continue;
                 if (beforeUtc.HasValue && msgDate > beforeUtc.Value) continue;
+                if (queryBeforeUtc.HasValue && msgDate > queryBeforeUtc.Value) continue;
             }
             if (priority.HasValue && message.Priority != ConvertPriority(priority.Value)) continue;
+            if (queryPriority.HasValue && message.Priority != ConvertPriority(queryPriority.Value)) continue;
             if (hasAttachment && !message.Attachments.Any()) continue;
             if (messageContainsTerms.Any(term => !MessageContains(message, term))) continue;
             results.Add(new Pop3EmailMessage(i, message));
@@ -200,15 +233,24 @@ public static partial class MailboxSearcher {
     private static bool Pop3HeadersMatch(
         HeaderList headers,
         string? subject,
+        string? querySubject,
         string? fromContains,
+        string? queryFromContains,
         string? toContains,
+        string? queryToContains,
         DateTime? sinceUtc,
-        DateTime? beforeUtc) {
+        DateTime? querySinceUtc,
+        DateTime? beforeUtc,
+        DateTime? queryBeforeUtc) {
         var message = new MimeMessage(headers);
         if ((!string.IsNullOrWhiteSpace(subject) &&
              (message.Subject == null || message.Subject.IndexOf(subject, StringComparison.OrdinalIgnoreCase) < 0)) ||
+            (!string.IsNullOrWhiteSpace(querySubject) &&
+             (message.Subject == null || message.Subject.IndexOf(querySubject, StringComparison.OrdinalIgnoreCase) < 0)) ||
             (!string.IsNullOrWhiteSpace(fromContains) && !AddressMatches(message.From, fromContains!)) ||
-            (!string.IsNullOrWhiteSpace(toContains) && !AddressMatches(message.To, toContains!))) {
+            (!string.IsNullOrWhiteSpace(queryFromContains) && !AddressMatches(message.From, queryFromContains!)) ||
+            (!string.IsNullOrWhiteSpace(toContains) && !AddressMatches(message.To, toContains!)) ||
+            (!string.IsNullOrWhiteSpace(queryToContains) && !AddressMatches(message.To, queryToContains!))) {
             return false;
         }
 
@@ -216,7 +258,13 @@ public static partial class MailboxSearcher {
         if (sinceUtc.HasValue && messageDate < sinceUtc.Value) {
             return false;
         }
+        if (querySinceUtc.HasValue && messageDate < querySinceUtc.Value) {
+            return false;
+        }
         if (beforeUtc.HasValue && messageDate > beforeUtc.Value) {
+            return false;
+        }
+        if (queryBeforeUtc.HasValue && messageDate > queryBeforeUtc.Value) {
             return false;
         }
         return true;

--- a/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.cs
+++ b/Sources/Mailozaurr.Internet/Receive/MailboxSearcher.cs
@@ -173,7 +173,7 @@ public static partial class MailboxSearcher {
              beforeUtc.HasValue ||
              querySinceUtc.HasValue ||
              queryBeforeUtc.HasValue);
-        for (int i = 0; i < client.Count; i++) {
+        for (int i = client.Count - 1; i >= 0; i--) {
             if (useHeaderPrefilter) {
                 var headers = await client.GetMessageHeadersAsync(i, cancellationToken).ConfigureAwait(false);
                 if (!Pop3HeadersMatch(

--- a/Sources/Mailozaurr.Internet/Receive/Pop3MailboxBrowser.cs
+++ b/Sources/Mailozaurr.Internet/Receive/Pop3MailboxBrowser.cs
@@ -167,7 +167,12 @@ public static class Pop3MailboxBrowser {
         var messages = new List<Pop3MessageHeaderSnapshot>();
         var start = totalCount - 1 - offset;
         for (var index = start; index >= 0 && messages.Count < limit; index--) {
-            var headers = await client.GetMessageHeadersAsync(index, cancellationToken).ConfigureAwait(false);
+            HeaderList headers;
+            try {
+                headers = await client.GetMessageHeadersAsync(index, cancellationToken).ConfigureAwait(false);
+            } catch (NotSupportedException) {
+                headers = (await client.GetMessageAsync(index, cancellationToken).ConfigureAwait(false)).Headers;
+            }
             var uid = await TryGetMessageUidAsync(client, index, cancellationToken).ConfigureAwait(false);
             var messageSize = TryGetMessageSize(client, index, cancellationToken);
 

--- a/Sources/Mailozaurr.Tests/ApplicationBuilderTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationBuilderTests.cs
@@ -38,6 +38,7 @@ public sealed class ApplicationBuilderTests {
         Assert.NotNull(app.Send);
         Assert.NotNull(app.Queue);
         Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Imap);
+        Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Pop3);
         Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Graph);
         Assert.Contains(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Gmail);
         Assert.Contains(app.MessageActionHandlers, handler => handler.Kind == MailProfileKind.Imap);
@@ -55,6 +56,7 @@ public sealed class ApplicationBuilderTests {
     public void BuildHonorsDisabledImapHandlerOption() {
         var builder = new MailApplicationBuilder(new MailApplicationOptions {
             EnableImapReadHandler = false,
+            EnablePop3ReadHandler = false,
             EnableGraphReadHandler = false,
             EnableGraphSendHandler = false,
             EnableGmailReadHandler = false,
@@ -70,6 +72,7 @@ public sealed class ApplicationBuilderTests {
         var app = builder.Build();
 
         Assert.DoesNotContain(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Imap);
+        Assert.DoesNotContain(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Pop3);
         Assert.DoesNotContain(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Graph);
         Assert.DoesNotContain(app.ReadHandlers, handler => handler.Kind == MailProfileKind.Gmail);
         Assert.DoesNotContain(app.SendHandlers, handler => handler.Kind == MailProfileKind.Graph);

--- a/Sources/Mailozaurr.Tests/ApplicationCapabilitiesTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationCapabilitiesTests.cs
@@ -5,6 +5,7 @@ namespace Mailozaurr.Tests;
 public sealed class ApplicationCapabilitiesTests {
     [Theory]
     [InlineData(MailProfileKind.Imap, MailCapability.ListFolders | MailCapability.SearchMessages | MailCapability.ReadMessages | MailCapability.MoveMessages)]
+    [InlineData(MailProfileKind.Pop3, MailCapability.ListFolders | MailCapability.SearchMessages | MailCapability.ReadMessages | MailCapability.SaveAttachments)]
     [InlineData(MailProfileKind.Graph, MailCapability.ListFolders | MailCapability.SendMessages | MailCapability.MarkMessages)]
     [InlineData(MailProfileKind.Gmail, MailCapability.SearchMessages | MailCapability.MarkMessages | MailCapability.MoveMessages | MailCapability.SendMessages)]
     [InlineData(MailProfileKind.Smtp, MailCapability.SendMessages)]
@@ -31,12 +32,6 @@ public sealed class ApplicationCapabilitiesTests {
         Assert.True(capabilities.Supports(MailCapability.SearchMessages));
         Assert.False(capabilities.Supports(MailCapability.WaitForMessages));
         Assert.False(capabilities.Supports(MailCapability.SendMessages));
-    }
-
-    [Theory]
-    [InlineData(MailProfileKind.Pop3)]
-    public void CatalogDoesNotAdvertiseProvidersWithoutNormalizedHandlers(MailProfileKind kind) {
-        Assert.Equal(MailCapability.None, MailCapabilityCatalog.For(kind).Capabilities);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/ApplicationGraphMailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationGraphMailReadHandlerTests.cs
@@ -3,6 +3,15 @@ using Mailozaurr;
 namespace Mailozaurr.Tests;
 
 public sealed class ApplicationGraphMailReadHandlerTests {
+    [Theory]
+    [InlineData(null, "me")]
+    [InlineData("", "me")]
+    [InlineData(" ME ", "me")]
+    [InlineData("User@Example.test", "User@Example.test")]
+    public void GraphStorageIdentityCanonicalizesMeLikeTheRequestRoute(string? userId, string expected) {
+        Assert.Equal(expected, GraphMailReadHandler.CanonicalizeUserIdForStorage(userId));
+    }
+
     [Fact]
     public async Task HandlerUsesInjectedFolderDelegate() {
         var handler = new GraphMailReadHandler(

--- a/Sources/Mailozaurr.Tests/ApplicationImapMailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationImapMailReadHandlerTests.cs
@@ -4,6 +4,14 @@ using Mailozaurr;
 namespace Mailozaurr.Tests;
 
 public sealed class ApplicationImapMailReadHandlerTests {
+    [Theory]
+    [InlineData("INBOX")]
+    [InlineData("inbox")]
+    [InlineData("Inbox")]
+    public void ImapInboxAliasesUseOneCanonicalStorageIdentity(string fullName) {
+        Assert.Equal("INBOX", ImapMailReadHandler.CanonicalizeFolderForStorage(fullName));
+    }
+
     [Fact]
     public async Task HandlerUsesInjectedSearchDelegate() {
         var handler = new ImapMailReadHandler(

--- a/Sources/Mailozaurr.Tests/ApplicationImapMailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationImapMailReadHandlerTests.cs
@@ -12,6 +12,13 @@ public sealed class ApplicationImapMailReadHandlerTests {
         Assert.Equal("INBOX", ImapMailReadHandler.CanonicalizeFolderForStorage(fullName));
     }
 
+    [Theory]
+    [InlineData(1u, "1")]
+    [InlineData(42u, "42")]
+    public void ImapUidStorageIdentityUsesCanonicalNumericValue(uint value, string expected) {
+        Assert.Equal(expected, ImapMailReadHandler.CanonicalizeUidForStorage(new MailKit.UniqueId(value)));
+    }
+
     [Fact]
     public async Task HandlerUsesInjectedSearchDelegate() {
         var handler = new ImapMailReadHandler(

--- a/Sources/Mailozaurr.Tests/ApplicationImapMailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationImapMailReadHandlerTests.cs
@@ -19,6 +19,18 @@ public sealed class ApplicationImapMailReadHandlerTests {
         Assert.Equal(expected, ImapMailReadHandler.CanonicalizeUidForStorage(new MailKit.UniqueId(value)));
     }
 
+    [Theory]
+    [InlineData("1")]
+    [InlineData("001")]
+    public void UnnamedAttachmentFallbackUsesCanonicalImapUid(string requestedId) {
+        var canonical = ImapMailReadHandler.CanonicalizeUidForStorage(requestedId);
+        var identity = ImapMailReadHandler.CreateAttachmentFallbackIdentity("work-imap", canonical, 0);
+
+        Assert.Equal(
+            ImapMailReadHandler.CreateAttachmentFallbackIdentity("work-imap", "1", 0),
+            identity);
+    }
+
     [Fact]
     public async Task HandlerUsesInjectedSearchDelegate() {
         var handler = new ImapMailReadHandler(

--- a/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
@@ -175,6 +175,28 @@ public sealed class ApplicationPop3MailReadHandlerTests {
     }
 
     [Fact]
+    public void UnnamedAttachmentUsesDeterministicPerPartFallback() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            var attachment = new MimePart("application", "octet-stream");
+            var firstIdentity = MimeAttachmentStorage.CreateStorageIdentity("profile-a", "message-a", "0");
+            var secondIdentity = MimeAttachmentStorage.CreateStorageIdentity("profile-a", "message-a", "1");
+
+            var first = MimeAttachmentStorage.ResolveDestinationPath(directory, attachment, firstIdentity);
+            var repeated = MimeAttachmentStorage.ResolveDestinationPath(directory, attachment, firstIdentity);
+            var second = MimeAttachmentStorage.ResolveDestinationPath(directory, attachment, secondIdentity);
+
+            Assert.Equal(first, repeated);
+            Assert.NotEqual(first, second);
+            Assert.StartsWith("attachment-", Path.GetFileName(first), StringComparison.Ordinal);
+            Assert.EndsWith(".bin", first, StringComparison.Ordinal);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void BatchAttachmentNamesIncludeProfileFolderAndMessageIdentity() {
         var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);

--- a/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
@@ -71,6 +71,21 @@ public sealed class ApplicationPop3MailReadHandlerTests {
         Assert.Equal(1, secondId.Occurrence);
     }
 
+    [Theory]
+    [InlineData("uid:stable-id")]
+    [InlineData("stable-id")]
+    public void Pop3UidAliasesUseOneCanonicalStorageIdentity(string requestedId) {
+        var message = new MimeMessage { Subject = "Stable content" };
+        message.Body = new TextPart("plain") { Text = "Body" };
+        var snapshot = new Pop3MailboxBrowser.Pop3ResolvedMessageSnapshot(0, "stable-id", 10, message);
+
+        var canonical = Pop3MailReadHandler.CanonicalizeMessageIdForStorage(
+            Pop3MailReadHandler.ParseMessageId(requestedId),
+            snapshot);
+
+        Assert.Equal("uid:stable-id", canonical);
+    }
+
     [Fact]
     public async Task HashFallbackIdsResolveTheIntendedDuplicateOccurrence() {
         var duplicate = new MimeMessage { Subject = "Duplicate" };

--- a/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
@@ -1,4 +1,5 @@
 using MailKit.Net.Pop3;
+using MailKit;
 using Mailozaurr;
 using MimeKit;
 using System.Text;
@@ -39,13 +40,67 @@ public sealed class ApplicationPop3MailReadHandlerTests {
         Assert.Equal("uid:stable-id", Pop3MailReadHandler.FormatMessageId("stable-id", message));
         var fallback = Pop3MailReadHandler.FormatMessageId(null, message);
         Assert.StartsWith("hash:", fallback, StringComparison.Ordinal);
-        Assert.Equal(("stable-id", null), Pop3MailReadHandler.ParseMessageId("uid:stable-id"));
-        Assert.Equal((null, fallback.Substring(5)), Pop3MailReadHandler.ParseMessageId(fallback));
+        Assert.EndsWith(":0", fallback, StringComparison.Ordinal);
+        Assert.Equal(("stable-id", null, 0), Pop3MailReadHandler.ParseMessageId("uid:stable-id"));
+        var parsedFallback = Pop3MailReadHandler.ParseMessageId(fallback);
+        Assert.Null(parsedFallback.Uid);
+        Assert.Equal(0, parsedFallback.Occurrence);
+        Assert.Equal(fallback.Substring(5, fallback.Length - 7), parsedFallback.Fingerprint);
+        Assert.Equal(parsedFallback.Fingerprint, Pop3MailReadHandler.ParseMessageId("hash:" + parsedFallback.Fingerprint).Fingerprint);
         Assert.Throws<InvalidOperationException>(() => Pop3MailReadHandler.ParseMessageId("index:4"));
         Assert.Throws<InvalidOperationException>(() => Pop3MailReadHandler.ParseMessageId("4"));
+        Assert.Throws<InvalidOperationException>(() => Pop3MailReadHandler.ParseMessageId("hash:value:not-a-number"));
 
         message.Subject = "Changed content";
         Assert.NotEqual(fallback, Pop3MailReadHandler.FormatMessageId(null, message));
+    }
+
+    [Fact]
+    public void HashFallbackIdsDisambiguateByteIdenticalMailboxEntries() {
+        var message = new MimeMessage { Subject = "Duplicate" };
+        message.Body = new TextPart("plain") { Text = "Same bytes" };
+
+        var first = Pop3MailReadHandler.FormatMessageId(null, message, occurrence: 0);
+        var second = Pop3MailReadHandler.FormatMessageId(null, message, occurrence: 1);
+
+        Assert.NotEqual(first, second);
+        var firstId = Pop3MailReadHandler.ParseMessageId(first);
+        var secondId = Pop3MailReadHandler.ParseMessageId(second);
+        Assert.Equal(firstId.Fingerprint, secondId.Fingerprint);
+        Assert.Equal(0, firstId.Occurrence);
+        Assert.Equal(1, secondId.Occurrence);
+    }
+
+    [Fact]
+    public async Task HashFallbackIdsResolveTheIntendedDuplicateOccurrence() {
+        var duplicate = new MimeMessage { Subject = "Duplicate" };
+        duplicate.Body = new TextPart("plain") { Text = "Same bytes" };
+        var downloads = new List<int>();
+        var handler = new Pop3MailReadHandler(
+            new DuplicateMessagePop3SessionFactory(new[] { duplicate, duplicate }, downloads));
+
+        var results = await handler.SearchAsync(CreateProfile(), new MailSearchRequest {
+            ProfileId = "work-pop3"
+        });
+
+        Assert.Equal(2, results.Count);
+        Assert.NotEqual(results[0].Id, results[1].Id);
+
+        downloads.Clear();
+        var first = await handler.GetMessageAsync(CreateProfile(), new GetMessageRequest {
+            ProfileId = "work-pop3",
+            MessageId = results[0].Id
+        });
+        Assert.NotNull(first);
+        Assert.Equal(new[] { 0 }, downloads);
+
+        downloads.Clear();
+        var second = await handler.GetMessageAsync(CreateProfile(), new GetMessageRequest {
+            ProfileId = "work-pop3",
+            MessageId = results[1].Id
+        });
+        Assert.NotNull(second);
+        Assert.Equal(new[] { 0, 1 }, downloads);
     }
 
     [Fact]
@@ -99,6 +154,46 @@ public sealed class ApplicationPop3MailReadHandlerTests {
             Assert.StartsWith("report_a~", Path.GetFileName(question), StringComparison.Ordinal);
             Assert.EndsWith(".txt", colon, StringComparison.Ordinal);
             Assert.EndsWith(".txt", question, StringComparison.Ordinal);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RepeatedAttachmentNamesUsePerPartIdentity() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            var first = MimeAttachmentStorage.ResolveDestinationPath(directory, "report.txt", "0");
+            var second = MimeAttachmentStorage.ResolveDestinationPath(directory, "report.txt", "1");
+
+            Assert.NotEqual(first, second);
+            Assert.Equal(first, MimeAttachmentStorage.ResolveDestinationPath(directory, "report.txt", "0"));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void BatchAttachmentNamesIncludeProfileFolderAndMessageIdentity() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            var firstIdentity = MimeAttachmentStorage.CreateStorageIdentity("profile-a", "Pop3", "INBOX", "message-a", "0");
+            var otherMessageIdentity = MimeAttachmentStorage.CreateStorageIdentity("profile-a", "Pop3", "INBOX", "message-b", "0");
+            var otherFolderIdentity = MimeAttachmentStorage.CreateStorageIdentity("profile-a", "Imap", "Archive", "message-a", "0");
+            var otherProfileIdentity = MimeAttachmentStorage.CreateStorageIdentity("profile-b", "Pop3", "INBOX", "message-a", "0");
+
+            var first = MimeAttachmentStorage.ResolveDestinationPath(directory, "report.txt", firstIdentity);
+            var paths = new[] {
+                first,
+                MimeAttachmentStorage.ResolveDestinationPath(directory, "report.txt", otherMessageIdentity),
+                MimeAttachmentStorage.ResolveDestinationPath(directory, "report.txt", otherFolderIdentity),
+                MimeAttachmentStorage.ResolveDestinationPath(directory, "report.txt", otherProfileIdentity)
+            };
+
+            Assert.Equal(4, paths.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+            Assert.Equal(first, MimeAttachmentStorage.ResolveDestinationPath(directory, "report.txt", firstIdentity));
         } finally {
             Directory.Delete(directory, recursive: true);
         }
@@ -186,5 +281,43 @@ public sealed class ApplicationPop3MailReadHandlerTests {
     private sealed class FakePop3SessionFactory : IPop3SessionFactory {
         public Task<Pop3Client> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
             Task.FromResult(new Pop3Client());
+    }
+
+    private sealed class DuplicateMessagePop3SessionFactory : IPop3SessionFactory {
+        private readonly IReadOnlyList<MimeMessage> _messages;
+        private readonly List<int> _downloads;
+
+        public DuplicateMessagePop3SessionFactory(IReadOnlyList<MimeMessage> messages, List<int> downloads) {
+            _messages = messages;
+            _downloads = downloads;
+        }
+
+        public Task<Pop3Client> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult<Pop3Client>(new DuplicateMessagePop3Client(_messages, _downloads));
+    }
+
+    private sealed class DuplicateMessagePop3Client : Pop3Client {
+        private readonly IReadOnlyList<MimeMessage> _messages;
+        private readonly List<int> _downloads;
+
+        public DuplicateMessagePop3Client(IReadOnlyList<MimeMessage> messages, List<int> downloads) {
+            _messages = messages;
+            _downloads = downloads;
+        }
+
+        public override bool IsConnected => true;
+        public override bool IsAuthenticated => true;
+        public override int Count => _messages.Count;
+
+        public override Task<MimeMessage> GetMessageAsync(
+            int index,
+            CancellationToken cancellationToken = default,
+            ITransferProgress? progress = null) {
+            _downloads.Add(index);
+            return Task.FromResult(_messages[index]);
+        }
+
+        public override Task<string> GetMessageUidAsync(int index, CancellationToken cancellationToken = default) =>
+            Task.FromException<string>(new NotSupportedException("UIDL is unavailable."));
     }
 }

--- a/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
@@ -1,0 +1,99 @@
+using MailKit.Net.Pop3;
+using Mailozaurr;
+using MimeKit;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationPop3MailReadHandlerTests {
+    [Fact]
+    public async Task HandlerUsesInjectedSearchDelegate() {
+        var handler = new Pop3MailReadHandler(
+            new FakePop3SessionFactory(),
+            searchAsync: (client, profile, request, cancellationToken) =>
+                Task.FromResult<IReadOnlyList<MessageSummary>>(new[] {
+                    new MessageSummary {
+                        ProfileId = profile.Id,
+                        Id = "uid:message-42",
+                        FolderId = "INBOX",
+                        Subject = request.QueryText
+                    }
+                }));
+
+        var results = await handler.SearchAsync(CreateProfile(), new MailSearchRequest {
+            ProfileId = "work-pop3",
+            QueryText = "reports"
+        });
+
+        Assert.Single(results);
+        Assert.Equal("uid:message-42", results[0].Id);
+        Assert.Equal("INBOX", results[0].FolderId);
+        Assert.Equal("reports", results[0].Subject);
+    }
+
+    [Fact]
+    public void MessageIdsPreferUidAndUseContentHashWhenUidlIsUnavailable() {
+        var message = new MimeMessage { Subject = "Stable content" };
+        message.Body = new TextPart("plain") { Text = "Body" };
+
+        Assert.Equal("uid:stable-id", Pop3MailReadHandler.FormatMessageId("stable-id", message));
+        var fallback = Pop3MailReadHandler.FormatMessageId(null, message);
+        Assert.StartsWith("hash:", fallback, StringComparison.Ordinal);
+        Assert.Equal(("stable-id", null), Pop3MailReadHandler.ParseMessageId("uid:stable-id"));
+        Assert.Equal((null, fallback.Substring(5)), Pop3MailReadHandler.ParseMessageId(fallback));
+        Assert.Throws<InvalidOperationException>(() => Pop3MailReadHandler.ParseMessageId("index:4"));
+        Assert.Throws<InvalidOperationException>(() => Pop3MailReadHandler.ParseMessageId("4"));
+
+        message.Subject = "Changed content";
+        Assert.NotEqual(fallback, Pop3MailReadHandler.FormatMessageId(null, message));
+    }
+
+    [Fact]
+    public void SummaryMappingUsesNormalizedPop3IdentityAndInbox() {
+        var message = new MimeMessage {
+            Subject = "Quarterly report",
+            Date = new DateTimeOffset(2026, 8, 22, 10, 0, 0, TimeSpan.Zero),
+            Body = new TextPart("plain") { Text = "Ready" }
+        };
+        message.From.Add(new MailboxAddress("Sender", "sender@example.com"));
+        message.To.Add(new MailboxAddress("Recipient", "recipient@example.com"));
+
+        var summary = Pop3MailReadHandler.MapSummary("work-pop3", "uid-7", message);
+
+        Assert.Equal("uid:uid-7", summary.Id);
+        Assert.Equal("INBOX", summary.FolderId);
+        Assert.Equal("Quarterly report", summary.Subject);
+        Assert.Equal("sender@example.com", Assert.Single(summary.From).Address);
+        Assert.Equal("recipient@example.com", Assert.Single(summary.To).Address);
+    }
+
+    [Fact]
+    public void AttachmentDestinationUsesOnlyTheRemoteFileNameBase() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            var attachment = new MimePart("application", "octet-stream") {
+                FileName = @"..\outside.bin"
+            };
+
+            var destination = MimeAttachmentStorage.ResolveDestinationPath(directory, attachment);
+
+            Assert.Equal(Path.Combine(directory, "outside.bin"), destination);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static MailProfile CreateProfile() => new() {
+        Id = "work-pop3",
+        DisplayName = "Work POP3",
+        Kind = MailProfileKind.Pop3,
+        Settings = new Dictionary<string, string> {
+            [MailProfileSettingsKeys.Server] = "pop.example.com"
+        }
+    };
+
+    private sealed class FakePop3SessionFactory : IPop3SessionFactory {
+        public Task<Pop3Client> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new Pop3Client());
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
@@ -92,7 +92,7 @@ public sealed class ApplicationPop3MailReadHandlerTests {
             MessageId = results[0].Id
         });
         Assert.NotNull(first);
-        Assert.Equal(new[] { 0 }, downloads);
+        Assert.Equal(new[] { 1 }, downloads);
 
         downloads.Clear();
         var second = await handler.GetMessageAsync(CreateProfile(), new GetMessageRequest {
@@ -100,7 +100,33 @@ public sealed class ApplicationPop3MailReadHandlerTests {
             MessageId = results[1].Id
         });
         Assert.NotNull(second);
-        Assert.Equal(new[] { 0, 1 }, downloads);
+        Assert.Equal(new[] { 1, 0 }, downloads);
+    }
+
+    [Fact]
+    public async Task HashOccurrencesCountMatchingMessagesThatHaveUids() {
+        var duplicate = new MimeMessage { Subject = "Mixed UIDL" };
+        duplicate.Body = new TextPart("plain") { Text = "Same bytes" };
+        var downloads = new List<int>();
+        var handler = new Pop3MailReadHandler(
+            new MixedUidlPop3SessionFactory(new[] { duplicate, duplicate }, downloads));
+
+        var results = await handler.SearchAsync(CreateProfile(), new MailSearchRequest {
+            ProfileId = "work-pop3"
+        });
+
+        Assert.Equal(2, results.Count);
+        Assert.StartsWith("hash:", results[0].Id, StringComparison.Ordinal);
+        Assert.Equal("uid:older-uid", results[1].Id);
+
+        downloads.Clear();
+        var detail = await handler.GetMessageAsync(CreateProfile(), new GetMessageRequest {
+            ProfileId = "work-pop3",
+            MessageId = results[0].Id
+        });
+
+        Assert.NotNull(detail);
+        Assert.Equal(new[] { 1 }, downloads);
     }
 
     [Fact]
@@ -211,6 +237,21 @@ public sealed class ApplicationPop3MailReadHandlerTests {
         } finally {
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    [Fact]
+    public void NumericAndFileNameAttachmentAliasesResolveToOneCanonicalIdentity() {
+        var attachment = new MimePart("application", "octet-stream") { FileName = "report.txt" };
+        IReadOnlyList<MimeEntity> attachments = new[] { attachment };
+
+        var numericIndex = MimeAttachmentStorage.ResolveAttachmentIndex(attachments, "0");
+        var fileNameIndex = MimeAttachmentStorage.ResolveAttachmentIndex(attachments, "report.txt");
+
+        Assert.Equal(0, numericIndex);
+        Assert.Equal(numericIndex, fileNameIndex);
+        Assert.Equal(
+            MimeAttachmentStorage.CreateStorageIdentity("profile", "message", numericIndex.ToString()),
+            MimeAttachmentStorage.CreateStorageIdentity("profile", "message", fileNameIndex.ToString()));
     }
 
     [Fact]
@@ -373,6 +414,29 @@ public sealed class ApplicationPop3MailReadHandlerTests {
         }
     }
 
+    private sealed class MixedUidlPop3SessionFactory : IPop3SessionFactory {
+        private readonly IReadOnlyList<MimeMessage> _messages;
+        private readonly List<int> _downloads;
+
+        public MixedUidlPop3SessionFactory(IReadOnlyList<MimeMessage> messages, List<int> downloads) {
+            _messages = messages;
+            _downloads = downloads;
+        }
+
+        public Task<Pop3Client> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult<Pop3Client>(new MixedUidlPop3Client(_messages, _downloads));
+    }
+
+    private sealed class MixedUidlPop3Client : DuplicateMessagePop3Client {
+        public MixedUidlPop3Client(IReadOnlyList<MimeMessage> messages, List<int> downloads)
+            : base(messages, downloads) { }
+
+        public override Task<string> GetMessageUidAsync(int index, CancellationToken cancellationToken = default) =>
+            index == 0
+                ? Task.FromResult("older-uid")
+                : Task.FromException<string>(new Pop3CommandException("UIDL failed transiently."));
+    }
+
     private sealed class RecoveringUidlPop3Client : Pop3Client {
         private readonly MimeMessage _message;
         private readonly bool _uidlAvailable;
@@ -397,7 +461,7 @@ public sealed class ApplicationPop3MailReadHandlerTests {
                 : Task.FromException<string>(new Pop3CommandException("UIDL failed transiently."));
     }
 
-    private sealed class DuplicateMessagePop3Client : Pop3Client {
+    private class DuplicateMessagePop3Client : Pop3Client {
         private readonly IReadOnlyList<MimeMessage> _messages;
         private readonly List<int> _downloads;
 

--- a/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
@@ -292,6 +292,23 @@ public sealed class ApplicationPop3MailReadHandlerTests {
     }
 
     [Fact]
+    public void UnnamedAttachmentFallbackAliasResolvesToTheListedPart() {
+        IReadOnlyList<MimeEntity> attachments = new MimeEntity[] {
+            new MimePart("application", "octet-stream"),
+            new MimePart("application", "octet-stream")
+        };
+        string Identity(int index) => MimeAttachmentStorage.CreateStorageIdentity(
+            "profile-a",
+            "message-a",
+            index.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        var listedName = MimeAttachmentStorage.GetAttachmentFileName(attachments[1], Identity(1));
+
+        var resolved = MimeAttachmentStorage.ResolveAttachmentIndex(attachments, listedName, Identity);
+
+        Assert.Equal(1, resolved);
+    }
+
+    [Fact]
     public void BatchAttachmentNamesIncludeProfileFolderAndMessageIdentity() {
         var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);

--- a/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
@@ -86,6 +86,24 @@ public sealed class ApplicationPop3MailReadHandlerTests {
         Assert.Equal("uid:stable-id", canonical);
     }
 
+    [Theory]
+    [InlineData("uid:stable-id")]
+    [InlineData("stable-id")]
+    public void UnnamedAttachmentFallbackUsesCanonicalPop3MessageId(string requestedId) {
+        var message = new MimeMessage { Subject = "Stable content" };
+        message.Body = new TextPart("plain") { Text = "Body" };
+        var snapshot = new Pop3MailboxBrowser.Pop3ResolvedMessageSnapshot(0, "stable-id", 10, message);
+        var canonical = Pop3MailReadHandler.CanonicalizeMessageIdForStorage(
+            Pop3MailReadHandler.ParseMessageId(requestedId),
+            snapshot);
+
+        var identity = Pop3MailReadHandler.CreateAttachmentFallbackIdentity("work-pop3", canonical, 0);
+
+        Assert.Equal(
+            Pop3MailReadHandler.CreateAttachmentFallbackIdentity("work-pop3", "uid:stable-id", 0),
+            identity);
+    }
+
     [Fact]
     public async Task HashFallbackIdsResolveTheIntendedDuplicateOccurrence() {
         var duplicate = new MimeMessage { Subject = "Duplicate" };

--- a/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
@@ -104,6 +104,45 @@ public sealed class ApplicationPop3MailReadHandlerTests {
     }
 
     [Fact]
+    public async Task HashFallbackIdRemainsResolvableWhenUidlRecovers() {
+        var message = new MimeMessage { Subject = "Transient UIDL" };
+        message.Body = new TextPart("plain") { Text = "Same message" };
+        var handler = new Pop3MailReadHandler(new RecoveringUidlPop3SessionFactory(message));
+
+        var result = Assert.Single(await handler.SearchAsync(CreateProfile(), new MailSearchRequest {
+            ProfileId = "work-pop3"
+        }));
+        Assert.StartsWith("hash:", result.Id, StringComparison.Ordinal);
+
+        var detail = await handler.GetMessageAsync(CreateProfile(), new GetMessageRequest {
+            ProfileId = "work-pop3",
+            MessageId = result.Id
+        });
+
+        Assert.NotNull(detail);
+        Assert.Equal(result.Id, detail!.Id);
+        Assert.Equal(result.Id, detail.Summary!.Id);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("INBOX")]
+    [InlineData(" inbox ")]
+    public void Pop3FolderAliasesNormalizeToOneStorageIdentity(string? folderId) {
+        var normalized = Pop3MailReadHandler.NormalizeFolderId(folderId);
+        var identity = MimeAttachmentStorage.CreateStorageIdentity(
+            "work-pop3", "Pop3", normalized, "message", "attachment");
+
+        Assert.Equal("INBOX", normalized);
+        Assert.Equal(
+            MimeAttachmentStorage.CreateStorageIdentity(
+                "work-pop3", "Pop3", "INBOX", "message", "attachment"),
+            identity);
+    }
+
+    [Fact]
     public void SummaryMappingUsesNormalizedPop3IdentityAndInbox() {
         var message = new MimeMessage {
             Subject = "Quarterly report",
@@ -316,6 +355,46 @@ public sealed class ApplicationPop3MailReadHandlerTests {
 
         public Task<Pop3Client> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
             Task.FromResult<Pop3Client>(new DuplicateMessagePop3Client(_messages, _downloads));
+    }
+
+    private sealed class RecoveringUidlPop3SessionFactory : IPop3SessionFactory {
+        private readonly MimeMessage _message;
+        private int _connectionCount;
+
+        public RecoveringUidlPop3SessionFactory(MimeMessage message) {
+            _message = message;
+        }
+
+        public Task<Pop3Client> ConnectAsync(
+            MailProfile profile,
+            CancellationToken cancellationToken = default) {
+            var uidlAvailable = Interlocked.Increment(ref _connectionCount) > 1;
+            return Task.FromResult<Pop3Client>(new RecoveringUidlPop3Client(_message, uidlAvailable));
+        }
+    }
+
+    private sealed class RecoveringUidlPop3Client : Pop3Client {
+        private readonly MimeMessage _message;
+        private readonly bool _uidlAvailable;
+
+        public RecoveringUidlPop3Client(MimeMessage message, bool uidlAvailable) {
+            _message = message;
+            _uidlAvailable = uidlAvailable;
+        }
+
+        public override bool IsConnected => true;
+        public override bool IsAuthenticated => true;
+        public override int Count => 1;
+
+        public override Task<MimeMessage> GetMessageAsync(
+            int index,
+            CancellationToken cancellationToken = default,
+            ITransferProgress? progress = null) => Task.FromResult(_message);
+
+        public override Task<string> GetMessageUidAsync(int index, CancellationToken cancellationToken = default) =>
+            _uidlAvailable
+                ? Task.FromResult("recovered-uid")
+                : Task.FromException<string>(new Pop3CommandException("UIDL failed transiently."));
     }
 
     private sealed class DuplicateMessagePop3Client : Pop3Client {

--- a/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationPop3MailReadHandlerTests.cs
@@ -1,6 +1,7 @@
 using MailKit.Net.Pop3;
 using Mailozaurr;
 using MimeKit;
+using System.Text;
 
 namespace Mailozaurr.Tests;
 
@@ -77,7 +78,97 @@ public sealed class ApplicationPop3MailReadHandlerTests {
 
             var destination = MimeAttachmentStorage.ResolveDestinationPath(directory, attachment);
 
-            Assert.Equal(Path.Combine(directory, "outside.bin"), destination);
+            Assert.Equal(directory, Path.GetDirectoryName(destination));
+            Assert.StartsWith("outside~", Path.GetFileName(destination), StringComparison.Ordinal);
+            Assert.EndsWith(".bin", destination, StringComparison.Ordinal);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SanitizedAttachmentNamesPreserveDistinctRemoteIdentity() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            var colon = MimeAttachmentStorage.ResolveDestinationPath(directory, "report:a.txt");
+            var question = MimeAttachmentStorage.ResolveDestinationPath(directory, "report?a.txt");
+
+            Assert.NotEqual(colon, question);
+            Assert.StartsWith("report_a~", Path.GetFileName(colon), StringComparison.Ordinal);
+            Assert.StartsWith("report_a~", Path.GetFileName(question), StringComparison.Ordinal);
+            Assert.EndsWith(".txt", colon, StringComparison.Ordinal);
+            Assert.EndsWith(".txt", question, StringComparison.Ordinal);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AttachmentNameIdentityIsCaseAndSeparatorSensitive() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            var lower = MimeAttachmentStorage.ResolveDestinationPath(directory, "report.txt");
+            var upper = MimeAttachmentStorage.ResolveDestinationPath(directory, "REPORT.txt");
+            var slash = MimeAttachmentStorage.ResolveDestinationPath(directory, "folder/report.txt");
+            var backslash = MimeAttachmentStorage.ResolveDestinationPath(directory, @"folder\report.txt");
+
+            Assert.Equal(4, new[] { lower, upper, slash, backslash }.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+            Assert.Equal(lower, MimeAttachmentStorage.ResolveDestinationPath(directory, "report.txt"));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GeneratedAttachmentNameCannotCollideWithAnotherRemoteName() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            var transformed = MimeAttachmentStorage.ResolveDestinationPath(directory, "report:a.txt");
+            var generatedLookingRemoteName = Path.GetFileName(transformed);
+            var generatedLooking = MimeAttachmentStorage.ResolveDestinationPath(directory, generatedLookingRemoteName);
+
+            Assert.NotEqual(transformed, generatedLooking);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("CON.txt")]
+    [InlineData("LPT1.log")]
+    [InlineData("NUL.tar.gz")]
+    [InlineData("CON.backup.txt")]
+    [InlineData("trailing. ")]
+    public void PortableUnsafeAttachmentNamesAreDisambiguated(string remoteFileName) {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            var destination = MimeAttachmentStorage.ResolveDestinationPath(directory, remoteFileName);
+
+            Assert.Equal(directory, Path.GetDirectoryName(destination));
+            Assert.Contains("~", Path.GetFileName(destination), StringComparison.Ordinal);
+            Assert.False(Path.GetFileName(destination).StartsWith("CON.", StringComparison.OrdinalIgnoreCase));
+            Assert.False(Path.GetFileName(destination).StartsWith("NUL.", StringComparison.OrdinalIgnoreCase));
+            Assert.False(Path.GetFileName(destination).StartsWith("LPT1.", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AttachmentNameHashingKeepsPortableComponentLength() {
+        var directory = Path.Combine(Path.GetTempPath(), "Mailozaurr.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            var remoteFileName = new string('ż', 190) + ":x." + new string('ę', 80);
+            var destination = MimeAttachmentStorage.ResolveDestinationPath(directory, remoteFileName);
+            var fileName = Path.GetFileName(destination);
+
+            Assert.True(Encoding.UTF8.GetByteCount(fileName) <= 193);
+            Assert.Contains("~", fileName, StringComparison.Ordinal);
         } finally {
             Directory.Delete(directory, recursive: true);
         }

--- a/Sources/Mailozaurr.Tests/ApplicationPop3SessionFactoryTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationPop3SessionFactoryTests.cs
@@ -1,0 +1,66 @@
+using MailKit.Net.Pop3;
+using MailKit.Security;
+using Mailozaurr;
+
+namespace Mailozaurr.Tests;
+
+public sealed class ApplicationPop3SessionFactoryTests {
+    [Fact]
+    public async Task FactoryBuildsBasicAuthSessionRequestFromProfileAndSecrets() {
+        var secretStore = new InMemoryMailSecretStore();
+        await secretStore.SetSecretAsync("work-pop3", MailSecretNames.Password, "super-secret");
+
+        Pop3SessionRequest? captured = null;
+        var factory = new Pop3SessionFactory(secretStore, (request, _) => {
+            captured = request;
+            return Task.FromResult(new Pop3Client());
+        });
+
+        await factory.ConnectAsync(new MailProfile {
+            Id = "work-pop3",
+            DisplayName = "Work POP3",
+            Kind = MailProfileKind.Pop3,
+            DefaultMailbox = "user@example.com",
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Server] = "pop.example.com",
+                [MailProfileSettingsKeys.Port] = "1995",
+                [MailProfileSettingsKeys.SecureSocketOptions] = SecureSocketOptions.SslOnConnect.ToString()
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal("pop.example.com", captured!.Connection.Server);
+        Assert.Equal(1995, captured.Connection.Port);
+        Assert.Equal(SecureSocketOptions.SslOnConnect, captured.Connection.Options);
+        Assert.Equal("user@example.com", captured.UserName);
+        Assert.Equal("super-secret", captured.Secret);
+        Assert.Equal(ProtocolAuthMode.Basic, captured.AuthMode);
+    }
+
+    [Fact]
+    public async Task FactoryUsesOAuthAccessTokenWhenConfigured() {
+        var secretStore = new InMemoryMailSecretStore();
+        await secretStore.SetSecretAsync("oauth-pop3", MailSecretNames.AccessToken, "oauth-token");
+
+        Pop3SessionRequest? captured = null;
+        var factory = new Pop3SessionFactory(secretStore, (request, _) => {
+            captured = request;
+            return Task.FromResult(new Pop3Client());
+        });
+
+        await factory.ConnectAsync(new MailProfile {
+            Id = "oauth-pop3",
+            DisplayName = "OAuth POP3",
+            Kind = MailProfileKind.Pop3,
+            Settings = new Dictionary<string, string> {
+                [MailProfileSettingsKeys.Server] = "pop.example.com",
+                [MailProfileSettingsKeys.UserName] = "user@example.com",
+                [MailProfileSettingsKeys.AuthMode] = "oauth2"
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal(ProtocolAuthMode.OAuth2, captured!.AuthMode);
+        Assert.Equal("oauth-token", captured.Secret);
+    }
+}

--- a/Sources/Mailozaurr.Tests/ApplicationProfileConnectionServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileConnectionServiceTests.cs
@@ -195,6 +195,31 @@ public sealed class ApplicationProfileConnectionServiceTests {
             });
     }
 
+    [Fact]
+    public async Task TestAsyncConvertsSessionDisposalFailureIntoStructuredResult() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "imap-work",
+                DisplayName = "Work IMAP",
+                Kind = MailProfileKind.Imap,
+                DefaultMailbox = "user@example.com"
+            }
+        });
+        var service = new MailProfileConnectionService(
+            profileStore,
+            imapSessionFactory: new ThrowingDisposeImapSessionFactory(),
+            probeImapAsync: (_, _) => Task.CompletedTask);
+
+        var result = await service.TestAsync("imap-work", MailProfileConnectionTestScope.Auth);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("connection_test_failed", result.Code);
+        var cleanup = result.Stages[result.Stages.Count - 1];
+        Assert.Equal(MailProfileConnectionTestPhase.Cleanup, cleanup.Phase);
+        Assert.Equal("dispose", cleanup.Probe);
+        Assert.Contains("dispose failed", cleanup.Message);
+    }
+
     private sealed class InMemoryProfileStore : IMailProfileStore {
         private readonly Dictionary<string, MailProfile> _profiles;
 
@@ -236,6 +261,20 @@ public sealed class ApplicationProfileConnectionServiceTests {
     private sealed class FakeImapSessionFactory : IImapSessionFactory {
         public Task<ImapClient> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
             Task.FromResult(new ImapClient());
+    }
+
+    private sealed class ThrowingDisposeImapSessionFactory : IImapSessionFactory {
+        public Task<ImapClient> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult<ImapClient>(new ThrowingDisposeImapClient());
+    }
+
+    private sealed class ThrowingDisposeImapClient : ImapClient {
+        protected override void Dispose(bool disposing) {
+            base.Dispose(disposing);
+            if (disposing) {
+                throw new InvalidOperationException("dispose failed");
+            }
+        }
     }
 
     private sealed class FakePop3SessionFactory : IPop3SessionFactory {

--- a/Sources/Mailozaurr.Tests/ApplicationProfileConnectionServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileConnectionServiceTests.cs
@@ -1,9 +1,19 @@
 using MailKit.Net.Imap;
+using MailKit.Net.Pop3;
 using Mailozaurr;
 
 namespace Mailozaurr.Tests;
 
 public sealed class ApplicationProfileConnectionServiceTests {
+    [Fact]
+    public void OriginalConstructorRemainsUnambiguousForPositionalNullArguments() {
+        var profileStore = new InMemoryProfileStore(Array.Empty<MailProfile>());
+
+        var service = new MailProfileConnectionService(profileStore, null, null, null, null, null);
+
+        Assert.NotNull(service);
+    }
+
     [Fact]
     public async Task TestAsyncUsesMailboxScopeByDefaultForGmail() {
         var profileStore = new InMemoryProfileStore(new[] {
@@ -37,6 +47,21 @@ public sealed class ApplicationProfileConnectionServiceTests {
         Assert.Equal("listFolders", result.Probe);
         Assert.Equal(0, authProbeCalls);
         Assert.Equal(1, mailboxProbeCalls);
+        Assert.Collection(
+            result.Stages,
+            stage => {
+                Assert.Equal(MailProfileConnectionTestPhase.Profile, stage.Phase);
+                Assert.True(stage.Succeeded);
+            },
+            stage => {
+                Assert.Equal(MailProfileConnectionTestPhase.Session, stage.Phase);
+                Assert.True(stage.Succeeded);
+            },
+            stage => {
+                Assert.Equal(MailProfileConnectionTestPhase.Mailbox, stage.Phase);
+                Assert.True(stage.Succeeded);
+                Assert.Equal("listFolders", stage.Probe);
+            });
     }
 
     [Fact]
@@ -97,6 +122,70 @@ public sealed class ApplicationProfileConnectionServiceTests {
         Assert.Equal("connect", result.Probe);
     }
 
+    [Fact]
+    public async Task TestAsyncUsesMailboxScopeByDefaultForPop3() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "pop3-work",
+                DisplayName = "Work POP3",
+                Kind = MailProfileKind.Pop3,
+                DefaultMailbox = "user@example.com"
+            }
+        });
+        var mailboxProbeCalls = 0;
+        var service = MailProfileConnectionService.CreateWithPop3(
+            profileStore,
+            new FakePop3SessionFactory(),
+            imapSessionFactory: null,
+            graphSessionFactory: null,
+            gmailSessionFactory: null,
+            smtpSessionFactory: null,
+            probePop3Async: (_, _) => Task.CompletedTask,
+            probePop3MailboxAsync: (_, _) => {
+                mailboxProbeCalls++;
+                return Task.CompletedTask;
+            });
+
+        var result = await service.TestAsync("pop3-work");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(MailProfileKind.Pop3, result.ProfileKind);
+        Assert.Equal(MailProfileConnectionTestScope.Mailbox, result.ExecutedScope);
+        Assert.Equal("inspectMailbox", result.Probe);
+        Assert.Equal(1, mailboxProbeCalls);
+        Assert.Equal(MailProfileConnectionTestPhase.Mailbox, result.Stages[result.Stages.Count - 1].Phase);
+    }
+
+    [Fact]
+    public async Task TestAsyncRecordsFailedProbeWithoutLosingCompletedStages() {
+        var profileStore = new InMemoryProfileStore(new[] {
+            new MailProfile {
+                Id = "imap-work",
+                DisplayName = "Work IMAP",
+                Kind = MailProfileKind.Imap,
+                DefaultMailbox = "user@example.com"
+            }
+        });
+        var service = new MailProfileConnectionService(
+            profileStore,
+            imapSessionFactory: new FakeImapSessionFactory(),
+            probeImapAsync: (_, _) => throw new InvalidOperationException("Authentication probe failed."));
+
+        var result = await service.TestAsync("imap-work", MailProfileConnectionTestScope.Auth);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("connection_test_failed", result.Code);
+        Assert.Collection(
+            result.Stages,
+            stage => Assert.Equal(MailProfileConnectionTestPhase.Profile, stage.Phase),
+            stage => Assert.Equal(MailProfileConnectionTestPhase.Session, stage.Phase),
+            stage => {
+                Assert.Equal(MailProfileConnectionTestPhase.Probe, stage.Phase);
+                Assert.False(stage.Succeeded);
+                Assert.Equal("connection_test_failed", stage.Code);
+            });
+    }
+
     private sealed class InMemoryProfileStore : IMailProfileStore {
         private readonly Dictionary<string, MailProfile> _profiles;
 
@@ -138,6 +227,11 @@ public sealed class ApplicationProfileConnectionServiceTests {
     private sealed class FakeImapSessionFactory : IImapSessionFactory {
         public Task<ImapClient> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
             Task.FromResult(new ImapClient());
+    }
+
+    private sealed class FakePop3SessionFactory : IPop3SessionFactory {
+        public Task<Pop3Client> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new Pop3Client());
     }
 
     private sealed class FakeGraphSessionFactory : IGraphSessionFactory {

--- a/Sources/Mailozaurr.Tests/ApplicationProfileConnectionServiceTests.cs
+++ b/Sources/Mailozaurr.Tests/ApplicationProfileConnectionServiceTests.cs
@@ -15,6 +15,15 @@ public sealed class ApplicationProfileConnectionServiceTests {
     }
 
     [Fact]
+    public void Pop3FactoryIsPublicForDirectLibraryComposition() {
+        var method = typeof(MailProfileConnectionService).GetMethod(
+            nameof(MailProfileConnectionService.CreateWithPop3));
+
+        Assert.NotNull(method);
+        Assert.True(method!.IsPublic);
+    }
+
+    [Fact]
     public async Task TestAsyncUsesMailboxScopeByDefaultForGmail() {
         var profileStore = new InMemoryProfileStore(new[] {
             new MailProfile {

--- a/Sources/Mailozaurr.Tests/CliRunnerTests.FakeDraftQueueProfile.cs
+++ b/Sources/Mailozaurr.Tests/CliRunnerTests.FakeDraftQueueProfile.cs
@@ -357,7 +357,17 @@ public sealed partial class CliRunnerTests {
                 Probe = "connect",
                 Target = "work@example.com",
                 RequestedScope = scope,
-                ExecutedScope = scope == MailProfileConnectionTestScope.Auto ? MailProfileConnectionTestScope.Auth : scope
+                ExecutedScope = scope == MailProfileConnectionTestScope.Auto ? MailProfileConnectionTestScope.Auth : scope,
+                Stages = new List<MailProfileConnectionTestStage> {
+                    new() {
+                        Phase = MailProfileConnectionTestPhase.Profile,
+                        Succeeded = true,
+                        Probe = "resolveProfile",
+                        Target = profileId,
+                        DurationMilliseconds = 3,
+                        Message = "Profile resolved."
+                    }
+                }
             });
         }
     }

--- a/Sources/Mailozaurr.Tests/CliRunnerTests.Profile.cs
+++ b/Sources/Mailozaurr.Tests/CliRunnerTests.Profile.cs
@@ -603,6 +603,8 @@ public sealed partial class CliRunnerTests {
         Assert.Equal(0, exitCode);
         Assert.Equal("work-imap", fixture.ProfileConnectionService.LastProfileId);
         Assert.Contains("\"Probe\": \"connect\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"Stages\"", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"DurationMilliseconds\": 3", stdout.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/ImapConnectionRequestTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapConnectionRequestTests.cs
@@ -37,5 +37,7 @@ public class ImapConnectionRequestTests {
         Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, retryCount: -1));
         Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, retryDelayMilliseconds: -1));
         Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, retryDelayBackoff: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, retryDelayBackoff: double.NaN));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ImapConnectionRequest("imap.example.test", 993, retryDelayBackoff: double.PositiveInfinity));
     }
 }

--- a/Sources/Mailozaurr.Tests/ImapMessageReaderTests.cs
+++ b/Sources/Mailozaurr.Tests/ImapMessageReaderTests.cs
@@ -24,6 +24,13 @@ public sealed class ImapMessageReaderTests {
         };
         builder.Attachments.Add("report.txt", new byte[] { 1, 2, 3 });
         message.Body = builder.ToMessageBody();
+        var forwarded = new MessagePart {
+            Message = new MimeMessage(),
+            ContentDisposition = new ContentDisposition(ContentDisposition.Attachment) {
+                FileName = "forwarded.eml"
+            }
+        };
+        Assert.IsAssignableFrom<Multipart>(message.Body).Add(forwarded);
 
         var folder = new Mock<IMailFolder>();
         folder.SetupGet(f => f.FullName).Returns("Inbox/Sub");
@@ -61,8 +68,10 @@ public sealed class ImapMessageReaderTests {
         Assert.True(result.TextTruncated);
         Assert.True(result.HtmlTruncated);
         Assert.True(result.HasAttachments);
-        var attachment = Assert.Single(result.Attachments);
-        Assert.Equal("report.txt", attachment.FileName);
+        Assert.Collection(
+            result.Attachments,
+            attachment => Assert.Equal("report.txt", attachment.FileName),
+            attachment => Assert.Equal("forwarded.eml", attachment.FileName));
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/MailMcpToolsTests.FakeActionsQueueProfile.cs
+++ b/Sources/Mailozaurr.Tests/MailMcpToolsTests.FakeActionsQueueProfile.cs
@@ -288,7 +288,17 @@ public sealed partial class MailMcpToolsTests {
                 Probe = "getProfile",
                 Target = "gmail-work",
                 RequestedScope = scope,
-                ExecutedScope = scope == MailProfileConnectionTestScope.Auto ? MailProfileConnectionTestScope.Mailbox : scope
+                ExecutedScope = scope == MailProfileConnectionTestScope.Auto ? MailProfileConnectionTestScope.Mailbox : scope,
+                Stages = new List<MailProfileConnectionTestStage> {
+                    new() {
+                        Phase = MailProfileConnectionTestPhase.Profile,
+                        Succeeded = true,
+                        Probe = "resolveProfile",
+                        Target = profileId,
+                        DurationMilliseconds = 2,
+                        Message = "Profile resolved."
+                    }
+                }
             });
         }
     }

--- a/Sources/Mailozaurr.Tests/MailMcpToolsTests.Profile.cs
+++ b/Sources/Mailozaurr.Tests/MailMcpToolsTests.Profile.cs
@@ -435,6 +435,7 @@ public sealed partial class MailMcpToolsTests {
         Assert.True(result.Succeeded);
         Assert.Equal("gmail-work", fixture.ProfileConnectionService.LastProfileId);
         Assert.Equal("getProfile", result.Probe);
+        Assert.Equal(MailProfileConnectionTestPhase.Profile, Assert.Single(result.Stages).Phase);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
+++ b/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
@@ -111,16 +111,30 @@ public class MailboxSearcherBodyTests {
         Assert.Equal(1, client.FullMessageDownloads);
     }
 
+    [Fact]
+    public async Task SearchPop3Async_HeaderOnlyFilterFallsBackWhenTopIsUnsupported() {
+        var matching = new MimeMessage { Subject = "Quarterly report" };
+        var client = new FakePop3Client(new[] { matching }) { ThrowHeadersNotSupported = true };
+
+        var result = await MailboxSearcher.SearchPop3Async(client, subject: "report");
+
+        Assert.Single(result);
+        Assert.Equal(1, client.HeaderDownloads);
+        Assert.Equal(1, client.FullMessageDownloads);
+    }
+
     private sealed class FakePop3Client : Pop3Client {
         private readonly List<MimeMessage> _messages;
         public FakePop3Client(IEnumerable<MimeMessage> messages) => _messages = new List<MimeMessage>(messages);
         public int HeaderDownloads { get; private set; }
         public int FullMessageDownloads { get; private set; }
+        public bool ThrowHeadersNotSupported { get; set; }
         public override bool IsConnected => true;
         public override bool IsAuthenticated => true;
         public override int Count => _messages.Count;
         public override Task<HeaderList> GetMessageHeadersAsync(int index, CancellationToken cancellationToken = default) {
             HeaderDownloads++;
+            if (ThrowHeadersNotSupported) throw new NotSupportedException("TOP is unavailable.");
             return Task.FromResult(_messages[index].Headers);
         }
         public override Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {

--- a/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
+++ b/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
@@ -20,6 +20,26 @@ public class MailboxSearcherBodyTests {
         Assert.Single(result);
     }
 
+    [Fact]
+    public async Task SearchPop3Async_UnqualifiedQueryFiltersHeaderAndBodyBeforeLimit() {
+        var unrelated = new MimeMessage { Subject = "Unrelated" };
+        unrelated.Body = new TextPart("plain") { Text = "Other content" };
+        var matching = new MimeMessage { Subject = "Invoice 42" };
+        matching.Body = new TextPart("plain") { Text = "Approved for payment" };
+        var alsoMatching = new MimeMessage { Subject = "Invoice 43" };
+        alsoMatching.Body = new TextPart("plain") { Text = "Approved for payment" };
+        var client = new FakePop3Client(new[] { unrelated, matching, alsoMatching });
+
+        var result = await MailboxSearcher.SearchPop3Async(
+            client,
+            maxResults: 1,
+            queryString: "Invoice approved");
+
+        var message = Assert.Single(result);
+        Assert.Equal(1, message.Index);
+        Assert.Equal("Invoice 42", message.Message.Subject);
+    }
+
     private sealed class FakePop3Client : Pop3Client {
         private readonly List<MimeMessage> _messages;
         public FakePop3Client(IEnumerable<MimeMessage> messages) => _messages = new List<MimeMessage>(messages);

--- a/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
+++ b/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
@@ -21,6 +21,20 @@ public class MailboxSearcherBodyTests {
     }
 
     [Fact]
+    public async Task SearchPop3Async_AppliesLimitToNewestMatches() {
+        var oldest = new MimeMessage { Subject = "Oldest" };
+        var middle = new MimeMessage { Subject = "Middle" };
+        var newest = new MimeMessage { Subject = "Newest" };
+        var client = new FakePop3Client(new[] { oldest, middle, newest });
+
+        var result = await MailboxSearcher.SearchPop3Async(client, maxResults: 1);
+
+        var message = Assert.Single(result);
+        Assert.Equal(2, message.Index);
+        Assert.Equal("Newest", message.Message.Subject);
+    }
+
+    [Fact]
     public async Task SearchPop3Async_UnqualifiedQueryFiltersHeaderAndBodyBeforeLimit() {
         var unrelated = new MimeMessage { Subject = "Unrelated" };
         unrelated.Body = new TextPart("plain") { Text = "Other content" };
@@ -36,8 +50,8 @@ public class MailboxSearcherBodyTests {
             queryString: "Invoice approved");
 
         var message = Assert.Single(result);
-        Assert.Equal(1, message.Index);
-        Assert.Equal("Invoice 42", message.Message.Subject);
+        Assert.Equal(2, message.Index);
+        Assert.Equal("Invoice 43", message.Message.Subject);
     }
 
     [Fact]

--- a/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
+++ b/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
@@ -40,13 +40,59 @@ public class MailboxSearcherBodyTests {
         Assert.Equal("Invoice 42", message.Message.Subject);
     }
 
+    [Fact]
+    public async Task SearchPop3Async_HeaderOnlyFilterDownloadsBodiesOnlyForMatches() {
+        var unrelated = new MimeMessage { Subject = "Unrelated" };
+        unrelated.Body = new TextPart("plain") { Text = new string('x', 100_000) };
+        var matching = new MimeMessage { Subject = "Invoice 42" };
+        matching.Body = new TextPart("plain") { Text = new string('y', 100_000) };
+        var client = new FakePop3Client(new[] { unrelated, matching });
+
+        var result = await MailboxSearcher.SearchPop3Async(client, subject: "Invoice");
+
+        Assert.Single(result);
+        Assert.Equal(2, client.HeaderDownloads);
+        Assert.Equal(1, client.FullMessageDownloads);
+    }
+
+    [Fact]
+    public async Task SearchPop3Async_AddressHeaderFilterUsesParsedMailboxSemantics() {
+        var misleading = new MimeMessage();
+        misleading.Headers.Add(HeaderId.From, "Sender <sender@example.com> (comment-only-token)");
+        misleading.Body = new TextPart("plain") { Text = "Not a match" };
+        var matching = new MimeMessage();
+        matching.Headers.Add(HeaderId.From, "Team: Alice <alice@example.com>, Bob <bob@example.com>;");
+        matching.Body = new TextPart("plain") { Text = "Match" };
+        var client = new FakePop3Client(new[] { misleading, matching });
+
+        var falsePositiveResult = await MailboxSearcher.SearchPop3Async(client, fromContains: "comment-only-token");
+
+        Assert.Empty(falsePositiveResult);
+        Assert.Equal(2, client.HeaderDownloads);
+        Assert.Equal(0, client.FullMessageDownloads);
+
+        var groupResult = await MailboxSearcher.SearchPop3Async(client, fromContains: "bob@example.com");
+
+        Assert.Single(groupResult);
+        Assert.Equal(4, client.HeaderDownloads);
+        Assert.Equal(1, client.FullMessageDownloads);
+    }
+
     private sealed class FakePop3Client : Pop3Client {
         private readonly List<MimeMessage> _messages;
         public FakePop3Client(IEnumerable<MimeMessage> messages) => _messages = new List<MimeMessage>(messages);
+        public int HeaderDownloads { get; private set; }
+        public int FullMessageDownloads { get; private set; }
         public override bool IsConnected => true;
         public override bool IsAuthenticated => true;
         public override int Count => _messages.Count;
-        public override Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken = default, ITransferProgress? progress = null)
-            => Task.FromResult(_messages[index]);
+        public override Task<HeaderList> GetMessageHeadersAsync(int index, CancellationToken cancellationToken = default) {
+            HeaderDownloads++;
+            return Task.FromResult(_messages[index].Headers);
+        }
+        public override Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken = default, ITransferProgress? progress = null) {
+            FullMessageDownloads++;
+            return Task.FromResult(_messages[index]);
+        }
     }
 }

--- a/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
+++ b/Sources/Mailozaurr.Tests/MailboxSearcherBodyTests.cs
@@ -41,6 +41,25 @@ public class MailboxSearcherBodyTests {
     }
 
     [Fact]
+    public async Task SearchPop3Async_CombinesStructuredAndQualifiedQueryFilters() {
+        var structuredOnly = new MimeMessage { Subject = "Invoice ready" };
+        var queryOnly = new MimeMessage { Subject = "Overdue notice" };
+        var matching = new MimeMessage { Subject = "Overdue invoice" };
+        var client = new FakePop3Client(new[] { structuredOnly, queryOnly, matching });
+
+        var result = await MailboxSearcher.SearchPop3Async(
+            client,
+            subject: "Invoice",
+            queryString: "subject:Overdue");
+
+        var message = Assert.Single(result);
+        Assert.Equal(2, message.Index);
+        Assert.Equal("Overdue invoice", message.Message.Subject);
+        Assert.Equal(3, client.HeaderDownloads);
+        Assert.Equal(1, client.FullMessageDownloads);
+    }
+
+    [Fact]
     public async Task SearchPop3Async_HeaderOnlyFilterDownloadsBodiesOnlyForMatches() {
         var unrelated = new MimeMessage { Subject = "Unrelated" };
         unrelated.Body = new TextPart("plain") { Text = new string('x', 100_000) };

--- a/Sources/Mailozaurr.Tests/Pop3ConnectionRequestTests.cs
+++ b/Sources/Mailozaurr.Tests/Pop3ConnectionRequestTests.cs
@@ -1,0 +1,43 @@
+using MailKit.Security;
+using Mailozaurr;
+
+namespace Mailozaurr.Tests;
+
+public sealed class Pop3ConnectionRequestTests {
+    [Fact]
+    public void ConstructorSetsValidatedValues() {
+        var request = new Pop3ConnectionRequest(
+            "pop.example.test",
+            995,
+            SecureSocketOptions.SslOnConnect,
+            timeout: 1234,
+            skipCertificateRevocation: true,
+            skipCertificateValidation: true,
+            retryCount: 7,
+            retryDelayMilliseconds: 150,
+            retryDelayBackoff: 1.5);
+
+        Assert.Equal("pop.example.test", request.Server);
+        Assert.Equal(995, request.Port);
+        Assert.Equal(SecureSocketOptions.SslOnConnect, request.Options);
+        Assert.Equal(1234, request.Timeout);
+        Assert.True(request.SkipCertificateRevocation);
+        Assert.True(request.SkipCertificateValidation);
+        Assert.Equal(7, request.RetryCount);
+        Assert.Equal(150, request.RetryDelayMilliseconds);
+        Assert.Equal(1.5, request.RetryDelayBackoff);
+    }
+
+    [Fact]
+    public void ConstructorRejectsInvalidConnectionSettings() {
+        Assert.Throws<ArgumentException>(() => new Pop3ConnectionRequest("", 995));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Pop3ConnectionRequest("pop.example.test", 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Pop3ConnectionRequest("pop.example.test", 65536));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Pop3ConnectionRequest("pop.example.test", timeout: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Pop3ConnectionRequest("pop.example.test", retryCount: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Pop3ConnectionRequest("pop.example.test", retryDelayMilliseconds: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Pop3ConnectionRequest("pop.example.test", retryDelayBackoff: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Pop3ConnectionRequest("pop.example.test", retryDelayBackoff: double.NaN));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Pop3ConnectionRequest("pop.example.test", retryDelayBackoff: double.PositiveInfinity));
+    }
+}

--- a/Sources/Mailozaurr.Tests/Pop3MailboxBrowserTests.cs
+++ b/Sources/Mailozaurr.Tests/Pop3MailboxBrowserTests.cs
@@ -119,6 +119,17 @@ public sealed class Pop3MailboxBrowserTests {
     }
 
     [Fact]
+    public async Task ListMessageHeadersCoreAsync_FallsBackWhenTopIsUnsupported() {
+        var fake = new FakePop3Client(count: 1) { ThrowHeadersNotSupported = true };
+        fake.SetMessage(0, new MimeMessage { Subject = "Fallback" });
+
+        var result = await Pop3MailboxBrowser.ListMessageHeadersCoreAsync(fake, 1, 0, CancellationToken.None);
+
+        Assert.Single(result.Messages);
+        Assert.Equal("Fallback", result.Messages[0].Subject);
+    }
+
+    [Fact]
     public void NormalizeMessageIdValue_StripsAngleBrackets() {
         Assert.Equal("x@y", Pop3MailboxBrowser.NormalizeMessageIdValue("<x@y>"));
         Assert.Equal("x@y", Pop3MailboxBrowser.NormalizeMessageIdValue("x@y"));
@@ -147,6 +158,7 @@ public sealed class Pop3MailboxBrowserTests {
 
         public int Count { get; }
         public bool ThrowUidListNotSupported { get; set; }
+        public bool ThrowHeadersNotSupported { get; set; }
         public IList<string> Uids { get; set; } = new List<string>();
         public List<int> DeletedIndices { get; } = new();
 
@@ -155,8 +167,10 @@ public sealed class Pop3MailboxBrowserTests {
         internal void SetSize(int index, long size) => _sizes[index] = size;
         internal void SetMessage(int index, MimeMessage msg) => _messages[index] = msg;
 
-        public Task<HeaderList> GetMessageHeadersAsync(int index, CancellationToken cancellationToken) =>
-            Task.FromResult(_headers.TryGetValue(index, out var h) ? h : new HeaderList());
+        public Task<HeaderList> GetMessageHeadersAsync(int index, CancellationToken cancellationToken) {
+            if (ThrowHeadersNotSupported) throw new NotSupportedException("TOP is unavailable.");
+            return Task.FromResult(_headers.TryGetValue(index, out var h) ? h : new HeaderList());
+        }
 
         public Task<MimeMessage> GetMessageAsync(int index, CancellationToken cancellationToken) =>
             Task.FromResult(_messages.TryGetValue(index, out var m) ? m : new MimeMessage());

--- a/Sources/Mailozaurr/GmailMailReadHandler.cs
+++ b/Sources/Mailozaurr/GmailMailReadHandler.cs
@@ -183,7 +183,7 @@ public sealed class GmailMailReadHandler : IMailReadHandler {
         }
 
         var fileName = string.IsNullOrWhiteSpace(resolved.FileName) ? resolved.Id!.Trim() : resolved.FileName!.Trim();
-        var destinationPath = ResolveDestinationPath(request.DestinationPath, fileName);
+        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(request.DestinationPath, fileName);
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
         }
@@ -296,20 +296,6 @@ public sealed class GmailMailReadHandler : IMailReadHandler {
         return attachments.FirstOrDefault(attachment =>
             string.Equals(attachment.Id, attachmentId, StringComparison.OrdinalIgnoreCase) ||
             string.Equals(attachment.FileName, attachmentId, StringComparison.OrdinalIgnoreCase));
-    }
-
-    private static string ResolveDestinationPath(string requestedPath, string fileName) {
-        var destinationPath = Path.GetFullPath(requestedPath);
-        if (Directory.Exists(destinationPath)) {
-            return Path.Combine(destinationPath, fileName);
-        }
-
-        var directory = Path.GetDirectoryName(destinationPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            Directory.CreateDirectory(directory);
-        }
-
-        return destinationPath;
     }
 
     private static string? GetParentPath(string path) {

--- a/Sources/Mailozaurr/GmailMailReadHandler.cs
+++ b/Sources/Mailozaurr/GmailMailReadHandler.cs
@@ -190,9 +190,8 @@ public sealed class GmailMailReadHandler : IMailReadHandler {
                 profile.Id,
                 profile.Kind.ToString(),
                 session.UserId,
-                request.FolderId,
                 request.MessageId,
-                request.AttachmentId));
+                resolved.Id!.Trim()));
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
         }

--- a/Sources/Mailozaurr/GmailMailReadHandler.cs
+++ b/Sources/Mailozaurr/GmailMailReadHandler.cs
@@ -183,7 +183,16 @@ public sealed class GmailMailReadHandler : IMailReadHandler {
         }
 
         var fileName = string.IsNullOrWhiteSpace(resolved.FileName) ? resolved.Id!.Trim() : resolved.FileName!.Trim();
-        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(request.DestinationPath, fileName);
+        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(
+            request.DestinationPath,
+            fileName,
+            MimeAttachmentStorage.CreateStorageIdentity(
+                profile.Id,
+                profile.Kind.ToString(),
+                session.UserId,
+                request.FolderId,
+                request.MessageId,
+                request.AttachmentId));
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
         }

--- a/Sources/Mailozaurr/GraphMailReadHandler.cs
+++ b/Sources/Mailozaurr/GraphMailReadHandler.cs
@@ -260,10 +260,11 @@ public sealed class GraphMailReadHandler : IMailReadHandler {
             return OperationResult.Failure("attachment_not_found", "Message has no attachments.");
         }
 
-        var attachment = MimeAttachmentStorage.ResolveAttachment(attachments, request.AttachmentId);
-        if (attachment == null) {
+        var attachmentIndex = MimeAttachmentStorage.ResolveAttachmentIndex(attachments, request.AttachmentId);
+        if (attachmentIndex < 0) {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }
+        var attachment = attachments[attachmentIndex];
 
         var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(
             request.DestinationPath,
@@ -272,9 +273,8 @@ public sealed class GraphMailReadHandler : IMailReadHandler {
                 profile.Id,
                 profile.Kind.ToString(),
                 userId,
-                request.FolderId,
                 request.MessageId,
-                request.AttachmentId));
+                attachmentIndex.ToString(CultureInfo.InvariantCulture)));
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
         }

--- a/Sources/Mailozaurr/GraphMailReadHandler.cs
+++ b/Sources/Mailozaurr/GraphMailReadHandler.cs
@@ -260,7 +260,13 @@ public sealed class GraphMailReadHandler : IMailReadHandler {
             return OperationResult.Failure("attachment_not_found", "Message has no attachments.");
         }
 
-        var attachmentIndex = MimeAttachmentStorage.ResolveAttachmentIndex(attachments, request.AttachmentId);
+        var attachmentIndex = MimeAttachmentStorage.ResolveAttachmentIndex(
+            attachments,
+            request.AttachmentId,
+            index => MimeAttachmentStorage.CreateStorageIdentity(
+                profile.Id,
+                request.MessageId,
+                index.ToString(CultureInfo.InvariantCulture)));
         if (attachmentIndex < 0) {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }
@@ -272,7 +278,7 @@ public sealed class GraphMailReadHandler : IMailReadHandler {
             MimeAttachmentStorage.CreateStorageIdentity(
                 profile.Id,
                 profile.Kind.ToString(),
-                userId,
+                CanonicalizeUserIdForStorage(userId),
                 request.MessageId,
                 attachmentIndex.ToString(CultureInfo.InvariantCulture)));
         if (File.Exists(destinationPath) && !request.Overwrite) {
@@ -363,6 +369,11 @@ public sealed class GraphMailReadHandler : IMailReadHandler {
         }
 
         return "me";
+    }
+
+    internal static string CanonicalizeUserIdForStorage(string? userId) {
+        var normalized = string.IsNullOrWhiteSpace(userId) ? "me" : userId!.Trim();
+        return string.Equals(normalized, "me", StringComparison.OrdinalIgnoreCase) ? "me" : normalized;
     }
 
     private static int GetMaxMimeBytes(MailProfile profile) {

--- a/Sources/Mailozaurr/GraphMailReadHandler.cs
+++ b/Sources/Mailozaurr/GraphMailReadHandler.cs
@@ -219,7 +219,9 @@ public sealed class GraphMailReadHandler : IMailReadHandler {
             Attachments = message.Attachments.Select((attachment, index) => new AttachmentSummary {
                 MessageId = summary.Id,
                 Id = index.ToString(CultureInfo.InvariantCulture),
-                FileName = MimeAttachmentStorage.GetAttachmentFileName(attachment),
+                FileName = MimeAttachmentStorage.GetAttachmentFileName(
+                    attachment,
+                    MimeAttachmentStorage.CreateStorageIdentity(profile.Id, summary.Id, index.ToString(CultureInfo.InvariantCulture))),
                 ContentType = attachment.ContentType?.MimeType
             }).ToList()
         };

--- a/Sources/Mailozaurr/GraphMailReadHandler.cs
+++ b/Sources/Mailozaurr/GraphMailReadHandler.cs
@@ -263,7 +263,16 @@ public sealed class GraphMailReadHandler : IMailReadHandler {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }
 
-        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(request.DestinationPath, attachment);
+        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(
+            request.DestinationPath,
+            attachment,
+            MimeAttachmentStorage.CreateStorageIdentity(
+                profile.Id,
+                profile.Kind.ToString(),
+                userId,
+                request.FolderId,
+                request.MessageId,
+                request.AttachmentId));
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
         }

--- a/Sources/Mailozaurr/IPop3SessionFactory.cs
+++ b/Sources/Mailozaurr/IPop3SessionFactory.cs
@@ -1,0 +1,11 @@
+using MailKit.Net.Pop3;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Creates authenticated POP3 sessions from stored profiles.
+/// </summary>
+public interface IPop3SessionFactory {
+    /// <summary>Connects an authenticated POP3 client for the provided profile.</summary>
+    Task<Pop3Client> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default);
+}

--- a/Sources/Mailozaurr/ImapMailReadHandler.cs
+++ b/Sources/Mailozaurr/ImapMailReadHandler.cs
@@ -197,10 +197,11 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
             return OperationResult.Failure("attachment_not_found", "Message has no attachments.");
         }
 
-        var attachment = ResolveAttachment(attachments, request.AttachmentId);
-        if (attachment == null) {
+        var attachmentIndex = MimeAttachmentStorage.ResolveAttachmentIndex(attachments, request.AttachmentId);
+        if (attachmentIndex < 0) {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }
+        var attachment = attachments[attachmentIndex];
 
         var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(
             request.DestinationPath,
@@ -210,7 +211,7 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
                 profile.Kind.ToString(),
                 folder,
                 request.MessageId,
-                request.AttachmentId));
+                attachmentIndex.ToString(System.Globalization.CultureInfo.InvariantCulture)));
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
         }
@@ -283,6 +284,4 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
             .ToList();
     }
 
-    private static MimeEntity? ResolveAttachment(IReadOnlyList<MimeEntity> attachments, string attachmentId) =>
-        MimeAttachmentStorage.ResolveAttachment(attachments, attachmentId);
 }

--- a/Sources/Mailozaurr/ImapMailReadHandler.cs
+++ b/Sources/Mailozaurr/ImapMailReadHandler.cs
@@ -202,6 +202,7 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }
         var attachment = attachments[attachmentIndex];
+        var canonicalFolder = CanonicalizeFolderForStorage(mailFolder.FullName);
 
         var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(
             request.DestinationPath,
@@ -209,7 +210,7 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
             MimeAttachmentStorage.CreateStorageIdentity(
                 profile.Id,
                 profile.Kind.ToString(),
-                folder,
+                canonicalFolder,
                 request.MessageId,
                 attachmentIndex.ToString(System.Globalization.CultureInfo.InvariantCulture)));
         if (File.Exists(destinationPath) && !request.Overwrite) {
@@ -244,7 +245,7 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
         }
     };
 
-    private static UniqueId ParseUid(string value) {
+    internal static UniqueId ParseUid(string value) {
         if (uint.TryParse(value, out var uid)) {
             return new UniqueId(uid);
         }
@@ -252,7 +253,12 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
         throw new InvalidOperationException($"Message id '{value}' is not a valid IMAP UID.");
     }
 
-    private static string ResolveFolder(string? folderId, MailProfile profile) {
+    internal static string CanonicalizeFolderForStorage(string fullName) =>
+        string.Equals(fullName, "INBOX", StringComparison.OrdinalIgnoreCase)
+            ? "INBOX"
+            : fullName;
+
+    internal static string ResolveFolder(string? folderId, MailProfile profile) {
         if (!string.IsNullOrWhiteSpace(folderId)) {
             return folderId!.Trim();
         }

--- a/Sources/Mailozaurr/ImapMailReadHandler.cs
+++ b/Sources/Mailozaurr/ImapMailReadHandler.cs
@@ -202,7 +202,15 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }
 
-        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(request.DestinationPath, attachment);
+        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(
+            request.DestinationPath,
+            attachment,
+            MimeAttachmentStorage.CreateStorageIdentity(
+                profile.Id,
+                profile.Kind.ToString(),
+                folder,
+                request.MessageId,
+                request.AttachmentId));
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
         }

--- a/Sources/Mailozaurr/ImapMailReadHandler.cs
+++ b/Sources/Mailozaurr/ImapMailReadHandler.cs
@@ -165,7 +165,12 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
             Attachments = result.Attachments.Select((attachment, index) => new AttachmentSummary {
                 MessageId = summary.Id,
                 Id = index.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                FileName = attachment.FileName,
+                FileName = MimeAttachmentStorage.GetAttachmentFileName(
+                    attachment.FileName,
+                    MimeAttachmentStorage.CreateStorageIdentity(
+                        profile.Id,
+                        summary.Id,
+                        index.ToString(System.Globalization.CultureInfo.InvariantCulture))),
                 ContentType = attachment.ContentType
             }).ToList()
         };
@@ -197,7 +202,13 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
             return OperationResult.Failure("attachment_not_found", "Message has no attachments.");
         }
 
-        var attachmentIndex = MimeAttachmentStorage.ResolveAttachmentIndex(attachments, request.AttachmentId);
+        var attachmentIndex = MimeAttachmentStorage.ResolveAttachmentIndex(
+            attachments,
+            request.AttachmentId,
+            index => MimeAttachmentStorage.CreateStorageIdentity(
+                profile.Id,
+                request.MessageId,
+                index.ToString(System.Globalization.CultureInfo.InvariantCulture)));
         if (attachmentIndex < 0) {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }

--- a/Sources/Mailozaurr/ImapMailReadHandler.cs
+++ b/Sources/Mailozaurr/ImapMailReadHandler.cs
@@ -195,6 +195,7 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
         CancellationToken cancellationToken) {
         var folder = ResolveFolder(request.FolderId, profile);
         var uid = ParseUid(request.MessageId);
+        var canonicalUid = CanonicalizeUidForStorage(request.MessageId);
         var mailFolder = client.GetCachedFolder(folder, FolderAccess.ReadOnly);
         var message = await mailFolder.GetMessageAsync(uid, cancellationToken).ConfigureAwait(false);
         var attachments = message.Attachments.ToList();
@@ -205,10 +206,7 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
         var attachmentIndex = MimeAttachmentStorage.ResolveAttachmentIndex(
             attachments,
             request.AttachmentId,
-            index => MimeAttachmentStorage.CreateStorageIdentity(
-                profile.Id,
-                request.MessageId,
-                index.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+            index => CreateAttachmentFallbackIdentity(profile.Id, canonicalUid, index));
         if (attachmentIndex < 0) {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }
@@ -222,7 +220,7 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
                 profile.Id,
                 profile.Kind.ToString(),
                 canonicalFolder,
-                CanonicalizeUidForStorage(uid),
+                canonicalUid,
                 attachmentIndex.ToString(System.Globalization.CultureInfo.InvariantCulture)));
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
@@ -234,6 +232,15 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
 
     internal static string CanonicalizeUidForStorage(MailKit.UniqueId uid) =>
         uid.Id.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    internal static string CanonicalizeUidForStorage(string messageId) =>
+        CanonicalizeUidForStorage(ParseUid(messageId));
+
+    internal static string CreateAttachmentFallbackIdentity(string profileId, string canonicalUid, int attachmentIndex) =>
+        MimeAttachmentStorage.CreateStorageIdentity(
+            profileId,
+            canonicalUid,
+            attachmentIndex.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
     private static MessageSummary MapSummary(string profileId, string folder, ImapEmailMessage message) => new() {
         ProfileId = profileId,

--- a/Sources/Mailozaurr/ImapMailReadHandler.cs
+++ b/Sources/Mailozaurr/ImapMailReadHandler.cs
@@ -211,7 +211,7 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
                 profile.Id,
                 profile.Kind.ToString(),
                 canonicalFolder,
-                request.MessageId,
+                CanonicalizeUidForStorage(uid),
                 attachmentIndex.ToString(System.Globalization.CultureInfo.InvariantCulture)));
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
@@ -220,6 +220,9 @@ public sealed class ImapMailReadHandler : IMailReadHandler {
         MimeAttachmentStorage.SaveAttachment(attachment, destinationPath);
         return OperationResult.Success($"Attachment saved to '{destinationPath}'.");
     }
+
+    internal static string CanonicalizeUidForStorage(MailKit.UniqueId uid) =>
+        uid.Id.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
     private static MessageSummary MapSummary(string profileId, string folder, ImapEmailMessage message) => new() {
         ProfileId = profileId,

--- a/Sources/Mailozaurr/MailApplicationBuilder.cs
+++ b/Sources/Mailozaurr/MailApplicationBuilder.cs
@@ -35,6 +35,7 @@ public sealed class MailApplicationBuilder {
     private IPendingMessageRepository? _pendingMessageRepository;
     private IPendingMessageDeadLetterRepository? _pendingMessageDeadLetterRepository;
     private IImapSessionFactory? _imapSessionFactory;
+    private IPop3SessionFactory? _pop3SessionFactory;
     private IGraphSessionFactory? _graphSessionFactory;
     private IGmailSessionFactory? _gmailSessionFactory;
     private ISmtpSessionFactory? _smtpSessionFactory;
@@ -222,6 +223,12 @@ public sealed class MailApplicationBuilder {
         return this;
     }
 
+    /// <summary>Uses an explicit POP3 session factory.</summary>
+    public MailApplicationBuilder UsePop3SessionFactory(IPop3SessionFactory pop3SessionFactory) {
+        _pop3SessionFactory = pop3SessionFactory ?? throw new ArgumentNullException(nameof(pop3SessionFactory));
+        return this;
+    }
+
     /// <summary>Uses an explicit Graph session factory.</summary>
     public MailApplicationBuilder UseGraphSessionFactory(IGraphSessionFactory graphSessionFactory) {
         _graphSessionFactory = graphSessionFactory ?? throw new ArgumentNullException(nameof(graphSessionFactory));
@@ -267,6 +274,7 @@ public sealed class MailApplicationBuilder {
         var draftStore = _draftStore ?? new FileMailDraftStore(_options.DraftStore);
         var messageActionPlanBatchStore = _messageActionPlanBatchStore ?? new FileMailMessageActionPlanBatchStore(_options.ActionPlanBatchStore);
         var imapSessionFactory = _imapSessionFactory ?? new ImapSessionFactory(secretStore);
+        var pop3SessionFactory = _pop3SessionFactory ?? new Pop3SessionFactory(secretStore);
         var graphSessionFactory = _graphSessionFactory ?? new GraphSessionFactory(secretStore);
         var gmailSessionFactory = _gmailSessionFactory ?? new GmailSessionFactory(secretStore);
         var smtpSessionFactory = _smtpSessionFactory ?? new SmtpSessionFactory(secretStore);
@@ -279,6 +287,9 @@ public sealed class MailApplicationBuilder {
         var readHandlers = new List<IMailReadHandler>(_readHandlers);
         if (_options.EnableImapReadHandler && !readHandlers.Any(handler => handler.Kind == MailProfileKind.Imap)) {
             readHandlers.Add(new ImapMailReadHandler(imapSessionFactory));
+        }
+        if (_options.EnablePop3ReadHandler && !readHandlers.Any(handler => handler.Kind == MailProfileKind.Pop3)) {
+            readHandlers.Add(new Pop3MailReadHandler(pop3SessionFactory));
         }
         if (_options.EnableGraphReadHandler && !readHandlers.Any(handler => handler.Kind == MailProfileKind.Graph)) {
             readHandlers.Add(new GraphMailReadHandler(graphSessionFactory));
@@ -330,7 +341,13 @@ public sealed class MailApplicationBuilder {
         var profileBootstrapService = _profileBootstrapService ?? new MailProfileBootstrapService(profileService, profileSecretService, secretStore);
         var profileAuthService = _profileAuthService ?? new MailProfileAuthService(profileService, profileSecretService, secretStore);
         var profileOverviewService = _profileOverviewService ?? new MailProfileOverviewService(profileService, profileAuthService);
-        var profileConnectionService = _profileConnectionService ?? new MailProfileConnectionService(profileStore, imapSessionFactory, graphSessionFactory, gmailSessionFactory, smtpSessionFactory);
+        var profileConnectionService = _profileConnectionService ?? MailProfileConnectionService.CreateWithPop3(
+            profileStore,
+            pop3SessionFactory,
+            imapSessionFactory,
+            graphSessionFactory,
+            gmailSessionFactory,
+            smtpSessionFactory);
         var draftService = _draftService ?? new MailDraftService(draftStore, profileStore);
         var draftExchangeService = _draftExchangeService ?? new JsonMailDraftExchangeService();
 

--- a/Sources/Mailozaurr/MailApplicationOptions.cs
+++ b/Sources/Mailozaurr/MailApplicationOptions.cs
@@ -22,6 +22,9 @@ public sealed class MailApplicationOptions {
     /// <summary>Whether the built-in IMAP read handler should be registered.</summary>
     public bool EnableImapReadHandler { get; set; } = true;
 
+    /// <summary>Whether the built-in POP3 read handler should be registered.</summary>
+    public bool EnablePop3ReadHandler { get; set; } = true;
+
     /// <summary>Whether the built-in Graph read handler should be registered.</summary>
     public bool EnableGraphReadHandler { get; set; } = true;
 

--- a/Sources/Mailozaurr/MailCapabilityCatalog.cs
+++ b/Sources/Mailozaurr/MailCapabilityCatalog.cs
@@ -43,6 +43,10 @@ public static class MailCapabilityCatalog {
                 | MailCapability.MarkMessages
                 | MailCapability.MoveMessages
                 | MailCapability.DeleteMessages,
+            MailProfileKind.Pop3 => MailCapability.ListFolders
+                | MailCapability.SearchMessages
+                | MailCapability.ReadMessages
+                | MailCapability.SaveAttachments,
             MailProfileKind.Graph => MailCapability.ListFolders
                 | MailCapability.SearchMessages
                 | MailCapability.ReadMessages

--- a/Sources/Mailozaurr/MailProfileConnectionService.cs
+++ b/Sources/Mailozaurr/MailProfileConnectionService.cs
@@ -61,9 +61,9 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
     }
 
     /// <summary>
-    /// Creates the builder-owned connection-test service with POP3 support.
+    /// Creates a connection-test service with explicit POP3 support for direct library composition.
     /// </summary>
-    internal static MailProfileConnectionService CreateWithPop3(
+    public static MailProfileConnectionService CreateWithPop3(
         IMailProfileStore profileStore,
         IPop3SessionFactory pop3SessionFactory,
         IImapSessionFactory? imapSessionFactory,

--- a/Sources/Mailozaurr/MailProfileConnectionService.cs
+++ b/Sources/Mailozaurr/MailProfileConnectionService.cs
@@ -1,6 +1,7 @@
 using MailKit;
 using MailKit.Net.Imap;
-using Mailozaurr;
+using MailKit.Net.Pop3;
+using System.Diagnostics;
 
 namespace Mailozaurr;
 
@@ -10,11 +11,14 @@ namespace Mailozaurr;
 public sealed class MailProfileConnectionService : IMailProfileConnectionService {
     private readonly IMailProfileStore _profileStore;
     private readonly IImapSessionFactory? _imapSessionFactory;
+    private readonly IPop3SessionFactory? _pop3SessionFactory;
     private readonly IGraphSessionFactory? _graphSessionFactory;
     private readonly IGmailSessionFactory? _gmailSessionFactory;
     private readonly ISmtpSessionFactory? _smtpSessionFactory;
     private readonly Func<ImapClient, CancellationToken, Task> _probeImapAsync;
     private readonly Func<ImapClient, CancellationToken, Task> _probeImapMailboxAsync;
+    private readonly Func<Pop3Client, CancellationToken, Task> _probePop3Async;
+    private readonly Func<Pop3Client, CancellationToken, Task> _probePop3MailboxAsync;
     private readonly Func<GraphSession, CancellationToken, Task> _probeGraphAsync;
     private readonly Func<GraphSession, CancellationToken, Task> _probeGraphMailboxAsync;
     private readonly Func<GmailSession, CancellationToken, Task> _probeGmailAsync;
@@ -22,7 +26,7 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
     private readonly Func<Smtp, CancellationToken, Task> _probeSmtpAsync;
 
     /// <summary>
-    /// Creates a new connection-test service.
+    /// Creates a connection-test service while preserving the original constructor contract.
     /// </summary>
     public MailProfileConnectionService(
         IMailProfileStore profileStore,
@@ -36,14 +40,91 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
         Func<GraphSession, CancellationToken, Task>? probeGraphMailboxAsync = null,
         Func<GmailSession, CancellationToken, Task>? probeGmailAsync = null,
         Func<GmailSession, CancellationToken, Task>? probeGmailMailboxAsync = null,
-        Func<Smtp, CancellationToken, Task>? probeSmtpAsync = null) {
+        Func<Smtp, CancellationToken, Task>? probeSmtpAsync = null)
+        : this(
+            profileStore,
+            pop3SessionFactory: null,
+            imapSessionFactory,
+            graphSessionFactory,
+            gmailSessionFactory,
+            smtpSessionFactory,
+            probeImapAsync,
+            probeImapMailboxAsync,
+            probePop3Async: null,
+            probePop3MailboxAsync: null,
+            probeGraphAsync,
+            probeGraphMailboxAsync,
+            probeGmailAsync,
+            probeGmailMailboxAsync,
+            probeSmtpAsync,
+            initialize: true) {
+    }
+
+    /// <summary>
+    /// Creates the builder-owned connection-test service with POP3 support.
+    /// </summary>
+    internal static MailProfileConnectionService CreateWithPop3(
+        IMailProfileStore profileStore,
+        IPop3SessionFactory pop3SessionFactory,
+        IImapSessionFactory? imapSessionFactory,
+        IGraphSessionFactory? graphSessionFactory,
+        IGmailSessionFactory? gmailSessionFactory,
+        ISmtpSessionFactory? smtpSessionFactory,
+        Func<ImapClient, CancellationToken, Task>? probeImapAsync = null,
+        Func<ImapClient, CancellationToken, Task>? probeImapMailboxAsync = null,
+        Func<Pop3Client, CancellationToken, Task>? probePop3Async = null,
+        Func<Pop3Client, CancellationToken, Task>? probePop3MailboxAsync = null,
+        Func<GraphSession, CancellationToken, Task>? probeGraphAsync = null,
+        Func<GraphSession, CancellationToken, Task>? probeGraphMailboxAsync = null,
+        Func<GmailSession, CancellationToken, Task>? probeGmailAsync = null,
+        Func<GmailSession, CancellationToken, Task>? probeGmailMailboxAsync = null,
+        Func<Smtp, CancellationToken, Task>? probeSmtpAsync = null) =>
+        new MailProfileConnectionService(
+            profileStore,
+            pop3SessionFactory ?? throw new ArgumentNullException(nameof(pop3SessionFactory)),
+            imapSessionFactory,
+            graphSessionFactory,
+            gmailSessionFactory,
+            smtpSessionFactory,
+            probeImapAsync,
+            probeImapMailboxAsync,
+            probePop3Async,
+            probePop3MailboxAsync,
+            probeGraphAsync,
+            probeGraphMailboxAsync,
+            probeGmailAsync,
+            probeGmailMailboxAsync,
+            probeSmtpAsync,
+            initialize: true);
+
+    private MailProfileConnectionService(
+        IMailProfileStore profileStore,
+        IPop3SessionFactory? pop3SessionFactory,
+        IImapSessionFactory? imapSessionFactory,
+        IGraphSessionFactory? graphSessionFactory,
+        IGmailSessionFactory? gmailSessionFactory,
+        ISmtpSessionFactory? smtpSessionFactory,
+        Func<ImapClient, CancellationToken, Task>? probeImapAsync,
+        Func<ImapClient, CancellationToken, Task>? probeImapMailboxAsync,
+        Func<Pop3Client, CancellationToken, Task>? probePop3Async,
+        Func<Pop3Client, CancellationToken, Task>? probePop3MailboxAsync,
+        Func<GraphSession, CancellationToken, Task>? probeGraphAsync,
+        Func<GraphSession, CancellationToken, Task>? probeGraphMailboxAsync,
+        Func<GmailSession, CancellationToken, Task>? probeGmailAsync,
+        Func<GmailSession, CancellationToken, Task>? probeGmailMailboxAsync,
+        Func<Smtp, CancellationToken, Task>? probeSmtpAsync,
+        bool initialize) {
+        _ = initialize;
         _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        _pop3SessionFactory = pop3SessionFactory;
         _imapSessionFactory = imapSessionFactory;
         _graphSessionFactory = graphSessionFactory;
         _gmailSessionFactory = gmailSessionFactory;
         _smtpSessionFactory = smtpSessionFactory;
         _probeImapAsync = probeImapAsync ?? DefaultProbeImapAsync;
         _probeImapMailboxAsync = probeImapMailboxAsync ?? DefaultProbeImapMailboxAsync;
+        _probePop3Async = probePop3Async ?? DefaultProbePop3Async;
+        _probePop3MailboxAsync = probePop3MailboxAsync ?? DefaultProbePop3MailboxAsync;
         _probeGraphAsync = probeGraphAsync ?? DefaultProbeGraphAsync;
         _probeGraphMailboxAsync = probeGraphMailboxAsync ?? DefaultProbeGraphMailboxAsync;
         _probeGmailAsync = probeGmailAsync ?? DefaultProbeGmailAsync;
@@ -56,117 +137,216 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
         string profileId,
         MailProfileConnectionTestScope scope = MailProfileConnectionTestScope.Auto,
         CancellationToken cancellationToken = default) {
+        var stages = new List<MailProfileConnectionTestStage>();
         if (string.IsNullOrWhiteSpace(profileId)) {
-            return Failure("profile_required", "Profile id is required.", profileId, MailProfileKind.Unknown, scope, MailProfileConnectionTestScope.Auto);
+            AddStage(stages, MailProfileConnectionTestPhase.Profile, false, "resolveProfile", null, 0,
+                "profile_required", "Profile id is required.");
+            return Failure("profile_required", "Profile id is required.", profileId, MailProfileKind.Unknown, scope, MailProfileConnectionTestScope.Auto, stages);
         }
 
+        var timer = Stopwatch.StartNew();
         var profile = await _profileStore.GetByIdAsync(profileId.Trim(), cancellationToken).ConfigureAwait(false);
+        timer.Stop();
         if (profile == null) {
-            return Failure("profile_not_found", "Profile was not found.", profileId, MailProfileKind.Unknown, scope, MailProfileConnectionTestScope.Auto);
+            AddStage(stages, MailProfileConnectionTestPhase.Profile, false, "resolveProfile", profileId.Trim(), timer.ElapsedMilliseconds,
+                "profile_not_found", "Profile was not found.");
+            return Failure("profile_not_found", "Profile was not found.", profileId, MailProfileKind.Unknown, scope, MailProfileConnectionTestScope.Auto, stages);
         }
 
         var effectiveScope = ResolveScope(profile, scope);
+        AddStage(stages, MailProfileConnectionTestPhase.Profile, true, "resolveProfile", profile.Id, timer.ElapsedMilliseconds,
+            null, $"Profile '{profile.Id}' resolved as {profile.Kind}.");
+
+        return profile.Kind switch {
+            MailProfileKind.Imap => await TestImapAsync(profile, scope, effectiveScope, stages, cancellationToken).ConfigureAwait(false),
+            MailProfileKind.Pop3 => await TestPop3Async(profile, scope, effectiveScope, stages, cancellationToken).ConfigureAwait(false),
+            MailProfileKind.Graph => await TestGraphAsync(profile, scope, effectiveScope, stages, cancellationToken).ConfigureAwait(false),
+            MailProfileKind.Gmail => await TestGmailAsync(profile, scope, effectiveScope, stages, cancellationToken).ConfigureAwait(false),
+            MailProfileKind.Smtp => await TestSmtpAsync(profile, scope, effectiveScope, stages, cancellationToken).ConfigureAwait(false),
+            _ => Unsupported(profile, scope, effectiveScope, stages)
+        };
+    }
+
+    private Task<MailProfileConnectionTestResult> TestImapAsync(
+        MailProfile profile,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope effectiveScope,
+        List<MailProfileConnectionTestStage> stages,
+        CancellationToken cancellationToken) {
+        if (_imapSessionFactory == null) {
+            return Task.FromResult(Unsupported(profile, requestedScope, effectiveScope, stages, "IMAP connection testing is not configured."));
+        }
+
+        var mailbox = effectiveScope == MailProfileConnectionTestScope.Mailbox;
+        return ExecuteSessionAsync(
+            profile, requestedScope, effectiveScope, stages,
+            token => _imapSessionFactory.ConnectAsync(profile, token),
+            session => session.Dispose(),
+            mailbox ? _probeImapMailboxAsync : _probeImapAsync,
+            mailbox ? MailProfileConnectionTestPhase.Mailbox : MailProfileConnectionTestPhase.Probe,
+            mailbox ? "openInbox" : "connect",
+            ResolveTarget(profile),
+            "IMAP authenticated session created.",
+            mailbox ? "IMAP mailbox probe succeeded." : "IMAP authentication succeeded.",
+            cancellationToken);
+    }
+
+    private Task<MailProfileConnectionTestResult> TestPop3Async(
+        MailProfile profile,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope effectiveScope,
+        List<MailProfileConnectionTestStage> stages,
+        CancellationToken cancellationToken) {
+        if (_pop3SessionFactory == null) {
+            return Task.FromResult(Unsupported(profile, requestedScope, effectiveScope, stages, "POP3 connection testing is not configured."));
+        }
+
+        var mailbox = effectiveScope == MailProfileConnectionTestScope.Mailbox;
+        return ExecuteSessionAsync(
+            profile, requestedScope, effectiveScope, stages,
+            token => _pop3SessionFactory.ConnectAsync(profile, token),
+            session => session.Dispose(),
+            mailbox ? _probePop3MailboxAsync : _probePop3Async,
+            mailbox ? MailProfileConnectionTestPhase.Mailbox : MailProfileConnectionTestPhase.Probe,
+            mailbox ? "inspectMailbox" : "connect",
+            ResolveTarget(profile),
+            "POP3 authenticated session created.",
+            mailbox ? "POP3 mailbox inspection succeeded." : "POP3 authentication succeeded.",
+            cancellationToken);
+    }
+
+    private Task<MailProfileConnectionTestResult> TestGraphAsync(
+        MailProfile profile,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope effectiveScope,
+        List<MailProfileConnectionTestStage> stages,
+        CancellationToken cancellationToken) {
+        if (_graphSessionFactory == null) {
+            return Task.FromResult(Unsupported(profile, requestedScope, effectiveScope, stages, "Graph connection testing is not configured."));
+        }
+
+        var mailbox = effectiveScope == MailProfileConnectionTestScope.Mailbox;
+        var send = effectiveScope == MailProfileConnectionTestScope.Send;
+        return ExecuteSessionAsync(
+            profile, requestedScope, effectiveScope, stages,
+            token => _graphSessionFactory.ConnectAsync(profile, token),
+            session => session.Dispose(),
+            mailbox ? _probeGraphMailboxAsync : _probeGraphAsync,
+            mailbox ? MailProfileConnectionTestPhase.Mailbox : send ? MailProfileConnectionTestPhase.SendPreflight : MailProfileConnectionTestPhase.Probe,
+            mailbox ? "listFolders" : "connect",
+            ResolveTarget(profile),
+            "Graph credential session created.",
+            mailbox ? "Graph mailbox probe succeeded." : send ? "Graph send preflight succeeded." : "Graph credential probe succeeded.",
+            cancellationToken,
+            session => session.UserId);
+    }
+
+    private Task<MailProfileConnectionTestResult> TestGmailAsync(
+        MailProfile profile,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope effectiveScope,
+        List<MailProfileConnectionTestStage> stages,
+        CancellationToken cancellationToken) {
+        if (_gmailSessionFactory == null) {
+            return Task.FromResult(Unsupported(profile, requestedScope, effectiveScope, stages, "Gmail connection testing is not configured."));
+        }
+
+        var mailbox = effectiveScope == MailProfileConnectionTestScope.Mailbox;
+        var send = effectiveScope == MailProfileConnectionTestScope.Send;
+        return ExecuteSessionAsync(
+            profile, requestedScope, effectiveScope, stages,
+            token => _gmailSessionFactory.ConnectAsync(profile, token),
+            session => session.Dispose(),
+            mailbox ? _probeGmailMailboxAsync : _probeGmailAsync,
+            mailbox ? MailProfileConnectionTestPhase.Mailbox : send ? MailProfileConnectionTestPhase.SendPreflight : MailProfileConnectionTestPhase.Probe,
+            mailbox ? "listFolders" : "getProfile",
+            ResolveTarget(profile),
+            "Gmail credential session created.",
+            mailbox ? "Gmail mailbox probe succeeded." : send ? "Gmail send preflight succeeded." : "Gmail provider probe succeeded.",
+            cancellationToken,
+            session => session.UserId);
+    }
+
+    private Task<MailProfileConnectionTestResult> TestSmtpAsync(
+        MailProfile profile,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope effectiveScope,
+        List<MailProfileConnectionTestStage> stages,
+        CancellationToken cancellationToken) {
+        if (_smtpSessionFactory == null) {
+            return Task.FromResult(Unsupported(profile, requestedScope, effectiveScope, stages, "SMTP connection testing is not configured."));
+        }
+
+        var send = effectiveScope == MailProfileConnectionTestScope.Send;
+        return ExecuteSessionAsync(
+            profile, requestedScope, effectiveScope, stages,
+            token => _smtpSessionFactory.ConnectAsync(profile, token),
+            session => session.Dispose(),
+            _probeSmtpAsync,
+            send ? MailProfileConnectionTestPhase.SendPreflight : MailProfileConnectionTestPhase.Probe,
+            "connect",
+            ResolveTarget(profile),
+            "SMTP authenticated session created.",
+            send ? "SMTP send preflight succeeded." : "SMTP authentication succeeded.",
+            cancellationToken);
+    }
+
+    private static async Task<MailProfileConnectionTestResult> ExecuteSessionAsync<TSession>(
+        MailProfile profile,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope effectiveScope,
+        List<MailProfileConnectionTestStage> stages,
+        Func<CancellationToken, Task<TSession>> connectAsync,
+        Action<TSession> dispose,
+        Func<TSession, CancellationToken, Task> probeAsync,
+        MailProfileConnectionTestPhase probePhase,
+        string probe,
+        string? target,
+        string sessionMessage,
+        string successMessage,
+        CancellationToken cancellationToken,
+        Func<TSession, string?>? targetResolver = null) {
+        TSession session;
+        var timer = Stopwatch.StartNew();
         try {
-            return profile.Kind switch {
-                MailProfileKind.Imap => await TestImapAsync(profile, scope, effectiveScope, cancellationToken).ConfigureAwait(false),
-                MailProfileKind.Graph => await TestGraphAsync(profile, scope, effectiveScope, cancellationToken).ConfigureAwait(false),
-                MailProfileKind.Gmail => await TestGmailAsync(profile, scope, effectiveScope, cancellationToken).ConfigureAwait(false),
-                MailProfileKind.Smtp => await TestSmtpAsync(profile, scope, effectiveScope, cancellationToken).ConfigureAwait(false),
-                _ => Failure("connection_test_not_supported", $"Live connection testing is not supported for profile kind '{profile.Kind}'.", profile.Id, profile.Kind, scope, effectiveScope)
-            };
+            session = await connectAsync(cancellationToken).ConfigureAwait(false);
         } catch (OperationCanceledException) {
             throw;
         } catch (Exception ex) {
-            return Failure("connection_test_failed", ex.Message, profile.Id, profile.Kind, scope, effectiveScope);
-        }
-    }
-
-    private async Task<MailProfileConnectionTestResult> TestImapAsync(
-        MailProfile profile,
-        MailProfileConnectionTestScope requestedScope,
-        MailProfileConnectionTestScope effectiveScope,
-        CancellationToken cancellationToken) {
-        if (_imapSessionFactory == null) {
-            return Failure("connection_test_not_supported", "IMAP connection testing is not configured.", profile.Id, profile.Kind, requestedScope, effectiveScope);
+            timer.Stop();
+            AddStage(stages, MailProfileConnectionTestPhase.Session, false, "connect", target, timer.ElapsedMilliseconds,
+                "connection_test_failed", ex.Message);
+            return Failure("connection_test_failed", ex.Message, profile.Id, profile.Kind, requestedScope, effectiveScope, stages);
         }
 
-        using var client = await _imapSessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
-        if (effectiveScope == MailProfileConnectionTestScope.Mailbox) {
-            await _probeImapMailboxAsync(client, cancellationToken).ConfigureAwait(false);
-            return Success(profile, "openInbox", ResolveTarget(profile), "IMAP mailbox probe succeeded.", requestedScope, effectiveScope);
-        }
-
-        await _probeImapAsync(client, cancellationToken).ConfigureAwait(false);
-        return Success(profile, "connect", ResolveTarget(profile), "IMAP authentication succeeded.", requestedScope, effectiveScope);
-    }
-
-    private async Task<MailProfileConnectionTestResult> TestGraphAsync(
-        MailProfile profile,
-        MailProfileConnectionTestScope requestedScope,
-        MailProfileConnectionTestScope effectiveScope,
-        CancellationToken cancellationToken) {
-        if (_graphSessionFactory == null) {
-            return Failure("connection_test_not_supported", "Graph connection testing is not configured.", profile.Id, profile.Kind, requestedScope, effectiveScope);
-        }
-
-        using var session = await _graphSessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
-        if (effectiveScope == MailProfileConnectionTestScope.Mailbox) {
-            await _probeGraphMailboxAsync(session, cancellationToken).ConfigureAwait(false);
-            return Success(profile, "listFolders", session.UserId, "Graph mailbox probe succeeded.", requestedScope, effectiveScope);
-        }
-
-        await _probeGraphAsync(session, cancellationToken).ConfigureAwait(false);
-        return Success(profile, "connect", session.UserId, effectiveScope == MailProfileConnectionTestScope.Send ? "Graph send preflight succeeded." : "Graph authentication succeeded.", requestedScope, effectiveScope);
-    }
-
-    private async Task<MailProfileConnectionTestResult> TestGmailAsync(
-        MailProfile profile,
-        MailProfileConnectionTestScope requestedScope,
-        MailProfileConnectionTestScope effectiveScope,
-        CancellationToken cancellationToken) {
-        if (_gmailSessionFactory == null) {
-            return Failure("connection_test_not_supported", "Gmail connection testing is not configured.", profile.Id, profile.Kind, requestedScope, effectiveScope);
-        }
-
-        using var session = await _gmailSessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
-        if (effectiveScope == MailProfileConnectionTestScope.Mailbox) {
-            await _probeGmailMailboxAsync(session, cancellationToken).ConfigureAwait(false);
-            return Success(profile, "listFolders", session.UserId, "Gmail mailbox probe succeeded.", requestedScope, effectiveScope);
-        }
-
-        await _probeGmailAsync(session, cancellationToken).ConfigureAwait(false);
-        return Success(profile, "getProfile", session.UserId, effectiveScope == MailProfileConnectionTestScope.Send ? "Gmail send preflight succeeded." : "Gmail authentication succeeded.", requestedScope, effectiveScope);
-    }
-
-    private async Task<MailProfileConnectionTestResult> TestSmtpAsync(
-        MailProfile profile,
-        MailProfileConnectionTestScope requestedScope,
-        MailProfileConnectionTestScope effectiveScope,
-        CancellationToken cancellationToken) {
-        if (_smtpSessionFactory == null) {
-            return Failure("connection_test_not_supported", "SMTP connection testing is not configured.", profile.Id, profile.Kind, requestedScope, effectiveScope);
-        }
-
-        var smtp = await _smtpSessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
         try {
-            await _probeSmtpAsync(smtp, cancellationToken).ConfigureAwait(false);
-            return Success(
-                profile,
-                "connect",
-                ResolveTarget(profile),
-                effectiveScope == MailProfileConnectionTestScope.Send ? "SMTP send preflight succeeded." : "SMTP authentication succeeded.",
-                requestedScope,
-                effectiveScope);
+            timer.Stop();
+            target = targetResolver?.Invoke(session) ?? target;
+            AddStage(stages, MailProfileConnectionTestPhase.Session, true, "connect", target, timer.ElapsedMilliseconds,
+                null, sessionMessage);
+
+            timer.Restart();
+            try {
+                await probeAsync(session, cancellationToken).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                timer.Stop();
+                AddStage(stages, probePhase, false, probe, target, timer.ElapsedMilliseconds,
+                    "connection_test_failed", ex.Message);
+                return Failure("connection_test_failed", ex.Message, profile.Id, profile.Kind, requestedScope, effectiveScope, stages);
+            }
+
+            timer.Stop();
+            AddStage(stages, probePhase, true, probe, target, timer.ElapsedMilliseconds, null, successMessage);
+            return Success(profile, probe, target, successMessage, requestedScope, effectiveScope, stages);
         } finally {
-            smtp.Dispose();
+            dispose(session);
         }
     }
 
     private static Task DefaultProbeImapAsync(ImapClient client, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
-        if (client == null) {
-            throw new ArgumentNullException(nameof(client));
-        }
         if (!client.IsConnected || !client.IsAuthenticated) {
             throw new InvalidOperationException("IMAP client is not connected and authenticated.");
         }
@@ -179,14 +359,33 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
         await inbox.OpenAsync(FolderAccess.ReadOnly, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task DefaultProbeGraphAsync(GraphSession session, CancellationToken cancellationToken) {
+    private static Task DefaultProbePop3Async(Pop3Client client, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!client.IsConnected || !client.IsAuthenticated) {
+            throw new InvalidOperationException("POP3 client is not connected and authenticated.");
+        }
+        return Task.CompletedTask;
+    }
+
+    private static async Task DefaultProbePop3MailboxAsync(Pop3Client client, CancellationToken cancellationToken) {
+        await DefaultProbePop3Async(client, cancellationToken).ConfigureAwait(false);
+        if (client.Count > 0) {
+            await client.GetMessageHeadersAsync(client.Count - 1, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static Task DefaultProbeGraphAsync(GraphSession session, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
         _ = session.UserId;
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 
     private static async Task DefaultProbeGraphMailboxAsync(GraphSession session, CancellationToken cancellationToken) {
-        var folders = await session.Client.ListMailFoldersRecursiveAsync(session.UserId, top: 1, maxRequests: 1, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var folders = await session.Client.ListMailFoldersRecursiveAsync(
+            session.UserId,
+            top: 1,
+            maxRequests: 1,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
         _ = folders.Count;
     }
 
@@ -204,18 +403,26 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
 
     private static Task DefaultProbeSmtpAsync(Smtp smtp, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
-        if (smtp == null) {
-            throw new ArgumentNullException(nameof(smtp));
-        }
         if (!smtp.Client.IsConnected) {
             throw new InvalidOperationException("SMTP client is not connected.");
         }
         return Task.CompletedTask;
     }
 
+    private static MailProfileConnectionTestResult Unsupported(
+        MailProfile profile,
+        MailProfileConnectionTestScope requestedScope,
+        MailProfileConnectionTestScope effectiveScope,
+        List<MailProfileConnectionTestStage> stages,
+        string? message = null) {
+        message ??= $"Live connection testing is not supported for profile kind '{profile.Kind}'.";
+        AddStage(stages, MailProfileConnectionTestPhase.Session, false, "connect", ResolveTarget(profile), 0,
+            "connection_test_not_supported", message);
+        return Failure("connection_test_not_supported", message, profile.Id, profile.Kind, requestedScope, effectiveScope, stages);
+    }
+
     private static string? ResolveTarget(MailProfile profile) {
-        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) &&
-            !string.IsNullOrWhiteSpace(mailbox)) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) && !string.IsNullOrWhiteSpace(mailbox)) {
             return mailbox.Trim();
         }
         if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
@@ -224,11 +431,9 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
         if (!string.IsNullOrWhiteSpace(profile.DefaultSender)) {
             return profile.DefaultSender!.Trim();
         }
-        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.UserName, out var userName) &&
-            !string.IsNullOrWhiteSpace(userName)) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.UserName, out var userName) && !string.IsNullOrWhiteSpace(userName)) {
             return userName.Trim();
         }
-
         return null;
     }
 
@@ -236,16 +441,34 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
         scope switch {
             MailProfileConnectionTestScope.Auto => profile.Kind switch {
                 MailProfileKind.Imap => MailProfileConnectionTestScope.Mailbox,
+                MailProfileKind.Pop3 => MailProfileConnectionTestScope.Mailbox,
                 MailProfileKind.Graph => MailProfileConnectionTestScope.Mailbox,
                 MailProfileKind.Gmail => MailProfileConnectionTestScope.Mailbox,
                 MailProfileKind.Smtp => MailProfileConnectionTestScope.Send,
                 _ => MailProfileConnectionTestScope.Auth
             },
             MailProfileConnectionTestScope.Mailbox when profile.Kind == MailProfileKind.Smtp => MailProfileConnectionTestScope.Send,
-            MailProfileConnectionTestScope.Send when profile.Kind == MailProfileKind.Imap => MailProfileConnectionTestScope.Auth,
-            MailProfileConnectionTestScope.Send when profile.Kind == MailProfileKind.Pop3 => MailProfileConnectionTestScope.Auth,
+            MailProfileConnectionTestScope.Send when profile.Kind is MailProfileKind.Imap or MailProfileKind.Pop3 => MailProfileConnectionTestScope.Auth,
             _ => scope
         };
+
+    private static void AddStage(
+        ICollection<MailProfileConnectionTestStage> stages,
+        MailProfileConnectionTestPhase phase,
+        bool succeeded,
+        string probe,
+        string? target,
+        long durationMilliseconds,
+        string? code,
+        string message) => stages.Add(new MailProfileConnectionTestStage {
+            Phase = phase,
+            Succeeded = succeeded,
+            Probe = probe,
+            Target = target,
+            DurationMilliseconds = durationMilliseconds,
+            Code = code,
+            Message = message
+        });
 
     private static MailProfileConnectionTestResult Success(
         MailProfile profile,
@@ -253,7 +476,8 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
         string? target,
         string message,
         MailProfileConnectionTestScope requestedScope,
-        MailProfileConnectionTestScope executedScope) => new() {
+        MailProfileConnectionTestScope executedScope,
+        List<MailProfileConnectionTestStage> stages) => new() {
             Succeeded = true,
             Message = message,
             ProfileId = profile.Id,
@@ -261,7 +485,8 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
             Probe = probe,
             Target = target,
             RequestedScope = requestedScope,
-            ExecutedScope = executedScope
+            ExecutedScope = executedScope,
+            Stages = stages
         };
 
     private static MailProfileConnectionTestResult Failure(
@@ -270,13 +495,15 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
         string? profileId,
         MailProfileKind kind,
         MailProfileConnectionTestScope requestedScope,
-        MailProfileConnectionTestScope executedScope) => new() {
+        MailProfileConnectionTestScope executedScope,
+        List<MailProfileConnectionTestStage> stages) => new() {
             Succeeded = false,
             Code = code,
             Message = message,
             ProfileId = string.IsNullOrWhiteSpace(profileId) ? null : profileId,
             ProfileKind = kind,
             RequestedScope = requestedScope,
-            ExecutedScope = executedScope
+            ExecutedScope = executedScope,
+            Stages = stages
         };
 }

--- a/Sources/Mailozaurr/MailProfileConnectionService.cs
+++ b/Sources/Mailozaurr/MailProfileConnectionService.cs
@@ -386,7 +386,11 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
     private static async Task DefaultProbePop3MailboxAsync(Pop3Client client, CancellationToken cancellationToken) {
         await DefaultProbePop3Async(client, cancellationToken).ConfigureAwait(false);
         if (client.Count > 0) {
-            await client.GetMessageHeadersAsync(client.Count - 1, cancellationToken).ConfigureAwait(false);
+            try {
+                await client.GetMessageHeadersAsync(client.Count - 1, cancellationToken).ConfigureAwait(false);
+            } catch (NotSupportedException) {
+                await client.GetMessageAsync(client.Count - 1, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 

--- a/Sources/Mailozaurr/MailProfileConnectionService.cs
+++ b/Sources/Mailozaurr/MailProfileConnectionService.cs
@@ -319,6 +319,7 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
             return Failure("connection_test_failed", ex.Message, profile.Id, profile.Kind, requestedScope, effectiveScope, stages);
         }
 
+        MailProfileConnectionTestResult result;
         try {
             timer.Stop();
             target = targetResolver?.Invoke(session) ?? target;
@@ -326,23 +327,38 @@ public sealed class MailProfileConnectionService : IMailProfileConnectionService
                 null, sessionMessage);
 
             timer.Restart();
-            try {
-                await probeAsync(session, cancellationToken).ConfigureAwait(false);
-            } catch (OperationCanceledException) {
-                throw;
-            } catch (Exception ex) {
-                timer.Stop();
-                AddStage(stages, probePhase, false, probe, target, timer.ElapsedMilliseconds,
-                    "connection_test_failed", ex.Message);
-                return Failure("connection_test_failed", ex.Message, profile.Id, profile.Kind, requestedScope, effectiveScope, stages);
-            }
-
+            await probeAsync(session, cancellationToken).ConfigureAwait(false);
             timer.Stop();
             AddStage(stages, probePhase, true, probe, target, timer.ElapsedMilliseconds, null, successMessage);
-            return Success(profile, probe, target, successMessage, requestedScope, effectiveScope, stages);
-        } finally {
-            dispose(session);
+            result = Success(profile, probe, target, successMessage, requestedScope, effectiveScope, stages);
+        } catch (OperationCanceledException) {
+            try {
+                dispose(session);
+            } catch (Exception) {
+                // Preserve cancellation as the controlling outcome.
+            }
+            throw;
+        } catch (Exception ex) {
+            timer.Stop();
+            AddStage(stages, probePhase, false, probe, target, timer.ElapsedMilliseconds,
+                "connection_test_failed", ex.Message);
+            result = Failure("connection_test_failed", ex.Message, profile.Id, profile.Kind, requestedScope, effectiveScope, stages);
         }
+
+        timer.Restart();
+        try {
+            dispose(session);
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception ex) {
+            timer.Stop();
+            AddStage(stages, MailProfileConnectionTestPhase.Cleanup, false, "dispose", target, timer.ElapsedMilliseconds,
+                "connection_test_failed", ex.Message);
+            if (result.Succeeded) {
+                return Failure("connection_test_failed", ex.Message, profile.Id, profile.Kind, requestedScope, effectiveScope, stages);
+            }
+        }
+        return result;
     }
 
     private static Task DefaultProbeImapAsync(ImapClient client, CancellationToken cancellationToken) {

--- a/Sources/Mailozaurr/MailProfileConnectionTestPhase.cs
+++ b/Sources/Mailozaurr/MailProfileConnectionTestPhase.cs
@@ -1,0 +1,21 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Identifies an observable phase of a profile connection test.
+/// </summary>
+public enum MailProfileConnectionTestPhase {
+    /// <summary>Resolving and validating the saved profile.</summary>
+    Profile,
+
+    /// <summary>Creating the provider session and resolving its authentication material.</summary>
+    Session,
+
+    /// <summary>Running a lightweight provider or authenticated-session probe.</summary>
+    Probe,
+
+    /// <summary>Running a lightweight mailbox read probe.</summary>
+    Mailbox,
+
+    /// <summary>Running a non-destructive send-path preflight.</summary>
+    SendPreflight
+}

--- a/Sources/Mailozaurr/MailProfileConnectionTestPhase.cs
+++ b/Sources/Mailozaurr/MailProfileConnectionTestPhase.cs
@@ -17,5 +17,8 @@ public enum MailProfileConnectionTestPhase {
     Mailbox,
 
     /// <summary>Running a non-destructive send-path preflight.</summary>
-    SendPreflight
+    SendPreflight,
+
+    /// <summary>Tearing down the provider session and releasing its resources.</summary>
+    Cleanup
 }

--- a/Sources/Mailozaurr/MailProfileConnectionTestResult.cs
+++ b/Sources/Mailozaurr/MailProfileConnectionTestResult.cs
@@ -21,4 +21,7 @@ public sealed class MailProfileConnectionTestResult : OperationResult {
 
     /// <summary>The scope that was actually executed.</summary>
     public MailProfileConnectionTestScope ExecutedScope { get; set; }
+
+    /// <summary>Ordered evidence for the observable phases executed by the test.</summary>
+    public List<MailProfileConnectionTestStage> Stages { get; set; } = new();
 }

--- a/Sources/Mailozaurr/MailProfileConnectionTestStage.cs
+++ b/Sources/Mailozaurr/MailProfileConnectionTestStage.cs
@@ -1,0 +1,18 @@
+namespace Mailozaurr;
+
+/// <summary>
+/// Records one observable phase of a profile connection test.
+/// </summary>
+public sealed class MailProfileConnectionTestStage : OperationResult {
+    /// <summary>Phase represented by this stage.</summary>
+    public MailProfileConnectionTestPhase Phase { get; set; }
+
+    /// <summary>Provider operation used for the phase.</summary>
+    public string? Probe { get; set; }
+
+    /// <summary>Mailbox, account, or transport target when available.</summary>
+    public string? Target { get; set; }
+
+    /// <summary>Elapsed phase duration in milliseconds.</summary>
+    public long DurationMilliseconds { get; set; }
+}

--- a/Sources/Mailozaurr/MimeAttachmentStorage.cs
+++ b/Sources/Mailozaurr/MimeAttachmentStorage.cs
@@ -1,4 +1,6 @@
 using MimeKit;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Mailozaurr;
 
@@ -46,16 +48,105 @@ internal static class MimeAttachmentStorage {
     };
 
     private static string GetSafeAttachmentFileName(string remoteFileName) {
-        var raw = (remoteFileName ?? string.Empty).Replace('\\', '/');
-        var fileName = Path.GetFileName(raw);
+        var sourceFileName = remoteFileName ?? string.Empty;
+        var raw = sourceFileName.Replace('\\', '/');
+        var separatorIndex = raw.LastIndexOf('/');
+        var fileName = separatorIndex >= 0 ? raw.Substring(separatorIndex + 1) : raw;
         if (string.IsNullOrWhiteSpace(fileName) || fileName == "." || fileName == "..") {
             return Path.GetRandomFileName();
         }
 
         var invalid = Path.GetInvalidFileNameChars();
-        var sanitized = new string(fileName.Select(character => invalid.Contains(character) ? '_' : character).ToArray())
-            .TrimEnd(' ', '.');
-        return string.IsNullOrWhiteSpace(sanitized) ? Path.GetRandomFileName() : sanitized;
+        var builder = new StringBuilder(fileName.Length);
+        foreach (var character in fileName) {
+            if (character < 32 || invalid.Contains(character) || IsPortableInvalidFileNameCharacter(character)) {
+                builder.Append('_');
+            } else {
+                builder.Append(character);
+            }
+        }
+
+        var sanitized = builder.ToString().TrimEnd(' ', '.');
+        if (string.IsNullOrWhiteSpace(sanitized)) {
+            return Path.GetRandomFileName();
+        }
+
+        if (IsReservedWindowsFileName(sanitized)) {
+            sanitized = "_" + sanitized;
+        }
+
+        return AppendSourceNameHash(sanitized, sourceFileName);
+    }
+
+    private static bool IsPortableInvalidFileNameCharacter(char character) => character switch {
+        '<' or '>' or ':' or '"' or '/' or '\\' or '|' or '?' or '*' => true,
+        _ => false
+    };
+
+    private static bool IsReservedWindowsFileName(string fileName) {
+        var separatorIndex = fileName.IndexOf('.');
+        var stem = (separatorIndex < 0 ? fileName : fileName.Substring(0, separatorIndex)).TrimEnd(' ', '.');
+        if (stem.Equals("CON", StringComparison.OrdinalIgnoreCase)
+            || stem.Equals("PRN", StringComparison.OrdinalIgnoreCase)
+            || stem.Equals("AUX", StringComparison.OrdinalIgnoreCase)
+            || stem.Equals("NUL", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        if (stem.Length != 4) {
+            return false;
+        }
+
+        var prefix = stem.Substring(0, 3);
+        var suffix = stem[3];
+        return suffix is >= '1' and <= '9'
+            && (prefix.Equals("COM", StringComparison.OrdinalIgnoreCase)
+                || prefix.Equals("LPT", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string AppendSourceNameHash(string sanitizedFileName, string sourceFileName) {
+        using var sha256 = SHA256.Create();
+        var hash = sha256.ComputeHash(Encoding.Unicode.GetBytes(sourceFileName));
+        var hashText = BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+        var extension = TruncateUtf8(Path.GetExtension(sanitizedFileName), 32);
+        var stem = TruncateUtf8(Path.GetFileNameWithoutExtension(sanitizedFileName), 96);
+        if (string.IsNullOrWhiteSpace(stem)) {
+            stem = "attachment";
+        }
+        return stem + "~" + hashText + extension;
+    }
+
+    private static string TruncateUtf8(string value, int maxBytes) {
+        if (Encoding.UTF8.GetByteCount(value) <= maxBytes) {
+            return value;
+        }
+
+        var builder = new StringBuilder(value.Length);
+        var byteCount = 0;
+        for (var index = 0; index < value.Length;) {
+            var character = value[index];
+            var characterLength = char.IsHighSurrogate(character)
+                && index + 1 < value.Length
+                && char.IsLowSurrogate(value[index + 1])
+                    ? 2
+                    : 1;
+            var characterBytes = characterLength == 2
+                ? 4
+                : character <= 0x7f
+                    ? 1
+                    : character <= 0x7ff
+                        ? 2
+                        : 3;
+            if (byteCount + characterBytes > maxBytes) {
+                break;
+            }
+
+            builder.Append(value, index, characterLength);
+            byteCount += characterBytes;
+            index += characterLength;
+        }
+
+        return builder.ToString();
     }
 
     public static void SaveAttachment(MimeEntity attachment, string destinationPath) {

--- a/Sources/Mailozaurr/MimeAttachmentStorage.cs
+++ b/Sources/Mailozaurr/MimeAttachmentStorage.cs
@@ -17,10 +17,19 @@ internal static class MimeAttachmentStorage {
     public static string ResolveDestinationPath(string requestedPath, MimeEntity attachment) =>
         ResolveDestinationPath(requestedPath, GetAttachmentFileName(attachment));
 
-    public static string ResolveDestinationPath(string requestedPath, string remoteFileName) {
+    public static string ResolveDestinationPath(
+        string requestedPath,
+        MimeEntity attachment,
+        string storageIdentity) =>
+        ResolveDestinationPath(requestedPath, GetAttachmentFileName(attachment), storageIdentity);
+
+    public static string ResolveDestinationPath(
+        string requestedPath,
+        string remoteFileName,
+        string? attachmentIdentity = null) {
         var destinationPath = Path.GetFullPath(requestedPath);
         if (Directory.Exists(destinationPath)) {
-            var fileName = GetSafeAttachmentFileName(remoteFileName);
+            var fileName = GetSafeAttachmentFileName(remoteFileName, attachmentIdentity);
             var resolvedPath = Path.GetFullPath(Path.Combine(destinationPath, fileName));
             var directoryPrefix = destinationPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
                 + Path.DirectorySeparatorChar;
@@ -41,13 +50,28 @@ internal static class MimeAttachmentStorage {
         return destinationPath;
     }
 
+    public static string CreateStorageIdentity(params string?[] components) {
+        if (components == null) {
+            throw new ArgumentNullException(nameof(components));
+        }
+
+        var builder = new StringBuilder();
+        foreach (var component in components) {
+            var value = component ?? string.Empty;
+            builder.Append(value.Length.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            builder.Append(':');
+            builder.Append(value);
+        }
+        return builder.ToString();
+    }
+
     public static string GetAttachmentFileName(MimeEntity attachment) => attachment switch {
         MimePart part => part.FileName ?? Path.GetRandomFileName(),
         MessagePart messagePart => messagePart.ContentDisposition?.FileName ?? messagePart.ContentType?.Name ?? Path.GetRandomFileName(),
         _ => Path.GetRandomFileName()
     };
 
-    private static string GetSafeAttachmentFileName(string remoteFileName) {
+    private static string GetSafeAttachmentFileName(string remoteFileName, string? attachmentIdentity) {
         var sourceFileName = remoteFileName ?? string.Empty;
         var raw = sourceFileName.Replace('\\', '/');
         var separatorIndex = raw.LastIndexOf('/');
@@ -75,7 +99,7 @@ internal static class MimeAttachmentStorage {
             sanitized = "_" + sanitized;
         }
 
-        return AppendSourceNameHash(sanitized, sourceFileName);
+        return AppendSourceNameHash(sanitized, sourceFileName, attachmentIdentity);
     }
 
     private static bool IsPortableInvalidFileNameCharacter(char character) => character switch {
@@ -104,9 +128,15 @@ internal static class MimeAttachmentStorage {
                 || prefix.Equals("LPT", StringComparison.OrdinalIgnoreCase));
     }
 
-    private static string AppendSourceNameHash(string sanitizedFileName, string sourceFileName) {
+    private static string AppendSourceNameHash(
+        string sanitizedFileName,
+        string sourceFileName,
+        string? attachmentIdentity) {
         using var sha256 = SHA256.Create();
-        var hash = sha256.ComputeHash(Encoding.Unicode.GetBytes(sourceFileName));
+        var identityInput = string.IsNullOrWhiteSpace(attachmentIdentity)
+            ? sourceFileName
+            : sourceFileName + "\0" + attachmentIdentity;
+        var hash = sha256.ComputeHash(Encoding.Unicode.GetBytes(identityInput));
         var hashText = BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
         var extension = TruncateUtf8(Path.GetExtension(sanitizedFileName), 32);
         var stem = TruncateUtf8(Path.GetFileNameWithoutExtension(sanitizedFileName), 96);

--- a/Sources/Mailozaurr/MimeAttachmentStorage.cs
+++ b/Sources/Mailozaurr/MimeAttachmentStorage.cs
@@ -11,12 +11,20 @@ internal static class MimeAttachmentStorage {
     }
 
     public static int ResolveAttachmentIndex(IReadOnlyList<MimeEntity> attachments, string attachmentId) {
+        return ResolveAttachmentIndex(attachments, attachmentId, fallbackIdentityFactory: null);
+    }
+
+    public static int ResolveAttachmentIndex(
+        IReadOnlyList<MimeEntity> attachments,
+        string attachmentId,
+        Func<int, string?>? fallbackIdentityFactory) {
         if (int.TryParse(attachmentId, out var index) && index >= 0 && index < attachments.Count) {
             return index;
         }
 
         for (var attachmentIndex = 0; attachmentIndex < attachments.Count; attachmentIndex++) {
-            if (string.Equals(GetAttachmentFileName(attachments[attachmentIndex]), attachmentId,
+            var fallbackIdentity = fallbackIdentityFactory?.Invoke(attachmentIndex);
+            if (string.Equals(GetAttachmentFileName(attachments[attachmentIndex], fallbackIdentity), attachmentId,
                 StringComparison.OrdinalIgnoreCase)) {
                 return attachmentIndex;
             }
@@ -86,6 +94,9 @@ internal static class MimeAttachmentStorage {
             ? CreateFallbackFileName(fallbackIdentity)
             : fileName!;
     }
+
+    public static string GetAttachmentFileName(string? fileName, string? fallbackIdentity = null) =>
+        string.IsNullOrWhiteSpace(fileName) ? CreateFallbackFileName(fallbackIdentity) : fileName!;
 
     private static string GetSafeAttachmentFileName(string remoteFileName, string? attachmentIdentity) {
         var sourceFileName = remoteFileName ?? string.Empty;

--- a/Sources/Mailozaurr/MimeAttachmentStorage.cs
+++ b/Sources/Mailozaurr/MimeAttachmentStorage.cs
@@ -21,7 +21,7 @@ internal static class MimeAttachmentStorage {
         string requestedPath,
         MimeEntity attachment,
         string storageIdentity) =>
-        ResolveDestinationPath(requestedPath, GetAttachmentFileName(attachment), storageIdentity);
+        ResolveDestinationPath(requestedPath, GetAttachmentFileName(attachment, storageIdentity), storageIdentity);
 
     public static string ResolveDestinationPath(
         string requestedPath,
@@ -65,11 +65,16 @@ internal static class MimeAttachmentStorage {
         return builder.ToString();
     }
 
-    public static string GetAttachmentFileName(MimeEntity attachment) => attachment switch {
-        MimePart part => part.FileName ?? Path.GetRandomFileName(),
-        MessagePart messagePart => messagePart.ContentDisposition?.FileName ?? messagePart.ContentType?.Name ?? Path.GetRandomFileName(),
-        _ => Path.GetRandomFileName()
-    };
+    public static string GetAttachmentFileName(MimeEntity attachment, string? fallbackIdentity = null) {
+        var fileName = attachment switch {
+            MimePart part => part.FileName,
+            MessagePart messagePart => messagePart.ContentDisposition?.FileName ?? messagePart.ContentType?.Name,
+            _ => null
+        };
+        return string.IsNullOrWhiteSpace(fileName)
+            ? CreateFallbackFileName(fallbackIdentity)
+            : fileName!;
+    }
 
     private static string GetSafeAttachmentFileName(string remoteFileName, string? attachmentIdentity) {
         var sourceFileName = remoteFileName ?? string.Empty;
@@ -77,7 +82,8 @@ internal static class MimeAttachmentStorage {
         var separatorIndex = raw.LastIndexOf('/');
         var fileName = separatorIndex >= 0 ? raw.Substring(separatorIndex + 1) : raw;
         if (string.IsNullOrWhiteSpace(fileName) || fileName == "." || fileName == "..") {
-            return Path.GetRandomFileName();
+            fileName = CreateFallbackFileName(attachmentIdentity);
+            sourceFileName = fileName;
         }
 
         var invalid = Path.GetInvalidFileNameChars();
@@ -92,7 +98,7 @@ internal static class MimeAttachmentStorage {
 
         var sanitized = builder.ToString().TrimEnd(' ', '.');
         if (string.IsNullOrWhiteSpace(sanitized)) {
-            return Path.GetRandomFileName();
+            sanitized = CreateFallbackFileName(attachmentIdentity);
         }
 
         if (IsReservedWindowsFileName(sanitized)) {
@@ -100,6 +106,17 @@ internal static class MimeAttachmentStorage {
         }
 
         return AppendSourceNameHash(sanitized, sourceFileName, attachmentIdentity);
+    }
+
+    private static string CreateFallbackFileName(string? attachmentIdentity) {
+        if (string.IsNullOrWhiteSpace(attachmentIdentity)) {
+            return "attachment.bin";
+        }
+
+        using var sha256 = SHA256.Create();
+        var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(attachmentIdentity));
+        var hashText = BitConverter.ToString(hash, 0, 8).Replace("-", string.Empty).ToLowerInvariant();
+        return "attachment-" + hashText + ".bin";
     }
 
     private static bool IsPortableInvalidFileNameCharacter(char character) => character switch {

--- a/Sources/Mailozaurr/MimeAttachmentStorage.cs
+++ b/Sources/Mailozaurr/MimeAttachmentStorage.cs
@@ -12,10 +12,23 @@ internal static class MimeAttachmentStorage {
             string.Equals(GetAttachmentFileName(attachment), attachmentId, StringComparison.OrdinalIgnoreCase));
     }
 
-    public static string ResolveDestinationPath(string requestedPath, MimeEntity attachment) {
+    public static string ResolveDestinationPath(string requestedPath, MimeEntity attachment) =>
+        ResolveDestinationPath(requestedPath, GetAttachmentFileName(attachment));
+
+    public static string ResolveDestinationPath(string requestedPath, string remoteFileName) {
         var destinationPath = Path.GetFullPath(requestedPath);
         if (Directory.Exists(destinationPath)) {
-            return Path.Combine(destinationPath, GetAttachmentFileName(attachment));
+            var fileName = GetSafeAttachmentFileName(remoteFileName);
+            var resolvedPath = Path.GetFullPath(Path.Combine(destinationPath, fileName));
+            var directoryPrefix = destinationPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
+            var comparison = Path.DirectorySeparatorChar == '\\'
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            if (!resolvedPath.StartsWith(directoryPrefix, comparison)) {
+                throw new InvalidOperationException("Attachment destination escaped the requested directory.");
+            }
+            return resolvedPath;
         }
 
         var directory = Path.GetDirectoryName(destinationPath);
@@ -31,6 +44,19 @@ internal static class MimeAttachmentStorage {
         MessagePart messagePart => messagePart.ContentDisposition?.FileName ?? messagePart.ContentType?.Name ?? Path.GetRandomFileName(),
         _ => Path.GetRandomFileName()
     };
+
+    private static string GetSafeAttachmentFileName(string remoteFileName) {
+        var raw = (remoteFileName ?? string.Empty).Replace('\\', '/');
+        var fileName = Path.GetFileName(raw);
+        if (string.IsNullOrWhiteSpace(fileName) || fileName == "." || fileName == "..") {
+            return Path.GetRandomFileName();
+        }
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var sanitized = new string(fileName.Select(character => invalid.Contains(character) ? '_' : character).ToArray())
+            .TrimEnd(' ', '.');
+        return string.IsNullOrWhiteSpace(sanitized) ? Path.GetRandomFileName() : sanitized;
+    }
 
     public static void SaveAttachment(MimeEntity attachment, string destinationPath) {
         switch (attachment) {

--- a/Sources/Mailozaurr/MimeAttachmentStorage.cs
+++ b/Sources/Mailozaurr/MimeAttachmentStorage.cs
@@ -6,12 +6,23 @@ namespace Mailozaurr;
 
 internal static class MimeAttachmentStorage {
     public static MimeEntity? ResolveAttachment(IReadOnlyList<MimeEntity> attachments, string attachmentId) {
+        var index = ResolveAttachmentIndex(attachments, attachmentId);
+        return index >= 0 ? attachments[index] : null;
+    }
+
+    public static int ResolveAttachmentIndex(IReadOnlyList<MimeEntity> attachments, string attachmentId) {
         if (int.TryParse(attachmentId, out var index) && index >= 0 && index < attachments.Count) {
-            return attachments[index];
+            return index;
         }
 
-        return attachments.FirstOrDefault(attachment =>
-            string.Equals(GetAttachmentFileName(attachment), attachmentId, StringComparison.OrdinalIgnoreCase));
+        for (var attachmentIndex = 0; attachmentIndex < attachments.Count; attachmentIndex++) {
+            if (string.Equals(GetAttachmentFileName(attachments[attachmentIndex]), attachmentId,
+                StringComparison.OrdinalIgnoreCase)) {
+                return attachmentIndex;
+            }
+        }
+
+        return -1;
     }
 
     public static string ResolveDestinationPath(string requestedPath, MimeEntity attachment) =>

--- a/Sources/Mailozaurr/Pop3MailReadHandler.cs
+++ b/Sources/Mailozaurr/Pop3MailReadHandler.cs
@@ -97,7 +97,7 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
         MailProfile profile,
         MailSearchRequest request,
         CancellationToken cancellationToken) {
-        ValidateFolder(request.FolderId);
+        _ = NormalizeFolderId(request.FolderId);
         if (request.IsRead.HasValue) {
             throw new InvalidOperationException("POP3 does not expose persistent read state.");
         }
@@ -134,7 +134,7 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
         MailProfile profile,
         GetMessageRequest request,
         CancellationToken cancellationToken) {
-        ValidateFolder(request.FolderId);
+        _ = NormalizeFolderId(request.FolderId);
         var identifier = ParseMessageId(request.MessageId);
         var resolved = await ResolveMessageAsync(client, identifier, cancellationToken).ConfigureAwait(false);
         if (resolved.Status == Pop3MailboxBrowser.Pop3MessageResolveStatus.NotFound) {
@@ -144,7 +144,7 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
             throw new InvalidOperationException($"POP3 message '{request.MessageId}' could not be resolved ({resolved.Status}).");
         }
 
-        return MapDetail(profile.Id, resolved.Snapshot, request.IncludeRawContent, identifier.Occurrence);
+        return MapDetail(profile.Id, resolved.Snapshot, request.IncludeRawContent, identifier);
     }
 
     private static async Task<OperationResult> DefaultSaveAttachmentAsync(
@@ -152,7 +152,7 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
         MailProfile profile,
         SaveAttachmentRequest request,
         CancellationToken cancellationToken) {
-        ValidateFolder(request.FolderId);
+        var folderId = NormalizeFolderId(request.FolderId);
         var identifier = ParseMessageId(request.MessageId);
         var resolved = await ResolveMessageAsync(client, identifier, cancellationToken).ConfigureAwait(false);
         if (resolved.Status != Pop3MailboxBrowser.Pop3MessageResolveStatus.Success || resolved.Snapshot == null) {
@@ -171,7 +171,7 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
             MimeAttachmentStorage.CreateStorageIdentity(
                 profile.Id,
                 profile.Kind.ToString(),
-                request.FolderId,
+                folderId,
                 request.MessageId,
                 request.AttachmentId));
         if (File.Exists(destinationPath) && !request.Overwrite) {
@@ -260,12 +260,18 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
         string profileId,
         Pop3MailboxBrowser.Pop3ResolvedMessageSnapshot snapshot,
         bool includeRawContent,
-        int occurrence) {
-        var id = FormatMessageId(snapshot.Uid, snapshot.Message, occurrence);
+        (string? Uid, string? Fingerprint, int Occurrence) identifier) {
+        var id = string.IsNullOrWhiteSpace(identifier.Fingerprint)
+            ? FormatMessageId(snapshot.Uid, snapshot.Message)
+            : FormatMessageId(null, snapshot.Message, identifier.Occurrence);
         var detail = new MessageDetail {
             ProfileId = profileId,
             Id = id,
-            Summary = MapSummary(profileId, snapshot.Uid, snapshot.Message, occurrence),
+            Summary = MapSummary(
+                profileId,
+                string.IsNullOrWhiteSpace(identifier.Fingerprint) ? snapshot.Uid : null,
+                snapshot.Message,
+                identifier.Occurrence),
             TextBody = snapshot.Message.TextBody,
             HtmlBody = snapshot.Message.HtmlBody,
             Attachments = snapshot.Message.Attachments.Select((attachment, index) => new AttachmentSummary {
@@ -325,7 +331,6 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
                 cancellationToken: cancellationToken).ConfigureAwait(false);
             if (candidate.Status == Pop3MailboxBrowser.Pop3MessageResolveStatus.Success &&
                 candidate.Snapshot != null &&
-                string.IsNullOrWhiteSpace(candidate.Snapshot.Uid) &&
                 string.Equals(
                     ComputeMessageFingerprint(candidate.Snapshot.Message),
                     identifier.Fingerprint,
@@ -358,11 +363,12 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
             .Replace('/', '_');
     }
 
-    private static void ValidateFolder(string? folderId) {
+    internal static string NormalizeFolderId(string? folderId) {
         if (!string.IsNullOrWhiteSpace(folderId) &&
             !string.Equals(folderId!.Trim(), Inbox, StringComparison.OrdinalIgnoreCase)) {
             throw new InvalidOperationException($"POP3 exposes only the '{Inbox}' folder.");
         }
+        return Inbox;
     }
 
     private static List<MessageRecipient> MapRecipients(InternetAddressList addresses) =>

--- a/Sources/Mailozaurr/Pop3MailReadHandler.cs
+++ b/Sources/Mailozaurr/Pop3MailReadHandler.cs
@@ -157,7 +157,13 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
         }
 
         var attachments = resolved.Snapshot.Message.Attachments.ToList();
-        var attachmentIndex = MimeAttachmentStorage.ResolveAttachmentIndex(attachments, request.AttachmentId);
+        var attachmentIndex = MimeAttachmentStorage.ResolveAttachmentIndex(
+            attachments,
+            request.AttachmentId,
+            index => MimeAttachmentStorage.CreateStorageIdentity(
+                profile.Id,
+                request.MessageId,
+                index.ToString(System.Globalization.CultureInfo.InvariantCulture)));
         if (attachmentIndex < 0) {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }

--- a/Sources/Mailozaurr/Pop3MailReadHandler.cs
+++ b/Sources/Mailozaurr/Pop3MailReadHandler.cs
@@ -115,9 +115,16 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
             queryString: request.QueryText).ConfigureAwait(false);
 
         var results = new List<MessageSummary>(messages.Count);
+        var fingerprintOccurrences = new Dictionary<string, int>(StringComparer.Ordinal);
         foreach (var message in messages) {
             var uid = await TryGetUidAsync(client, message.Index, cancellationToken).ConfigureAwait(false);
-            results.Add(MapSummary(profile.Id, uid, message.Message));
+            var occurrence = 0;
+            if (string.IsNullOrWhiteSpace(uid)) {
+                var fingerprint = ComputeMessageFingerprint(message.Message);
+                _ = fingerprintOccurrences.TryGetValue(fingerprint, out occurrence);
+                fingerprintOccurrences[fingerprint] = occurrence + 1;
+            }
+            results.Add(MapSummary(profile.Id, uid, message.Message, occurrence));
         }
         return results;
     }
@@ -137,7 +144,7 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
             throw new InvalidOperationException($"POP3 message '{request.MessageId}' could not be resolved ({resolved.Status}).");
         }
 
-        return MapDetail(profile.Id, resolved.Snapshot, request.IncludeRawContent);
+        return MapDetail(profile.Id, resolved.Snapshot, request.IncludeRawContent, identifier.Occurrence);
     }
 
     private static async Task<OperationResult> DefaultSaveAttachmentAsync(
@@ -158,7 +165,15 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }
 
-        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(request.DestinationPath, attachment);
+        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(
+            request.DestinationPath,
+            attachment,
+            MimeAttachmentStorage.CreateStorageIdentity(
+                profile.Id,
+                profile.Kind.ToString(),
+                request.FolderId,
+                request.MessageId,
+                request.AttachmentId));
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
         }
@@ -167,12 +182,16 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
         return OperationResult.Success($"Attachment saved to '{destinationPath}'.");
     }
 
-    internal static string FormatMessageId(string? uid, MimeMessage message) =>
-        string.IsNullOrWhiteSpace(uid)
-            ? $"hash:{ComputeMessageFingerprint(message)}"
+    internal static string FormatMessageId(string? uid, MimeMessage message, int occurrence = 0) {
+        if (occurrence < 0) {
+            throw new ArgumentOutOfRangeException(nameof(occurrence));
+        }
+        return string.IsNullOrWhiteSpace(uid)
+            ? $"hash:{ComputeMessageFingerprint(message)}:{occurrence.ToString(System.Globalization.CultureInfo.InvariantCulture)}"
             : $"uid:{uid}";
+    }
 
-    internal static (string? Uid, string? Fingerprint) ParseMessageId(string value) {
+    internal static (string? Uid, string? Fingerprint, int Occurrence) ParseMessageId(string value) {
         if (string.IsNullOrWhiteSpace(value)) {
             throw new InvalidOperationException("A POP3 message id is required.");
         }
@@ -183,14 +202,27 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
             if (string.IsNullOrWhiteSpace(uid)) {
                 throw new InvalidOperationException("A POP3 UID value is required after 'uid:'.");
             }
-            return (uid, null);
+            return (uid, null, 0);
         }
         if (normalized.StartsWith("hash:", StringComparison.OrdinalIgnoreCase)) {
-            var fingerprint = normalized.Substring(5);
+            var fingerprintWithOccurrence = normalized.Substring(5);
+            var separatorIndex = fingerprintWithOccurrence.LastIndexOf(':');
+            var fingerprint = separatorIndex < 0
+                ? fingerprintWithOccurrence
+                : fingerprintWithOccurrence.Substring(0, separatorIndex);
             if (string.IsNullOrWhiteSpace(fingerprint)) {
                 throw new InvalidOperationException("A POP3 content fingerprint is required after 'hash:'.");
             }
-            return (null, fingerprint);
+            var occurrence = 0;
+            if (separatorIndex >= 0 &&
+                (!int.TryParse(
+                    fingerprintWithOccurrence.Substring(separatorIndex + 1),
+                    System.Globalization.NumberStyles.None,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out occurrence) || occurrence < 0)) {
+                throw new InvalidOperationException("A POP3 hash occurrence must be a non-negative integer.");
+            }
+            return (null, fingerprint, occurrence);
         }
         if (normalized.StartsWith("index:", StringComparison.OrdinalIgnoreCase) ||
             int.TryParse(normalized, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out _)) {
@@ -198,12 +230,16 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
                 "Session-local POP3 index ids are not reusable. Use the uid: or hash: id returned by search.");
         }
 
-        return (normalized, null);
+        return (normalized, null, 0);
     }
 
-    internal static MessageSummary MapSummary(string profileId, string? uid, MimeMessage message) => new() {
+    internal static MessageSummary MapSummary(
+        string profileId,
+        string? uid,
+        MimeMessage message,
+        int occurrence = 0) => new() {
         ProfileId = profileId,
-        Id = FormatMessageId(uid, message),
+        Id = FormatMessageId(uid, message, occurrence),
         FolderId = Inbox,
         Subject = message.Subject,
         Preview = CreatePreview(message.TextBody),
@@ -223,12 +259,13 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
     private static MessageDetail MapDetail(
         string profileId,
         Pop3MailboxBrowser.Pop3ResolvedMessageSnapshot snapshot,
-        bool includeRawContent) {
-        var id = FormatMessageId(snapshot.Uid, snapshot.Message);
+        bool includeRawContent,
+        int occurrence) {
+        var id = FormatMessageId(snapshot.Uid, snapshot.Message, occurrence);
         var detail = new MessageDetail {
             ProfileId = profileId,
             Id = id,
-            Summary = MapSummary(profileId, snapshot.Uid, snapshot.Message),
+            Summary = MapSummary(profileId, snapshot.Uid, snapshot.Message, occurrence),
             TextBody = snapshot.Message.TextBody,
             HtmlBody = snapshot.Message.HtmlBody,
             Attachments = snapshot.Message.Attachments.Select((attachment, index) => new AttachmentSummary {
@@ -266,7 +303,7 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
 
     private static async Task<Pop3MailboxBrowser.Pop3MessageResolveResult> ResolveMessageAsync(
         Pop3Client client,
-        (string? Uid, string? Fingerprint) identifier,
+        (string? Uid, string? Fingerprint, int Occurrence) identifier,
         CancellationToken cancellationToken) {
         if (string.IsNullOrWhiteSpace(identifier.Fingerprint)) {
             return await Pop3MailboxBrowser.ResolveMessageAsync(
@@ -276,7 +313,8 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
                 cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        for (var index = client.Count - 1; index >= 0; index--) {
+        var occurrence = 0;
+        for (var index = 0; index < client.Count; index++) {
             cancellationToken.ThrowIfCancellationRequested();
             var candidate = await Pop3MailboxBrowser.ResolveMessageAsync(
                 client,
@@ -285,11 +323,15 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
                 cancellationToken: cancellationToken).ConfigureAwait(false);
             if (candidate.Status == Pop3MailboxBrowser.Pop3MessageResolveStatus.Success &&
                 candidate.Snapshot != null &&
+                string.IsNullOrWhiteSpace(candidate.Snapshot.Uid) &&
                 string.Equals(
                     ComputeMessageFingerprint(candidate.Snapshot.Message),
                     identifier.Fingerprint,
                     StringComparison.Ordinal)) {
-                return candidate;
+                if (occurrence == identifier.Occurrence) {
+                    return candidate;
+                }
+                occurrence++;
             }
         }
 

--- a/Sources/Mailozaurr/Pop3MailReadHandler.cs
+++ b/Sources/Mailozaurr/Pop3MailReadHandler.cs
@@ -1,0 +1,337 @@
+using MailKit.Net.Pop3;
+using MimeKit;
+using System.Security.Cryptography;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Normalized POP3 read handler backed by Mailozaurr POP3 helpers.
+/// </summary>
+/// <remarks>
+/// POP3 exposes a single inbox and does not provide server-side folders or persistent read/move state.
+/// </remarks>
+public sealed class Pop3MailReadHandler : IMailReadHandler {
+    private const string Inbox = "INBOX";
+    private readonly IPop3SessionFactory _sessionFactory;
+    private readonly Func<Pop3Client, MailProfile, MailFolderQuery, CancellationToken, Task<IReadOnlyList<FolderRef>>> _getFoldersAsync;
+    private readonly Func<Pop3Client, MailProfile, MailSearchRequest, CancellationToken, Task<IReadOnlyList<MessageSummary>>> _searchAsync;
+    private readonly Func<Pop3Client, MailProfile, GetMessageRequest, CancellationToken, Task<MessageDetail?>> _getMessageAsync;
+    private readonly Func<Pop3Client, MailProfile, SaveAttachmentRequest, CancellationToken, Task<OperationResult>> _saveAttachmentAsync;
+
+    /// <summary>Creates a new POP3 read handler.</summary>
+    public Pop3MailReadHandler(
+        IPop3SessionFactory sessionFactory,
+        Func<Pop3Client, MailProfile, MailFolderQuery, CancellationToken, Task<IReadOnlyList<FolderRef>>>? getFoldersAsync = null,
+        Func<Pop3Client, MailProfile, MailSearchRequest, CancellationToken, Task<IReadOnlyList<MessageSummary>>>? searchAsync = null,
+        Func<Pop3Client, MailProfile, GetMessageRequest, CancellationToken, Task<MessageDetail?>>? getMessageAsync = null,
+        Func<Pop3Client, MailProfile, SaveAttachmentRequest, CancellationToken, Task<OperationResult>>? saveAttachmentAsync = null) {
+        _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
+        _getFoldersAsync = getFoldersAsync ?? DefaultGetFoldersAsync;
+        _searchAsync = searchAsync ?? DefaultSearchAsync;
+        _getMessageAsync = getMessageAsync ?? DefaultGetMessageAsync;
+        _saveAttachmentAsync = saveAttachmentAsync ?? DefaultSaveAttachmentAsync;
+    }
+
+    /// <inheritdoc />
+    public MailProfileKind Kind => MailProfileKind.Pop3;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FolderRef>> GetFoldersAsync(
+        MailProfile profile,
+        MailFolderQuery query,
+        CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _getFoldersAsync(client, profile, query, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MessageSummary>> SearchAsync(
+        MailProfile profile,
+        MailSearchRequest request,
+        CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _searchAsync(client, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<MessageDetail?> GetMessageAsync(
+        MailProfile profile,
+        GetMessageRequest request,
+        CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _getMessageAsync(client, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> SaveAttachmentAsync(
+        MailProfile profile,
+        SaveAttachmentRequest request,
+        CancellationToken cancellationToken = default) {
+        using var client = await _sessionFactory.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _saveAttachmentAsync(client, profile, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Task<IReadOnlyList<FolderRef>> DefaultGetFoldersAsync(
+        Pop3Client client,
+        MailProfile profile,
+        MailFolderQuery query,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        IReadOnlyList<FolderRef> folders = string.IsNullOrWhiteSpace(query.ParentFolderId)
+            ? new[] {
+                new FolderRef {
+                    ProfileId = profile.Id,
+                    Id = Inbox,
+                    DisplayName = "Inbox",
+                    Path = Inbox,
+                    SpecialUse = "Inbox",
+                    MessageCount = client.Count
+                }
+            }
+            : Array.Empty<FolderRef>();
+        return Task.FromResult(folders);
+    }
+
+    private static async Task<IReadOnlyList<MessageSummary>> DefaultSearchAsync(
+        Pop3Client client,
+        MailProfile profile,
+        MailSearchRequest request,
+        CancellationToken cancellationToken) {
+        ValidateFolder(request.FolderId);
+        if (request.IsRead.HasValue) {
+            throw new InvalidOperationException("POP3 does not expose persistent read state.");
+        }
+
+        var messages = await MailboxSearcher.SearchPop3Async(
+            client,
+            subject: request.SubjectContains,
+            fromContains: request.FromContains,
+            toContains: request.ToContains,
+            since: request.Since?.UtcDateTime,
+            before: request.Before?.UtcDateTime,
+            hasAttachment: request.HasAttachments,
+            maxResults: request.Limit ?? 0,
+            cancellationToken: cancellationToken,
+            queryString: request.QueryText).ConfigureAwait(false);
+
+        var results = new List<MessageSummary>(messages.Count);
+        foreach (var message in messages) {
+            var uid = await TryGetUidAsync(client, message.Index, cancellationToken).ConfigureAwait(false);
+            results.Add(MapSummary(profile.Id, uid, message.Message));
+        }
+        return results;
+    }
+
+    private static async Task<MessageDetail?> DefaultGetMessageAsync(
+        Pop3Client client,
+        MailProfile profile,
+        GetMessageRequest request,
+        CancellationToken cancellationToken) {
+        ValidateFolder(request.FolderId);
+        var identifier = ParseMessageId(request.MessageId);
+        var resolved = await ResolveMessageAsync(client, identifier, cancellationToken).ConfigureAwait(false);
+        if (resolved.Status == Pop3MailboxBrowser.Pop3MessageResolveStatus.NotFound) {
+            return null;
+        }
+        if (resolved.Status != Pop3MailboxBrowser.Pop3MessageResolveStatus.Success || resolved.Snapshot == null) {
+            throw new InvalidOperationException($"POP3 message '{request.MessageId}' could not be resolved ({resolved.Status}).");
+        }
+
+        return MapDetail(profile.Id, resolved.Snapshot, request.IncludeRawContent);
+    }
+
+    private static async Task<OperationResult> DefaultSaveAttachmentAsync(
+        Pop3Client client,
+        MailProfile profile,
+        SaveAttachmentRequest request,
+        CancellationToken cancellationToken) {
+        ValidateFolder(request.FolderId);
+        var identifier = ParseMessageId(request.MessageId);
+        var resolved = await ResolveMessageAsync(client, identifier, cancellationToken).ConfigureAwait(false);
+        if (resolved.Status != Pop3MailboxBrowser.Pop3MessageResolveStatus.Success || resolved.Snapshot == null) {
+            return OperationResult.Failure("message_not_found", $"POP3 message '{request.MessageId}' was not found.");
+        }
+
+        var attachments = resolved.Snapshot.Message.Attachments.ToList();
+        var attachment = MimeAttachmentStorage.ResolveAttachment(attachments, request.AttachmentId);
+        if (attachment == null) {
+            return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
+        }
+
+        var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(request.DestinationPath, attachment);
+        if (File.Exists(destinationPath) && !request.Overwrite) {
+            return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
+        }
+
+        MimeAttachmentStorage.SaveAttachment(attachment, destinationPath);
+        return OperationResult.Success($"Attachment saved to '{destinationPath}'.");
+    }
+
+    internal static string FormatMessageId(string? uid, MimeMessage message) =>
+        string.IsNullOrWhiteSpace(uid)
+            ? $"hash:{ComputeMessageFingerprint(message)}"
+            : $"uid:{uid}";
+
+    internal static (string? Uid, string? Fingerprint) ParseMessageId(string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            throw new InvalidOperationException("A POP3 message id is required.");
+        }
+
+        var normalized = value.Trim();
+        if (normalized.StartsWith("uid:", StringComparison.OrdinalIgnoreCase)) {
+            var uid = normalized.Substring(4);
+            if (string.IsNullOrWhiteSpace(uid)) {
+                throw new InvalidOperationException("A POP3 UID value is required after 'uid:'.");
+            }
+            return (uid, null);
+        }
+        if (normalized.StartsWith("hash:", StringComparison.OrdinalIgnoreCase)) {
+            var fingerprint = normalized.Substring(5);
+            if (string.IsNullOrWhiteSpace(fingerprint)) {
+                throw new InvalidOperationException("A POP3 content fingerprint is required after 'hash:'.");
+            }
+            return (null, fingerprint);
+        }
+        if (normalized.StartsWith("index:", StringComparison.OrdinalIgnoreCase) ||
+            int.TryParse(normalized, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out _)) {
+            throw new InvalidOperationException(
+                "Session-local POP3 index ids are not reusable. Use the uid: or hash: id returned by search.");
+        }
+
+        return (normalized, null);
+    }
+
+    internal static MessageSummary MapSummary(string profileId, string? uid, MimeMessage message) => new() {
+        ProfileId = profileId,
+        Id = FormatMessageId(uid, message),
+        FolderId = Inbox,
+        Subject = message.Subject,
+        Preview = CreatePreview(message.TextBody),
+        From = MapRecipients(message.From),
+        To = MapRecipients(message.To),
+        Cc = MapRecipients(message.Cc),
+        SentAt = message.Date,
+        ReceivedAt = message.Date,
+        HasAttachments = message.Attachments.Any(),
+        Priority = message.Priority switch {
+            MimeKit.MessagePriority.Urgent => MessagePriority.High,
+            MimeKit.MessagePriority.NonUrgent => MessagePriority.Low,
+            _ => MessagePriority.Normal
+        }
+    };
+
+    private static MessageDetail MapDetail(
+        string profileId,
+        Pop3MailboxBrowser.Pop3ResolvedMessageSnapshot snapshot,
+        bool includeRawContent) {
+        var id = FormatMessageId(snapshot.Uid, snapshot.Message);
+        var detail = new MessageDetail {
+            ProfileId = profileId,
+            Id = id,
+            Summary = MapSummary(profileId, snapshot.Uid, snapshot.Message),
+            TextBody = snapshot.Message.TextBody,
+            HtmlBody = snapshot.Message.HtmlBody,
+            Attachments = snapshot.Message.Attachments.Select((attachment, index) => new AttachmentSummary {
+                MessageId = id,
+                Id = index.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                FileName = MimeAttachmentStorage.GetAttachmentFileName(attachment),
+                ContentType = attachment.ContentType.MimeType
+            }).ToList()
+        };
+
+        if (includeRawContent) {
+            using var stream = new MemoryStream();
+            snapshot.Message.WriteTo(stream);
+            stream.Position = 0;
+            using var reader = new StreamReader(stream);
+            detail.RawContent = reader.ReadToEnd();
+        }
+        return detail;
+    }
+
+    private static async Task<string?> TryGetUidAsync(
+        Pop3Client client,
+        int index,
+        CancellationToken cancellationToken) {
+        try {
+            return await client.GetMessageUidAsync(index, cancellationToken).ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (NotSupportedException) {
+            return null;
+        } catch (Pop3CommandException) {
+            return null;
+        }
+    }
+
+    private static async Task<Pop3MailboxBrowser.Pop3MessageResolveResult> ResolveMessageAsync(
+        Pop3Client client,
+        (string? Uid, string? Fingerprint) identifier,
+        CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(identifier.Fingerprint)) {
+            return await Pop3MailboxBrowser.ResolveMessageAsync(
+                client,
+                requestedIndex: null,
+                requestedUid: identifier.Uid,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        for (var index = client.Count - 1; index >= 0; index--) {
+            cancellationToken.ThrowIfCancellationRequested();
+            var candidate = await Pop3MailboxBrowser.ResolveMessageAsync(
+                client,
+                index,
+                requestedUid: null,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (candidate.Status == Pop3MailboxBrowser.Pop3MessageResolveStatus.Success &&
+                candidate.Snapshot != null &&
+                string.Equals(
+                    ComputeMessageFingerprint(candidate.Snapshot.Message),
+                    identifier.Fingerprint,
+                    StringComparison.Ordinal)) {
+                return candidate;
+            }
+        }
+
+        return new Pop3MailboxBrowser.Pop3MessageResolveResult(
+            Pop3MailboxBrowser.Pop3MessageResolveStatus.NotFound,
+            null);
+    }
+
+    internal static string ComputeMessageFingerprint(MimeMessage message) {
+        if (message == null) {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        using var stream = new MemoryStream();
+        message.WriteTo(stream);
+        stream.Position = 0;
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(stream);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private static void ValidateFolder(string? folderId) {
+        if (!string.IsNullOrWhiteSpace(folderId) &&
+            !string.Equals(folderId!.Trim(), Inbox, StringComparison.OrdinalIgnoreCase)) {
+            throw new InvalidOperationException($"POP3 exposes only the '{Inbox}' folder.");
+        }
+    }
+
+    private static List<MessageRecipient> MapRecipients(InternetAddressList addresses) =>
+        addresses.Mailboxes.Select(mailbox => new MessageRecipient {
+            Name = mailbox.Name,
+            Address = mailbox.Address ?? string.Empty
+        }).ToList();
+
+    private static string? CreatePreview(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return value;
+        }
+        const int maxLength = 512;
+        return value!.Length <= maxLength ? value : value.Substring(0, maxLength);
+    }
+}

--- a/Sources/Mailozaurr/Pop3MailReadHandler.cs
+++ b/Sources/Mailozaurr/Pop3MailReadHandler.cs
@@ -156,19 +156,16 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
             return OperationResult.Failure("message_not_found", $"POP3 message '{request.MessageId}' was not found.");
         }
 
+        var canonicalMessageId = CanonicalizeMessageIdForStorage(identifier, resolved.Snapshot);
         var attachments = resolved.Snapshot.Message.Attachments.ToList();
         var attachmentIndex = MimeAttachmentStorage.ResolveAttachmentIndex(
             attachments,
             request.AttachmentId,
-            index => MimeAttachmentStorage.CreateStorageIdentity(
-                profile.Id,
-                request.MessageId,
-                index.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+            index => CreateAttachmentFallbackIdentity(profile.Id, canonicalMessageId, index));
         if (attachmentIndex < 0) {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }
         var attachment = attachments[attachmentIndex];
-        var canonicalMessageId = CanonicalizeMessageIdForStorage(identifier, resolved.Snapshot);
 
         var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(
             request.DestinationPath,
@@ -186,6 +183,12 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
         MimeAttachmentStorage.SaveAttachment(attachment, destinationPath);
         return OperationResult.Success($"Attachment saved to '{destinationPath}'.");
     }
+
+    internal static string CreateAttachmentFallbackIdentity(string profileId, string canonicalMessageId, int attachmentIndex) =>
+        MimeAttachmentStorage.CreateStorageIdentity(
+            profileId,
+            canonicalMessageId,
+            attachmentIndex.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
     internal static string FormatMessageId(string? uid, MimeMessage message, int occurrence = 0) {
         if (occurrence < 0) {

--- a/Sources/Mailozaurr/Pop3MailReadHandler.cs
+++ b/Sources/Mailozaurr/Pop3MailReadHandler.cs
@@ -162,6 +162,7 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }
         var attachment = attachments[attachmentIndex];
+        var canonicalMessageId = CanonicalizeMessageIdForStorage(identifier, resolved.Snapshot);
 
         var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(
             request.DestinationPath,
@@ -170,7 +171,7 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
                 profile.Id,
                 profile.Kind.ToString(),
                 folderId,
-                request.MessageId,
+                canonicalMessageId,
                 attachmentIndex.ToString(System.Globalization.CultureInfo.InvariantCulture)));
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
@@ -188,6 +189,13 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
             ? $"hash:{ComputeMessageFingerprint(message)}:{occurrence.ToString(System.Globalization.CultureInfo.InvariantCulture)}"
             : $"uid:{uid}";
     }
+
+    internal static string CanonicalizeMessageIdForStorage(
+        (string? Uid, string? Fingerprint, int Occurrence) identifier,
+        Pop3MailboxBrowser.Pop3ResolvedMessageSnapshot snapshot) =>
+        string.IsNullOrWhiteSpace(identifier.Fingerprint)
+            ? FormatMessageId(snapshot.Uid, snapshot.Message)
+            : FormatMessageId(null, snapshot.Message, identifier.Occurrence);
 
     internal static (string? Uid, string? Fingerprint, int Occurrence) ParseMessageId(string value) {
         if (string.IsNullOrWhiteSpace(value)) {

--- a/Sources/Mailozaurr/Pop3MailReadHandler.cs
+++ b/Sources/Mailozaurr/Pop3MailReadHandler.cs
@@ -271,7 +271,9 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
             Attachments = snapshot.Message.Attachments.Select((attachment, index) => new AttachmentSummary {
                 MessageId = id,
                 Id = index.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                FileName = MimeAttachmentStorage.GetAttachmentFileName(attachment),
+                FileName = MimeAttachmentStorage.GetAttachmentFileName(
+                    attachment,
+                    MimeAttachmentStorage.CreateStorageIdentity(profileId, id, index.ToString(System.Globalization.CultureInfo.InvariantCulture))),
                 ContentType = attachment.ContentType.MimeType
             }).ToList()
         };

--- a/Sources/Mailozaurr/Pop3MailReadHandler.cs
+++ b/Sources/Mailozaurr/Pop3MailReadHandler.cs
@@ -117,13 +117,10 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
         var results = new List<MessageSummary>(messages.Count);
         var fingerprintOccurrences = new Dictionary<string, int>(StringComparer.Ordinal);
         foreach (var message in messages) {
+            var fingerprint = ComputeMessageFingerprint(message.Message);
+            _ = fingerprintOccurrences.TryGetValue(fingerprint, out var occurrence);
+            fingerprintOccurrences[fingerprint] = occurrence + 1;
             var uid = await TryGetUidAsync(client, message.Index, cancellationToken).ConfigureAwait(false);
-            var occurrence = 0;
-            if (string.IsNullOrWhiteSpace(uid)) {
-                var fingerprint = ComputeMessageFingerprint(message.Message);
-                _ = fingerprintOccurrences.TryGetValue(fingerprint, out occurrence);
-                fingerprintOccurrences[fingerprint] = occurrence + 1;
-            }
             results.Add(MapSummary(profile.Id, uid, message.Message, occurrence));
         }
         return results;
@@ -160,10 +157,11 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
         }
 
         var attachments = resolved.Snapshot.Message.Attachments.ToList();
-        var attachment = MimeAttachmentStorage.ResolveAttachment(attachments, request.AttachmentId);
-        if (attachment == null) {
+        var attachmentIndex = MimeAttachmentStorage.ResolveAttachmentIndex(attachments, request.AttachmentId);
+        if (attachmentIndex < 0) {
             return OperationResult.Failure("attachment_not_found", $"Attachment '{request.AttachmentId}' was not found.");
         }
+        var attachment = attachments[attachmentIndex];
 
         var destinationPath = MimeAttachmentStorage.ResolveDestinationPath(
             request.DestinationPath,
@@ -173,7 +171,7 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
                 profile.Kind.ToString(),
                 folderId,
                 request.MessageId,
-                request.AttachmentId));
+                attachmentIndex.ToString(System.Globalization.CultureInfo.InvariantCulture)));
         if (File.Exists(destinationPath) && !request.Overwrite) {
             return OperationResult.Failure("destination_exists", $"Destination '{destinationPath}' already exists.");
         }
@@ -322,7 +320,7 @@ public sealed class Pop3MailReadHandler : IMailReadHandler {
         }
 
         var occurrence = 0;
-        for (var index = 0; index < client.Count; index++) {
+        for (var index = client.Count - 1; index >= 0; index--) {
             cancellationToken.ThrowIfCancellationRequested();
             var candidate = await Pop3MailboxBrowser.ResolveMessageAsync(
                 client,

--- a/Sources/Mailozaurr/Pop3SessionFactory.cs
+++ b/Sources/Mailozaurr/Pop3SessionFactory.cs
@@ -1,0 +1,150 @@
+using MailKit.Net.Pop3;
+using MailKit.Security;
+
+namespace Mailozaurr;
+
+/// <summary>
+/// Creates authenticated POP3 sessions using profile settings and stored secrets.
+/// </summary>
+public sealed class Pop3SessionFactory : IPop3SessionFactory {
+    private readonly IMailSecretStore? _secretStore;
+    private readonly Func<Pop3SessionRequest, CancellationToken, Task<Pop3Client>> _connectAsync;
+
+    /// <summary>Creates a new POP3 session factory.</summary>
+    public Pop3SessionFactory(
+        IMailSecretStore? secretStore = null,
+        Func<Pop3SessionRequest, CancellationToken, Task<Pop3Client>>? connectAsync = null) {
+        _secretStore = secretStore;
+        _connectAsync = connectAsync ?? ((request, cancellationToken) => Pop3SessionService.ConnectAsync(request, cancellationToken));
+    }
+
+    /// <inheritdoc />
+    public async Task<Pop3Client> ConnectAsync(MailProfile profile, CancellationToken cancellationToken = default) {
+        if (profile == null) {
+            throw new ArgumentNullException(nameof(profile));
+        }
+        if (profile.Kind != MailProfileKind.Pop3) {
+            throw new InvalidOperationException($"Profile '{profile.Id}' is not a POP3 profile.");
+        }
+
+        var request = await CreateRequestAsync(profile, cancellationToken).ConfigureAwait(false);
+        return await _connectAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<Pop3SessionRequest> CreateRequestAsync(MailProfile profile, CancellationToken cancellationToken) {
+        var authMode = GetAuthMode(profile);
+        var userName = ResolveUserName(profile);
+        var secret = await ResolveSecretAsync(profile, authMode, cancellationToken).ConfigureAwait(false);
+
+        return new Pop3SessionRequest {
+            Connection = new Pop3ConnectionRequest(
+                RequireSetting(profile, MailProfileSettingsKeys.Server),
+                GetIntSetting(profile, MailProfileSettingsKeys.Port) ?? 995,
+                GetSecureSocketOptions(profile),
+                GetIntSetting(profile, MailProfileSettingsKeys.Timeout) ?? 30000,
+                GetBoolSetting(profile, MailProfileSettingsKeys.SkipCertificateRevocation) ?? false,
+                GetBoolSetting(profile, MailProfileSettingsKeys.SkipCertificateValidation) ?? false,
+                GetIntSetting(profile, MailProfileSettingsKeys.RetryCount) ?? 3,
+                GetIntSetting(profile, MailProfileSettingsKeys.RetryDelayMilliseconds) ?? 500,
+                GetDoubleSetting(profile, MailProfileSettingsKeys.RetryDelayBackoff) ?? 2.0),
+            UserName = userName,
+            Secret = secret,
+            AuthMode = authMode
+        };
+    }
+
+    private async Task<string> ResolveSecretAsync(
+        MailProfile profile,
+        ProtocolAuthMode authMode,
+        CancellationToken cancellationToken) {
+        var primarySecretName = authMode == ProtocolAuthMode.OAuth2
+            ? MailSecretNames.AccessToken
+            : MailSecretNames.Password;
+        var fallbackSecretName = authMode == ProtocolAuthMode.OAuth2
+            ? MailSecretNames.Password
+            : null;
+
+        var secret = _secretStore == null
+            ? null
+            : await _secretStore.GetSecretAsync(profile.Id, primarySecretName, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(secret) && fallbackSecretName != null && _secretStore != null) {
+            secret = await _secretStore.GetSecretAsync(profile.Id, fallbackSecretName, cancellationToken).ConfigureAwait(false);
+        }
+        if (string.IsNullOrWhiteSpace(secret)) {
+            throw new InvalidOperationException($"Secret '{primarySecretName}' is required for profile '{profile.Id}'.");
+        }
+
+        return secret!;
+    }
+
+    private static string ResolveUserName(MailProfile profile) {
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.UserName, out var userName) && !string.IsNullOrWhiteSpace(userName)) {
+            return userName.Trim();
+        }
+        if (profile.Settings.TryGetValue(MailProfileSettingsKeys.Mailbox, out var mailbox) && !string.IsNullOrWhiteSpace(mailbox)) {
+            return mailbox.Trim();
+        }
+        if (!string.IsNullOrWhiteSpace(profile.DefaultMailbox)) {
+            return profile.DefaultMailbox!.Trim();
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' requires '{MailProfileSettingsKeys.UserName}' or a mailbox value.");
+    }
+
+    private static string RequireSetting(MailProfile profile, string key) {
+        if (profile.Settings.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)) {
+            return value.Trim();
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' requires setting '{key}'.");
+    }
+
+    private static ProtocolAuthMode GetAuthMode(MailProfile profile) {
+        profile.Settings.TryGetValue(MailProfileSettingsKeys.AuthMode, out var rawMode);
+        return ProtocolAuth.ParseMode(rawMode, ProtocolAuthMode.Basic);
+    }
+
+    private static SecureSocketOptions GetSecureSocketOptions(MailProfile profile) {
+        if (!profile.Settings.TryGetValue(MailProfileSettingsKeys.SecureSocketOptions, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return SecureSocketOptions.Auto;
+        }
+        if (Enum.TryParse<SecureSocketOptions>(raw, ignoreCase: true, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid secure socket option '{raw}'.");
+    }
+
+    private static int? GetIntSetting(MailProfile profile, string key) {
+        if (!profile.Settings.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+        if (int.TryParse(raw, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid integer setting '{key}'.");
+    }
+
+    private static double? GetDoubleSetting(MailProfile profile, string key) {
+        if (!profile.Settings.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+        if (double.TryParse(raw, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid numeric setting '{key}'.");
+    }
+
+    private static bool? GetBoolSetting(MailProfile profile, string key) {
+        if (!profile.Settings.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw)) {
+            return null;
+        }
+        if (bool.TryParse(raw, out var value)) {
+            return value;
+        }
+
+        throw new InvalidOperationException($"Profile '{profile.Id}' has invalid boolean setting '{key}'.");
+    }
+}


### PR DESCRIPTION
## Summary

Adds POP3 as a first-class Mailozaurr application provider and expands profile diagnostics across IMAP, POP3, SMTP, Graph, and Gmail.

- adds POP3 profile connection, search, read, attachment, and capability workflows
- returns newest POP3 matches first and preserves stable addressing when UIDL is unsupported, transiently unavailable, or mixed across duplicate messages
- keeps attachment export identities deterministic across folder, message, attachment-index, filename, and provider aliases
- validates POP3 connection settings and preserves structured failure evidence
- keeps CLI and MCP surfaces thin over the shared application services

## Compatibility and safety

POP3 remains read-only at the application layer. Hash fallback IDs include duplicate occurrence identity and remain resolvable if UIDL later recovers. Attachment paths are sanitized, deterministic, and canonically keyed so aliases cannot bypass existing-destination handling.

## Validation

- .NET 8: 1,364 passed, 2 skipped
- .NET Framework: 1,160 passed, 1 skipped
- focused POP3/search contracts: 32 passed on each target