### PR TITLE
Update OfficeIMO dependencies to 3.4.0

### DIFF
--- a/Sources/Mailozaurr.Artifacts/Mailozaurr.Artifacts.csproj
+++ b/Sources/Mailozaurr.Artifacts/Mailozaurr.Artifacts.csproj
@@ -3,7 +3,7 @@
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <OfficeIMOVersion>3.2.7</OfficeIMOVersion>
+    <OfficeIMOVersion>3.4.0</OfficeIMOVersion>
     <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Mailozaurr.Artifacts</AssemblyName>
     <PackageId>Mailozaurr.Artifacts</PackageId>

--- a/Sources/Mailozaurr.Internet/Mailozaurr.Internet.csproj
+++ b/Sources/Mailozaurr.Internet/Mailozaurr.Internet.csproj
@@ -24,7 +24,7 @@
     <PackageTags>Windows;MacOS;Linux;Mail;Email;SMTP;IMAP;POP3;MIME;SendGrid;Mailgun;AmazonSES;DMARC;DKIM</PackageTags>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/artifacts/**;**/Artifacts/**</DefaultItemExcludes>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <OfficeIMOVersion>3.2.7</OfficeIMOVersion>
+    <OfficeIMOVersion>3.4.0</OfficeIMOVersion>
     <OfficeIMORoot Condition=" '$(OfficeIMORoot)' == '' ">..\..\..\OfficeIMO</OfficeIMORoot>
     <UseOfficeIMOProjectReferences Condition=" '$(UseOfficeIMOProjectReferences)' == '' ">false</UseOfficeIMOProjectReferences>
   </PropertyGroup>

--- a/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
+++ b/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
@@ -20,7 +20,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <OfficeIMOVersion Condition=" '$(OfficeIMOVersion)' == '' ">3.2.7</OfficeIMOVersion>
+        <OfficeIMOVersion Condition=" '$(OfficeIMOVersion)' == '' ">3.4.0</OfficeIMOVersion>
         <OfficeIMORoot Condition=" '$(OfficeIMORoot)' == '' ">..\..\..\OfficeIMO</OfficeIMORoot>
         <UseOfficeIMOProjectReferences Condition=" '$(UseOfficeIMOProjectReferences)' == '' ">false</UseOfficeIMOProjectReferences>
     </PropertyGroup>


### PR DESCRIPTION
## Summary

- update the three OfficeIMO dependency defaults from `3.2.7` to the current public `3.4.0` package set
- keep the Artifacts, Internet, and PowerShell projects on one aligned OfficeIMO version

## Compatibility

The solution builds successfully across its target frameworks with zero warnings or errors. The test suite passes on .NET 8 and .NET Framework with 3,293 successful tests and three expected environment-dependent skips.

## Release relationship

This PR consumes the latest currently published OfficeIMO packages. The Release-path normalization in [OfficeIMO #2463](https://github.com/EvotecIT/OfficeIMO/pull/2463) must ship in a later OfficeIMO version before Mailozaurr can consume path-clean OfficeIMO binaries; this PR does not pin an unpublished version.
