### PR TITLE
Update OfficeIMO packages to 3.4.2

### DIFF
--- a/Sources/Mailozaurr.Artifacts/Mailozaurr.Artifacts.csproj
+++ b/Sources/Mailozaurr.Artifacts/Mailozaurr.Artifacts.csproj
@@ -3,7 +3,7 @@
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <OfficeIMOVersion>3.4.0</OfficeIMOVersion>
+    <OfficeIMOVersion>3.4.2</OfficeIMOVersion>
     <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Mailozaurr.Artifacts</AssemblyName>
     <PackageId>Mailozaurr.Artifacts</PackageId>

--- a/Sources/Mailozaurr.Internet/Mailozaurr.Internet.csproj
+++ b/Sources/Mailozaurr.Internet/Mailozaurr.Internet.csproj
@@ -24,7 +24,7 @@
     <PackageTags>Windows;MacOS;Linux;Mail;Email;SMTP;IMAP;POP3;MIME;SendGrid;Mailgun;AmazonSES;DMARC;DKIM</PackageTags>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/artifacts/**;**/Artifacts/**</DefaultItemExcludes>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <OfficeIMOVersion>3.4.0</OfficeIMOVersion>
+    <OfficeIMOVersion>3.4.2</OfficeIMOVersion>
     <OfficeIMORoot Condition=" '$(OfficeIMORoot)' == '' ">..\..\..\OfficeIMO</OfficeIMORoot>
     <UseOfficeIMOProjectReferences Condition=" '$(UseOfficeIMOProjectReferences)' == '' ">false</UseOfficeIMOProjectReferences>
   </PropertyGroup>

--- a/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
+++ b/Sources/Mailozaurr.PowerShell/Mailozaurr.PowerShell.csproj
@@ -20,7 +20,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <OfficeIMOVersion Condition=" '$(OfficeIMOVersion)' == '' ">3.4.0</OfficeIMOVersion>
+        <OfficeIMOVersion Condition=" '$(OfficeIMOVersion)' == '' ">3.4.2</OfficeIMOVersion>
         <OfficeIMORoot Condition=" '$(OfficeIMORoot)' == '' ">..\..\..\OfficeIMO</OfficeIMORoot>
         <UseOfficeIMOProjectReferences Condition=" '$(UseOfficeIMOProjectReferences)' == '' ">false</UseOfficeIMOProjectReferences>
     </PropertyGroup>


### PR DESCRIPTION
## Summary

- Update OfficeIMO.Email, OfficeIMO.Email.Html, and OfficeIMO.Security from 3.4.0 to 3.4.2.
- Keep the Mailozaurr library, PowerShell, and packaged-artifact dependency graphs aligned on the same OfficeIMO release.

## Compatibility

This is a dependency maintenance update with no Mailozaurr API changes. The existing .NET Framework, .NET Standard, .NET 8, and PowerShell compatibility targets are unchanged.
