### PR TITLE
Fix module release artifact layout

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -158,8 +158,8 @@ Build-Module -ModuleName 'Mailozaurr' {
     New-ConfigurationProjectBuild -Name 'Mailozaurr' -ConfigPath $ProjectBuildConfigPath -Enabled -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget -PublishGitHub
     New-ConfigurationRelease -StageRoot 'Artefacts\UploadReady' -VersionSource ProjectBuild -PrimaryProject 'Mailozaurr' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
 
-    New-ConfigurationArtefact -Type Unpacked -Enable -Path 'Artefacts\Unpacked' -ModulesPath 'Artefacts\Unpacked\Modules'
-    New-ConfigurationArtefact -Type Packed -Enable -Path 'Artefacts\Packed' -ModulesPath 'Artefacts\Packed\Modules' -IncludeTagName
+    New-ConfigurationArtefact -Type Unpacked -Enable -Path 'Artefacts\Unpacked' -ModulesPath 'Modules'
+    New-ConfigurationArtefact -Type Packed -Enable -Path 'Artefacts\Packed' -IncludeTagName
 
     #New-ConfigurationTest -TestsPath "$PSScriptRoot\..\Tests" -Enable
 


### PR DESCRIPTION
## Summary

- Correct the unpacked artifact destination so it is relative to the configured artifact root.
- Let packed artifacts use PSPublishModule's default module root.
- Prevent repository-relative `Artefacts/...` directories from being embedded in the public module ZIP.

## Validation

- Built the coordinated release with public PSPublishModule 3.0.137 and signing enabled.
- Verified all seven NuGet package payloads against fresh release assemblies.
- Verified the module ZIP contains one `Mailozaurr/` root with the expected manifest and module entry script.
- Verified the unpacked manifest is under `Artefacts/Unpacked/Modules/Mailozaurr`.
- Imported the generated 3.0.1 module and verified all owned module files have valid Authenticode signatures.